### PR TITLE
Put the merge gate's trigger comment back into English (#156)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,14 +21,15 @@ on:
       - '**/*.md'
   # Every branch, not only pull requests aimed at master: a release branch would
   # otherwise take changes that nothing built.
-  # KEIN paths-ignore hier. Der Kommentar oben nennt die Falle bei den Namen;
-  # dies ist dieselbe Falle mit einer anderen Ursache. Das Ruleset verlangt
-  # `call / build` und `call / test`, und ein Filter, der den Lauf bei einer
-  # reinen Dokumentaenderung ueberspringt, laesst diese Kontexte NIE melden.
-  # Der PR ist dann nicht rot, sondern dauerhaft wartend, und nichts an ihm
-  # sieht falsch aus. Am 07.08. hing daran ein README-PR fest.
   #
-  # Beim push oben bleibt der Filter: dort gatet er nichts.
+  # No paths-ignore here. The comment at the top of this file names the trap at
+  # the check names; this is the same trap arrived at a different way. The
+  # ruleset requires `call / build` and `call / test`, so a filter that skips
+  # the run on a documentation-only change does not make those contexts pass,
+  # it stops them reporting at all. Such a pull request is not red, it waits
+  # forever, and nothing on it looks wrong to the person waiting.
+  #
+  # The filter stays on the push above, because nothing is gated there.
   pull_request:
     branches: ['**']
   workflow_dispatch:


### PR DESCRIPTION
Closes #156.

The six lines above the `pull_request` trigger in `.github/workflows/build.yaml`
were in German, directly under the English comment at the top of the same file
that they continue. A reader following the explanation of why `call / build` and
`call / test` may not be renamed reached the second half of that pair in a
language they may not read. An unreadable comment is the one the next person
deletes, and deleting this one brings back the `paths-ignore` it warns against.

The reason is unchanged and still stated where it was. A `paths-ignore` on the
pull request trigger does not make the two required contexts pass, it stops them
reporting at all, so the pull request waits instead of failing and nothing on it
looks wrong.

The last line of the block recorded a date and a pull request that had been stuck
on it. That is a note about one incident rather than about what the file does,
and it means nothing to a later reader, so the reason the rule exists stands
there now instead.

One correction to the issue. It puts the block at lines 24 to 29, six lines. The
line after the blank one, saying the filter stays on the push trigger, is the
same language and is at line 31, so eight lines were translated rather than six.

Means: the artefact is a comment inside an existing GitHub Actions workflow file,
so the means is fixed by the file it lives in and adds no language, runtime or
dependency to the tree.

Evidence, run on this branch at 424c0e1:

    $ git grep -nE "KEIN paths-ignore|dieselbe Falle|dauerhaft wartend" -- .github/workflows/build.yaml
    $ echo "exit=$?"
    exit=1

    $ git grep -lniE "\b(nicht|dieser|werden|damit|weil|falle)\b" -- .
    $ echo "exit=$?"
    exit=1

The file still parses and still declares the same three triggers:

    $ python -c "import yaml; d=yaml.safe_load(open('.github/workflows/build.yaml',encoding='utf-8')); print(sorted(d[True].keys()))"
    ['pull_request', 'push', 'workflow_dispatch']

    $ git diff --name-only origin/master...HEAD
    .github/workflows/build.yaml

The change is comments only. No trigger, filter, permission or job was touched,
which the diff shows.

This change has had no second reader. The evidence above stands in place of one.
