### PR TITLE
Run the inherited guards on this branch and let the tree pass the workflow audit

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,4 +15,8 @@ on:
 
 jobs:
   call:
-    uses: jellyfin/jellyfin-meta-plugins/.github/workflows/build.yaml@master
+    # The called workflow checks out, builds and uploads an artifact. Reading the
+    # tree is all of that; artifact upload uses the runtime token, not this one.
+    permissions:
+      contents: read
+    uses: jellyfin/jellyfin-meta-plugins/.github/workflows/build.yaml@eb99033a7ff644881b014bc0b4169916c854a68b # master

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -13,7 +13,12 @@ on:
 
 jobs:
   call:
-    uses: jellyfin/jellyfin-meta-plugins/.github/workflows/changelog.yaml@master
+    # release-drafter writes the release draft, and the called workflow pushes a
+    # prepare-<version> branch and opens the bump pull request against it.
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: jellyfin/jellyfin-meta-plugins/.github/workflows/changelog.yaml@eb99033a7ff644881b014bc0b4169916c854a68b # master
     with:
       repository-name: jellyfin/jellyfin-plugin-template
     secrets:

--- a/.github/workflows/command-dispatch.yaml
+++ b/.github/workflows/command-dispatch.yaml
@@ -8,6 +8,10 @@ on:
 
 jobs:
   call:
-    uses: jellyfin/jellyfin-meta-plugins/.github/workflows/command-dispatch.yaml@master
+    # The dispatcher acts with the token passed in below, not with this job's.
+    # Reading the tree is all this job itself needs.
+    permissions:
+      contents: read
+    uses: jellyfin/jellyfin-meta-plugins/.github/workflows/command-dispatch.yaml@eb99033a7ff644881b014bc0b4169916c854a68b # master
     secrets:
       token: .

--- a/.github/workflows/command-rebase.yaml
+++ b/.github/workflows/command-rebase.yaml
@@ -7,7 +7,13 @@ on:
 
 jobs:
   call:
-    uses: jellyfin/jellyfin-meta-plugins/.github/workflows/command-rebase.yaml@master
+    # The rebase pushes the pull request's head branch and reacts on the comment
+    # that asked for it.
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    uses: jellyfin/jellyfin-meta-plugins/.github/workflows/command-rebase.yaml@eb99033a7ff644881b014bc0b4169916c854a68b # master
     with:
       rebase-head: ${{ github.event.client_payload.pull_request.head.label }}
       repository-full-name: ${{ github.event.client_payload.github.payload.repository.full_name }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,7 +8,10 @@ on:
 
 jobs:
   call:
-    uses: jellyfin/jellyfin-meta-plugins/.github/workflows/publish.yaml@master
+    # The upload job attaches the built package and its checksums to the release.
+    permissions:
+      contents: write
+    uses: jellyfin/jellyfin-meta-plugins/.github/workflows/publish.yaml@eb99033a7ff644881b014bc0b4169916c854a68b # master
     with:
       version: ${{ github.event.release.tag_name }}
       is-unstable: ${{ github.event.release.prerelease }}

--- a/.github/workflows/scan-codeql.yaml
+++ b/.github/workflows/scan-codeql.yaml
@@ -15,6 +15,12 @@ on:
 
 jobs:
   call:
-    uses: jellyfin/jellyfin-meta-plugins/.github/workflows/scan-codeql.yaml@master
+    # CodeQL init/autobuild/analyze: read the tree, read the workflow run for the
+    # analysis metadata, and write the results into the code-scanning tab.
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
+    uses: jellyfin/jellyfin-meta-plugins/.github/workflows/scan-codeql.yaml@eb99033a7ff644881b014bc0b4169916c854a68b # master
     with:
       repository-name: jellyfin/jellyfin-plugin-template

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -30,7 +30,7 @@ on:
   schedule:
     - cron: "27 4 * * 1"
   push:
-    branches: [main]
+    branches: [master]
 
 # Read-only by default; the analysis job adds only the scopes it needs. A
 # read-only top-level declaration is itself one of the Token-Permissions checks

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   call:
-    uses: jellyfin/jellyfin-meta-plugins/.github/workflows/sync-labels.yaml@master
+    # Label sync creates, edits and deletes labels, which is the issues scope.
+    permissions:
+      issues: write
+    uses: jellyfin/jellyfin-meta-plugins/.github/workflows/sync-labels.yaml@eb99033a7ff644881b014bc0b4169916c854a68b # master
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,4 +15,7 @@ on:
 
 jobs:
   call:
-    uses: jellyfin/jellyfin-meta-plugins/.github/workflows/test.yaml@master
+    # The called workflow restores, builds and tests. It writes nothing back.
+    permissions:
+      contents: read
+    uses: jellyfin/jellyfin-meta-plugins/.github/workflows/test.yaml@eb99033a7ff644881b014bc0b4169916c854a68b # master

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -22,7 +22,7 @@ name: Workflow Security Analysis
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
     branches: [ "**" ]
 
@@ -65,13 +65,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload SARIF
-        # Only upload where the GITHUB_TOKEN can write security events: pushes to main
+        # Only upload where the GITHUB_TOKEN can write security events: pushes to master
         # and same-repo human PRs. Fork and Dependabot pull requests run with a
         # read-only token, so the upload is skipped there - the gate step below still
         # runs and blocks on findings. continue-on-error keeps the security gate
         # independent of the upload: a transient code-scanning upload failure must not
         # skip the "Fail on actionable findings" step below.
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/master') || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')
         continue-on-error: true
         uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:


### PR DESCRIPTION
Refs #25. This does not close it. What it lands is the first of that issue's four
conditions and the precondition for the third; the two that remain are set out at
the bottom.

The five guards that arrived with this repository are the workflow audit, the
Trojan Source guard, the supply-chain scorecard, dependency review and the DCO
sign-off check. Two of them named `main` in their triggers while the default
branch here is `master`, and the tree they were meant to judge could not pass the
first of them at all.

## The triggers

`zizmor.yml` and `scorecard.yml` both carried `push: branches: [main]`. The audit
still fired through its `pull_request` trigger, so it was visible on pull requests
and never on the branch everything merges into. The scorecard has no pull-request
trigger by design, so it had never run here once. Both now name `master`.

The audit also gated its code-scanning upload on `github.ref == 'refs/heads/main'`,
so a push to the default branch would have run the audit and thrown the SARIF away.
That condition names `master` now too.

## The audit findings

The audit was red on every pull request on this board, for sixteen findings in the
eight workflows inherited from the plugin template. Eight `unpinned-uses` errors,
one per file, each a reusable workflow called at `@master`. Eight
`excessive-permissions` warnings, one per file, each a caller job with no
`permissions:` block, which hands the called workflow the repository default token.

Every reference is now pinned to `eb99033a7ff644881b014bc0b4169916c854a68b`, which
is what `@master` resolved to when this was written:

    $ gh api repos/jellyfin/jellyfin-meta-plugins/commits/master --jq .sha
    eb99033a7ff644881b014bc0b4169916c854a68b

Each caller job grants only what the workflow it calls uses. The scopes were read
off the called workflows at that same commit rather than guessed: `contents: read`
for build and test, which check out and compile and write nothing back;
`contents: read` plus `actions: read` plus `security-events: write` for CodeQL;
`contents: write` and `pull-requests: write` for the changelog, which pushes a
`prepare-<version>` branch and opens a pull request; `contents: write` for publish,
which attaches the package and its checksums to the release; `contents: write`,
`pull-requests: write` and `issues: write` for the rebase command, which pushes a
head branch and reacts on the comment that asked for it; `issues: write` for the
label sync, since labels are the issues scope.

None of the reusable workflows declares a `permissions:` block of its own, which is
why the caller is the only place this can be said.

## The means

No new language, tool or runtime. The change is the two fields GitHub Actions
already provides for this, a pinned `uses:` reference and a job-level
`permissions:` block, in the workflow files that already exist. Renovate is
already configured on this tree and is what moves a pin forward.

## Evidence

Run at `80196fb47c92ad9aadbad2691907736dcb21537e`, the head of this branch.

The workflow audit is green on this tree for the first time:

    $ gh pr checks 123 --repo iderex/jellyfin-plugin-requests
    Audit workflows (zizmor)        pass  20s  .../actions/runs/31044822697
    DCO sign-off                    pass   7s  .../actions/runs/31044822703
    Reject Trojan Source Unicode    pass   4s  .../actions/runs/31044822778
    call / build                    pass  21s  .../actions/runs/31044824549
    call / test                     pass  22s  .../actions/runs/31044823971
    dependency-review               pass   6s  .../actions/runs/31044822718
    call / Analyze                  skipping   .../actions/runs/31044824905

The same audit on the previous head of this board, run 31041799794 on pull
request #121, printed sixteen findings: an `unpinned-uses` error and an
`excessive-permissions` warning against each of `build.yaml`, `changelog.yaml`,
`command-dispatch.yaml`, `command-rebase.yaml`, `publish.yaml`,
`scan-codeql.yaml`, `sync-labels.yaml` and `test.yaml`.

The default branch this board actually has, which is what the two triggers now
name:

    $ gh api repos/iderex/jellyfin-plugin-requests --jq .default_branch
    master

Build and test were green before this change and are green after it, so the
permission sets did not take away a scope those two were using. The four
workflows that do not fire on a pull request are covered under what this does
not prove.

## What this does not prove

The pins freeze the shared workflows at one commit. That is the point of a pin and
it is also a cost: an upstream fix no longer arrives on its own, and nothing here
fails if the pin goes stale. `.github/renovate.json` is what would move it, and
whether it covers reusable-workflow references on this tree is not measured here.

The permission sets are read off the called workflows, not observed. Only build,
test and the audit itself run on a pull request. The changelog, publish, label sync
and both command workflows do not fire on this branch, so a scope that turns out to
be one too few will surface the first time one of them runs. The CodeQL caller is
skipped on this repository for a different reason: the called workflow guards on
`github.repository == inputs.repository-name` and the input is still
`jellyfin/jellyfin-plugin-template`, which #16 clears when it renames the tree.

Three comments inherited with these files still describe another repository. The
audit's own header names a `publish-beta.yml` that is not in this tree, the Trojan
Source guard cites an issue number from somewhere else, and dependency review names
a "Protect main" ruleset. None of them changes what runs, and correcting text about
another repository's workflows is not what this issue asks for.

## What is left on #25

Two of its four conditions are not met here.

A recorded red run for each of the five guards is not in this change. The audit has
one already, run 31041799794 on pull request #121, which went red for the sixteen
findings above, which is exactly what it exists to refuse. The other four do not.

The scorecard cannot have one. It scores the repository and uploads the result; it
declares no threshold and fails only if the action itself errors, so there is no
input that makes it go red for the reason it names. That is a defect in the
condition rather than in the guard, and it is written into #25 rather than worked
around here.

## Review

No second reader ran on this change.
