### PR TITLE
Deliberate red runs for three inherited guards, not for merge

### DIFF
--- a/Jellyfin.Plugin.Template/Jellyfin.Plugin.Template.csproj
+++ b/Jellyfin.Plugin.Template/Jellyfin.Plugin.Template.csproj
@@ -33,6 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
     <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" PrivateAssets="All" />

--- a/PROOF-unicode-guard.md
+++ b/PROOF-unicode-guard.md
@@ -4,3 +4,5 @@ The line below carries U+202E RIGHT-TO-LEFT OVERRIDE, which is the class of
 character the Trojan Source guard exists to refuse.
 
 if (isAdmin) { ‮ grant(); }
+
+The commit that adds this line carries no Signed-off-by trailer.

--- a/PROOF-unicode-guard.md
+++ b/PROOF-unicode-guard.md
@@ -1,0 +1,6 @@
+Deliberate guard proof. This branch is never merged.
+
+The line below carries U+202E RIGHT-TO-LEFT OVERRIDE, which is the class of
+character the Trojan Source guard exists to refuse.
+
+if (isAdmin) { ‮ grant(); }


### PR DESCRIPTION
Refs #25. Do not merge this. It exists to make three of the five inherited guards
go red for the reason each one names, so that the record of the red run exists.
It is closed as soon as the runs have finished.

What each commit is for:

`a023171` adds a file carrying U+202E, a right-to-left override, which is the
character class the Trojan Source guard refuses.

`e55d0e2` carries no `Signed-off-by` trailer, which is what the DCO check
refuses. It is signed, so only the sign-off is missing.

`bee97c0` adds Newtonsoft.Json 12.0.3, below the 13.0.1 fix line of
GHSA-5crp-9r3c-p9vr, which is a newly introduced dependency with a published
advisory and is what dependency review refuses.

The build and test checks are expected to be affected by the third commit as
well. That is a side effect of the input, not part of what is being proved.

The two guards not exercised here are the workflow audit, which already has its
red run on pull request #121, and the scorecard, which has no failure condition
to trigger. Both are written up on #25.

## Review

No second reader ran on this change, and it is not proposed for merge.
