### PR TITLE
Define the request record with approval and availability kept apart

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Model/MediaRequestTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Model/MediaRequestTests.cs
@@ -1,0 +1,219 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using Jellyfin.Plugin.Requests.Model;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Model;
+
+/// <summary>
+/// What the request record must keep true. Two of these are about the shape of the record rather
+/// than about a value, because the failures they stand for are additions somebody makes later
+/// without reading why the record looks the way it does.
+/// </summary>
+public class MediaRequestTests
+{
+    /// <summary>
+    /// The names every public field on the record carries. Written out rather than derived, so an
+    /// addition is a deliberate edit to this list and its reason is in the commit that made it. A
+    /// field that arrives without one reds this test, which is the only reason the list is here.
+    /// </summary>
+    private static readonly string[] ExpectedFields =
+    [
+        "Availability",
+        "AvailabilityCheckedAt",
+        "DisplayTitle",
+        "DisplayYear",
+        "Id",
+        "Kind",
+        "ProviderIds",
+        "RequestedAt",
+        "RequestedByUserId",
+        "State",
+        "StateChangedAt",
+        "StateChangedByUserId"
+    ];
+
+    /// <summary>
+    /// The vocabulary of the thing that fetches media. None of it belongs on this record: those
+    /// settings are the external service's, and a copy of them here is the beginning of a second,
+    /// worse one. The fragments are matched against field names, so <c>QualityProfileId</c> and
+    /// <c>DefaultRootFolder</c> are both caught.
+    /// </summary>
+    private static readonly string[] FetchVocabulary =
+    [
+        "client",
+        "download",
+        "folder",
+        "indexer",
+        "path",
+        "profile",
+        "quality",
+        "seed",
+        "torrent",
+        "tracker",
+        "url",
+        "usenet"
+    ];
+
+    /// <summary>
+    /// The case the whole separation exists for. An operator approves something on Tuesday and the
+    /// file arrives on Friday, and for three days the request is approved and the server does not
+    /// have it. A model that expressed approval and availability as one value would have to call
+    /// those three days something, and every candidate is a lie.
+    /// </summary>
+    [Fact]
+    public void ARequestCanBeApprovedAndNotYetAvailable()
+    {
+        var request = ARequest() with
+        {
+            State = RequestState.Approved,
+            Availability = LibraryAvailability.Absent,
+            AvailabilityCheckedAt = new DateTimeOffset(2026, 8, 6, 9, 0, 0, TimeSpan.Zero)
+        };
+
+        Assert.Equal(RequestState.Approved, request.State);
+        Assert.Equal(LibraryAvailability.Absent, request.Availability);
+    }
+
+    /// <summary>
+    /// The two fields do not read each other. This is the near miss the test above does not catch:
+    /// a later change could make availability follow from the state, or the state follow from
+    /// availability, and the single approved-and-absent value above would still hold while every
+    /// other pairing quietly stopped being representable.
+    /// </summary>
+    [Fact]
+    public void ApprovalAndAvailabilityMoveIndependently()
+    {
+        var request = ARequest();
+
+        foreach (var state in Enum.GetValues<RequestState>())
+        {
+            foreach (var availability in Enum.GetValues<LibraryAvailability>())
+            {
+                var moved = request with { State = state, Availability = availability };
+
+                Assert.Equal(state, moved.State);
+                Assert.Equal(availability, moved.Availability);
+            }
+        }
+    }
+
+    /// <summary>
+    /// A request nothing has decided and nothing has looked at says exactly that. The failure this
+    /// stands for is a default of <c>Absent</c>, which reads as "the server does not have it" when
+    /// what happened is that no check has run, and which would make a fresh queue look like a list
+    /// of things the server is missing.
+    /// </summary>
+    [Fact]
+    public void ANewRequestIsOpenAndItsAvailabilityHasNotBeenLookedAt()
+    {
+        var request = ARequest();
+
+        Assert.Equal(RequestState.Open, request.State);
+        Assert.Equal(LibraryAvailability.Unknown, request.Availability);
+        Assert.Null(request.AvailabilityCheckedAt);
+        Assert.Null(request.StateChangedByUserId);
+        Assert.Empty(request.ProviderIds);
+    }
+
+    /// <summary>
+    /// The record holds what it says it holds and nothing else. This is the guard that makes the
+    /// documented field list something other than a comment: a field added to the record without a
+    /// line here fails, and so does one removed from the record while the list still names it.
+    /// </summary>
+    [Fact]
+    public void TheFieldSetIsExactlyTheOneThisRecordDocuments()
+    {
+        Assert.Equal(ExpectedFields, PublicFieldNames());
+    }
+
+    /// <summary>
+    /// No field describes how media is fetched. The exact list above would already catch such an
+    /// addition, but it would catch it as "an unexpected field" and say nothing about why the field
+    /// is unwelcome, and somebody repairing a red test reads the reason before the assertion. This
+    /// one names the reason, and it also refuses the case where somebody adds the field to both
+    /// places at once.
+    /// </summary>
+    [Fact]
+    public void NoFieldDescribesHowMediaIsFetched()
+    {
+        var offending = PublicFieldNames()
+            .Where(name => FetchVocabulary.Any(fragment =>
+                name.Contains(fragment, StringComparison.OrdinalIgnoreCase)))
+            .ToArray();
+
+        Assert.Empty(offending);
+    }
+
+    /// <summary>
+    /// Every field is a plain value. This is what makes the display snapshot a snapshot: a record
+    /// whose fields are numbers, strings, identifiers, times and enumerations has nothing to ask,
+    /// so a title on it can only be the one that was written when the request was made. A field
+    /// typed as a manager, a client or a factory would let a later reader resolve the title at read
+    /// time, which is the behaviour this record exists to refuse.
+    /// </summary>
+    [Fact]
+    public void EveryFieldIsAPlainValueSoTheRecordCannotFetchAnything()
+    {
+        var offending = typeof(MediaRequest)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(property => !IsAPlainValue(property.PropertyType))
+            .Select(property => string.Format(
+                CultureInfo.InvariantCulture,
+                "{0} is {1}",
+                property.Name,
+                property.PropertyType.Name))
+            .ToArray();
+
+        Assert.Empty(offending);
+    }
+
+    private static bool IsAPlainValue(Type type)
+    {
+        var underlying = Nullable.GetUnderlyingType(type) ?? type;
+
+        if (underlying.IsPrimitive || underlying.IsEnum)
+        {
+            return true;
+        }
+
+        if (underlying == typeof(string) || underlying == typeof(Guid) || underlying == typeof(DateTimeOffset))
+        {
+            return true;
+        }
+
+        // The one collection on the record, and only in the shape it is declared in: a read-only
+        // map of string to string carries no behaviour a caller could reach through.
+        return underlying == typeof(IReadOnlyDictionary<string, string>);
+    }
+
+    private static string[] PublicFieldNames()
+        => typeof(MediaRequest)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Select(property => property.Name)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+    /// <summary>
+    /// A request with only the fields that have no default. Every test above starts here and moves
+    /// what it is about, so a test says what it is testing and nothing else.
+    /// </summary>
+    /// <returns>A newly asked-for request.</returns>
+    private static MediaRequest ARequest()
+    {
+        var asked = new DateTimeOffset(2026, 8, 6, 8, 0, 0, TimeSpan.Zero);
+
+        return new MediaRequest
+        {
+            Id = new Guid("6f2a1c34-8f0a-4c0e-9a3d-2c9a5b7e1d40"),
+            RequestedByUserId = new Guid("b31d0f9a-5c2e-4a71-8f6b-0d4c3e2a1b58"),
+            RequestedAt = asked,
+            StateChangedAt = asked,
+            Kind = RequestedItemKind.Movie,
+            DisplayTitle = "The Conversation"
+        };
+    }
+}

--- a/Jellyfin.Plugin.Requests/Model/LibraryAvailability.cs
+++ b/Jellyfin.Plugin.Requests/Model/LibraryAvailability.cs
@@ -1,0 +1,35 @@
+namespace Jellyfin.Plugin.Requests.Model;
+
+/// <summary>
+/// Whether the server actually holds what was asked for. This is an observation about the library
+/// and never a decision anybody made, which is why it is not a <see cref="RequestState"/>: "an
+/// administrator approved it" and "the file is there" are different facts, and a model that
+/// collapses them cannot say that an approved request has not arrived.
+/// <para>
+/// What sets it is a look at the library rather than a hand edit, which is #42.
+/// </para>
+/// </summary>
+public enum LibraryAvailability
+{
+    /// <summary>
+    /// Nothing has looked yet. The value a request carries when it is created, so an absence that
+    /// was never checked cannot be read as an absence that was.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// Looked, and the server does not hold it.
+    /// </summary>
+    Absent = 1,
+
+    /// <summary>
+    /// Looked, and the server holds some of what was asked for. A series with some of its seasons
+    /// is the case this exists for; a film is never partial.
+    /// </summary>
+    Partial = 2,
+
+    /// <summary>
+    /// Looked, and the server holds it.
+    /// </summary>
+    Present = 3
+}

--- a/Jellyfin.Plugin.Requests/Model/MediaRequest.cs
+++ b/Jellyfin.Plugin.Requests/Model/MediaRequest.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Jellyfin.Plugin.Requests.Model;
+
+/// <summary>
+/// One person asking for one thing. This is the object the plugin is about, and everything else on
+/// this board reads or moves it.
+/// <para>
+/// It is a value with no behaviour and no dependencies. Every property is a number, a string, an
+/// identifier, a time or an enumeration, so the record cannot reach a metadata source, a library or
+/// a client to answer a question about itself. That is deliberate and it is what makes the display
+/// snapshot below meaningful.
+/// </para>
+/// <para>
+/// The snapshot is stored rather than fetched because the queue has to be readable when no metadata
+/// source is reachable, and because this plugin calls none by design, decided in #92. A title that
+/// is only an identifier is a row an operator cannot decide on the day the sibling that resolved it
+/// is uninstalled, and a title that was renamed upstream should still read in the history as what
+/// the person actually asked for.
+/// </para>
+/// <para>
+/// It holds nothing about how media is fetched. Quality profiles, root folders, download clients
+/// and indexers belong to whatever service does the fetching, and carrying them here would make
+/// this plugin a worse copy of one.
+/// </para>
+/// <para>
+/// The record is immutable. A move produces a new value with <c>with</c> rather than an edit in
+/// place, so the history in #43 and the store contract in #45 are free to decide what a change
+/// means without a caller having already made one behind their back.
+/// </para>
+/// </summary>
+public sealed record MediaRequest
+{
+    /// <summary>
+    /// Gets this request's own identifier, which is not the identifier of anything it refers to.
+    /// Where it comes from is the injected identifier source in #34, so a test does not get a
+    /// different value on every run.
+    /// </summary>
+    public required Guid Id { get; init; }
+
+    /// <summary>
+    /// Gets the Jellyfin user who asked. Held as the server's user identifier rather than a name,
+    /// because a name is renamed and because the surfaces have to answer "is this yours" against
+    /// the identifier the session carries.
+    /// </summary>
+    public required Guid RequestedByUserId { get; init; }
+
+    /// <summary>
+    /// Gets when it was asked for, from the injected clock in #34 rather than the wall clock. An
+    /// offset rather than a bare time, so a server that moves timezone does not reorder its own
+    /// queue.
+    /// </summary>
+    public required DateTimeOffset RequestedAt { get; init; }
+
+    /// <summary>
+    /// Gets what sort of thing was asked for.
+    /// </summary>
+    public required RequestedItemKind Kind { get; init; }
+
+    /// <summary>
+    /// Gets the title as it read at the moment of the request. This is the snapshot: an operator
+    /// reads the queue from it with nothing else reachable, and it stays what was asked for even if
+    /// the upstream title changes afterwards.
+    /// </summary>
+    public required string DisplayTitle { get; init; }
+
+    /// <summary>
+    /// Gets the release year as it read at the moment of the request, or <see langword="null"/>
+    /// where the request arrived without one. Part of the same snapshot, and the field that
+    /// separates two films sharing a title.
+    /// </summary>
+    public int? DisplayYear { get; init; }
+
+    /// <summary>
+    /// Gets the external identifiers the request arrived with, keyed by provider name. Empty is a
+    /// real case: a request typed by a person carries a title and nothing else.
+    /// <para>
+    /// This is what a fulfilment check and a bridge match on, and whether two requests naming the
+    /// same title are the same request is decided against these rather than against
+    /// <see cref="DisplayTitle"/>, in #38. Nothing here says which providers exist.
+    /// </para>
+    /// </summary>
+    public IReadOnlyDictionary<string, string> ProviderIds { get; init; } = ReadOnlyDictionary<string, string>.Empty;
+
+    /// <summary>
+    /// Gets where the request stands. Defaults to <see cref="RequestState.Open"/>, because a
+    /// request that was never decided is the state a new one is in.
+    /// </summary>
+    public RequestState State { get; init; } = RequestState.Open;
+
+    /// <summary>
+    /// Gets when the state last moved. On a request nothing has decided this is when it was
+    /// created, so the queue can be sorted by it without a null case.
+    /// </summary>
+    public required DateTimeOffset StateChangedAt { get; init; }
+
+    /// <summary>
+    /// Gets the Jellyfin user who last moved the state, or <see langword="null"/> where no person
+    /// did: a request that has not moved since it was created, or one the plugin moved on its own
+    /// after looking at the library. This is the current mover only. Who moved it at every earlier
+    /// step is the append-only history in #43, and this field is not a substitute for it.
+    /// </summary>
+    public Guid? StateChangedByUserId { get; init; }
+
+    /// <summary>
+    /// Gets whether the server holds what was asked for. Separate from <see cref="State"/> on
+    /// purpose: approval is a decision and availability is an observation, and the pair
+    /// approved-and-absent is the ordinary case rather than a contradiction.
+    /// </summary>
+    public LibraryAvailability Availability { get; init; } = LibraryAvailability.Unknown;
+
+    /// <summary>
+    /// Gets when the library was last looked at for this request, or <see langword="null"/> where
+    /// nothing has looked. An availability with no observation time is a claim with no date, and an
+    /// operator asking why a request still says absent needs to know whether anything checked.
+    /// </summary>
+    public DateTimeOffset? AvailabilityCheckedAt { get; init; }
+}

--- a/Jellyfin.Plugin.Requests/Model/RequestState.cs
+++ b/Jellyfin.Plugin.Requests/Model/RequestState.cs
@@ -1,0 +1,35 @@
+namespace Jellyfin.Plugin.Requests.Model;
+
+/// <summary>
+/// Where a request stands, as far as the people using this plugin are concerned. This says nothing
+/// about whether the server holds the media: that is <see cref="LibraryAvailability"/>, and the two
+/// are separate because an approved request that has not arrived yet is the ordinary case rather
+/// than an edge one.
+/// <para>
+/// Which moves between these values are legal is a table rather than a set of conditionals, and it
+/// is #39. Whether four values are enough, or whether a cancelled or failed value is also needed,
+/// is decision 3 on #113; adding one is an entry here and a row there.
+/// </para>
+/// </summary>
+public enum RequestState
+{
+    /// <summary>
+    /// Asked for, and nothing has been decided. The state a request is created in.
+    /// </summary>
+    Open = 0,
+
+    /// <summary>
+    /// An operator said yes. It does not follow that the server has the media, or ever will.
+    /// </summary>
+    Approved = 1,
+
+    /// <summary>
+    /// An operator said no. The reason, where there is one, is #41.
+    /// </summary>
+    Declined = 2,
+
+    /// <summary>
+    /// The thing that was asked for is in the library and the person who asked can watch it.
+    /// </summary>
+    Fulfilled = 3
+}

--- a/Jellyfin.Plugin.Requests/Model/RequestedItemKind.cs
+++ b/Jellyfin.Plugin.Requests/Model/RequestedItemKind.cs
@@ -1,0 +1,25 @@
+namespace Jellyfin.Plugin.Requests.Model;
+
+/// <summary>
+/// What sort of thing was asked for. The kind decides how fulfilment is recognised later, because
+/// a film is one item in the library and a series is a set of them, so it is carried on the record
+/// rather than inferred from the title.
+/// <para>
+/// Which kinds an install accepts is configuration and is #95; decision 7 on #113 is where the set
+/// shipped at 1.0 is settled. This enum is what the record can express, not what any install
+/// allows, and the two are different questions.
+/// </para>
+/// </summary>
+public enum RequestedItemKind
+{
+    /// <summary>
+    /// One film.
+    /// </summary>
+    Movie = 0,
+
+    /// <summary>
+    /// A series. Which seasons were asked for is not on this record yet; the queue needs it to be
+    /// decidable and #59 is where that is settled.
+    /// </summary>
+    Series = 1
+}


### PR DESCRIPTION
Closes #37.

The object this plugin is about did not exist in the tree, so every issue after
it would have settled its shape while working on something else.

## What is in it

A `MediaRequest` value with twelve fields, each documented where it is declared:
an identifier, who asked, when, what was asked for, a display snapshot of the
title, the current state, when the state last moved and who moved it, and
separately what the library holds and when that was last looked at. Three
enumerations beside it: the four states, the kinds a request can name, and what
the library holds.

Approval and availability are separate fields. An operator approving something
and the server having the file are different facts, and a model that collapses
them cannot say that an approved request has not arrived yet, which is the
ordinary case. Overseerr keeps a request status apart from a media status and
Ombi keeps `Approved` apart from `Available`, for the same reason.

The display snapshot is stored rather than resolved when the queue is read,
because the queue has to be decidable on a server where nothing can reach a
metadata source, and because this plugin calls none by design. The comment is
not what holds that: every field on the record is a number, a string, an
identifier, a time or an enumeration, so the record has nothing it could ask.

## What is not in it

Nothing about how media is fetched. No quality profile, no root folder, no
download client, no indexer. Those belong to whatever service does the fetching.

Nothing about which moves between states are legal, which is #39, and nothing
about which media kinds an install accepts, which is #95. The state values are
named so a record can carry one. Whether four states are enough is decision 3
on #113 and adding one is an entry in the enumeration and a row in that table.

Which seasons of a series were asked for is not a field yet. #59 is where the
queue decides what it must show for a decision to be possible, and that is the
issue that settles the shape.

## The means

C# in the plugin project and xunit in the existing test project, which is what
the tree already carries and what the gate already builds for both claimed
server lines. A record type rather than a class with setters, so a move produces
a new value and the store contract in #45 is free to decide what a change means.
Nothing new is added to the dependency graph, so neither lockfile moves.

## Evidence

Green, on both claimed lines, at `109ed0a`:

    $ dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler:     0, erfolgreich:    17, uebersprungen:     0, gesamt:    17, Dauer: 130 ms - Jellyfin.Plugin.Requests.Tests.dll (net9.0)
    Bestanden!   : Fehler:     0, erfolgreich:    17, uebersprungen:     0, gesamt:    17, Dauer: 125 ms - Jellyfin.Plugin.Requests.Tests.dll (net10.0)

Those two lines are what the runner printed, on a machine whose runner speaks
German, with one character folded so this file stays plain ASCII. An earlier
version of this body trimmed them into a shorter shape that no command prints,
which is a paraphrase presented as output. This is the correction, and the
numbers were the same before and after it.

Eleven of those seventeen were already here. The six added are the ones below,
and each was proven by breaking what it stands for and watching the suite go
red, on both lines, rather than by being written and observed to pass.

| Defect introduced | What went red |
| --- | --- |
| `public int? QualityProfileId` added to the record | `TheFieldSetIsExactlyTheOneThisRecordDocuments`, `NoFieldDescribesHowMediaIsFetched` |
| `public Func<string>? TitleResolver` added, and its name added to the documented field list so the list agrees with it | `EveryFieldIsAPlainValueSoTheRecordCannotFetchAnything` |
| `Availability` defaulting to `Absent` rather than `Unknown` | `ANewRequestIsOpenAndItsAvailabilityHasNotBeenLookedAt` |
| `Availability` derived from `State` instead of held | `ARequestCanBeApprovedAndNotYetAvailable`, `ApprovalAndAvailabilityMoveIndependently` |

The second row is the near miss the first row does not catch: somebody who adds
a field and dutifully updates the list. Only the plain-value guard bit there,
one failure of seventeen, which is what makes it a guard of its own rather than
a restatement of the field list.

Each red run was thrown away. What is kept is the table.

## What this does not prove

Nothing here is exercised by a running server. The record is not persisted, not
serialised and not reachable over any API, because none of those exist yet, so
the suite says the shape is what it says it is and says nothing about how it
behaves under a store or a controller. The storage version rule in #47 is where
its serialised form is first held to anything.

This change had no second reader. The evidence above stands in place of one.

