### PR TITLE
Deliberate red run for the ABI floor job, not for merge

### DIFF
--- a/Jellyfin.Plugin.Requests/FloorProof.cs
+++ b/Jellyfin.Plugin.Requests/FloorProof.cs
@@ -1,0 +1,19 @@
+using MediaBrowser.Controller.Entities;
+
+namespace Jellyfin.Plugin.Requests;
+
+/// <summary>
+/// Deliberate use of an API that does not exist on the floor the packaging metadata claims.
+/// This file exists to make the floor build go red and is thrown away afterwards.
+/// </summary>
+internal static class FloorProof
+{
+    /// <summary>
+    /// Sets a property added to <see cref="InternalItemsQuery"/> after 10.11.0.
+    /// </summary>
+    /// <returns>The query.</returns>
+    public static InternalItemsQuery Build()
+    {
+        return new InternalItemsQuery { UseRawName = true };
+    }
+}


### PR DESCRIPTION
Refs #23. NOT FOR MERGE, and closed. This branch existed to make the floor job
go red for the reason it names, the run happened, and the evidence is in the
body of #136.

`Jellyfin.Plugin.Requests/FloorProof.cs` set `InternalItemsQuery.UseRawName`,
a property absent from Jellyfin.Controller 10.11.0, which is the floor
`build.yaml` declares, and present in 10.11.11, which the project compiles
against.

At `bc36591`, runs 31095776433 and 31095776826:

    floor 10.11.0.0  failure
    floor 12.0.0.0   success
    call / build     success
    call / test      success

    ##[error]Jellyfin.Plugin.Requests/FloorProof.cs(17,41): error CS0117:
    'InternalItemsQuery' does not contain a definition for 'UseRawName'
    [Jellyfin.Plugin.Requests.csproj::TargetFramework=net9.0]

The floor job refused the change, the line that does not declare that floor did
not, and the shipping build and the suite stayed green on the same commit.

## Review

No second reader ran on this change, and it is not being merged.
