### PR TITLE
Say that this plugin belongs to Flowfin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> [!NOTE]
+>
+> **Part of [Flowfin](https://github.com/Flowfin).** It works with any Jellyfin
+> server, and with the Flowfin clients.
+
 # Jellyfin Requests
 
 Media requests for Jellyfin as first-class server objects. A user asks the


### PR DESCRIPTION
The repository moved to the Flowfin organisation. The readme now says so, and its own links point at the new location instead of relying on a redirect.