### PR TITLE
Add the intended-use notice

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,8 @@
+# Notice
+
+This software is developed for lawful use. Operators and users are
+responsible for making sure that their deployment and use comply with the
+laws that apply to them, including copyright and data protection law. The
+project does not endorse or support unlawful use of any kind, and nothing
+in it is designed to enable such use. The license contains the full
+warranty and liability disclaimer.

--- a/README.md
+++ b/README.md
@@ -55,3 +55,5 @@ terms, the warranty disclaimer and the limitation of liability.
 
 Jellyfin plugins are linked against GPLv3 server code, so a plugin distributed
 to others has to be under the GPLv3 or a permissive license compatible with it.
+
+See [NOTICE.md](NOTICE.md) for the intended-use notice.


### PR DESCRIPTION
A root `NOTICE.md` stating lawful use as the purpose and operator
responsibility for legal compliance, with copyright and data protection named,
linked from the README. The license is untouched; its warranty and liability
disclaimer is referenced rather than repeated.

The license is left alone deliberately. This plugin is GPL-3.0, and the GPL
forbids adding restrictions on top of it, so a lawful-use clause written into
the license would itself breach the license the code is under. A notice beside
the license says the intent without changing the terms.

## The gate cannot go green on this pull request, and that is not this change

`call / build` and `call / test` are required by the branch ruleset.
`.github/workflows/test.yaml` declares `paths-ignore: '**/*.md'` on both its
`push` and its `pull_request` trigger, so a pull request that changes only
markdown never starts that workflow, and the two required contexts are never
reported. GitHub treats a required context that never arrives as pending, so
this pull request stays BLOCKED however long it waits. Nothing about the
change is wrong; the gate simply has no way to say so.

Two ways out exist and both are somebody else's call, because both touch files
this change is not permitted to open: drop `paths-ignore` from the workflow, or
take the two contexts out of the required set. Until one of them happens this
pull request should stay open rather than be merged around.
