### PR TITLE
Give a test run one directory instead of one per double

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Doubles/FakeApplicationPaths.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/FakeApplicationPaths.cs
@@ -1,14 +1,15 @@
 using System;
-using System.Globalization;
 using System.IO;
 using MediaBrowser.Common.Configuration;
 
 namespace Jellyfin.Plugin.Requests.Tests.Doubles;
 
 /// <summary>
-/// The host's application paths, rooted at a directory this instance creates and deletes. Every
-/// path is under that root, so a test that writes through the plugin cannot reach a real server's
-/// data directory, and nothing survives the test that created it.
+/// The host's application paths, rooted at a subdirectory of <see cref="TestRunDirectory"/> that
+/// this instance creates and deletes. Every path is under that root, so a test that writes through
+/// the plugin cannot reach a real server's data directory, and nothing survives the test that
+/// created it. The root is a subdirectory rather than a directory of its own beside everything else
+/// on the machine, so what a run wrote is one directory rather than a scattering of them.
 /// </summary>
 internal sealed class FakeApplicationPaths : IApplicationPaths, IDisposable
 {
@@ -19,11 +20,8 @@ internal sealed class FakeApplicationPaths : IApplicationPaths, IDisposable
     /// </summary>
     public FakeApplicationPaths()
     {
-        ProgramDataPath = Path.Combine(
-            Path.GetTempPath(),
-            string.Create(CultureInfo.InvariantCulture, $"jellyfin-plugin-requests-tests-{Guid.NewGuid():N}"));
+        ProgramDataPath = TestRunDirectory.CreateSubdirectory();
 
-        Directory.CreateDirectory(ProgramDataPath);
         Directory.CreateDirectory(PluginConfigurationsPath);
     }
 
@@ -94,10 +92,7 @@ internal sealed class FakeApplicationPaths : IApplicationPaths, IDisposable
 
         disposed = true;
 
-        if (Directory.Exists(ProgramDataPath))
-        {
-            Directory.Delete(ProgramDataPath, true);
-        }
+        TestRunDirectory.Remove(ProgramDataPath);
     }
 
     private string Under(string name) => Path.Combine(ProgramDataPath, name);

--- a/Jellyfin.Plugin.Requests.Tests/Doubles/TestRunDirectory.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/TestRunDirectory.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Globalization;
+using System.IO;
+
+namespace Jellyfin.Plugin.Requests.Tests.Doubles;
+
+/// <summary>
+/// The one directory a test host process owns, and the only place in the suite that names the
+/// machine's temporary root. Every double that needs somewhere to write takes a subdirectory of it.
+/// <para>
+/// Without this each double made its own directory beside everything else in the machine's
+/// temporary root, so a run left as many siblings as it constructed doubles and there was no single
+/// directory an assertion about the whole run could be made about. There is one per test host
+/// process rather than one per <c>dotnet test</c>, because the suite runs a process per target
+/// framework and the two do not share memory.
+/// </para>
+/// </summary>
+internal static class TestRunDirectory
+{
+    private static readonly string RootPath = Path.Combine(
+        Path.GetTempPath(),
+        string.Create(CultureInfo.InvariantCulture, $"jellyfin-plugin-requests-tests-{Guid.NewGuid():N}"));
+
+    /// <summary>
+    /// Gets the directory this test host process owns. Created on first use so a run that
+    /// constructs no double leaves nothing behind.
+    /// </summary>
+    public static string Root
+    {
+        get
+        {
+            Directory.CreateDirectory(RootPath);
+            return RootPath;
+        }
+    }
+
+    /// <summary>
+    /// Creates a fresh subdirectory of <see cref="Root"/>.
+    /// </summary>
+    /// <returns>The full path of the new subdirectory.</returns>
+    public static string CreateSubdirectory()
+    {
+        var path = Path.Combine(
+            Root,
+            string.Create(CultureInfo.InvariantCulture, $"{Guid.NewGuid():N}"));
+
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    /// <summary>
+    /// Removes a subdirectory and everything under it, and then removes <see cref="Root"/> itself
+    /// if nothing else is left in it. The last double disposed is what takes the run's directory
+    /// with it; while others still hold subdirectories the delete is refused and the directory
+    /// stays, which is why the failure is swallowed rather than reported.
+    /// </summary>
+    /// <param name="subdirectory">A path returned by <see cref="CreateSubdirectory"/>.</param>
+    public static void Remove(string subdirectory)
+    {
+        if (Directory.Exists(subdirectory))
+        {
+            Directory.Delete(subdirectory, true);
+        }
+
+        try
+        {
+            Directory.Delete(RootPath);
+        }
+        catch (IOException)
+        {
+            // Something else in this process still has a subdirectory here.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Same case, reported differently by the platform.
+        }
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/TestRunDirectoryTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/TestRunDirectoryTests.cs
@@ -60,6 +60,10 @@ public class TestRunDirectoryTests
     [Fact]
     public void DisposingADoubleLeavesTheRunDirectoryForTheOthers()
     {
+        // Read through the property once and hold the string. Asking for it again would create the
+        // directory before asserting it exists, which is an assertion that cannot fail.
+        var runDirectory = TestRunDirectory.Root;
+
         using var held = new FakeApplicationPaths();
 
         string disposedRoot;
@@ -71,6 +75,6 @@ public class TestRunDirectoryTests
 
         Assert.False(Directory.Exists(disposedRoot));
         Assert.True(Directory.Exists(held.ProgramDataPath));
-        Assert.True(Directory.Exists(TestRunDirectory.Root));
+        Assert.True(Directory.Exists(runDirectory));
     }
 }

--- a/Jellyfin.Plugin.Requests.Tests/TestRunDirectoryTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/TestRunDirectoryTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.IO;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests;
+
+/// <summary>
+/// The directory a test host process owns, and the doubles that take subdirectories of it. The
+/// headless rule says a run writes only under a temporary directory given to it, and a run that
+/// makes a fresh directory per double has no such directory: it has as many as it constructed,
+/// each a sibling of everything else in the machine's temporary root. These tests are what refuses
+/// the return of that shape.
+/// </summary>
+public class TestRunDirectoryTests
+{
+    /// <summary>
+    /// Every paths double is rooted under the run's own directory, and two of them do not collide.
+    /// A double that reached for the machine's temporary root directly would pass every per-instance
+    /// assertion in the suite and fail here.
+    /// </summary>
+    [Fact]
+    public void EveryDoubleIsRootedUnderTheRunDirectory()
+    {
+        var runDirectory = Path.GetFullPath(TestRunDirectory.Root);
+
+        using var first = new FakeApplicationPaths();
+        using var second = new FakeApplicationPaths();
+
+        var firstRoot = Path.GetFullPath(first.ProgramDataPath);
+        var secondRoot = Path.GetFullPath(second.ProgramDataPath);
+
+        Assert.StartsWith(runDirectory, firstRoot, StringComparison.Ordinal);
+        Assert.StartsWith(runDirectory, secondRoot, StringComparison.Ordinal);
+        Assert.NotEqual(firstRoot, secondRoot, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// The run's directory sits directly under the machine's temporary root rather than somewhere a
+    /// test chose. This is the half that says where the run writes, and it is what a later check
+    /// over the whole run would be made about.
+    /// </summary>
+    [Fact]
+    public void TheRunDirectoryIsDirectlyUnderTheMachineTemporaryRoot()
+    {
+        var runDirectory = Path.GetFullPath(TestRunDirectory.Root);
+        var parent = Path.GetFullPath(Path.GetDirectoryName(runDirectory)!);
+
+        Assert.Equal(
+            Path.GetFullPath(Path.GetTempPath()).TrimEnd(Path.DirectorySeparatorChar),
+            parent.TrimEnd(Path.DirectorySeparatorChar),
+            StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Disposing a double removes its own subdirectory and leaves the run's directory for whatever
+    /// else is still using it. The suite runs test classes in parallel, so a double disposing must
+    /// not take the directory another one is writing into.
+    /// </summary>
+    [Fact]
+    public void DisposingADoubleLeavesTheRunDirectoryForTheOthers()
+    {
+        using var held = new FakeApplicationPaths();
+
+        string disposedRoot;
+        using (var temporary = new FakeApplicationPaths())
+        {
+            disposedRoot = temporary.ProgramDataPath;
+            Assert.True(Directory.Exists(disposedRoot));
+        }
+
+        Assert.False(Directory.Exists(disposedRoot));
+        Assert.True(Directory.Exists(held.ProgramDataPath));
+        Assert.True(Directory.Exists(TestRunDirectory.Root));
+    }
+}


### PR DESCRIPTION
Part of #115, and the first half of one of that issue's four mechanisms. It does
not close it, and what is still missing is at the bottom.

The headless rule says a run writes only under a temporary directory given to
it. There was no such directory. Each paths double made its own under whatever
the machine calls its temporary root:

    $ git grep -n "GetTempPath" origin/master -- Jellyfin.Plugin.Requests.Tests/
    origin/master:Jellyfin.Plugin.Requests.Tests/Doubles/FakeApplicationPaths.cs:23:            Path.GetTempPath(),

followed by a fresh identifier per instance, so a run left as many directories
as it constructed doubles, each a sibling of everything else on the machine, and
there was nothing a statement about the whole run could be made about. On this
branch the same command names one file, and it is the type that owns the run's
directory:

    $ git grep -n "GetTempPath" HEAD -- Jellyfin.Plugin.Requests.Tests/
    HEAD:Jellyfin.Plugin.Requests.Tests/Doubles/TestRunDirectory.cs:21:        Path.GetTempPath(),
    HEAD:Jellyfin.Plugin.Requests.Tests/TestRunDirectoryTests.cs:50:            Path.GetFullPath(Path.GetTempPath()).TrimEnd(Path.DirectorySeparatorChar),

`TestRunDirectory` owns one directory per test host process and hands out a
subdirectory per double. It is per process rather than per `dotnet test` because
the suite runs a process per target framework, and that is said in the type's
own documentation rather than left for a reader to find out from two directories.

Disposing a double removes its own subdirectory and then removes the run's
directory once nothing else is left in it. That second delete is allowed to
fail: test classes run in parallel, so while another double still holds a
subdirectory the refusal is the correct outcome rather than an error worth
reporting, and the two exception types the platforms use for it are caught by
name.

Three tests refuse the return of the old shape. Every double is rooted under the
run's directory and two do not collide. The run's directory is directly under
the machine's temporary root. Disposing one double leaves the others theirs.

The first of them bites. With the double rooted at the machine's temporary root
again, exactly that test fails, on both claimed lines, and the other nineteen do
not move:

    $ dotnet test --nologo
    Failed TestRunDirectoryTests.EveryDoubleIsRootedUnderTheRunDirectory
       Assert.StartsWith() Failure: String start does not match
    Failed!  - Failed:     1, Passed:    19, Skipped:     0, Total:    20 (net9.0)
    Failed!  - Failed:     1, Passed:    19, Skipped:     0, Total:    20 (net10.0)

Restored, the suite is green on both:

    $ dotnet test --nologo
    Passed!  - Failed:     0, Passed:    20, Skipped:     0, Total:    20 (net9.0)
    Passed!  - Failed:     0, Passed:    20, Skipped:     0, Total:    20 (net10.0)

The means is C# in the existing test project, using nothing the suite did not
already reference. The alternative worth naming is a run-level hook that asserts
at the end of a run. The version of xunit this suite references offers a fixture
per class and per collection and none per assembly:

    $ strings -a ~/.nuget/packages/xunit.extensibility.core/2.9.3/lib/net452/xunit.core.dll         | grep -iE 'IAssemblyFixture|ICollectionFixture|IClassFixture' | sort -u
    IClassFixture`1
    ICollectionFixture`1

Such a hook would in any case have to read the machine's shared temporary root,
and would go red when an unrelated process wrote a file while the suite happened
to be running.

What this does not do, and what keeps #115 open. Nothing here refuses a test
that names a path without going through a double: that is a rule about source
text and it belongs to the lint in #28, along with the browser-automation and
certificate-store mechanisms. The network mechanism needs an outbound client to
refuse, which is #35 behind #80. This is the part that needed none of them.

One thing this deliberately does not add is a check that walks the machine's
temporary root at the end of a run and fails on anything created since it
started. That directory is shared with every other process running as the same
user, so such a check reds for a reason nobody in this repository caused, and a
guard like that gets switched off rather than fixed.

This change has had no second reader. The evidence above stands in place of one.


A follow-up commit on this branch makes the third assertion able to fail. It
read the run directory through the property that creates it, so it passed
whatever the code under it did. With the path held instead, deleting the parent
recursively rather than only when empty reds it on both lines.