### PR TITLE
Scan the languages this repository contains, on every branch

### DIFF
--- a/.github/workflows/scan-codeql.yaml
+++ b/.github/workflows/scan-codeql.yaml
@@ -1,26 +1,99 @@
+# Semantic code scanning, configured here rather than left to the repository
+# default.
+#
+# The default analyses the default branch and the pull requests aimed at it, and
+# nothing else, so a release branch and the pull requests aimed at that branch
+# would carry no scan at all. The triggers below name every branch on both
+# sides.
+#
+# The languages are the ones this repository actually contains, and each is
+# named rather than discovered: C#, the JavaScript inside the embedded
+# configuration page, and the workflow files themselves, which are as much a
+# part of the attack surface as the plugin is. A language that is added to the
+# tree and not added here is a language nobody scans, and that is a visible
+# change to this file rather than a silent gap.
+#
+# The query suite is security-extended. The default suite trades recall for
+# precision, and the finding this is meant to catch is the one nobody was
+# looking for.
 name: '🔬 Run CodeQL'
 
 on:
   push:
-    branches: [ master ]
+    branches: ['**']
     paths-ignore:
       - '**/*.md'
   pull_request:
-    branches: [ master ]
+    branches: ['**']
     paths-ignore:
       - '**/*.md'
   schedule:
     - cron: '24 2 * * 4'
   workflow_dispatch:
 
+# Explicit deny-all at workflow level; the job below grants only what it needs.
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  call:
-    # CodeQL init/autobuild/analyze: read the tree, read the workflow run for the
-    # analysis metadata, and write the results into the code-scanning tab.
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
+      # Read the tree, read the run's own metadata, and write the results into
+      # the code-scanning tab. Nothing here pushes to the repository.
       contents: read
       actions: read
       security-events: write
-    uses: jellyfin/jellyfin-meta-plugins/.github/workflows/scan-codeql.yaml@eb99033a7ff644881b014bc0b4169916c854a68b # master
-    with:
-      repository-name: iderex/jellyfin-plugin-requests
+
+    strategy:
+      # One language failing must not hide the result of the others.
+      fail-fast: false
+      matrix:
+        include:
+          - language: csharp
+            build-mode: manual
+          - language: javascript-typescript
+            build-mode: none
+          - language: actions
+            build-mode: none
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # No step pushes via git, so do not persist the GITHUB_TOKEN in .git/config.
+          persist-credentials: false
+
+      - if: matrix.language == 'csharp'
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          # Both claimed lines, so the analysis sees the same code the gate
+          # builds and not one target framework of two.
+          dotnet-version: |
+            9.0.x
+            10.0.x
+
+      - name: Initialise CodeQL
+        uses: github/codeql-action/init@18420e3271f74589575af831a523c833acda327f # codeql-bundle-v2.26.2
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-extended
+
+      - name: Build for the analysis
+        # Manual rather than autobuild, so the analysis is over what this
+        # repository's own gate builds: every claimed target framework, restored
+        # from the committed lockfiles.
+        if: matrix.language == 'csharp'
+        run: |
+          dotnet restore Jellyfin.Plugin.Requests.sln --locked-mode
+          dotnet build Jellyfin.Plugin.Requests.sln --configuration Release --no-restore
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@18420e3271f74589575af831a523c833acda327f # codeql-bundle-v2.26.2
+        with:
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
Part of #24.

## What changed

The scan was the repository default, reached through a workflow in another organisation. The default covers the default branch and the pull requests aimed at it and nothing else, so a release branch, and anything aimed at one, would carry no scan at all. The language set was left to discovery, which makes a language nobody looks at a silent gap rather than a visible one.

`scan-codeql.yaml` is now this repository's own. Three languages, each named: C#, the JavaScript inside the embedded configuration page, and the workflow files. `security-extended` rather than the default suite. Both triggers name every branch on both sides. The C# leg builds every claimed target framework from the committed lockfiles instead of letting autobuild choose, so the analysis sees what the gate builds.

## Evidence

One run, three languages, on this branch:

    Analyze (csharp, manual)                pass  1m37s
    Analyze (javascript-typescript, none)   pass    53s
    Analyze (actions, none)                 pass    40s

A push to a branch that is not `master` gets its own scan. `proof/24-scan-finds-each` is a branch with no pull request open, and the workflow ran on the push:

    gh run list --branch proof/24-scan-finds-each
    🔬 Run CodeQL   completed   success

A planted finding is found. The embedded page's script was given a DOM sink fed from the URL fragment, and the scan raised it:

    gh api "repos/iderex/jellyfin-plugin-requests/code-scanning/alerts?ref=refs/heads/proof/24-scan-finds-each&state=open"
    js/xss  high  Jellyfin.Plugin.Requests/Configuration/configPage.html:29

## What this does not do

The third condition has two halves and this branch settles one of them.

The C# and workflow plants did not raise an alert on the first attempt, and both are cases of the plant being wrong rather than of the scan being silent. The workflow plant interpolated a pull request title inside a workflow whose only trigger was manual, so the value was not one an outsider can set, and no alert is the correct answer there. The C# plant was a constant used to build a header by hand rather than a credential the query recognises. Both were changed on the proof branch and the result of that is written into the issue rather than claimed here.

The other half, that the tree is otherwise clean, is false today. `master` carries open alerts, and they are not from this change:

    gh api "repos/iderex/jellyfin-plugin-requests/code-scanning/alerts?ref=refs/heads/master&state=open" --jq 'length'
    22

Most are Scorecard rather than CodeQL. The CodeQL ones are `cs/path-combine`, four of them, and `cs/linq/missed-where`, one, all in the test project. Two of those are in a file this effort added. Cleaning them is not this issue's scope and turning the extended suite on is what makes them visible, so this change increases the count it is measured against rather than reducing it.

The `pull_request` trigger naming every base branch is a declaration in this file; no pull request aimed at a branch other than `master` has been opened, so that half is configured and not measured.

## Means

GitHub Actions YAML and the CodeQL action, both forced by where the analysis has to run. The languages and the suite are the two things this file exists to say out loud.

## Review

No second person has read this change. The output above is pasted from runs on this head and on the proof branch, and stands in place of a review.
