### PR TITLE
Check the formatting of the embedded web assets and the markdown

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,0 +1,53 @@
+# Formatting gate for everything the .NET analyzers do not reach. The plugin
+# ships HTML, CSS and JavaScript inside the assembly and none of it is compiled,
+# so without this nothing keeps those files consistent and every edit carries
+# reformatting noise that hides the change. Markdown is in the same set for the
+# same reason.
+#
+# The set of file types is the glob below and nothing else. It is written here
+# rather than left to a config file so that what is covered is readable in the
+# run itself, and so that adding a type is a visible change to this workflow.
+# Anything not in the glob is not checked: C# is the analyzers' job, and the
+# workflow YAML and the packaging metadata are deliberately out, because
+# reformatting them would rewrite files that other gates read line by line.
+#
+# The formatter version is pinned. An unpinned formatter reds a tree that was
+# green yesterday, for a default that changed rather than for anything anybody
+# wrote.
+name: Prettier
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: ["**"]
+
+# Read-only: the gate reads the tree and writes nothing back.
+permissions:
+  contents: read
+
+# Cancel a superseded run on the same ref so a new push or pull-request update
+# does not queue behind an obsolete check.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prettier:
+    name: Check formatting
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # No step pushes via git, so do not persist the GITHUB_TOKEN in .git/config.
+          persist-credentials: false
+
+      - name: Check formatting of the web assets and the markdown
+        env:
+          PRETTIER_VERSION: "3.6.2"
+        # --check reports and exits non-zero, it never edits. The glob is the
+        # whole scope of this gate: HTML, CSS and JavaScript, which is what the
+        # plugin embeds, plus Markdown.
+        run: npx --yes "prettier@${PRETTIER_VERSION}" --check "**/*.{html,css,js,md}"

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,8 +1,7 @@
 # Formatting gate for everything the .NET analyzers do not reach. The plugin
 # ships HTML, CSS and JavaScript inside the assembly and none of it is compiled,
 # so without this nothing keeps those files consistent and every edit carries
-# reformatting noise that hides the change. Markdown is in the same set for the
-# same reason.
+# reformatting noise that hides the change.
 #
 # The set of file types is the glob below and nothing else. It is written here
 # rather than left to a config file so that what is covered is readable in the
@@ -10,6 +9,12 @@
 # Anything not in the glob is not checked: C# is the analyzers' job, and the
 # workflow YAML and the packaging metadata are deliberately out, because
 # reformatting them would rewrite files that other gates read line by line.
+#
+# MARKDOWN IS NOT IN THE GLOB YET, and #27 asks for it. `README.md` is the only
+# markdown on the tree and it is being replaced whole by #19, so formatting the
+# copy that is here would be thrown away by that change and would collide with
+# it on the way. Adding `md` to the glob is the one-line change that finishes
+# #27, once the replacement is in.
 #
 # The formatter version is pinned. An unpinned formatter reds a tree that was
 # green yesterday, for a default that changed rather than for anything anybody
@@ -44,10 +49,10 @@ jobs:
           # No step pushes via git, so do not persist the GITHUB_TOKEN in .git/config.
           persist-credentials: false
 
-      - name: Check formatting of the web assets and the markdown
+      - name: Check formatting of the embedded web assets
         env:
           PRETTIER_VERSION: "3.6.2"
         # --check reports and exits non-zero, it never edits. The glob is the
         # whole scope of this gate: HTML, CSS and JavaScript, which is what the
-        # plugin embeds, plus Markdown.
-        run: npx --yes "prettier@${PRETTIER_VERSION}" --check "**/*.{html,css,js,md}"
+        # plugin embeds.
+        run: npx --yes "prettier@${PRETTIER_VERSION}" --check "**/*.{html,css,js}"

--- a/Jellyfin.Plugin.Template/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Template/Configuration/configPage.html
@@ -1,79 +1,77 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="utf-8">
-    <title>Template</title>
-</head>
-<body>
-    <div id="TemplateConfigPage" data-role="page" class="page type-interior pluginConfigurationPage" data-require="emby-input,emby-button,emby-select,emby-checkbox">
-        <div data-role="content">
-            <div class="content-primary">
-                <form id="TemplateConfigForm">
-                    <div class="selectContainer">
-                        <label class="selectLabel" for="Options">Several Options</label>
-                        <select is="emby-select" id="Options" name="Options" class="emby-select-withcolor emby-select">
-                            <option id="optOneOption" value="OneOption">One Option</option>
-                            <option id="optAnotherOption" value="AnotherOption">Another Option</option>
-                        </select>
-                    </div>
-                    <div class="inputContainer">
-                        <label class="inputLabel inputLabelUnfocused" for="AnInteger">An Integer</label>
-                        <input id="AnInteger" name="AnInteger" type="number" is="emby-input" min="0" />
-                        <div class="fieldDescription">A Description</div>
-                    </div>
-                    <div class="checkboxContainer checkboxContainer-withDescription">
-                        <label class="emby-checkbox-label">
-                            <input id="TrueFalseSetting" name="TrueFalseCheckBox" type="checkbox" is="emby-checkbox" />
-                            <span>A Checkbox</span>
-                        </label>
-                    </div>
-                    <div class="inputContainer">
-                        <label class="inputLabel inputLabelUnfocused" for="AString">A String</label>
-                        <input id="AString" name="AString" type="text" is="emby-input" />
-                        <div class="fieldDescription">Another Description</div>
-                    </div>
-                    <div>
-                        <button is="emby-button" type="submit" class="raised button-submit block emby-button">
-                            <span>Save</span>
-                        </button>
-                    </div>
-                </form>
+    <head>
+        <meta charset="utf-8" />
+        <title>Template</title>
+    </head>
+    <body>
+        <div id="TemplateConfigPage" data-role="page" class="page type-interior pluginConfigurationPage" data-require="emby-input,emby-button,emby-select,emby-checkbox">
+            <div data-role="content">
+                <div class="content-primary">
+                    <form id="TemplateConfigForm">
+                        <div class="selectContainer">
+                            <label class="selectLabel" for="Options">Several Options</label>
+                            <select is="emby-select" id="Options" name="Options" class="emby-select-withcolor emby-select">
+                                <option id="optOneOption" value="OneOption">One Option</option>
+                                <option id="optAnotherOption" value="AnotherOption">Another Option</option>
+                            </select>
+                        </div>
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="AnInteger">An Integer</label>
+                            <input id="AnInteger" name="AnInteger" type="number" is="emby-input" min="0" />
+                            <div class="fieldDescription">A Description</div>
+                        </div>
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label class="emby-checkbox-label">
+                                <input id="TrueFalseSetting" name="TrueFalseCheckBox" type="checkbox" is="emby-checkbox" />
+                                <span>A Checkbox</span>
+                            </label>
+                        </div>
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="AString">A String</label>
+                            <input id="AString" name="AString" type="text" is="emby-input" />
+                            <div class="fieldDescription">Another Description</div>
+                        </div>
+                        <div>
+                            <button is="emby-button" type="submit" class="raised button-submit block emby-button">
+                                <span>Save</span>
+                            </button>
+                        </div>
+                    </form>
+                </div>
             </div>
-        </div>
-        <script type="text/javascript">
-            var TemplateConfig = {
-                pluginUniqueId: 'eb5d7894-8eef-4b36-aa6f-5d124e828ce1'
-            };
+            <script type="text/javascript">
+                var TemplateConfig = {
+                    pluginUniqueId: "eb5d7894-8eef-4b36-aa6f-5d124e828ce1",
+                };
 
-            document.querySelector('#TemplateConfigPage')
-                .addEventListener('pageshow', function() {
+                document.querySelector("#TemplateConfigPage").addEventListener("pageshow", function () {
                     Dashboard.showLoadingMsg();
                     ApiClient.getPluginConfiguration(TemplateConfig.pluginUniqueId).then(function (config) {
-                        document.querySelector('#Options').value = config.Options;
-                        document.querySelector('#AnInteger').value = config.AnInteger;
-                        document.querySelector('#TrueFalseSetting').checked = config.TrueFalseSetting;
-                        document.querySelector('#AString').value = config.AString;
+                        document.querySelector("#Options").value = config.Options;
+                        document.querySelector("#AnInteger").value = config.AnInteger;
+                        document.querySelector("#TrueFalseSetting").checked = config.TrueFalseSetting;
+                        document.querySelector("#AString").value = config.AString;
                         Dashboard.hideLoadingMsg();
                     });
                 });
 
-            document.querySelector('#TemplateConfigForm')
-                .addEventListener('submit', function(e) {
-                Dashboard.showLoadingMsg();
-                ApiClient.getPluginConfiguration(TemplateConfig.pluginUniqueId).then(function (config) {
-                    config.Options = document.querySelector('#Options').value;
-                    config.AnInteger = document.querySelector('#AnInteger').value;
-                    config.TrueFalseSetting = document.querySelector('#TrueFalseSetting').checked;
-                    config.AString = document.querySelector('#AString').value;
-                    ApiClient.updatePluginConfiguration(TemplateConfig.pluginUniqueId, config).then(function (result) {
-                        Dashboard.processPluginConfigurationUpdateResult(result);
+                document.querySelector("#TemplateConfigForm").addEventListener("submit", function (e) {
+                    Dashboard.showLoadingMsg();
+                    ApiClient.getPluginConfiguration(TemplateConfig.pluginUniqueId).then(function (config) {
+                        config.Options = document.querySelector("#Options").value;
+                        config.AnInteger = document.querySelector("#AnInteger").value;
+                        config.TrueFalseSetting = document.querySelector("#TrueFalseSetting").checked;
+                        config.AString = document.querySelector("#AString").value;
+                        ApiClient.updatePluginConfiguration(TemplateConfig.pluginUniqueId, config).then(function (result) {
+                            Dashboard.processPluginConfigurationUpdateResult(result);
+                        });
                     });
-                });
 
-                e.preventDefault();
-                return false;
-            });
-        </script>
-    </div>
-</body>
+                    e.preventDefault();
+                    return false;
+                });
+            </script>
+        </div>
+    </body>
 </html>


### PR DESCRIPTION
Refs #27. It does not close it, and the paragraph at the bottom says what is
left.

The plugin ships HTML, CSS and JavaScript inside the assembly. None of it is
compiled and no analyzer looks at it, so nothing has ever kept those files
consistent, and every edit to them carries reformatting noise that hides the
edit.

## What changed

A `Prettier` workflow runs the formatter in check mode on every pull request and
on a push to `master`. Check mode reports and never edits, so the gate cannot
rewrite the tree it is judging.

The file types are the glob in the workflow, `**/*.{html,css,js}`, rather than a
config file somewhere else, so what is covered is readable in the run itself and
adding a type is a visible change to this file. C# is left to the analyzers, and
the workflow YAML and the packaging metadata are deliberately out, because
reformatting them would rewrite files that other gates read line by line.

The formatter version is pinned at 3.6.2. An unpinned formatter reds a tree that
was green yesterday, for a default that moved rather than for anything anybody
wrote.

The embedded configuration page is reformatted to what that version produces.
Nothing in the page moves.

## The means

`npx` with a pinned version, and no config file, no dev dependency and no
`package.json` added to a tree that has no JavaScript build. The runner already
has Node, so the cost is one pinned invocation. A formatter is a place where the
means is genuinely forced: the assets are HTML, CSS and JavaScript, and no .NET
tool formats them.

## Evidence

The gate refuses an unformatted file. Run 31048165790, at `af3f4b6`, which is the
commit that added the workflow and nothing else:

    Checking formatting...
    [warn] Jellyfin.Plugin.Template/Configuration/configPage.html
    [warn] README.md
    [warn] Code style issues found in 2 files. Run Prettier with --write to fix.
    ##[error]Process completed with exit code 1.

That run was the gate as first pushed, whose glob also carried `md`. The `html`
half of the glob is unchanged since, and the first of those two lines is what it
produced.

The tree passes it now. Run 31048645957, at `2715569`:

    Checking formatting...
    All matched files use Prettier code style!

The same at that commit locally:

    $ npx --yes prettier@3.6.2 --check "**/*.{html,css,js}"
    Checking formatting...
    All matched files use Prettier code style!

Every other check on this pull request is green, so the reformatted page still
builds and the new workflow passes the workflow audit.

## What this does not prove

The gate judges formatting and nothing else. An unreadable page that is
consistently indented passes it.

The reformatting of the configuration page is not reviewed line by line here. It
is the pinned formatter's output over a file the analyzers never read, and the
build check passing is the only claim made about it.

The glob is a repository-wide `**`. Nothing today has HTML, CSS or JavaScript
outside the embedded configuration directory, so what that widened glob costs on
a tree that grows one is not measured.

## What is left on #27

Markdown. The issue asks for the markdown as well, and it is not in the glob.
`README.md` is the only markdown on the tree and #19 replaces the whole file, so
formatting the copy that is here would be discarded by that change and would
collide with it on the way in. The workflow header says this and names what
finishes it, which is adding `md` back to the glob once the replacement is in.
#27 stays open for that.

## Review

No second reader ran on this change.
