### PR TITLE
Multi-target both live server lines and package each one separately

### DIFF
--- a/Jellyfin.Plugin.Template/Jellyfin.Plugin.Template.csproj
+++ b/Jellyfin.Plugin.Template/Jellyfin.Plugin.Template.csproj
@@ -1,20 +1,33 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <!-- One codebase, both live Jellyfin generations: net9.0 is the runtime the 10.11 server line
+         provides, net10.0 the one the 12.0 line provides. A plugin compiled for one does not load on
+         the other, so each target is packaged separately with its own targetAbi (build.yaml and
+         build-jf12.yaml). The template shipped targetAbi 10.9.0.0, framework net8.0 and
+         TargetFramework net9.0 at the same time, which describes no server anybody runs. -->
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <RootNamespace>Jellyfin.Plugin.Template</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
+    <!-- The Jellyfin SDK the plugin compiles against, per target. Overridable from the command line so
+         an ABI floor build can lower it to the targetAbi each package claims and prove that every API
+         the plugin calls also exists on the oldest server of that line. -->
+    <JellyfinVersion Condition="'$(JellyfinVersion)' == '' and '$(TargetFramework)' == 'net9.0'">10.11.11</JellyfinVersion>
+    <JellyfinVersion Condition="'$(JellyfinVersion)' == '' and '$(TargetFramework)' == 'net10.0'">12.0.0-rc4</JellyfinVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.9.11" >
+    <!-- ExcludeAssets=runtime keeps the host's own copies out of the plugin package: the server
+         supplies these assemblies, and shipping a second copy at a different version is how a plugin
+         breaks on a server it was built for. -->
+    <PackageReference Include="Jellyfin.Controller" Version="$(JellyfinVersion)">
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
-    <PackageReference Include="Jellyfin.Model" Version="10.9.11">
+    <PackageReference Include="Jellyfin.Model" Version="$(JellyfinVersion)">
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
   </ItemGroup>

--- a/build-jf12.yaml
+++ b/build-jf12.yaml
@@ -1,0 +1,25 @@
+---
+# Packaging metadata for the Jellyfin 12.0 line. One plugin, two packages: a 10.11 server provides
+# .NET 9 and a 12.0 server provides .NET 10, and a plugin compiled for one runtime does not load on
+# the other. The identity fields below are word-identical with build.yaml on purpose, because a
+# catalogue holds one entry per plugin and a divergence there makes the entry flip between two texts
+# depending on which package was published last.
+name: "Template"
+# Same identifier as build.yaml, so a server that moves from 10.11 to 12.0 updates this plugin in
+# place instead of gaining a second, unrelated one. Still the template's identifier; #15 mints the
+# real one and has to change both files.
+guid: "eb5d7894-8eef-4b36-aa6f-5d124e828ce1"
+version: "1.0.0.0"
+# The 12.0 line's floor and the runtime it provides.
+targetAbi: "12.0.0.0"
+framework: "net10.0"
+overview: "Short description about your plugin"
+description: >
+  This is a longer description that can span more than one
+  line and include details about your plugin.
+category: "General"
+owner: "jellyfin"
+artifacts:
+- "Jellyfin.Plugin.Template.dll"
+changelog: >
+  changelog

--- a/build.yaml
+++ b/build.yaml
@@ -2,8 +2,12 @@
 name: "Template"
 guid: "eb5d7894-8eef-4b36-aa6f-5d124e828ce1"
 version: "1.0.0.0"
-targetAbi: "10.9.0.0"
-framework: "net8.0"
+# Packaging metadata for the Jellyfin 10.11 line. The oldest server of that line this package claims
+# to load on, and the runtime that line provides. The project compiles against a newer 10.11.x SDK,
+# so a floor build against this number is what would show that every API the plugin calls also exists
+# on the oldest claimed server; no such build exists in the gate yet (#23).
+targetAbi: "10.11.0.0"
+framework: "net9.0"
 overview: "Short description about your plugin"
 description: >
   This is a longer description that can span more than one


### PR DESCRIPTION
Closes #17.

`build.yaml` claimed `targetAbi: 10.9.0.0` and `framework: net8.0` while the
project file targeted `net9.0` against the Jellyfin 10.9.11 SDK. No server has
that combination, so nothing in it could be inherited.

Both live lines are claimed, as the issue asks: 10.11 on .NET 9 and 12.0 on
.NET 10. Dropping a target later is cheap; adding one after the API surface has
settled is not.

## What changed

`Jellyfin.Plugin.Template.csproj` builds `net9.0;net10.0`. The Jellyfin SDK
version is a `JellyfinVersion` property conditioned on the target framework,
10.11.11 for `net9.0` and 12.0.0-rc4 for `net10.0`, and it is left overridable
from the command line so an ABI floor build (#23) can lower it to the floor each
package claims without a second copy of the version anywhere.

`build.yaml` becomes the 10.11 line's metadata, `targetAbi: 10.11.0.0` and
`framework: net9.0`. `build-jf12.yaml` is new and carries the 12.0 line's,
`targetAbi: 12.0.0.0` and `framework: net10.0`. The identity fields are
duplicated word for word between the two files, so a catalogue entry does not
flip between two texts depending on which package published last.

The means is unchanged: MSBuild multi-targeting and the packaging metadata
format the Jellyfin plugin tooling already reads. Nothing new is added to the
tree, and a build matrix in the gate can be expressed against it later without
another apparatus.

## Evidence

Every command below was run at `eb5c5ba`.

Both claimed target frameworks build with no framework argument, from a clean
`bin/` and `obj/`:

    $ rm -rf Jellyfin.Plugin.Template/bin Jellyfin.Plugin.Template/obj
    $ dotnet build --nologo
      Jellyfin.Plugin.Template -> .../bin/Debug/net10.0/Jellyfin.Plugin.Template.dll
      Jellyfin.Plugin.Template -> .../bin/Debug/net9.0/Jellyfin.Plugin.Template.dll
    Build succeeded.
        0 Warning(s)
        0 Error(s)

The SDK version really is conditioned on the target and not just written twice:

    $ dotnet msbuild Jellyfin.Plugin.Template/Jellyfin.Plugin.Template.csproj \
        -getProperty:JellyfinVersion -p:TargetFramework=net9.0
    10.11.11
    $ dotnet msbuild Jellyfin.Plugin.Template/Jellyfin.Plugin.Template.csproj \
        -getProperty:JellyfinVersion -p:TargetFramework=net10.0
    12.0.0-rc4

## What this does not prove

Pairing a target with the wrong line's SDK is not refused by the compiler. It
builds clean:

    $ dotnet build Jellyfin.Plugin.Template/Jellyfin.Plugin.Template.csproj \
        -f net10.0 -p:JellyfinVersion=10.11.11 --nologo
    Build succeeded.

So the conditioning above is evidenced by the resolved property values, not by
a red build. A wrong pairing surfaces when a server loads the package, which is
what #20 exists to check and what an ABI floor build in #23 would gate. Nothing
here closes that gap.

The gate compiles both targets but packages only one. `call / test` ran
`dotnet build --configuration Release` and produced both, on a runner where
`setup-dotnet` only asked for `9.0.x`:

    dotnet-install: .NET Core SDK with version '9.0.316' is already installed.
    Jellyfin.Plugin.Template -> .../bin/Release/net9.0/Jellyfin.Plugin.Template.dll
    Jellyfin.Plugin.Template -> .../bin/Release/net10.0/Jellyfin.Plugin.Template.dll
    Build succeeded.

`call / build` is the leg that does not follow. It passes `net9.0` to the
packaging tool by default and reads `build.yaml` alone:

    debug: {'dotnet_config': 'Release', 'dotnet_framework': 'net9.0', ...}
    Artifact: ./artifacts/template_1.0.0.0.zip

So `build-jf12.yaml` exists and nothing in the gate reads it. A 12.0 package is
not produced, and the file's `targetAbi` is not checked against anything. That
is the matrix work in #22 and the packaging work in #108, both outside this
issue's scope, and it means the second line is claimed in metadata before it is
claimed in a shipped artefact.

`Audit workflows (zizmor)` is red on this pull request, and it is red on #120,
which changes two markdown files and nothing else. Its findings are all
`unpinned-uses` and `excessive-permissions` against the inherited
`jellyfin/jellyfin-meta-plugins/...@master` callers, none of which this change
opens. It is not one of the contexts the branch ruleset requires.

`build-jf12.yaml` carries the template's name, identifier, overview and artifact
list, unchanged and still wrong, because #15 mints the identity and #16 does the
rename. Both now have one more file to touch, which is noted in the file itself.

## Review

No second reader ran on this change.
