### PR TITLE
Add the host service doubles and route construction through one of them

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Doubles/FakeApplicationPaths.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/FakeApplicationPaths.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Globalization;
+using System.IO;
+using MediaBrowser.Common.Configuration;
+
+namespace Jellyfin.Plugin.Requests.Tests.Doubles;
+
+/// <summary>
+/// The host's application paths, rooted at a directory this instance creates and deletes. Every
+/// path is under that root, so a test that writes through the plugin cannot reach a real server's
+/// data directory, and nothing survives the test that created it.
+/// </summary>
+internal sealed class FakeApplicationPaths : IApplicationPaths, IDisposable
+{
+    private bool disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FakeApplicationPaths"/> class.
+    /// </summary>
+    public FakeApplicationPaths()
+    {
+        ProgramDataPath = Path.Combine(
+            Path.GetTempPath(),
+            string.Create(CultureInfo.InvariantCulture, $"jellyfin-plugin-requests-tests-{Guid.NewGuid():N}"));
+
+        Directory.CreateDirectory(ProgramDataPath);
+        Directory.CreateDirectory(PluginConfigurationsPath);
+    }
+
+    /// <inheritdoc />
+    public string ProgramDataPath { get; }
+
+    /// <inheritdoc />
+    public string WebPath => Under("web");
+
+    /// <inheritdoc />
+    public string ProgramSystemPath => Under("system");
+
+    /// <inheritdoc />
+    public string DataPath => Under("data");
+
+    /// <inheritdoc />
+    public string VirtualDataPath => Under("virtual-data");
+
+    /// <inheritdoc />
+    public string ImageCachePath => Under("image-cache");
+
+    /// <inheritdoc />
+    public string PluginsPath => Under("plugins");
+
+    /// <inheritdoc />
+    public string PluginConfigurationsPath => Under("plugin-configurations");
+
+    /// <inheritdoc />
+    public string LogDirectoryPath => Under("log");
+
+    /// <inheritdoc />
+    public string ConfigurationDirectoryPath => Under("config");
+
+    /// <inheritdoc />
+    public string SystemConfigurationFilePath => Path.Combine(ConfigurationDirectoryPath, "system.xml");
+
+    /// <inheritdoc />
+    public string CachePath { get; set; } = string.Empty;
+
+    /// <inheritdoc />
+    public string TempDirectory => Under("temp");
+
+    /// <inheritdoc />
+    public string TrickplayPath => Under("trickplay");
+
+    /// <inheritdoc />
+    public string BackupPath => Under("backup");
+
+    /// <inheritdoc />
+    public void CreateAndCheckMarker(string path, string markerName, bool recursive = false)
+    {
+        Directory.CreateDirectory(path);
+    }
+
+    /// <inheritdoc />
+    public void MakeSanityCheckOrThrow()
+    {
+        // Nothing to check: every path this double returns is under a directory it created itself.
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+
+        if (Directory.Exists(ProgramDataPath))
+        {
+            Directory.Delete(ProgramDataPath, true);
+        }
+    }
+
+    private string Under(string name) => Path.Combine(ProgramDataPath, name);
+}

--- a/Jellyfin.Plugin.Requests.Tests/Doubles/FakeXmlSerializer.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/FakeXmlSerializer.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using MediaBrowser.Model.Serialization;
+
+namespace Jellyfin.Plugin.Requests.Tests.Doubles;
+
+/// <summary>
+/// The host's XML serializer, holding what it was given in memory. Round trips through a real
+/// serializer are a property of the persisted shape rather than of the host, so this double keeps
+/// the object itself and a test that cares about serialisation asserts on the real thing instead.
+/// </summary>
+internal sealed class FakeXmlSerializer : IXmlSerializer
+{
+    private readonly Dictionary<string, object> byPath = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Gets the number of times anything was written to a file.
+    /// </summary>
+    public int WriteCount { get; private set; }
+
+    /// <inheritdoc />
+    public object? DeserializeFromStream(Type type, Stream stream) => null;
+
+    /// <inheritdoc />
+    public object? DeserializeFromFile(Type type, string file)
+        => byPath.TryGetValue(file, out var stored) ? stored : null;
+
+    /// <inheritdoc />
+    public object? DeserializeFromBytes(Type type, byte[] buffer) => null;
+
+    /// <inheritdoc />
+    public void SerializeToStream(object obj, Stream stream)
+    {
+        WriteCount++;
+    }
+
+    /// <inheritdoc />
+    public void SerializeToFile(object obj, string file)
+    {
+        ArgumentNullException.ThrowIfNull(obj);
+        byPath[file] = obj;
+        WriteCount++;
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/Doubles/PluginHost.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/PluginHost.cs
@@ -1,0 +1,52 @@
+using System;
+using PluginUnderTest = Jellyfin.Plugin.Template.Plugin;
+
+namespace Jellyfin.Plugin.Requests.Tests.Doubles;
+
+/// <summary>
+/// The one place in the suite that constructs the plugin. Every host service the plugin injects is
+/// passed from here, so a new constructor parameter fails to compile at this call site and the suite
+/// stops building until its double exists. That is the whole point of routing construction through
+/// one file rather than letting each test call the constructor.
+/// </summary>
+internal sealed class PluginHost : IDisposable
+{
+    private bool disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PluginHost"/> class.
+    /// </summary>
+    public PluginHost()
+    {
+        ApplicationPaths = new FakeApplicationPaths();
+        XmlSerializer = new FakeXmlSerializer();
+        Plugin = new PluginUnderTest(ApplicationPaths, XmlSerializer);
+    }
+
+    /// <summary>
+    /// Gets the plugin under test.
+    /// </summary>
+    public PluginUnderTest Plugin { get; }
+
+    /// <summary>
+    /// Gets the paths double the plugin was given.
+    /// </summary>
+    public FakeApplicationPaths ApplicationPaths { get; }
+
+    /// <summary>
+    /// Gets the serializer double the plugin was given.
+    /// </summary>
+    public FakeXmlSerializer XmlSerializer { get; }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+        ApplicationPaths.Dispose();
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/PluginConstructionTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/PluginConstructionTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.IO;
+using System.Linq;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using MediaBrowser.Model.Plugins;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests;
+
+/// <summary>
+/// The plugin constructed against doubles rather than a running server. These are the first tests
+/// on this board that reach the plugin's own behaviour, and they exist to show the doubles carry
+/// the construction path the host would.
+/// </summary>
+public class PluginConstructionTests
+{
+    /// <summary>
+    /// The plugin reads and writes its configuration through the host's paths and serializer. If
+    /// either double is short of what the constructor needs, this throws rather than failing an
+    /// assertion, which is the signal that the double set has drifted from the host surface.
+    /// </summary>
+    [Fact]
+    public void PluginConstructsAgainstTheDoubles()
+    {
+        using var host = new PluginHost();
+
+        Assert.NotNull(host.Plugin);
+        Assert.False(string.IsNullOrWhiteSpace(host.Plugin.Name));
+        Assert.NotEqual(Guid.Empty, host.Plugin.Id);
+    }
+
+    /// <summary>
+    /// Nothing the plugin writes may land outside the directory the paths double created. A test
+    /// that leaves a file in a real server's data directory is a test that changed the machine it
+    /// ran on.
+    /// </summary>
+    [Fact]
+    public void EveryPathThePluginIsGivenIsInsideTheTemporaryRoot()
+    {
+        using var host = new PluginHost();
+        var root = Path.GetFullPath(host.ApplicationPaths.ProgramDataPath);
+
+        var paths = new[]
+        {
+            host.ApplicationPaths.PluginConfigurationsPath,
+            host.ApplicationPaths.PluginsPath,
+            host.ApplicationPaths.DataPath,
+            host.ApplicationPaths.ConfigurationDirectoryPath,
+            host.ApplicationPaths.SystemConfigurationFilePath,
+            host.ApplicationPaths.LogDirectoryPath,
+            host.ApplicationPaths.TempDirectory,
+            host.ApplicationPaths.BackupPath,
+        };
+
+        Assert.All(paths, p => Assert.StartsWith(root, Path.GetFullPath(p), StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The configuration page the dashboard asks for comes from the plugin instance, not from the
+    /// assembly metadata alone, so this is the instance-level counterpart of the resource check in
+    /// <see cref="PluginContractTests"/>.
+    /// </summary>
+    [Fact]
+    public void GetPagesNamesTheEmbeddedConfigurationPage()
+    {
+        using var host = new PluginHost();
+
+        var pages = host.Plugin.GetPages().ToList();
+        var page = Assert.Single(pages);
+
+        Assert.IsType<PluginPageInfo>(page);
+        Assert.Contains(
+            page.EmbeddedResourcePath,
+            host.Plugin.GetType().Assembly.GetManifestResourceNames(),
+            StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// The paths double deletes what it created. A suite that leaves a directory per test run fills
+    /// the machine slowly enough that nobody connects it to the suite.
+    /// </summary>
+    [Fact]
+    public void DisposingTheHostRemovesTheTemporaryRoot()
+    {
+        string root;
+
+        using (var host = new PluginHost())
+        {
+            root = host.ApplicationPaths.ProgramDataPath;
+            Assert.True(Directory.Exists(root));
+        }
+
+        Assert.False(Directory.Exists(root));
+    }
+}


### PR DESCRIPTION
Closes #33.

The plugin could not be constructed in the suite at all. Its constructor takes
two host services, and #126's two tests worked entirely off assembly metadata
for that reason.

## What changed

`Jellyfin.Plugin.Requests.Tests/Doubles/` holds a double per host service the
plugin injects, and nothing else, so the set of host services this plugin
depends on is visible by reading one directory and is the list to re-check when
a server line changes.

`FakeApplicationPaths` roots every path it returns under a directory it creates
in the temporary directory and deletes on dispose. `FakeXmlSerializer` holds
what it was given in memory; a round trip through a real serializer is a
property of the persisted shape rather than of the host, and belongs to the
storage work.

`PluginHost` is the only type in the suite that calls the plugin's constructor.
That is not tidiness, it is the third condition: a new host dependency fails to
compile at one call site, so the suite stops building until the double exists.
Spreading construction across the tests would let a new dependency be satisfied
with a null in each one.

The means is hand-written doubles rather than a mocking library. Two interfaces,
one of which is fifteen path properties, so a mocking framework would add a
dependency and a second vocabulary to read the suite in, and the doubles hold
real behaviour (a temporary root that is created and deleted) that a mock would
not. When the plugin starts injecting the library, the users and the activity
log, that trade is worth re-running rather than inheriting.

## Evidence

At `b5fbe7e`.

Six tests, both claimed targets:

    $ dotnet test --nologo
    Passed!  - Failed: 0, Passed: 6, Skipped: 0, Total: 6 - ...(net9.0)
    Passed!  - Failed: 0, Passed: 6, Skipped: 0, Total: 6 - ...(net10.0)

The third condition holds, and this is the near-miss for it rather than a
description of one. A third parameter was added to the plugin's constructor in
the working tree, with its documentation so the plugin project itself stays
clean, and then reverted:

    $ dotnet build Jellyfin.Plugin.Template/Jellyfin.Plugin.Template.csproj --nologo
    Build succeeded.
    $ dotnet build Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj --nologo
    Doubles/PluginHost.cs(23,22): error CS7036: There is no argument given that corresponds to
      the required parameter 'libraryManager' of
      'Plugin.Plugin(IApplicationPaths, IXmlSerializer, ILibraryManager)'  [...net10.0]
    Doubles/PluginHost.cs(23,22): error CS7036: There is no argument given that corresponds to
      the required parameter 'libraryManager' of
      'Plugin.Plugin(IApplicationPaths, IXmlSerializer, ILibraryManager)'  [...net9.0]
    Build FAILED.

The plugin project builds and the suite does not, on both targets, at the one
call site. The probe is not in this branch; `Plugin.cs` is outside this issue's
scope and is unchanged here.

The first attempt at that near-miss failed for the wrong reason and is worth
recording: adding the parameter without its `<param>` tag failed the plugin
project on CS1573 and SA1611 before the suite was ever compiled. A near-miss
that reds the wrong project proves nothing about this one.

The paths double keeps the suite off the machine. Every path the plugin is
handed is asserted to be under the temporary root, and the root is asserted to
be gone after dispose, in `EveryPathThePluginIsGivenIsInsideTheTemporaryRoot`
and `DisposingTheHostRemovesTheTemporaryRoot`.

The doubles were written against a probe of the real interfaces on both lines
rather than from memory. `IApplicationPaths` and `IXmlSerializer` have the same
members on Jellyfin 10.11.11 and 12.0.0-rc4, seventeen and five, which is why no
target-conditional code is needed here and why a future divergence is a thing to
re-probe rather than assume.

## What this does not do

The second condition is met today and is not enforced. No test constructs a real
server type and none touches a path outside the temporary root, but nothing
refuses a test that does: the assertions above cover the paths the double hands
out, not every path a future test might open. A greppable invariant would be the
mechanism, and that is #28.

`WriteCount` and the stored-object map on the serializer double are not asserted
by any test yet. They exist because the plugin's configuration write path goes
through them and the storage work will need to see it, and an unasserted
affordance is a small piece of speculative code, which is worth saying rather
than leaving for a reader to notice.

The doubles cover the services the plugin injects today, which is two. The
library, the users, the user data, the activity log and the live sessions named
in the issue are not injected anywhere yet, because that code does not exist, so
a double for each would be written against a call nobody has made. The
compile-time guard above is what makes adding them a build failure rather than
an act of memory.

## Review

No second reader ran on this change.
