### PR TITLE
Say what the store promises two callers writing at once

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Doubles/InMemoryRequestStore.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/InMemoryRequestStore.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+
+namespace Jellyfin.Plugin.Requests.Tests.Doubles;
+
+/// <summary>
+/// A store that keeps everything in a dictionary and nothing on a disk. It exists so the contract
+/// in <see cref="IRequestStore"/> has something to be proven against before a durable store is
+/// built, and so the conformance suite that proves it is a suite rather than a set of assertions
+/// about one implementation.
+/// <para>
+/// It is deliberately in the test project. A store that loses every request when the server
+/// restarts is not a thing this plugin should be able to be configured with by accident, and which
+/// medium the shipped store uses is not settled here.
+/// </para>
+/// <para>
+/// The compare and the write are under one lock, which is what makes the conflict rule hold at all:
+/// with the read and the write apart, two callers both find the revision they expected and both
+/// write, which is the last-writer-wins behaviour the contract refuses.
+/// </para>
+/// </summary>
+internal sealed class InMemoryRequestStore : IRequestStore
+{
+    private readonly Dictionary<Guid, StoredRequest> _held = [];
+    private readonly object _gate = new object();
+
+    /// <inheritdoc />
+    public Task<StoredRequest?> GetAsync(Guid id, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_gate)
+        {
+            return Task.FromResult(_held.TryGetValue(id, out var stored) ? stored : (StoredRequest?)null);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<StoredRequest>> GetAllAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_gate)
+        {
+            return Task.FromResult<IReadOnlyList<StoredRequest>>(_held.Values.ToArray());
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<StoredRequest> AddAsync(MediaRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_gate)
+        {
+            if (_held.ContainsKey(request.Id))
+            {
+                throw new DuplicateRequestException(request.Id);
+            }
+
+            var stored = new StoredRequest(request, 1);
+            _held.Add(request.Id, stored);
+            return Task.FromResult(stored);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<StoredRequest> ReplaceAsync(MediaRequest request, long expectedRevision, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_gate)
+        {
+            var current = _held.TryGetValue(request.Id, out var held) ? held : (StoredRequest?)null;
+
+            if (current is null || current.Value.Revision != expectedRevision)
+            {
+                throw new RequestConcurrencyException(request.Id, expectedRevision, current);
+            }
+
+            var written = new StoredRequest(request, expectedRevision + 1);
+            _held[request.Id] = written;
+            return Task.FromResult(written);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<bool> RemoveAsync(Guid id, long expectedRevision, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_gate)
+        {
+            if (!_held.TryGetValue(id, out var held))
+            {
+                return Task.FromResult(false);
+            }
+
+            if (held.Revision != expectedRevision)
+            {
+                throw new RequestConcurrencyException(id, expectedRevision, held);
+            }
+
+            _held.Remove(id);
+            return Task.FromResult(true);
+        }
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/Storage/InMemoryRequestStoreTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Storage/InMemoryRequestStoreTests.cs
@@ -1,0 +1,20 @@
+using System.Diagnostics.CodeAnalysis;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+
+namespace Jellyfin.Plugin.Requests.Tests.Storage;
+
+/// <summary>
+/// The conformance suite run against the one implementation that exists. It adds no assertion of
+/// its own on purpose: an implementation is judged by the contract or it is judged by nothing, and
+/// a test written here rather than in the base class would be a promise only this store keeps.
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "The rule exempts a class that declares a test method and this one only inherits them, so it reads as an unused public type. xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public class InMemoryRequestStoreTests : RequestStoreContract
+{
+    /// <inheritdoc />
+    protected override IRequestStore NewStore() => new InMemoryRequestStore();
+}

--- a/Jellyfin.Plugin.Requests.Tests/Storage/RequestStoreContract.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Storage/RequestStoreContract.cs
@@ -1,0 +1,477 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Storage;
+
+/// <summary>
+/// Everything <see cref="IRequestStore"/> promises, as tests rather than as prose. Any store this
+/// plugin ever ships derives from this class and is judged by the same set, so a second
+/// implementation cannot quietly keep a weaker promise than the first.
+/// <para>
+/// The concurrency tests assert the documented outcome and not merely that nothing threw. A store
+/// that wrote last-writer-wins would never crash under any of them; what it would do is fail the
+/// count of accepted writes, which is the assertion these are built around.
+/// </para>
+/// </summary>
+public abstract class RequestStoreContract
+{
+    /// <summary>
+    /// How many callers the concurrent tests run at once. Large enough that they genuinely overlap
+    /// on an ordinary machine and small enough that the suite stays quick.
+    /// </summary>
+    private const int Writers = 32;
+
+    /// <summary>
+    /// A store with nothing in it. Each test gets its own.
+    /// </summary>
+    /// <returns>An empty store of the implementation under test.</returns>
+    protected abstract IRequestStore NewStore();
+
+    /// <summary>
+    /// The ordinary case, and the one every other test starts from. A request that has been added
+    /// reads back as itself, at revision 1, which is the number a caller hands back on its first
+    /// write.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AnAddedRequestReadsBackAtRevisionOne()
+    {
+        var store = NewStore();
+        var request = ARequest();
+
+        var added = await store.AddAsync(request, CancellationToken.None).ConfigureAwait(true);
+        var read = await store.GetAsync(request.Id, CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Equal(1, added.Revision);
+        Assert.Equal(request, added.Request);
+        Assert.NotNull(read);
+        Assert.Equal(added, read.Value);
+    }
+
+    /// <summary>
+    /// Asking about a request the store does not hold is an answer rather than a failure. The
+    /// failure this stands for is a store that throws here, which would make every caller holding
+    /// an identifier from an earlier read wrap its reads in a catch.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ReadingSomethingTheStoreDoesNotHoldIsNotAnError()
+    {
+        var store = NewStore();
+
+        var read = await store.GetAsync(Guid.NewGuid(), CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Null(read);
+    }
+
+    /// <summary>
+    /// Two requests with one identifier is a state the store never reaches. An identifier source
+    /// that repeats itself, or an add replayed by a retry, is refused rather than overwriting what
+    /// is already there.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AddingAnIdentifierTheStoreAlreadyHoldsIsRefused()
+    {
+        var store = NewStore();
+        var request = ARequest();
+        await store.AddAsync(request, CancellationToken.None).ConfigureAwait(true);
+
+        var refused = await Assert.ThrowsAsync<DuplicateRequestException>(
+            () => store.AddAsync(request with { DisplayTitle = "Something else" }, CancellationToken.None))
+            .ConfigureAwait(true);
+
+        var read = await store.GetAsync(request.Id, CancellationToken.None).ConfigureAwait(true);
+        Assert.Equal(request.Id, refused.RequestId);
+        Assert.Equal(request.DisplayTitle, read!.Value.Request.DisplayTitle);
+    }
+
+    /// <summary>
+    /// A write against the revision the caller read is accepted, and the revision moves by exactly
+    /// one. The exactness is the point: callers hand the number back and a store that moved it by
+    /// anything else would make every second write of a chain fail for no reason a caller could see.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AWriteAgainstTheRevisionThatWasReadIsAccepted()
+    {
+        var store = NewStore();
+        var added = await store.AddAsync(ARequest(), CancellationToken.None).ConfigureAwait(true);
+
+        var approved = added.Request with { State = RequestState.Approved };
+        var written = await store.ReplaceAsync(approved, added.Revision, CancellationToken.None).ConfigureAwait(true);
+        var again = await store.ReplaceAsync(
+            written.Request with { Availability = LibraryAvailability.Present },
+            written.Revision,
+            CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Equal(2, written.Revision);
+        Assert.Equal(3, again.Revision);
+        Assert.Equal(RequestState.Approved, again.Request.State);
+    }
+
+    /// <summary>
+    /// The case the whole contract exists for, made deterministic. An operator read the request and
+    /// went away to decide; something else moved it meanwhile; the operator's decision arrives
+    /// against a revision that is no longer there. It is refused, and the refusal carries what the
+    /// store holds now, so the surface can show the operator what actually happened rather than a
+    /// generic failure.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AWriteAgainstAnOvertakenRevisionIsRefusedAndSaysWhatTheStoreHolds()
+    {
+        var store = NewStore();
+        var added = await store.AddAsync(ARequest(), CancellationToken.None).ConfigureAwait(true);
+        var overtaking = await store.ReplaceAsync(
+            added.Request with { State = RequestState.Fulfilled },
+            added.Revision,
+            CancellationToken.None).ConfigureAwait(true);
+
+        var refused = await Assert.ThrowsAsync<RequestConcurrencyException>(
+            () => store.ReplaceAsync(
+                added.Request with { State = RequestState.Declined },
+                added.Revision,
+                CancellationToken.None))
+            .ConfigureAwait(true);
+
+        Assert.Equal(added.Request.Id, refused.RequestId);
+        Assert.Equal(added.Revision, refused.ExpectedRevision);
+        Assert.NotNull(refused.Current);
+        Assert.Equal(overtaking, refused.Current!.Value);
+
+        var read = await store.GetAsync(added.Request.Id, CancellationToken.None).ConfigureAwait(true);
+        Assert.Equal(RequestState.Fulfilled, read!.Value.Request.State);
+        Assert.Equal(overtaking.Revision, read.Value.Revision);
+    }
+
+    /// <summary>
+    /// A write against a request that has been removed says so rather than reporting a revision
+    /// nobody can act on. A caller told "gone" re-reads and finds nothing, which is a different
+    /// repair from "somebody moved it".
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AWriteAgainstARemovedRequestSaysItIsGone()
+    {
+        var store = NewStore();
+        var added = await store.AddAsync(ARequest(), CancellationToken.None).ConfigureAwait(true);
+        await store.RemoveAsync(added.Request.Id, added.Revision, CancellationToken.None).ConfigureAwait(true);
+
+        var refused = await Assert.ThrowsAsync<RequestConcurrencyException>(
+            () => store.ReplaceAsync(added.Request, added.Revision, CancellationToken.None))
+            .ConfigureAwait(true);
+
+        Assert.Null(refused.Current);
+    }
+
+    /// <summary>
+    /// A removal carries a revision for the same reason a write does. Deleting something on the
+    /// strength of a read that has since been overtaken is how a request an operator just approved
+    /// disappears.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task RemovingAgainstAnOvertakenRevisionIsRefused()
+    {
+        var store = NewStore();
+        var added = await store.AddAsync(ARequest(), CancellationToken.None).ConfigureAwait(true);
+        await store.ReplaceAsync(
+            added.Request with { State = RequestState.Approved },
+            added.Revision,
+            CancellationToken.None).ConfigureAwait(true);
+
+        await Assert.ThrowsAsync<RequestConcurrencyException>(
+            () => store.RemoveAsync(added.Request.Id, added.Revision, CancellationToken.None))
+            .ConfigureAwait(true);
+
+        var read = await store.GetAsync(added.Request.Id, CancellationToken.None).ConfigureAwait(true);
+        Assert.NotNull(read);
+    }
+
+    /// <summary>
+    /// Removing something already gone is not an error. A retention sweep and a person deleting the
+    /// same finished request is a race whose two outcomes are the same, and making the loser throw
+    /// would put a failure in a log for a thing that went right.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task RemovingSomethingTheStoreDoesNotHoldIsNotAnError()
+    {
+        var store = NewStore();
+
+        var removed = await store.RemoveAsync(Guid.NewGuid(), 1, CancellationToken.None).ConfigureAwait(true);
+
+        Assert.False(removed);
+    }
+
+    /// <summary>
+    /// The whole-store read returns every request, each at the revision it is held at.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task TheWholeStoreReadReturnsEveryRequestAtItsOwnRevision()
+    {
+        var store = NewStore();
+        var first = await store.AddAsync(ARequest(), CancellationToken.None).ConfigureAwait(true);
+        var second = await store.AddAsync(ARequest(), CancellationToken.None).ConfigureAwait(true);
+        var moved = await store.ReplaceAsync(
+            second.Request with { State = RequestState.Approved },
+            second.Revision,
+            CancellationToken.None).ConfigureAwait(true);
+
+        var all = await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Equal(2, all.Count);
+        Assert.Contains(first, all);
+        Assert.Contains(moved, all);
+    }
+
+    /// <summary>
+    /// Many callers write against one revision at the same moment. Exactly one is accepted, every
+    /// other is refused, and the store ends one revision on rather than <see cref="Writers"/> of
+    /// them.
+    /// <para>
+    /// This is the assertion a last-writer-wins store fails without ever throwing: it would accept
+    /// all of them, end at a revision nobody wrote against, and hold whichever value happened to
+    /// land last.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task OfManyWritersAgainstOneRevisionExactlyOneIsAccepted()
+    {
+        var store = NewStore();
+        var added = await store.AddAsync(ARequest(), CancellationToken.None).ConfigureAwait(true);
+        var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var attempts = Enumerable.Range(0, Writers).Select(async writer =>
+        {
+            await start.Task.ConfigureAwait(true);
+
+            try
+            {
+                var written = await store.ReplaceAsync(
+                    added.Request with { DisplayYear = writer },
+                    added.Revision,
+                    CancellationToken.None).ConfigureAwait(true);
+                return (Accepted: true, written.Revision, Writer: writer);
+            }
+            catch (RequestConcurrencyException)
+            {
+                return (Accepted: false, Revision: 0L, Writer: writer);
+            }
+        }).ToArray();
+
+        start.SetResult();
+        var outcomes = await Task.WhenAll(attempts).ConfigureAwait(true);
+
+        var accepted = outcomes.Where(outcome => outcome.Accepted).ToArray();
+        Assert.Single(accepted);
+        Assert.Equal(2, accepted[0].Revision);
+
+        var read = await store.GetAsync(added.Request.Id, CancellationToken.None).ConfigureAwait(true);
+        Assert.Equal(2, read!.Value.Revision);
+        Assert.Equal(accepted[0].Writer, read.Value.Request.DisplayYear);
+    }
+
+    /// <summary>
+    /// The same race with the callers doing what a real caller does, which is to read again and
+    /// decide again. Every writer eventually lands, each accepted write gets its own revision, and
+    /// no writer's change is overwritten by one that never saw it.
+    /// <para>
+    /// The set of returned revisions is the assertion that matters. Consecutive with no repeat is
+    /// what "exactly one accepted write per revision" means, and a store that lost an update would
+    /// still end at the right final number while the titles said otherwise, which is why both are
+    /// checked.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task EveryAcceptedWriteGetsItsOwnRevisionAndNoneIsLost()
+    {
+        var store = NewStore();
+        var added = await store.AddAsync(ARequest() with { DisplayTitle = "seed" }, CancellationToken.None).ConfigureAwait(true);
+        var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var attempts = Enumerable.Range(0, Writers).Select(async writer =>
+        {
+            await start.Task.ConfigureAwait(true);
+
+            while (true)
+            {
+                var read = await store.GetAsync(added.Request.Id, CancellationToken.None).ConfigureAwait(true);
+                var appended = string.Format(
+                    CultureInfo.InvariantCulture,
+                    "{0} {1}",
+                    read!.Value.Request.DisplayTitle,
+                    writer);
+
+                try
+                {
+                    var written = await store.ReplaceAsync(
+                        read.Value.Request with { DisplayTitle = appended },
+                        read.Value.Revision,
+                        CancellationToken.None).ConfigureAwait(true);
+                    return written.Revision;
+                }
+                catch (RequestConcurrencyException)
+                {
+                    // Exactly what a caller is meant to do with one: read again, decide against
+                    // what is there now, write again.
+                }
+            }
+        }).ToArray();
+
+        start.SetResult();
+        var revisions = await Task.WhenAll(attempts).ConfigureAwait(true);
+
+        Assert.Equal(Enumerable.Range(2, Writers).Select(revision => (long)revision), revisions.OrderBy(revision => revision));
+
+        var read = await store.GetAsync(added.Request.Id, CancellationToken.None).ConfigureAwait(true);
+        Assert.Equal(Writers + 1, read!.Value.Revision);
+
+        var words = read.Value.Request.DisplayTitle.Split(' ');
+        Assert.Equal("seed", words[0]);
+        Assert.Equal(
+            Enumerable.Range(0, Writers).Select(writer => writer.ToString(CultureInfo.InvariantCulture)).Order(StringComparer.Ordinal),
+            words.Skip(1).Order(StringComparer.Ordinal));
+    }
+
+    /// <summary>
+    /// The same rule on the way in. Several callers adding one identifier at the same moment leave
+    /// the store holding one request, and every caller but one is told why it was refused.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task OfManyAddsOfOneIdentifierExactlyOneIsAccepted()
+    {
+        var store = NewStore();
+        var request = ARequest();
+        var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var attempts = Enumerable.Range(0, Writers).Select(async writer =>
+        {
+            await start.Task.ConfigureAwait(true);
+
+            try
+            {
+                await store.AddAsync(request with { DisplayYear = writer }, CancellationToken.None).ConfigureAwait(true);
+                return true;
+            }
+            catch (DuplicateRequestException)
+            {
+                return false;
+            }
+        }).ToArray();
+
+        start.SetResult();
+        var outcomes = await Task.WhenAll(attempts).ConfigureAwait(true);
+
+        Assert.Single(outcomes, accepted => accepted);
+
+        var all = await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true);
+        Assert.Single(all);
+    }
+
+    /// <summary>
+    /// A reader running beside writers sees whole requests. Every read returns a value some write
+    /// completed and never a mixture of two, which is the promise that lets a queue be rendered
+    /// from a read taken while the plugin is working.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AReaderRunningBesideWritersOnlySeesValuesSomeWriteWrote()
+    {
+        var store = NewStore();
+        var added = await store.AddAsync(ARequest() with { DisplayTitle = "0", DisplayYear = 0 }, CancellationToken.None).ConfigureAwait(true);
+        var stop = new CancellationTokenSource();
+
+        var writing = Task.Run(async () =>
+        {
+            var held = added;
+
+            for (var write = 1; write <= 200; write++)
+            {
+                var next = held.Request with
+                {
+                    DisplayTitle = write.ToString(CultureInfo.InvariantCulture),
+                    DisplayYear = write
+                };
+
+                held = await store.ReplaceAsync(next, held.Revision, CancellationToken.None).ConfigureAwait(true);
+            }
+
+            await stop.CancelAsync().ConfigureAwait(true);
+        });
+
+        var mixtures = new List<string>();
+
+        while (!stop.IsCancellationRequested)
+        {
+            var read = await store.GetAsync(added.Request.Id, CancellationToken.None).ConfigureAwait(true);
+            var seen = read!.Value.Request;
+
+            if (seen.DisplayTitle != seen.DisplayYear?.ToString(CultureInfo.InvariantCulture))
+            {
+                mixtures.Add(string.Format(
+                    CultureInfo.InvariantCulture,
+                    "title {0} with year {1}",
+                    seen.DisplayTitle,
+                    seen.DisplayYear));
+            }
+        }
+
+        await writing.ConfigureAwait(true);
+        stop.Dispose();
+
+        Assert.Empty(mixtures);
+    }
+
+    /// <summary>
+    /// A cancelled call throws rather than returning something the caller reads as an answer. The
+    /// contract says nothing about whether a cancelled write took effect, so nothing here asserts
+    /// that it did or did not.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ACancelledCallThrows()
+    {
+        var store = NewStore();
+        var added = await store.AddAsync(ARequest(), CancellationToken.None).ConfigureAwait(true);
+        using var cancelled = new CancellationTokenSource();
+        await cancelled.CancelAsync().ConfigureAwait(true);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => store.GetAsync(added.Request.Id, cancelled.Token)).ConfigureAwait(true);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => store.ReplaceAsync(added.Request, added.Revision, cancelled.Token)).ConfigureAwait(true);
+    }
+
+    /// <summary>
+    /// A request with only the fields that have no default, and its own identifier each time so a
+    /// test can add two without arranging anything.
+    /// </summary>
+    /// <returns>A newly asked-for request.</returns>
+    private static MediaRequest ARequest()
+    {
+        var asked = new DateTimeOffset(2026, 8, 8, 8, 0, 0, TimeSpan.Zero);
+
+        return new MediaRequest
+        {
+            Id = Guid.NewGuid(),
+            RequestedByUserId = new Guid("b31d0f9a-5c2e-4a71-8f6b-0d4c3e2a1b58"),
+            RequestedAt = asked,
+            StateChangedAt = asked,
+            Kind = RequestedItemKind.Movie,
+            DisplayTitle = "The Conversation"
+        };
+    }
+}

--- a/Jellyfin.Plugin.Requests/Storage/DuplicateRequestException.cs
+++ b/Jellyfin.Plugin.Requests/Storage/DuplicateRequestException.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Globalization;
+
+namespace Jellyfin.Plugin.Requests.Storage;
+
+/// <summary>
+/// An add was refused because the store already holds a request with that identifier.
+/// <para>
+/// Separate from <see cref="RequestConcurrencyException"/> because the two say different things to
+/// a caller. A conflict means read again and decide again. This one means the identifier source
+/// handed out a value twice, or the same add was replayed, and re-reading changes nothing.
+/// </para>
+/// <para>
+/// This is not the answer to "somebody already asked for this title". Whether two requests are the
+/// same request is a question about providers and titles rather than about identifiers, and it is
+/// decided above the store.
+/// </para>
+/// </summary>
+public class DuplicateRequestException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DuplicateRequestException"/> class.
+    /// </summary>
+    /// <param name="requestId">The identifier the store already holds.</param>
+    public DuplicateRequestException(Guid requestId)
+        : base(string.Format(
+            CultureInfo.InvariantCulture,
+            "The store already holds a request with the identifier {0}.",
+            requestId))
+    {
+        RequestId = requestId;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DuplicateRequestException"/> class.
+    /// </summary>
+    public DuplicateRequestException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DuplicateRequestException"/> class.
+    /// </summary>
+    /// <param name="message">What happened.</param>
+    public DuplicateRequestException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DuplicateRequestException"/> class.
+    /// </summary>
+    /// <param name="message">What happened.</param>
+    /// <param name="innerException">What it happened because of.</param>
+    public DuplicateRequestException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    /// Gets the identifier the store already holds.
+    /// </summary>
+    public Guid RequestId { get; }
+}

--- a/Jellyfin.Plugin.Requests/Storage/IRequestStore.cs
+++ b/Jellyfin.Plugin.Requests/Storage/IRequestStore.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Model;
+
+namespace Jellyfin.Plugin.Requests.Storage;
+
+/// <summary>
+/// Where requests are kept, and the rules every implementation has to keep.
+/// <para>
+/// The rules are here rather than in a document because the callers are concurrent by
+/// construction. Two clients can create a request in the same moment, and a sweep that looks at the
+/// library can be walking the store while an operator approves something. A contract left implicit
+/// is one that holds on a machine with one user and stops holding on the machine nobody tested on.
+/// </para>
+/// <para>
+/// <b>What is atomic.</b> Each of <see cref="AddAsync"/>, <see cref="ReplaceAsync"/> and
+/// <see cref="RemoveAsync"/> either happens completely or not at all, for the one request it names.
+/// Nothing here is atomic across two requests: there is no operation that moves two requests
+/// together and no caller may assume one. Whether the write has reached a disk by the time the call
+/// returns is a separate promise and it is not made here.
+/// </para>
+/// <para>
+/// <b>What a reader may see.</b> A read returns a snapshot. Every request it returns is a value
+/// some write completed, never a mixture of two, and never a half-written one.
+/// <see cref="GetAllAsync"/> is a snapshot of each request rather than of the store, so a caller
+/// that reads the whole store while writes are running may see request A as of one moment and
+/// request B as of another. Reading never blocks a writer and never blocks another reader. A
+/// snapshot is stale the moment it is taken, which is exactly why a write carries the revision it
+/// was read at.
+/// </para>
+/// <para>
+/// <b>Two callers moving the same request.</b> Not last writer wins. Every write names the revision
+/// the caller read, the store accepts it only if that is still the revision it holds, and a write
+/// that does not match is refused with <see cref="RequestConcurrencyException"/> carrying what the
+/// store holds now. Where several callers write against one revision, exactly one is accepted and
+/// every other is refused. The refused caller has lost nothing it cannot recover: it re-reads,
+/// decides again against what it now sees, and writes again.
+/// </para>
+/// <para>
+/// <b>Ordering.</b> Revisions on one request are a total order and go up by one per accepted write.
+/// Across two requests there is no order: nothing here says which of two writes to two different
+/// requests happened first, and no caller may infer one from a revision.
+/// </para>
+/// <para>
+/// <b>Cancellation.</b> A cancelled call throws <see cref="OperationCanceledException"/>. Whether
+/// the write it was cancelled in the middle of took effect is not defined, so a caller that
+/// cancels a write and needs to know reads again.
+/// </para>
+/// <para>
+/// Which medium this is kept in, and what happens to a write that is interrupted, are not decided
+/// here. This interface is what those answers have to fit through, and it says nothing about files,
+/// databases or serialisation on purpose.
+/// </para>
+/// </summary>
+public interface IRequestStore
+{
+    /// <summary>
+    /// Reads one request.
+    /// </summary>
+    /// <param name="id">The request's own identifier.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>
+    /// The request and the revision the store holds it at, or <see langword="null"/> where the
+    /// store holds no request with that identifier. Absent is an ordinary answer and never an
+    /// exception, because a caller asking about a request that was removed while they held its
+    /// identifier is the normal case rather than a defect.
+    /// </returns>
+    Task<StoredRequest?> GetAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Reads every request the store holds.
+    /// <para>
+    /// This is the whole-store read the contract above is stated over, and it is not the query
+    /// surface the administrator and user pages need. Filtering, sorting and paging are their own
+    /// work and are not on this interface yet.
+    /// </para>
+    /// </summary>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>Every request, each with the revision the store holds it at, in no defined order.</returns>
+    Task<IReadOnlyList<StoredRequest>> GetAllAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Puts a request the store does not already hold into it.
+    /// </summary>
+    /// <param name="request">The request to keep.</param>
+    /// <param name="cancellationToken">Cancels the write.</param>
+    /// <returns>The request at revision 1.</returns>
+    /// <exception cref="DuplicateRequestException">
+    /// The store already holds a request with that identifier. Where several callers add the same
+    /// identifier at once, exactly one is accepted and every other is refused this way.
+    /// </exception>
+    Task<StoredRequest> AddAsync(MediaRequest request, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Writes a request the store already holds, against the revision the caller read.
+    /// </summary>
+    /// <param name="request">
+    /// The request as it should now read. Its identifier says which stored request is being
+    /// written, and it may not be changed by a write.
+    /// </param>
+    /// <param name="expectedRevision">The revision the caller read this request at.</param>
+    /// <param name="cancellationToken">Cancels the write.</param>
+    /// <returns>The request at its new revision, which is one higher than the one it was written against.</returns>
+    /// <exception cref="RequestConcurrencyException">
+    /// The store holds a different revision, or holds this request no longer. The exception carries
+    /// what the store holds now, so the caller can show it or decide again against it.
+    /// </exception>
+    Task<StoredRequest> ReplaceAsync(MediaRequest request, long expectedRevision, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Takes a request out of the store, against the revision the caller read.
+    /// </summary>
+    /// <param name="id">The request's own identifier.</param>
+    /// <param name="expectedRevision">The revision the caller read this request at.</param>
+    /// <param name="cancellationToken">Cancels the write.</param>
+    /// <returns>
+    /// <see langword="true"/> where a request was taken out, and <see langword="false"/> where the
+    /// store held none with that identifier. Removing something already gone is not an error,
+    /// because a retention sweep and a person deleting the same request is a race with no wrong
+    /// outcome.
+    /// </returns>
+    /// <exception cref="RequestConcurrencyException">
+    /// The store holds this request at a different revision, so the caller is deciding from a read
+    /// that has since been overtaken.
+    /// </exception>
+    Task<bool> RemoveAsync(Guid id, long expectedRevision, CancellationToken cancellationToken);
+}

--- a/Jellyfin.Plugin.Requests/Storage/RequestConcurrencyException.cs
+++ b/Jellyfin.Plugin.Requests/Storage/RequestConcurrencyException.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Globalization;
+
+namespace Jellyfin.Plugin.Requests.Storage;
+
+/// <summary>
+/// A write was refused because the caller's read is out of date. Somebody else moved the request
+/// between the read and the write.
+/// <para>
+/// This is thrown rather than returned as a false, because the alternative every store reaches for
+/// is to write anyway, and the two callers this plugin has are an operator declining and the
+/// plugin itself marking something fulfilled. Losing either one silently is the failure the whole
+/// contract in <see cref="IRequestStore"/> exists against.
+/// </para>
+/// <para>
+/// It carries what the caller needs to do something other than give up: which request, what they
+/// thought they had, and what the store holds now. The administrator surface shows the operator
+/// the second of those rather than a generic failure, and a sweep running on its own re-reads and
+/// retries.
+/// </para>
+/// </summary>
+public class RequestConcurrencyException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequestConcurrencyException"/> class.
+    /// </summary>
+    /// <param name="requestId">The request the write was refused on.</param>
+    /// <param name="expectedRevision">The revision the caller wrote against.</param>
+    /// <param name="current">
+    /// What the store holds now, or <see langword="null"/> where the request is no longer in the
+    /// store at all.
+    /// </param>
+    public RequestConcurrencyException(Guid requestId, long expectedRevision, StoredRequest? current)
+        : base(Describe(requestId, expectedRevision, current))
+    {
+        RequestId = requestId;
+        ExpectedRevision = expectedRevision;
+        Current = current;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequestConcurrencyException"/> class.
+    /// </summary>
+    public RequestConcurrencyException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequestConcurrencyException"/> class.
+    /// </summary>
+    /// <param name="message">What happened.</param>
+    public RequestConcurrencyException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequestConcurrencyException"/> class.
+    /// </summary>
+    /// <param name="message">What happened.</param>
+    /// <param name="innerException">What it happened because of.</param>
+    public RequestConcurrencyException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    /// Gets the request the write was refused on.
+    /// </summary>
+    public Guid RequestId { get; }
+
+    /// <summary>
+    /// Gets the revision the caller wrote against, which is the one they read.
+    /// </summary>
+    public long ExpectedRevision { get; }
+
+    /// <summary>
+    /// Gets what the store holds now, or <see langword="null"/> where the request has been removed
+    /// since the caller read it. A caller showing this to a person is showing them what actually
+    /// happened while they were deciding.
+    /// </summary>
+    public StoredRequest? Current { get; }
+
+    private static string Describe(Guid requestId, long expectedRevision, StoredRequest? current)
+        => current is null
+            ? string.Format(
+                CultureInfo.InvariantCulture,
+                "Request {0} was written against revision {1} and is no longer in the store.",
+                requestId,
+                expectedRevision)
+            : string.Format(
+                CultureInfo.InvariantCulture,
+                "Request {0} was written against revision {1} and the store holds revision {2}.",
+                requestId,
+                expectedRevision,
+                current.Value.Revision);
+}

--- a/Jellyfin.Plugin.Requests/Storage/StoredRequest.cs
+++ b/Jellyfin.Plugin.Requests/Storage/StoredRequest.cs
@@ -1,0 +1,22 @@
+using Jellyfin.Plugin.Requests.Model;
+
+namespace Jellyfin.Plugin.Requests.Storage;
+
+/// <summary>
+/// A request as the store holds it: the value, and the revision the store has it at.
+/// <para>
+/// The revision is the store's, not the request's, which is why it is here rather than on
+/// <see cref="MediaRequest"/>. A caller that reads a request and later writes it back hands the
+/// revision back with the write, and that is the whole of the conflict rule in
+/// <see cref="IRequestStore"/>. Putting the number on the record would mean every caller
+/// constructing a request had to invent one, and it would make the record's field list depend on
+/// where it happens to be kept.
+/// </para>
+/// </summary>
+/// <param name="Request">The request itself.</param>
+/// <param name="Revision">
+/// What the store has this request at. A request is at revision 1 when it is added and the number
+/// goes up by one on every accepted write. It is a counter and never a time: two writes in the same
+/// tick are still two revisions.
+/// </param>
+public readonly record struct StoredRequest(MediaRequest Request, long Revision);


### PR DESCRIPTION
Closes #45.

## What the contract says

`IRequestStore` carries the rule in its own documentation rather than in a file beside it, in four parts.

What is atomic. Each of add, replace and remove either happens completely or not at all, for the one request it names. Nothing is atomic across two requests and no caller may assume it. Whether the write has reached a disk by the time the call returns is a separate promise and this interface does not make it.

What a reader may see. A read is a snapshot. Every request it returns is a value some write completed, never a mixture of two. The whole-store read is a snapshot of each request rather than of the store, so a caller reading everything while writes are running may see one request as of one moment and another as of another. Reading blocks nothing.

Two callers moving one request. Not last writer wins. Every write names the revision the caller read; the store accepts it only if that is still the revision it holds; a write that does not match is refused with `RequestConcurrencyException`. Where several callers write against one revision, exactly one is accepted.

Ordering. Revisions on one request are a total order and go up by one per accepted write. Across two requests there is no order and none may be inferred.

The refusal carries the request, the revision the caller wrote against, and what the store holds now, with a null meaning the request has been removed. That is what makes it something a caller can act on: the administrator surface shows the operator what the request looks like now instead of a generic failure, and a sweep re-reads and retries. The case this exists for is an operator declining while the plugin marks the same request fulfilled, where last writer wins loses one of the two decisions and nothing says which.

The revision is on `StoredRequest` rather than on `MediaRequest`, so the record's field list does not depend on where the record is kept and no caller constructing a request has to invent a number.

## That the guards bite

Both plants were made in `InMemoryRequestStore.ReplaceAsync` and taken out again.

Last writer wins, which is the shape a store reaches for when the rule is not written down. The revision check is dropped and the write takes the revision after whatever is there:

    dotnet test --nologo --filter FullyQualifiedName~InMemoryRequestStoreTests

    Failed ...AWriteAgainstAnOvertakenRevisionIsRefusedAndSaysWhatTheStoreHolds
      Assert.Throws() Failure: No exception was thrown
      Expected: typeof(Jellyfin.Plugin.Requests.Storage.RequestConcurrencyException)
    Failed ...OfManyWritersAgainstOneRevisionExactlyOneIsAccepted
      Assert.Single() Failure: The collection contained 32 items
      Collection: [Tuple (True, 2, 0), Tuple (True, 3, 1), Tuple (True, 4, 2), Tuple (True, 7, 3), ...]
    Failed ...EveryAcceptedWriteGetsItsOwnRevisionAndNoneIsLost
      Assert.Equal() Failure: Collections differ
      Expected: ["0", "1", "10", "11", "12", ...]
      Actual:   ["1", "10", "11", "12", "13", ...]

    Failed!  - Failed: 3, Passed: 11, Skipped: 0, Total: 14 (net10.0)
    Failed!  - Failed: 3, Passed: 11, Skipped: 0, Total: 14 (net9.0)

Three tests, both claimed lines. Thirty-two writes accepted against one revision instead of one, and writer 0's mark gone from the value the store ended on, which is a lost update named rather than inferred.

The sharper near miss, and the one somebody actually writes. The revision check stays exactly as it is and only moves outside the lock, so the read and the write are two steps instead of one:

    dotnet test --nologo --no-build --filter FullyQualifiedName~InMemoryRequestStoreTests

    run1  Passed! (net9.0)   Passed! (net10.0)
    run2  Failed! (net9.0)   Failed! (net10.0)
    run3  Failed! (net9.0)   Passed! (net10.0)
    run4  Passed! (net9.0)   Failed! (net10.0)
    run5  Failed! (net9.0)   Passed! (net10.0)

Six of ten framework runs red, always on `OfManyWritersAgainstOneRevisionExactlyOneIsAccepted` and never on anything else. A race is what it is: a single run of this suite can pass with that defect present, and the number above is what happened on this machine rather than a rate anybody derived.

That is also the answer to why the concurrent tests are there at all. `AWriteAgainstAnOvertakenRevisionIsRefusedAndSaysWhatTheStoreHolds` is deterministic and it passes under the second plant, because the exception is still thrown for the caller it sequences. Only the count of accepted writes catches it.

With both plants taken out:

    dotnet test --nologo
    Passed!  - Failed: 0, Passed: 35, Skipped: 0, Total: 35 (net9.0)
    Passed!  - Failed: 0, Passed: 35, Skipped: 0, Total: 35 (net10.0)

## Where the implementation is, and why it is not shipped

`InMemoryRequestStore` is in the test project. A store that loses every request when the server restarts is not a thing an install should be able to end up with by accident, and which medium the shipped store uses is #44. What it gives this branch is something for the contract to be proven against, which is the difference between a suite and a set of assertions about one implementation.

`RequestStoreContract` is the suite, and any store this plugin ever ships derives from it. When #46 builds the durable one it inherits this set unchanged, so it cannot keep a weaker promise than this one and quietly pass.

## The means

C# in the projects that already exist, and no package added. The contract is a type the plugin's own code will compile against, so it has to be in the plugin assembly; the proof is xunit, which the suite already runs on both claimed lines. Nothing here needs a runtime, a service or a tool the tree does not carry.

## Size

924 added lines, which is over the 400 this family of repositories inherits as a cap.

    git diff --cached --numstat
    git diff --cached -U0 | grep -E '^\+' | grep -v '^+++' | sed 's/^+//' | grep -cE '^\s*(///|//)'
    352

352 of them are documentation or comment and 107 are blank, leaving 465 lines of code. The analyzer posture in `Directory.Build.props` requires a documentation file, so every public member carries an XML comment whether or not anybody wanted one there.

Splitting it was considered and is the wrong shape. The contract without the suite ships a guard with no proof that it bites, which this family of repositories refuses by name; the suite without the contract does not compile. Two pull requests that only make sense together is the cap satisfied and its purpose defeated. Re-planning the issue does not help either: the issue asks for an interface, its concurrency contract, and a test that drives concurrent writers, and each of the three is unreadable without the other two.

## What this does not cover

No store ships. Nothing in the plugin registers an `IRequestStore` and nothing constructs one, so this branch changes no behaviour an operator or a user can see. It is a contract and its proof.

Durability is not in it. Whether a write survives being interrupted is #46, and the interface says in as many words that it does not promise the write has reached a disk when the call returns.

The whole-store read is not the query surface. Filtering, sorting and paging are #48 and are not on this interface.

Nothing here was measured on a running server. The contract is about this plugin's own code and none of it crosses into the host.

This change has had no second reader. The evidence above stands in place of one.
