### PR TITLE
Check headless that the plugin loads on a server of each claimed line

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,129 @@
+# Testing
+
+## Does the plugin load on a real server
+
+A plugin that builds is not a plugin that loads. An ABI mismatch, an embedded resource path that
+stopped resolving after a rename, and a dependency the host does not provide all build clean and
+fail at server start or on first use. The suite cannot see any of the three, because it has no
+server.
+
+`scripts/verify-plugin-loads.sh` starts a server of one claimed line in a container, installs the
+plugin built for that line's runtime, and asks the server itself what it has. It ends non-zero
+unless the server reports the plugin as `Active`.
+
+    scripts/verify-plugin-loads.sh jellyfin/jellyfin:10.11.11 net9.0  18096
+    scripts/verify-plugin-loads.sh jellyfin/jellyfin:12.0-rc4  net10.0 18097
+
+Run them one after the other rather than together: each publishes into the same tree and each wants
+its own port, and the second argument has to be the target framework the image's runtime provides.
+
+What it needs is a container engine, a .NET SDK, `curl` and `python3`. What it does not need is a
+display, administrator rights or a trusted certificate. The server is reached over plain HTTP on
+the loopback interface, the container is removed when the run ends, and the one account it creates
+lives no longer than the container. Nothing it runs can raise a prompt on the machine it runs on.
+
+The plugin is copied into the container after the server has started, because `/config` is a volume
+and a copy made before that lands where the running server never looks. The server is then
+restarted, because plugins are read at start.
+
+### The recorded run
+
+Run on `e574918775c69640139ee1ecc1f2202efeff27aa`, 2026-08-06, against these images:
+
+    jellyfin/jellyfin@sha256:aefb67e6a7ff1debdd154a78a7bbb780fd0c873d8639210a7f6a2016ad2b35db
+    jellyfin/jellyfin@sha256:db1df1d111c27ba1f10bb8fce6630892f66eb66b12c2b24e79011453ac18b3db
+
+The 10.11 line, `scripts/verify-plugin-loads.sh jellyfin/jellyfin:10.11.11 net9.0 18096`:
+
+    == wait for the server to answer
+    {"LocalAddress":"http://172.17.0.2:8096","ServerName":"f12222e96abc","Version":"10.11.11","ProductName":"Jellyfin Server","OperatingSystem":"","Id":"5b159e1a1d02497997cf1f933901aafe","StartupWizardCompleted":false}
+
+    == what the server says about its plugins
+    Name=AudioDB  Version=10.11.11.0  Status=Active  Id=a629c0dafac54c7e931a7174223f14c8
+    Name=MusicBrainz  Version=10.11.11.0  Status=Active  Id=8c95c4d2e50c4fb0a4f36c06ff0f9a1a
+    Name=OMDb  Version=10.11.11.0  Status=Active  Id=a628c0dafac54c7e9d1a7134223f14c8
+    Name=Requests  Version=1.0.0.0  Status=Active  Id=eb5d78948eef4b36aa6f5d124e828ce1
+    Name=Studio Images  Version=10.11.11.0  Status=Active  Id=872a78491171458da6fb3de3d442ad30
+    Name=TMDb  Version=10.11.11.0  Status=Active  Id=b8715ed16c4745289ad3f72deb539cd4
+
+    == verdict
+    Requests is Active, id eb5d78948eef4b36aa6f5d124e828ce1
+
+    == the configuration page the dashboard would fetch
+    GET /web/ConfigurationPage?name=Requests -> 200
+    <!doctype html>
+    <html lang="en">
+        <head>
+            <meta charset="utf-8" />
+            <title>Requests</title>
+
+    == the configuration the page reads and writes
+    {}
+    POST /Plugins/<id>/Configuration -> 204
+
+    == done
+    Requests loaded and answered on jellyfin/jellyfin:10.11.11 (net9.0)
+
+The 12.0 line, `scripts/verify-plugin-loads.sh jellyfin/jellyfin:12.0-rc4 net10.0 18097`:
+
+    == wait for the server to answer
+    {"LocalAddress":"http://172.17.0.2:8096","ServerName":"2461813535d0","Version":"12.0.0","ProductName":"Jellyfin Server","OperatingSystem":"","Id":"2e7c15bb59eb43ad946f7e839158e207","StartupWizardCompleted":false}
+
+    == what the server says about its plugins
+    Name=AudioDB  Version=12.0.0.0  Status=Active  Id=a629c0dafac54c7e931a7174223f14c8
+    Name=ListenBrainz Similarity Provider  Version=12.0.0.0  Status=Active  Id=a5b2e8c19d4f4a3b8c7e6f1a2b3c4d5e
+    Name=MusicBrainz  Version=12.0.0.0  Status=Active  Id=8c95c4d2e50c4fb0a4f36c06ff0f9a1a
+    Name=OMDb  Version=12.0.0.0  Status=Active  Id=a628c0dafac54c7e9d1a7134223f14c8
+    Name=Requests  Version=1.0.0.0  Status=Active  Id=eb5d78948eef4b36aa6f5d124e828ce1
+    Name=Studio Images  Version=12.0.0.0  Status=Active  Id=872a78491171458da6fb3de3d442ad30
+    Name=TMDb  Version=12.0.0.0  Status=Active  Id=b8715ed16c4745289ad3f72deb539cd4
+
+    == verdict
+    Requests is Active, id eb5d78948eef4b36aa6f5d124e828ce1
+
+    == the configuration page the dashboard would fetch
+    GET /web/ConfigurationPage?name=Requests -> 200
+
+    == the configuration the page reads and writes
+    {}
+    POST /Plugins/<id>/Configuration -> 204
+
+    == done
+    Requests loaded and answered on jellyfin/jellyfin:12.0-rc4 (net10.0)
+
+### That the check bites
+
+A procedure that cannot fail proves nothing, so the mismatch it exists to catch was fed to it. The
+12.0 build, which compiles and packages cleanly, installed on a 10.11 server:
+
+    scripts/verify-plugin-loads.sh jellyfin/jellyfin:10.11.11 net10.0 18098
+
+    == what the server says about its plugins
+    Name=AudioDB  Version=10.11.11.0  Status=Active  Id=a629c0dafac54c7e931a7174223f14c8
+    Name=Jellyfin.Plugin.Requests  Version=10.11.11.0  Status=NotSupported  Id=ff768900c0ec47d72192ea5c133ecc62
+    Name=MusicBrainz  Version=10.11.11.0  Status=Active  Id=8c95c4d2e50c4fb0a4f36c06ff0f9a1a
+    Name=OMDb  Version=10.11.11.0  Status=Active  Id=a628c0dafac54c7e9d1a7134223f14c8
+    Name=Studio Images  Version=10.11.11.0  Status=Active  Id=872a78491171458da6fb3de3d442ad30
+    Name=TMDb  Version=10.11.11.0  Status=Active  Id=b8715ed16c4745289ad3f72deb539cd4
+
+    == verdict
+    Requests is not in the plugin list: the server did not load it.
+    exit=1
+
+The server keeps the plugin in its list under the file name rather than the plugin's own name, with
+`Status=NotSupported`, because it never got far enough to ask the plugin what it is called. That is
+the shape a reader should expect when this fails.
+
+### What this does not cover
+
+The run above happened on one machine, by hand. Nothing on a merge route runs it, so a change that
+breaks loading reaches the mainline the same way a change that does not.
+
+The 12.0 line is a release candidate. `12.0-rc4` is what exists today and the tag will move.
+
+The packages are not what a catalogue would serve. This installs the assembly the build produces
+into the plugin directory; it does not build the zip, publish a manifest, or exercise the install
+path an operator uses. Those are M14.
+
+Nothing here plays media, so the container's transcoding dependencies are never touched, and a
+failure that needs a real library to show would not show here.

--- a/scripts/verify-plugin-loads.sh
+++ b/scripts/verify-plugin-loads.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Start a Jellyfin server of one claimed line, install this plugin into it, and print what the
+# server itself says about the plugin.
+#
+# A plugin that builds is not a plugin that loads. An ABI mismatch, an embedded resource path that
+# stopped resolving after a rename, and a dependency the host does not provide all build clean and
+# fail at server start or on first use. Nothing short of a server answering about the plugin is
+# evidence that it loaded, and a dashboard somebody looked at is not evidence anybody else can
+# repeat.
+#
+# This needs no display, no administrator rights and no trusted certificate. The server runs in a
+# container, is reached over plain HTTP on the loopback interface, and is removed when the run
+# ends. The one credential it creates lives for the length of that container.
+#
+# usage: scripts/verify-plugin-loads.sh <image> <target-framework> [host-port]
+#   scripts/verify-plugin-loads.sh jellyfin/jellyfin:10.11.11 net9.0  18096
+#   scripts/verify-plugin-loads.sh jellyfin/jellyfin:12.0-rc4  net10.0 18097
+
+set -euo pipefail
+
+image=${1:?server image, for example jellyfin/jellyfin:10.11.11}
+framework=${2:?target framework, for example net9.0}
+port=${3:-18096}
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+project="$repo_root/Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.csproj"
+assembly=Jellyfin.Plugin.Requests
+plugin_name=Requests
+container="jellyfin-plugin-load-check-$framework"
+base="http://127.0.0.1:$port"
+plugin_dir="/config/plugins/$assembly"
+
+# The wizard needs an account before anything can be asked of the server. It exists for the length
+# of one container and is reachable only from this loopback port.
+admin_user=verify
+admin_password=$(python3 -c 'import secrets; print(secrets.token_urlsafe(24))')
+
+auth='MediaBrowser Client="plugin-load-check", Device="load-check", DeviceId="plugin-load-check", Version="1.0.0.0"'
+
+# Git Bash rewrites an argument that looks like an absolute path, which turns a container path into
+# a Windows one. Turning that off for the whole script would break dotnet, which wants the native
+# spelling, so it is turned off for the docker calls only.
+dk() {
+    MSYS_NO_PATHCONV=1 docker "$@"
+}
+
+cleanup() {
+    dk rm --force "$container" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+step() { printf '\n== %s\n' "$*"; }
+
+step "publish $assembly for $framework"
+# Under the repository rather than in the temporary directory, because this path is handed to both
+# dotnet and docker and those two disagree about what an absolute path looks like on this platform.
+publish_dir="$repo_root/artifacts/load-check/$framework"
+rm -rf "$publish_dir"
+dotnet publish "$project" -c Release -f "$framework" -o "$publish_dir" --nologo -v quiet
+ls -1 "$publish_dir"
+host_dll=$(cygpath --windows "$publish_dir/$assembly.dll" 2>/dev/null || printf '%s' "$publish_dir/$assembly.dll")
+
+step "start a server from $image"
+dk rm --force "$container" >/dev/null 2>&1 || true
+dk run --detach --name "$container" --publish "127.0.0.1:$port:8096" "$image" >/dev/null
+
+step "install the plugin"
+# The server is started first because /config is a volume: it is populated when the container runs,
+# and a copy made before that lands under a directory the running server never reads.
+for _ in $(seq 1 60); do
+    if dk exec "$container" test -d /config/plugins 2>/dev/null; then
+        break
+    fi
+    sleep 1
+done
+dk exec "$container" mkdir -p "$plugin_dir"
+# Only the assembly. The rest of the publish output is a symbol file and a documentation file, and
+# a package shipping those would be shipping what a server has no use for.
+dk cp "$host_dll" "$container:$plugin_dir/$assembly.dll"
+# Plugins are read at start, so the server has to come up again with the plugin already in place.
+dk restart "$container" >/dev/null
+dk exec "$container" ls -1 "$plugin_dir"
+
+step "wait for the server to answer"
+for _ in $(seq 1 90); do
+    if curl --silent --fail --max-time 5 "$base/System/Info/Public" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 2
+done
+curl --silent --fail --max-time 10 "$base/System/Info/Public"
+printf '\n'
+
+step "complete the startup wizard"
+# These are open on a server whose wizard has not been completed. Completing it is what makes an
+# authenticated call possible, and the plugin list is an authenticated call.
+curl --silent --fail --max-time 30 -X POST "$base/Startup/Configuration" \
+    -H 'Content-Type: application/json' \
+    -d '{"UICulture":"en-US","MetadataCountryCode":"US","PreferredMetadataLanguage":"en"}'
+curl --silent --fail --max-time 30 "$base/Startup/User" >/dev/null
+curl --silent --fail --max-time 30 -X POST "$base/Startup/User" \
+    -H 'Content-Type: application/json' \
+    -d "{\"Name\":\"$admin_user\",\"Password\":\"$admin_password\"}"
+curl --silent --fail --max-time 30 -X POST "$base/Startup/RemoteAccess" \
+    -H 'Content-Type: application/json' \
+    -d '{"EnableRemoteAccess":true,"EnableAutomaticPortMapping":false}'
+curl --silent --fail --max-time 30 -X POST "$base/Startup/Complete" -H 'Content-Length: 0'
+echo "wizard completed"
+
+step "authenticate"
+token=$(curl --silent --fail --max-time 30 -X POST "$base/Users/AuthenticateByName" \
+    -H 'Content-Type: application/json' \
+    -H "Authorization: $auth" \
+    -d "{\"Username\":\"$admin_user\",\"Pw\":\"$admin_password\"}" |
+    python3 -c 'import json,sys; print(json.load(sys.stdin)["AccessToken"])')
+test -n "$token"
+echo "authenticated"
+
+step "what the server says about its plugins"
+plugins=$(curl --silent --fail --max-time 30 "$base/Plugins" -H "Authorization: $auth, Token=\"$token\"")
+printf '%s' "$plugins" | python3 -c '
+import json, sys
+for plugin in json.load(sys.stdin):
+    print("Name={0}  Version={1}  Status={2}  Id={3}".format(
+        plugin.get("Name"), plugin.get("Version"), plugin.get("Status"), plugin.get("Id")))
+'
+
+step "verdict"
+plugin_id=$(printf '%s' "$plugins" | python3 -c '
+import json, sys
+name = sys.argv[1]
+mine = [p for p in json.load(sys.stdin) if p.get("Name") == name]
+if not mine:
+    sys.exit("{0} is not in the plugin list: the server did not load it.".format(name))
+if len(mine) != 1:
+    sys.exit("{0} appears {1} times in the plugin list.".format(name, len(mine)))
+status = mine[0].get("Status")
+if status != "Active":
+    sys.exit("{0} is {1} rather than Active.".format(name, status))
+print(mine[0]["Id"])
+' "$plugin_name")
+echo "$plugin_name is Active, id $plugin_id"
+
+step "the configuration page the dashboard would fetch"
+# The embedded resource path is built at run time from the plugin's namespace. A half rename leaves
+# a build that is green and a page that is empty, and this is where that shows.
+page_status=$(curl --silent --output /dev/null --write-out '%{http_code}' --max-time 30 \
+    "$base/web/ConfigurationPage?name=$plugin_name")
+echo "GET /web/ConfigurationPage?name=$plugin_name -> $page_status"
+test "$page_status" = "200"
+curl --silent --fail --max-time 30 "$base/web/ConfigurationPage?name=$plugin_name" | head -5
+
+step "the configuration the page reads and writes"
+curl --silent --fail --max-time 30 "$base/Plugins/$plugin_id/Configuration" \
+    -H "Authorization: $auth, Token=\"$token\""
+printf '\n'
+write_status=$(curl --silent --output /dev/null --write-out '%{http_code}' --max-time 30 \
+    -X POST "$base/Plugins/$plugin_id/Configuration" \
+    -H 'Content-Type: application/json' \
+    -H "Authorization: $auth, Token=\"$token\"" \
+    --data '{}')
+echo "POST /Plugins/<id>/Configuration -> $write_status"
+test "$write_status" = "204"
+
+step "done"
+echo "$plugin_name loaded and answered on $image ($framework)"


### PR DESCRIPTION
Part of #20.

## What changed

`scripts/verify-plugin-loads.sh` starts a Jellyfin server of one claimed line in a container, installs the assembly built for that line's runtime, completes the startup wizard over the server's own API, authenticates, and prints what the server says about its plugins. It ends non-zero unless this plugin is reported `Active`.

It then fetches the configuration page the dashboard would fetch and reads and writes the plugin's configuration. Those two are how the embedded resource path is shown to resolve on a real server, which no test in the suite can show, because the path is built at run time from the plugin's namespace.

`docs/testing.md` carries the procedure, the recorded run for both lines, the run that shows the check bites, and what the check does not cover.

## Evidence

The 10.11 line:

    scripts/verify-plugin-loads.sh jellyfin/jellyfin:10.11.11 net9.0 18096

    == wait for the server to answer
    {"LocalAddress":"http://172.17.0.2:8096","ServerName":"f12222e96abc","Version":"10.11.11","ProductName":"Jellyfin Server","OperatingSystem":"","Id":"5b159e1a1d02497997cf1f933901aafe","StartupWizardCompleted":false}

    == what the server says about its plugins
    Name=Requests  Version=1.0.0.0  Status=Active  Id=eb5d78948eef4b36aa6f5d124e828ce1

    == the configuration page the dashboard would fetch
    GET /web/ConfigurationPage?name=Requests -> 200

    == the configuration the page reads and writes
    {}
    POST /Plugins/<id>/Configuration -> 204

    == done
    Requests loaded and answered on jellyfin/jellyfin:10.11.11 (net9.0)

The 12.0 line:

    scripts/verify-plugin-loads.sh jellyfin/jellyfin:12.0-rc4 net10.0 18097

    == wait for the server to answer
    {"LocalAddress":"http://172.17.0.2:8096","ServerName":"2461813535d0","Version":"12.0.0","ProductName":"Jellyfin Server","OperatingSystem":"","Id":"2e7c15bb59eb43ad946f7e839158e207","StartupWizardCompleted":false}

    == what the server says about its plugins
    Name=Requests  Version=1.0.0.0  Status=Active  Id=eb5d78948eef4b36aa6f5d124e828ce1

    == done
    Requests loaded and answered on jellyfin/jellyfin:12.0-rc4 (net10.0)

The full plugin lists from both runs are in `docs/testing.md`; the lines above are the entry this is about.

The check bites. The 12.0 build, which compiles and packages cleanly, installed on a 10.11 server:

    scripts/verify-plugin-loads.sh jellyfin/jellyfin:10.11.11 net10.0 18098

    Name=Jellyfin.Plugin.Requests  Version=10.11.11.0  Status=NotSupported  Id=ff768900c0ec47d72192ea5c133ecc62

    == verdict
    Requests is not in the plugin list: the server did not load it.
    exit=1

The images the runs used:

    docker image inspect jellyfin/jellyfin:10.11.11 --format '{{index .RepoDigests 0}}'
    jellyfin/jellyfin@sha256:aefb67e6a7ff1debdd154a78a7bbb780fd0c873d8639210a7f6a2016ad2b35db
    docker image inspect jellyfin/jellyfin:12.0-rc4 --format '{{index .RepoDigests 0}}'
    jellyfin/jellyfin@sha256:db1df1d111c27ba1f10bb8fce6630892f66eb66b12c2b24e79011453ac18b3db

The suite is unaffected:

    dotnet test Jellyfin.Plugin.Requests.sln
    Bestanden! Fehler: 0, erfolgreich: 11, gesamt: 11 - Jellyfin.Plugin.Requests.Tests.dll (net9.0)
    Bestanden! Fehler: 0, erfolgreich: 11, gesamt: 11 - Jellyfin.Plugin.Requests.Tests.dll (net10.0)

## Headless, and no prompt

No display, no administrator rights, no certificate trust. Plain HTTP on the loopback interface, a container removed when the run ends, and one account that lives no longer than that container. The engine is spoken to through its already-running daemon; nothing here installs, registers or elevates anything.

## What this does not do

Nothing on a merge route runs it. A change that breaks loading reaches the mainline exactly as a change that does not, and putting this in the gate is not in this issue's scope.

It installs the assembly into the plugin directory. It does not build the package a catalogue would serve, publish a manifest, or exercise the install path an operator uses; those are M14.

The 12.0 line is a release candidate and `12.0-rc4` is the tag that exists today.

## Means

Bash, the container engine, `curl` and `python3`. A server of another runtime, started and driven from outside, is a forced means: the thing under test is whether a host this repository does not build loads the assembly, and no C# test in this tree can stand in for that. Python is already needed to read the server's JSON without adding a dependency, and it is what is on both this platform and a Linux runner; `jq` is not.

## Review

No second person has read this change. The output above is pasted from the runs and stands in place of a review.
