### PR TITLE
Hold the run directory's create and remove apart

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Doubles/TestRunDirectory.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/TestRunDirectory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 
@@ -14,12 +15,31 @@ namespace Jellyfin.Plugin.Requests.Tests.Doubles;
 /// process rather than one per <c>dotnet test</c>, because the suite runs a process per target
 /// framework and the two do not share memory.
 /// </para>
+/// <para>
+/// The suite runs test classes in parallel, so taking a subdirectory and giving one back are held
+/// apart by a lock and the live ones are counted rather than looked for on the disk. Asking the
+/// disk whether the run's directory is empty answers about the moment it was asked: a double that
+/// had already decided to create a subdirectory, and had not yet created it, is invisible to that
+/// question, and the answer was used to delete the directory underneath it.
+/// </para>
 /// </summary>
 internal static class TestRunDirectory
 {
     private static readonly string RootPath = Path.Combine(
         Path.GetTempPath(),
         string.Create(CultureInfo.InvariantCulture, $"jellyfin-plugin-requests-tests-{Guid.NewGuid():N}"));
+
+    /// <summary>
+    /// Held across every create and every remove, so no double can be part way through taking a
+    /// subdirectory while another is deciding whether the run's directory can go.
+    /// </summary>
+    private static readonly object Gate = new object();
+
+    /// <summary>
+    /// The subdirectories handed out and not yet given back. The count, rather than the state of
+    /// the disk, is what decides whether the run's directory is still wanted.
+    /// </summary>
+    private static readonly HashSet<string> Live = new HashSet<string>(StringComparer.Ordinal);
 
     /// <summary>
     /// Gets the directory this test host process owns. Created on first use so a run that
@@ -29,8 +49,11 @@ internal static class TestRunDirectory
     {
         get
         {
-            Directory.CreateDirectory(RootPath);
-            return RootPath;
+            lock (Gate)
+            {
+                Directory.CreateDirectory(RootPath);
+                return RootPath;
+            }
         }
     }
 
@@ -41,38 +64,54 @@ internal static class TestRunDirectory
     public static string CreateSubdirectory()
     {
         var path = Path.Combine(
-            Root,
+            RootPath,
             string.Create(CultureInfo.InvariantCulture, $"{Guid.NewGuid():N}"));
 
-        Directory.CreateDirectory(path);
+        lock (Gate)
+        {
+            Directory.CreateDirectory(RootPath);
+            Directory.CreateDirectory(path);
+            Live.Add(path);
+        }
+
         return path;
     }
 
     /// <summary>
     /// Removes a subdirectory and everything under it, and then removes <see cref="Root"/> itself
-    /// if nothing else is left in it. The last double disposed is what takes the run's directory
-    /// with it; while others still hold subdirectories the delete is refused and the directory
-    /// stays, which is why the failure is swallowed rather than reported.
+    /// if it was the last one out. The last double disposed is what takes the run's directory with
+    /// it. The delete is still allowed to fail without saying so, because something outside this
+    /// process can hold a handle on the directory and that is not a thing the suite can repair.
     /// </summary>
     /// <param name="subdirectory">A path returned by <see cref="CreateSubdirectory"/>.</param>
     public static void Remove(string subdirectory)
     {
-        if (Directory.Exists(subdirectory))
+        lock (Gate)
         {
-            Directory.Delete(subdirectory, true);
-        }
+            if (Directory.Exists(subdirectory))
+            {
+                Directory.Delete(subdirectory, true);
+            }
 
-        try
-        {
-            Directory.Delete(RootPath);
-        }
-        catch (IOException)
-        {
-            // Something else in this process still has a subdirectory here.
-        }
-        catch (UnauthorizedAccessException)
-        {
-            // Same case, reported differently by the platform.
+            Live.Remove(subdirectory);
+
+            if (Live.Count > 0)
+            {
+                return;
+            }
+
+            try
+            {
+                Directory.Delete(RootPath);
+            }
+            catch (IOException)
+            {
+                // Something outside this process is holding the directory open.
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // Same case, reported differently by the platform.
+            }
         }
     }
 }

--- a/Jellyfin.Plugin.Requests.Tests/TestRunDirectoryTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/TestRunDirectoryTests.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Concurrent;
 using System.IO;
+using System.Threading.Tasks;
 using Jellyfin.Plugin.Requests.Tests.Doubles;
 using Xunit;
 
@@ -76,5 +78,50 @@ public class TestRunDirectoryTests
         Assert.False(Directory.Exists(disposedRoot));
         Assert.True(Directory.Exists(held.ProgramDataPath));
         Assert.True(Directory.Exists(runDirectory));
+    }
+
+    /// <summary>
+    /// The same promise as the test above, made while doubles are being taken and given back at
+    /// once. The test above holds one double for its whole length, so the run's directory is never
+    /// a candidate for removal while it runs and the sequence that breaks this cannot occur in it.
+    /// <para>
+    /// That sequence is short. One double gives back the last subdirectory and the run's directory
+    /// becomes removable; another double has already asked for the run's directory and is about to
+    /// create its own inside it; the removal lands between the two and the second double creates a
+    /// directory inside one that is no longer there. The suite runs test classes in parallel, so
+    /// this is a failure in an unrelated test, on one target framework, that a re-run does not
+    /// reproduce.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void DoublesTakenAndGivenBackAtOnceDoNotRemoveTheRunDirectoryUnderEachOther()
+    {
+        var failures = new ConcurrentBag<string>();
+
+        Parallel.For(0, 32, _ =>
+        {
+            for (var round = 0; round < 32; round++)
+            {
+                try
+                {
+                    using var paths = new FakeApplicationPaths();
+
+                    if (!Directory.Exists(paths.ProgramDataPath))
+                    {
+                        failures.Add("a double's own directory was gone as soon as it was made");
+                    }
+                }
+                catch (IOException error)
+                {
+                    failures.Add(error.Message);
+                }
+                catch (UnauthorizedAccessException error)
+                {
+                    failures.Add(error.Message);
+                }
+            }
+        });
+
+        Assert.Empty(failures);
     }
 }


### PR DESCRIPTION
Part of #115. It does not close it: three of that issue's four done-conditions need the invariant lint from #28, which does not exist yet.

## What was wrong

`TestRunDirectory` gives every double a subdirectory of one directory the test host process owns, and removes that directory when the last subdirectory goes back. It decided whether the directory could go by asking the disk whether it was empty, and that answer is about the moment it was asked. A double that had already read the run's directory and had not yet created its own subdirectory inside it is invisible to that question, and the answer was used to delete the directory underneath it.

The sequence is short. One double gives back the last subdirectory, so the run's directory is now removable. Another double has already asked for the run's directory and is about to create its own inside it. The removal lands between the two, and the second double creates a directory inside one that is no longer there.

What it produces is a `DirectoryNotFoundException` out of `Directory.CreateDirectory`, reported against a test that is not about directories, on one target framework, which a re-run does not reproduce:

    Failed Jellyfin.Plugin.Requests.Tests.PluginConstructionTests.DisposingTheHostRemovesTheTemporaryRoot
      System.IO.DirectoryNotFoundException : Could not find a part of the path
      '...\jellyfin-plugin-requests-tests-b941a653d2cc412880a13e2ff64e3604\f7190272ba1e4b388f294b27e6550dad'
        at Jellyfin.Plugin.Requests.Tests.Doubles.TestRunDirectory.CreateSubdirectory() in TestRunDirectory.cs:line 47
        at Jellyfin.Plugin.Requests.Tests.Doubles.FakeApplicationPaths..ctor() in FakeApplicationPaths.cs:line 23
    Passed!  - Failed: 0, Passed: 34, Skipped: 0, Total: 34 (net10.0)
    Failed!  - Failed: 1, Passed: 33, Skipped: 0, Total: 34 (net9.0)

That run is how it was found. It carried test classes that are not in this branch, which is why its counts are 34 rather than 21: adding classes elsewhere in the suite changed how much of the suite overlaps, and the race needs the overlap.

## What changed

Create and remove are held apart by one lock, and the subdirectories handed out are counted in the process rather than looked for on the disk. The run's directory goes when the last holder gives it back rather than when the disk happens to look empty. The delete is still allowed to fail without saying so, because something outside this process can hold the directory open and that is not a thing the suite can repair.

`DoublesTakenAndGivenBackAtOnceDoNotRemoveTheRunDirectoryUnderEachOther` takes and gives back doubles from thirty-two callers at once and collects every path failure rather than throwing on the first, so what it reports is how often the race fired rather than that it fired.

## That the guard bites

`TestRunDirectory.cs` was put back to the shape `origin/master` has it, with the new test left in place:

    git show origin/master:Jellyfin.Plugin.Requests.Tests/Doubles/TestRunDirectory.cs \
        > Jellyfin.Plugin.Requests.Tests/Doubles/TestRunDirectory.cs
    dotnet test --nologo --filter FullyQualifiedName~TestRunDirectoryTests

    Failed Jellyfin.Plugin.Requests.Tests.TestRunDirectoryTests.DoublesTakenAndGivenBackAtOnceDoNotRemoveTheRunDirectoryUnderEachOther
      Assert.Empty() Failure: Collection was not empty
      Collection: ["Could not find a part of the path 'C:\\Users\\nils"..., ...]
    Failed!  - Failed: 1, Passed: 3, Skipped: 0, Total: 4 (net10.0)
    Failed!  - Failed: 1, Passed: 3, Skipped: 0, Total: 4 (net9.0)

Red on both claimed lines, on the new test and on no other. With the file as this branch has it:

    dotnet test --nologo
    Passed!  - Failed: 0, Passed: 21, Skipped: 0, Total: 21 (net10.0)
    Passed!  - Failed: 0, Passed: 21, Skipped: 0, Total: 21 (net9.0)

The test already in that file which names this promise, `DisposingADoubleLeavesTheRunDirectoryForTheOthers`, passes in both runs. It holds one double for its whole length, so the run's directory is never a candidate for removal while it runs and the sequence cannot occur in it. That is the near miss this test exists for.

## The means

C# in the existing test project, because the thing being fixed is a type in that project and the guard is an assertion the suite already knows how to run. It adds no package, no language and no runtime to the tree, and it is judged by `dotnet test` like everything else here.

## What this does not cover

The guard is a race the test provokes rather than a proof the race cannot happen. Thirty-two callers and thirty-two rounds each reproduce it every time it was run against the unguarded file on this machine, and neither number is derived from anything: a machine slow enough or serial enough might not reach it.

It says nothing about a second process. Two `dotnet test` runs at once own different directories by construction, because the name carries an identifier made once per test host process, and nothing here checks that.

This change has had no second reader. The evidence above stands in place of one.
