### PR TITLE
Add the sponsor button to this repository

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,7 @@
+# Sponsor button for this repository.
+#
+# The organisation's .github repository carries the same file as a default for
+# repositories without one. It is stated here explicitly because the default
+# did not arrive, and because an explicit file does not depend on how GitHub
+# resolves defaults.
+buy_me_a_coffee: iderex


### PR DESCRIPTION
Adds a sponsor button to this repository.

The same file exists in the organisation's `.github` repository, where GitHub
is meant to pick it up as a default for every repository that does not carry
its own. Measured over several hours it did not arrive, so the file is stated
here rather than inherited. An explicit file also cannot be undone by a cache
or by a change to how defaults resolve.

`jellyfin-plugin-sso` already carried the same file, which is why it is the one
repository not touched by this change.
