### PR TITLE
Keep an analyzer finding fatal after warnings-as-errors is lowered

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,11 +26,16 @@ indent_size = 2
 ###############################
 # Analyzer severities         #
 ###############################
-# What raises a security finding to an error here is TreatWarningsAsErrors in
-# Directory.Build.props, which applies to every project and to a plain build, not a severity in
-# this file. A category severity was tried and does not take effect: AnalysisMode set to
-# AllEnabledByDefault writes a severity per rule, and a per-rule setting outranks a per-category
-# one wherever it is written. The measurement and what it leaves uncovered are in issue #18.
+# What raises a security finding to an error here is not a severity in this file. A category
+# severity was tried and does not take effect: AnalysisMode set to AllEnabledByDefault writes a
+# severity per rule, and a per-rule setting outranks a per-category one wherever it is written.
+# The measurement is in issue #18.
+#
+# Two properties in Directory.Build.props do it instead. TreatWarningsAsErrors makes every warning
+# an error, and CodeAnalysisTreatWarningsAsErrors makes every analyzer finding one; the second is
+# what still refuses a security finding after the first has been lowered on a command line. Both
+# are outranked by jellyfin.ruleset, so a rule quietened there stays quiet whatever these say,
+# which today is CA5394. Measured in issue #132.
 
 ###############################
 # .NET Coding Conventions     #

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,6 +19,15 @@
              without anybody reading the other. -->
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <!-- The analyzer half of the line above, as a property of its own. TreatWarningsAsErrors is
+             one property and one command line away from being lowered, and lowering it turned a
+             security finding from an error into a warning while every route stayed green. This
+             property is what the SDK reads to choose the severity it writes per analyzer rule, it
+             is not touched by lowering TreatWarningsAsErrors, and a build with that lowered still
+             refuses a security finding. What it does not do is outrank jellyfin.ruleset: a rule
+             that file quietens stays quiet, which today is CA5394. #132 is where this was measured
+             and #25 is where that ruleset is reviewed. -->
+        <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
         <Nullable>enable</Nullable>
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)jellyfin.ruleset</CodeAnalysisRuleSet>


### PR DESCRIPTION
Closes #132.

The issue named three shapes. A fourth one exists, it is what landed, and the two that were measured against it are below with the commands.

What landed is one property in `Directory.Build.props`:

    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>

It is the lever the SDK reads to choose which severity it writes per analyzer rule, it is not `TreatWarningsAsErrors`, and lowering that one on a command line does not move it.

That it bites, for the reason it names. `MD5.HashData` added to the plugin project, on this branch, with warnings-as-errors lowered:

    dotnet build Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.csproj -f net9.0 -t:Rebuild -p:TreatWarningsAsErrors=false
    Md5Plant.cs(8,50): error CA5351: Hash uses a broken cryptographic algorithm MD5
        0 Warning(s)
        1 Error(s)

The same build with that file removed and nothing else changed:

        0 Warning(s)
        0 Error(s)

The same command on `963915cb8e6854b61e91a7a09cbde7ee4994df5d`, which is what this branches from, is what the issue reported and it reproduces: `warning CA5351`, `1 Warning(s)`, `0 Error(s)`.

The whole solution, both claimed target frameworks, on this branch:

    dotnet build Jellyfin.Plugin.Requests.sln -t:Rebuild
        0 Warning(s)
        0 Error(s)

Why not the two shapes the issue leaned toward.

A category severity does not take effect, which #18 said and which measures the same way here. With `dotnet_analyzer_diagnostic.category-Security.severity = error` in `.editorconfig` and the tree otherwise untouched, the same lowered build reports `warning CA5351` rather than `error`. It does take effect once `AnalysisMode` is at the SDK default, which is the same measurement from the other side: `-p:AnalysisMode=Default` with that line present reports `error CA5351`. So the cause is the per-rule severities `AllEnabledByDefault` writes, exactly as the issue states, and buying the category severity means paying whatever `AllEnabledByDefault` was enabling.

A list of rule identifiers in `WarningsAsErrors` does work: `-p:TreatWarningsAsErrors=false -p:WarningsAsErrors=CA5351` reports `error CA5351`. It is also a list in a file that drifts against the analyzer package every time that package adds a rule, which is the cost the issue names. The property that landed names no rule, so there is nothing to drift, and it changes no `AnalysisMode`, so it costs no coverage.

What this does to a rule the inherited ruleset quietens. Nothing, and that is measured rather than assumed. With `new Random().Next()` planted in the plugin project and `jellyfin.ruleset` as the tree has it, the build on this branch is green. With the two lines for `CA5394` taken out of that file and nothing else changed, the same build fails:

    RandomPlant.cs(8,39): error CA5394: Random is an insecure random number generator.
        0 Warning(s)
        1 Error(s)

So a ruleset entry outranks this property, `CA5394` stays at `Info`, and this change neither raises it nor hides that it is lowered. `jellyfin.ruleset` is not edited here; #25 is where that file is reviewed, and it is the only file of the three in this issue's scope that this change leaves alone.

The `.editorconfig` comment that named `TreatWarningsAsErrors` as what raises a security finding to an error now names both properties, says which one survives the other being lowered, and says that both are outranked by the ruleset.

The means is two MSBuild properties and a comment, in the files that already hold this tree's analyzer posture. Nothing new is introduced: no rule list to maintain, no tool, no language the tree does not already carry, and the whole change is readable in one diff.

What this does not claim. Nothing refuses a build that lowers `CodeAnalysisTreatWarningsAsErrors` as well, and no check reads either property. The measurements above are local runs on this machine at this commit; the gate builds this tree without lowering anything, so a route that proves the lowered case does not exist and this change does not add one. The property covers every analyzer category rather than the security category alone, which is more than the issue asked for and is stated here rather than left for a reader to discover.

This change has had no second reader. The evidence above stands in place of one.