### PR TITLE
Say in build-jf12.yaml which identifier is under the comment

### DIFF
--- a/build-jf12.yaml
+++ b/build-jf12.yaml
@@ -6,8 +6,8 @@
 # depending on which package was published last.
 name: "Requests"
 # Same identifier as build.yaml, so a server that moves from 10.11 to 12.0 updates this plugin in
-# place instead of gaining a second, unrelated one. Still the template's identifier; #15 mints the
-# real one and has to change both files.
+# place instead of gaining a second, unrelated one. Both files carry the minted identifier and
+# PackagingMetadataTests.BothPackagesClaimTheSameIdentity refuses them diverging on it.
 guid: "0f9c9107-b31b-459e-81fa-6d35dac25e79"
 imageUrl: "https://raw.githubusercontent.com/Flowfin/jellyfin-plugin-requests/master/img/logo.png"
 version: "0.1.0.0"


### PR DESCRIPTION
Part of #1. It does not close it: that milestone closes when every issue in it is closed, and #113 is one of them.

## What was wrong

`build-jf12.yaml` carried this, with the minted identifier directly underneath:

    # Same identifier as build.yaml, so a server that moves from 10.11 to 12.0 updates this plugin in
    # place instead of gaining a second, unrelated one. Still the template's identifier; #15 mints the
    # real one and has to change both files.
    guid: "0f9c9107-b31b-459e-81fa-6d35dac25e79"

So the comment described the line above it and contradicted the line below it. #15 declared its scope as `build.yaml` and `Jellyfin.Plugin.Requests/Plugin.cs`, the identifier was minted in both, and this file's note about the work was left behind.

## What it says now

What refuses the two packaging files diverging on the identifier, which is what a reader of that comment actually wants to know and is a fact a command can check:

    git show origin/master:Jellyfin.Plugin.Requests.Tests/PackagingMetadataTests.cs | grep -n BothPackagesClaimTheSameIdentity

## The condition that found it

`git grep -in template -- . ':(exclude)LICENSE'` is #1's second done-condition. Before this change it printed six lines and now it prints five:

    .github/workflows/zizmor.yml:7:# template-injection, cache-poisoning, dangerous-triggers, excessive-permissions,
    CHANGELOG.md:21:  template, which claimed a released first version of a plugin that has never
    docs/versioning.md:5:the packaging metadata, which is what an update check compares. The template
    docs/versioning.md:81:`0.1.0.0`. The template's `1.0.0.0` claimed a released first version, and
    jellyfin.ruleset:52:        <!-- error on CA2254: Template should be a static expression -->

All five are correct and none should be removed. Two of them quote somebody else's vocabulary, an audit rule called template-injection and the text of CA2254. Three say where the version numbers came from, which is the reason those numbers are what they are. So the condition cannot print nothing while the tree is right, and that is written into #1 rather than repaired here, because rewriting a milestone's done-condition is not a one-line change to a comment.

## The means

A comment in the file the comment is in. Nothing else was available and nothing else was needed.

## Evidence

    dotnet test --nologo
    Passed!  - Failed: 0, Passed: 35, Skipped: 0, Total: 35 (net10.0)
    Passed!  - Failed: 0, Passed: 35, Skipped: 0, Total: 35 (net9.0)

No changelog entry. `CHANGELOG.md` says an entry is for what changed for somebody using the plugin, and a comment alters nothing an operator or a user can observe.

## What this does not cover

The condition in #1 is still unmeetable as written, and this changes only which lines it finds. Nothing here touches the identifier itself, which was minted before this branch and is checked by the suite.

This change has had no second reader. The evidence above stands in place of one.
