### PR TITLE
Name each guard's own run in the parity table's green column

### DIFF
--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -143,16 +143,61 @@ table that reads as five gates.
 exists to refuse. The four that refuse have both. The one that reports has no
 red run and can have none, which is settled below rather than left blank.
 
-| Guard                          | Kind    | Red run                                                                        | Green run                          |
-| ------------------------------ | ------- | ------------------------------------------------------------------------------ | ---------------------------------- |
-| `Audit workflows (zizmor)`     | refuses | 31041799794, sixteen findings against the eight inherited callers              | 31095610752, at `1a18979`          |
-| `Reject Trojan Source Unicode` | refuses | 31047199620, a file carrying U+202E                                            | 31095610752, at `1a18979`          |
-| `DCO sign-off`                 | refuses | 31047200286, a commit with no `Signed-off-by` trailer                          | 31095610752, at `1a18979`          |
-| `dependency-review`            | refuses | 31047201526, Newtonsoft.Json 12.0.3, below the fix line of GHSA-5crp-9r3c-p9vr | 31095610752, at `1a18979`          |
-| `Scorecard analysis`           | reports | none, and none is possible                                                     | at `f1c8881` on the default branch |
+| Guard                          | Kind    | Red run                                                                        | Green run                 |
+| ------------------------------ | ------- | ------------------------------------------------------------------------------ | ------------------------- |
+| `Audit workflows (zizmor)`     | refuses | 31041799794, sixteen findings against the eight inherited callers              | 31095610611, at `1a18979` |
+| `Reject Trojan Source Unicode` | refuses | 31047199620, a file carrying U+202E                                            | 31095610670, at `1a18979` |
+| `DCO sign-off`                 | refuses | 31047200286, a commit with no `Signed-off-by` trailer                          | 31095610728, at `1a18979` |
+| `dependency-review`            | refuses | 31047201526, Newtonsoft.Json 12.0.3, below the fix line of GHSA-5crp-9r3c-p9vr | 31095610678, at `1a18979` |
+| `Scorecard analysis`           | reports | none, and none is possible                                                     | 31110915427, at `0ecd860` |
 
 The three red runs in the middle are on one head, `bee97c0`, which carried all
 three defects at once and was closed without merging.
+
+Every identifier in the green column is a run of the guard's own workflow, and
+the commit beside it is the commit that run happened on rather than the current
+head of the default branch. It stops being the current head at the next merge,
+and the commands below are what a reader can re-run when it has.
+
+    $ for r in 31095610611 31095610670 31095610728 31095610678 31110915427; do \
+        gh api repos/iderex/jellyfin-plugin-requests/actions/runs/$r \
+          --jq '"\(.id)  \(.name)  \(.head_sha[0:7])  \(.conclusion)"'; done
+    31095610611  Workflow Security Analysis  1a18979  success
+    31095610670  unicode-guard  1a18979  success
+    31095610728  DCO  1a18979  success
+    31095610678  Dependency review  1a18979  success
+    31110915427  Scorecard supply-chain security  0ecd860  success
+
+Two commits rather than one, because two of the four refusing guards start on a
+pull request and nothing else, and the scorecard has no pull request trigger at
+all, which the grep further down this page prints:
+
+    $ git grep -A1 "^on:" origin/master -- .github/workflows/dco.yml .github/workflows/dependency-review.yml
+    origin/master:.github/workflows/dco.yml:on:
+    origin/master:.github/workflows/dco.yml-  pull_request:
+    --
+    origin/master:.github/workflows/dependency-review.yml:on:
+    origin/master:.github/workflows/dependency-review.yml-  pull_request:
+
+So `1a18979` is a pull request head where all four refusing guards ran at once,
+and those triggers are why one commit carrying a run of all five is not
+something this repository can produce.
+
+The four cells above named 31095610752 until this correction, and that run is
+none of the four guards:
+
+    $ gh api repos/iderex/jellyfin-plugin-requests/actions/runs/31095610752/jobs --jq '.jobs[].name'
+    lines
+    floor 12.0.0.0
+    floor 10.11.0.0
+
+It is the ABI floor, which ran on the same head within seconds of the four and
+carries three jobs where each guard's run carries one. The identifier was read
+off the list of runs started by that pull request instead of off each guard's
+own check, which is the same shape as reading a working checkout and reporting
+it as mainline. The fifth cell carried a commit and no identifier at all. The
+claim each cell supported was true both times; what a reader following it landed
+in was a different workflow.
 
 ### The score is a report, and stays one
 


### PR DESCRIPTION
Part of #25, and the last thing that issue was waiting on. Its third condition
asks for a recorded green run per guard, and the record named the wrong run for
four of the five.

What was wrong. The green column of the inherited-guard table in
`docs/quality-parity.md` gave one identifier, 31095610752, for four different
guards. That run is the ABI floor:

    $ gh api repos/iderex/jellyfin-plugin-requests/actions/runs/31095610752 --jq '"\(.id)  \(.name)  \(.head_sha[0:7])  \(.conclusion)"'
    31095610752  ABI floor  1a18979  success
    $ gh api repos/iderex/jellyfin-plugin-requests/actions/runs/31095610752/jobs --jq '.jobs[].name'
    lines
    floor 12.0.0.0
    floor 10.11.0.0

None of the four guards is among its jobs, so a reader checking any of those
four cells landed in a workflow that is not the one the row is about. The fifth
cell named a commit and carried no identifier at all.

The claim each cell supported is true. The four guards did run green on
`1a18979` and the scorecard has run green on the default branch. Only the
pointer was wrong, which is why re-reading the table would not have found it.
What found it was resolving each identifier.

What the cells say now, each resolving to the workflow whose guard it is cited
for:

    $ for r in 31095610611 31095610670 31095610728 31095610678 31110915427; do gh api repos/iderex/jellyfin-plugin-requests/actions/runs/$r --jq '"\(.id)  \(.name)  \(.head_sha[0:7])  \(.conclusion)"'; done
    31095610611  Workflow Security Analysis  1a18979  success
    31095610670  unicode-guard  1a18979  success
    31095610728  DCO  1a18979  success
    31095610678  Dependency review  1a18979  success
    31110915427  Scorecard supply-chain security  0ecd860  success

and each of the four that ran on `1a18979` is the run behind that guard's own
check on that commit:

    $ gh api "repos/iderex/jellyfin-plugin-requests/commits/1a18979/check-runs?per_page=100" --jq '.check_runs[] | "\(.name)  \(.details_url)"' | sort -u | grep -E 'zizmor\)|Trojan|DCO sign-off|^dependency-review'
    Audit workflows (zizmor)  https://github.com/iderex/jellyfin-plugin-requests/actions/runs/31095610611/job/92596785124
    DCO sign-off  https://github.com/iderex/jellyfin-plugin-requests/actions/runs/31095610728/job/92596785665
    dependency-review  https://github.com/iderex/jellyfin-plugin-requests/actions/runs/31095610678/job/92596785225
    Reject Trojan Source Unicode  https://github.com/iderex/jellyfin-plugin-requests/actions/runs/31095569084/job/92596642190
    Reject Trojan Source Unicode  https://github.com/iderex/jellyfin-plugin-requests/actions/runs/31095610670/job/92596785052

Five rows for four guards, because the unicode guard starts on a push and on a
pull request both and has two green runs on that commit:

    $ for r in 31095569084 31095610670; do gh api repos/iderex/jellyfin-plugin-requests/actions/runs/$r --jq '"\(.id)  \(.name)  \(.event)  \(.conclusion)"'; done
    31095569084  unicode-guard  push  success
    31095610670  unicode-guard  pull_request  success

The cell names the second of the two. Either would be correct and both are that
guard's own workflow, which is the difference from what the cell held before.

The addition beside the table says why the five sit on two commits rather than
one. Two of the four refusing guards start on a pull request and nothing else,
and the scorecard has no pull request trigger, so no single commit carries a run
of all five. It also says what the four cells used to name and how the wrong
identifier was picked up, because a correction that removes the mistake and not
the reason for it invites the same one.

What is not claimed. Nothing here makes the scorecard refuse anything, and the
`reports` row is untouched. Nothing here is enforced either: no check reads this
document, and a cell naming a run that does not exist would move nothing red.
The document says that about itself in its last section, and this change does
not narrow it.

The means is markdown in `docs/`, unchanged from what the file already is. The
correction is four table cells and one addition, and it needs no code, because
what a run identifier resolves to is something a reader checks with the command
printed beside it.

Formatting is checked with the same version the gate uses:

    $ npx --yes prettier@3.6.2 --check "docs/quality-parity.md"
    Checking formatting...
    All matched files use Prettier code style!

`docs/quality-parity.md` is also edited by the open pull request #143, in a
different section. Whichever of the two lands second rebases onto the other.

This change has had no second reader. The evidence above stands in place of one.

This could not merge when it was opened, and the reason was the gate rather
than the change. It touches one file and that file is markdown, so the two build contexts
the ruleset requires are never reported:

    $ gh api "repos/iderex/jellyfin-plugin-requests/pulls/148/files" --jq '.[].filename'
    docs/quality-parity.md
    $ git grep -n -A1 "paths-ignore" origin/master -- .github/workflows/build.yaml
    origin/master:.github/workflows/build.yaml:20:    paths-ignore:
    origin/master:.github/workflows/build.yaml-21-      - '**/*.md'
    --
    origin/master:.github/workflows/build.yaml:26:    paths-ignore:
    origin/master:.github/workflows/build.yaml-27-      - '**/*.md'
    $ gh api -X PUT "repos/iderex/jellyfin-plugin-requests/pulls/148/merge" -f merge_method=merge
    {"message":"Repository rule violations found\n\n2 of 3 required status checks are expected.\n\n","status":"405"}

Both contexts have been run against this head by dispatching the build workflow
at the branch, and both are green:

    $ gh api "repos/iderex/jellyfin-plugin-requests/commits/e1ae832/check-runs?per_page=100" --jq '.check_runs[] | "\(.name)  \(.conclusion)"' | sort -u | grep '^call'
    call / build  success
    call / test  success

They sit on the commit and are not counted by the pull request, which is what
the refusal above says after that run finished. #124 hit the same wall and was
closed unmerged; #139 got past it by carrying a workflow file alongside the
markdown. Neither removing the `paths-ignore` blocks nor carrying an unrelated
file is done here: the first is the gate's shape and belongs to #30, and the
second is a second topic. This is recorded on #25 as well.

That is no longer the state, and what moved was `master` rather than this
change. #150 named the trap and #151 took the `paths-ignore` filter off the
`pull_request` trigger, which landed in `5c66048`. `master` is merged into this
branch here rather than rebased under it, so nothing already pushed was
rewritten, and the head this is judged on is `b1837be`. Both contexts now report
on the pull request itself:

    $ gh api "repos/Flowfin/jellyfin-plugin-requests/commits/b1837be/check-runs?per_page=100" --jq '.check_runs[] | "\(.name)  \(.conclusion)"' | sort -u
    Analyze (actions, none)  success
    Analyze (csharp, manual)  success
    Analyze (javascript-typescript, none)  success
    Audit workflows (zizmor)  success
    call / build  success
    call / test  success
    Check formatting  success
    CodeQL  neutral
    DCO sign-off  success
    dependency-review  success
    Reject Trojan Source Unicode  success
    zizmor  success

The three the ruleset requires are `call / build`, `call / test` and
`Reject Trojan Source Unicode`, and all three are in that list green:

    $ gh api repos/Flowfin/jellyfin-plugin-requests/rules/branches/master --jq '.[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context'
    call / build
    call / test
    Reject Trojan Source Unicode

`CodeQL` is `neutral` here as it is on every head in this repository, which is
the reason the document in this change gives for keeping it out of the set to
require. Nothing about that changed.

Both commits carry a verified signature:

    $ for c in e1ae832 b1837be; do gh api repos/Flowfin/jellyfin-plugin-requests/commits/$c --jq '"\(.sha[0:7])  \(.commit.verification.verified)  \(.commit.message | split("\n")[0])"'; done
    e1ae832  true  Name each guard's own run in the parity table's green column
    b1837be  true  Merge branch 'master' into docs/25-green-run-identifiers
