### PR TITLE
Fix the version scheme and start the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+One section per released version, newest first, and an `Unreleased` section
+holding what has landed since the last one. The scheme the numbers follow, and
+what each part of a number means for somebody who has this plugin installed, is
+in [docs/versioning.md](docs/versioning.md).
+
+Entries say what changed for somebody using the plugin. A change that alters
+nothing an operator or a user can observe, such as a workflow or a test, does
+not need an entry; the git history is where that is read.
+
+## Unreleased
+
+Nothing has been released. There are no tags and no packages, so everything in
+the tree is unreleased and this section starts here rather than reconstructing
+what came before it. What landed before this file existed is in the git history,
+where it carries the pull request and the issue it came from, and rewriting it
+from memory into entries would be a description nobody measured.
+
+- The version starts at `0.1.0.0`. It was `1.0.0.0`, inherited from the
+  template, which claimed a released first version of a plugin that has never
+  been released.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,8 +5,10 @@
              FileVersion drifting apart is how a server reports one version, a package claims a
              second and a changelog names a third. PluginVersionMatchesThePackagingMetadata refuses
              a disagreement between this number and the version field of both packaging files. The
-             scheme this number follows, and what moves it, is #107. -->
-        <PluginVersion>1.0.0.0</PluginVersion>
+             scheme this number follows, what each part of it means to somebody who has the plugin
+             installed, and why it starts below one, are in docs/versioning.md. Raising it and
+             writing the changelog entry are one change. -->
+        <PluginVersion>0.1.0.0</PluginVersion>
         <Version>$(PluginVersion)</Version>
         <AssemblyVersion>$(PluginVersion)</AssemblyVersion>
         <FileVersion>$(PluginVersion)</FileVersion>

--- a/build-jf12.yaml
+++ b/build-jf12.yaml
@@ -9,7 +9,7 @@ name: "Template"
 # place instead of gaining a second, unrelated one. Still the template's identifier; #15 mints the
 # real one and has to change both files.
 guid: "eb5d7894-8eef-4b36-aa6f-5d124e828ce1"
-version: "1.0.0.0"
+version: "0.1.0.0"
 # The 12.0 line's floor and the runtime it provides.
 targetAbi: "12.0.0.0"
 framework: "net10.0"

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Template"
 guid: "eb5d7894-8eef-4b36-aa6f-5d124e828ce1"
-version: "1.0.0.0"
+version: "0.1.0.0"
 # Packaging metadata for the Jellyfin 10.11 line. The oldest server of that line this package claims
 # to load on, and the runtime that line provides. The project compiles against a newer 10.11.x SDK,
 # so a floor build against this number is what would show that every API the plugin calls also exists

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,117 @@
+# Versioning
+
+Two numbers have to move together and mean the same thing: the version the
+assembly reports, which is what a server shows an operator, and the version in
+the packaging metadata, which is what an update check compares. The template
+this repository came from set the first to `0.0.0.0` and the second to
+`1.0.0.0`, so the drift was there on the first day.
+
+## One number, and what refuses a second
+
+`PluginVersion` in `Directory.Build.props` is the number. `Version`,
+`AssemblyVersion` and `FileVersion` are set from it, and both packaging files
+repeat it, because a JPRM metadata file is read by the release path rather than
+compiled and there is nothing in it that can reference an MSBuild property.
+
+A repeat is a thing that can be forgotten, so a test refuses a disagreement.
+`PackagingMetadataTests.PluginVersionMatchesThePackagingMetadata` reads the
+version out of the assembly under test and out of each packaging file as the
+release path reads it, and `BothPackagesClaimTheSameIdentity` refuses the two
+packages diverging on `name`, `guid` or `version`.
+
+It bites, and this is what it looked like when it did. The number was raised in
+`Directory.Build.props` and in neither packaging file:
+
+    $ dotnet test --nologo
+    Failed Jellyfin.Plugin.Requests.Tests.PackagingMetadataTests.PluginVersionMatchesThePackagingMetadata(packagingFile: "build.yaml")
+       Assert.Equal() Failure: Values differ
+    Expected: 0.1.0.0
+    Actual:   1.0.0.0
+    Failed Jellyfin.Plugin.Requests.Tests.PackagingMetadataTests.PluginVersionMatchesThePackagingMetadata(packagingFile: "build-jf12.yaml")
+       Assert.Equal() Failure: Values differ
+    Expected: 0.1.0.0
+    Actual:   1.0.0.0
+    Failed!  - Failed:     2, Passed:    15, Skipped:     0, Total:    17 (net10.0)
+    Failed!  - Failed:     2, Passed:    15, Skipped:     0, Total:    17 (net9.0)
+
+Both packaging files named, one failure each, on both claimed lines. With the
+two files carried along, the same command is green:
+
+    $ dotnet test --nologo
+    Passed!  - Failed:     0, Passed:    17, Skipped:     0, Total:    17 (net9.0)
+    Passed!  - Failed:     0, Passed:    17, Skipped:     0, Total:    17 (net10.0)
+
+What this does not do is make the packaging metadata read the number. It refuses
+a disagreement rather than removing the copy, and the copy is still three files.
+Removing it would mean generating the packaging files during the release, which
+is the release path's shape and belongs with #108 and #110 rather than here.
+
+## The scheme
+
+Four parts, `MAJOR.MINOR.PATCH.0`, because an assembly version is a four-field
+`System.Version` and a shorter one prints shorter and stops matching the string
+in the packaging file. The fourth field is always `0`. It is not a build counter
+and nothing sets it; a build that needs to be distinguished from another build
+of the same source is a question for the release path and not for this number.
+
+What each part means for somebody who already has the plugin installed:
+
+`MAJOR` moves when something they rely on is taken away or changes shape.
+Concretely, on this plugin: a route or a response field of the request API
+removed or given a different meaning, a stored request that this version can
+read and the previous one cannot, a claimed server line dropped, or a
+configuration key removed or reinterpreted. An operator reading a `MAJOR` bump
+is being told to read the changelog entry before updating.
+
+`MINOR` moves when behaviour is added and everything that worked still works. A
+new endpoint, a new field in a response, a new setting whose default leaves the
+plugin doing exactly what it did.
+
+`PATCH` moves when a defect is fixed and nothing is added. No new endpoint, no
+new field, no new setting.
+
+While `MAJOR` is `0` the promise is weaker, and it is worth saying plainly
+rather than leaving it to convention: below `1.0.0.0` a `MINOR` bump is allowed
+to carry a change that would otherwise be a `MAJOR` one, and the changelog entry
+says so. That state ends at the first `1.0.0.0`, and what compatibility is
+promised from then on is #105.
+
+## Where the number starts
+
+`0.1.0.0`. The template's `1.0.0.0` claimed a released first version, and
+nothing has been released:
+
+    $ gh release list --repo iderex/jellyfin-plugin-requests --json tagName --jq 'length'
+    0
+
+A version that says 1.0 to a catalogue, to a dashboard and to an operator, for a
+plugin with no request API and no store behind it, is a claim this tree cannot
+back.
+
+## What a bump does to an installed server, and what is not measured here
+
+What this repository promises is the paragraph above: the part that moved says
+what kind of change it was. What a server does with that is the server's
+behaviour, and this document does not measure it. That a Jellyfin server
+compares the version in a manifest entry against the installed one and offers
+the higher of the two is a claim taken from how the catalogue is used, not from
+a run recorded here, and the run that would settle it belongs with #110.
+
+Two of the promises above also need code that does not exist yet. A stored
+request that an older version cannot read is refused by the version marker in
+the store, which is #47 and is not built, and configuration carried between
+plugin versions is #97. Until those land, a `MAJOR` bump is a sentence in a
+changelog and nothing refuses a downgrade that eats data.
+
+## The changelog
+
+`CHANGELOG.md` at the root, one section per released version, newest first, and
+an `Unreleased` section at the top that collects what has landed since the last
+release. A version bump and a changelog entry are one change: raising
+`PluginVersion` without writing what moved leaves an operator with a number and
+no reason for it.
+
+Nothing refuses that today. No check reads `CHANGELOG.md`, and a commit raising
+`PluginVersion` with the file untouched is green everywhere. #26 is the hygiene
+check that would refuse it, and #107 stays open on that condition until it
+lands.


### PR DESCRIPTION
Part of #107. Two of that issue's three conditions; the third is named at the
bottom and is not in this diff.

The number said `1.0.0.0`, which came with the template and claims a released
first version. Nothing has been released:

    $ gh release list --repo iderex/jellyfin-plugin-requests --json tagName --jq 'length'
    0

So a catalogue entry, a dashboard and an operator were all being told this
plugin had shipped a stable one, for a tree with no request API and no store. It
starts at `0.1.0.0` instead, in the one place that holds it and in both packaging
files.

What is in the change:

- `docs/versioning.md`, the scheme. Four fields because an assembly version is
  four fields and a shorter one stops matching the string in the packaging file,
  the fourth always zero and set by nothing. What `MAJOR`, `MINOR` and `PATCH`
  each mean for somebody who already has the plugin installed, written in this
  plugin's own terms: a route or a response field removed, a stored request an
  older version cannot read, a claimed server line dropped, a configuration key
  reinterpreted. What is weaker below 1.0, said rather than left to convention.
- `CHANGELOG.md`, one section per release with `Unreleased` on top.
- `Directory.Build.props` and both packaging files at `0.1.0.0`.

The guard that keeps the three copies of the number together was proven rather
than described. Raising `PluginVersion` and touching neither packaging file:

    $ dotnet test --nologo
    Failed Jellyfin.Plugin.Requests.Tests.PackagingMetadataTests.PluginVersionMatchesThePackagingMetadata(packagingFile: "build.yaml")
       Assert.Equal() Failure: Values differ
    Expected: 0.1.0.0
    Actual:   1.0.0.0
    Failed Jellyfin.Plugin.Requests.Tests.PackagingMetadataTests.PluginVersionMatchesThePackagingMetadata(packagingFile: "build-jf12.yaml")
       Assert.Equal() Failure: Values differ
    Expected: 0.1.0.0
    Actual:   1.0.0.0
    Failed!  - Failed:     2, Passed:    15, Skipped:     0, Total:    17 (net10.0)
    Failed!  - Failed:     2, Passed:    15, Skipped:     0, Total:    17 (net9.0)

Both files named, one failure each, on both claimed lines. With the two files
carried along it is green:

    $ dotnet test --nologo
    Passed!  - Failed:     0, Passed:    17, Skipped:     0, Total:    17 (net9.0)
    Passed!  - Failed:     0, Passed:    17, Skipped:     0, Total:    17 (net10.0)

What is not claimed. The first condition of #107 asks for one place that holds
the version with the packaging metadata reading it. What is here refuses a
disagreement instead of removing the copy: a JPRM metadata file is read by the
release path rather than compiled, so it cannot reference an MSBuild property,
and generating those files during a release is the release path's shape and
belongs with #108 and #110. The document says that about itself.

What a server does with a version number is not measured here either. That it
compares a manifest entry against the installed version and offers the higher of
the two is written as a claim, not as a measurement, and #110 is where a run
would settle it.

The means is markdown in `docs/` plus the existing MSBuild property and the two
packaging files. No code and no new dependency: the scheme is an argument a
person reads, and the only mechanism it needs is the test that already exists.

What keeps #107 open. Its third condition is that a version bump with no
changelog entry fails the gate. Nothing reads `CHANGELOG.md` today, a commit
raising `PluginVersion` with the file untouched is green everywhere, and #26 is
the hygiene check that would refuse it. That is written into #107 rather than
left to be discovered, and this pull request does not close it.

This change has had no second reader. The evidence above stands in place of one.

`Directory.Build.props` is also edited by the open pull request #144, in a
different property group. Whichever of the two lands second rebases onto the
other.
