### PR TITLE
Check the change itself, not only the code in it (#26)

### DIFF
--- a/.github/workflows/pr-hygiene.yaml
+++ b/.github/workflows/pr-hygiene.yaml
@@ -112,12 +112,30 @@ jobs:
             // rather than a caught slip. The linkage is still wanted: whoever
             // handles the contribution supplies it.
             //
-            // `author_association` is the author's relationship to this
-            // repository, so a collaborator who is later added as a member stops
-            // being exempt from that moment. COLLABORATOR is deliberately not in
-            // the inside set.
+            // COLLABORATOR is in the inside set here, and the sibling board
+            // leaves it out. That is a difference measured rather than copied.
+            // `author_association` is not one value: the field a workflow reads
+            // out of the event payload and the field the REST API returns for
+            // the same pull request can disagree, and here they do. On the run
+            // that first exercised this check, the workflow read COLLABORATOR
+            // and the API answered MEMBER for the same number:
+            //
+            //   gh api repos/Flowfin/jellyfin-plugin-requests/pulls/163 --jq '.author_association'
+            //   MEMBER
+            //
+            //   ##[warning]The blocking tier was skipped because the author is
+            //   outside this repository (author_association: COLLABORATOR)
+            //
+            // The value that decides the check is the one the workflow reads,
+            // so an inside set of OWNER and MEMBER skips the blocking tier for
+            // every pull request this board actually opens, which is a check
+            // that refuses nothing while reporting success. What the wider set
+            // costs is that somebody given push access is inside the tier from
+            // that moment. That is the right reading here: the convention this
+            // tier enforces follows write access, and somebody with none is the
+            // audience the skip is for.
             const isBot = pr.user && pr.user.type === 'Bot';
-            const INSIDE_ASSOCIATIONS = ['OWNER', 'MEMBER'];
+            const INSIDE_ASSOCIATIONS = ['OWNER', 'MEMBER', 'COLLABORATOR'];
             const isOutside = !INSIDE_ASSOCIATIONS.includes(
               pr.author_association || 'NONE',
             );

--- a/.github/workflows/pr-hygiene.yaml
+++ b/.github/workflows/pr-hygiene.yaml
@@ -1,0 +1,271 @@
+# Deterministic pull request hygiene checks.
+#
+# Every other check on this board reasons about the code: the build, the tests,
+# the ABI floors, the analyzers, the formatter, the code scan, the workflow
+# audit. This one reasons about the change itself, which is a class none of them
+# reach. Whether a pull request says which issue it belongs to, whether a version
+# bump also records what it changed for somebody who has the plugin installed,
+# and whether a change to the plugin moved a test are facts about the pull
+# request rather than about any file in it.
+#
+# It is a first-party workflow with one `github-script` step rather than an
+# external review service. A service that reasons about a change is a third party
+# reading every diff before a maintainer does, and the same rules are a few
+# dozen lines of JavaScript against the pull request API. Nothing here is
+# checked out: every input is read from the pull request metadata through the
+# API, so there is no untrusted working tree, and no untrusted value is ever
+# interpolated into a shell command.
+#
+# The checks are tiered by confidence, because a check that fires on a
+# reasonable change teaches people to route around it.
+#
+#   FAIL, and holds the merge once the ruleset requires this job:
+#     * the pull request body carries an issue reference
+#     * a version bump in either packaging file also touches CHANGELOG.md
+#
+#   WARN, annotation only, never red:
+#     * the diff is large
+#     * the plugin changed and the test project did not
+#
+# The two WARN checks are in that tier on purpose. A rename, a documentation
+# move or a comment pass legitimately exceeds any line cap and legitimately
+# touches no test, and a merge blocked for either teaches people to split a
+# change badly, which is the opposite of what a size check is for.
+#
+# The FAIL tier is skipped for two audiences, for two different reasons, and
+# both skips are written at the check rather than only here. A skipped run says
+# so in its own annotations, so a run that checked less than the whole set
+# cannot be read as one that checked it and found nothing.
+#
+# Two checks the sibling board runs are deliberately not adopted here, and the
+# reasons are at checks 1b and 1c below where a reader looking for them will be.
+#
+# The job name is `Deterministic pull request hygiene checks`. A ruleset matches
+# a required check by name, literally, so renaming this job removes a
+# requirement rather than renaming one. What is actually required is a
+# repository setting rather than a line in this file, and is printed rather than
+# restated here:
+#
+#   gh api repos/Flowfin/jellyfin-plugin-requests/rules/branches/master \
+#     --jq '.[] | select(.type=="required_status_checks")
+#           | .parameters.required_status_checks[].context'
+name: '🧾 PR hygiene'
+
+on:
+  pull_request:
+    # Every branch, not only pull requests aimed at master, for the same reason
+    # the merge gate names every branch: a release branch would otherwise take
+    # changes this never looked at.
+    #
+    # `edited` is here so that adding the issue reference to the body re-runs
+    # the check. Without it the only way to clear check 1 is an empty push.
+    branches: ['**']
+    types: [opened, edited, synchronize, reopened]
+
+# Explicit deny-all at workflow level; the job below grants only what it reads.
+permissions: {}
+
+# Cancel a superseded run on the same pull request. This reads metadata and
+# writes nothing, so an obsolete run is safe to drop.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  hygiene:
+    name: Deterministic pull request hygiene checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      # The changed-file list and the patches behind it, and the pull request
+      # body, its author and its labels. Nothing here writes anything back.
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Run the hygiene checks
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const failures = [];
+            const warnings = [];
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+            const changed = files.map((f) => f.filename);
+
+            // --- Who the FAIL tier is for --------------------------------------
+            // An automated dependency update opens a pull request with no issue
+            // behind it, because there is no issue: the update is the whole
+            // change and the tool has nothing to link. Failing it would mean a
+            // permanently red check on every such pull request, which is the
+            // check that gets switched off rather than satisfied.
+            //
+            // Somebody arriving from outside this repository is a separate case
+            // with a separate reason. The issue convention is this board's, they
+            // have no way to know the numbers before they file, and often no
+            // issue exists yet, so failing their contribution on it is a ritual
+            // rather than a caught slip. The linkage is still wanted: whoever
+            // handles the contribution supplies it.
+            //
+            // `author_association` is the author's relationship to this
+            // repository, so a collaborator who is later added as a member stops
+            // being exempt from that moment. COLLABORATOR is deliberately not in
+            // the inside set.
+            const isBot = pr.user && pr.user.type === 'Bot';
+            const INSIDE_ASSOCIATIONS = ['OWNER', 'MEMBER'];
+            const isOutside = !INSIDE_ASSOCIATIONS.includes(
+              pr.author_association || 'NONE',
+            );
+            const failTierApplies = !isBot && !isOutside;
+
+            // Both skips are written at the check. A run that skipped the
+            // blocking tier says which checks it did not make and why, so it
+            // cannot be read as a run that made them and found nothing.
+            if (isBot) {
+              warnings.push(
+                'The blocking tier was skipped because this pull request was ' +
+                  `opened by a bot (user.type: ${pr.user.type}). The two checks ` +
+                  'not made are the issue reference in the body and the ' +
+                  'changelog entry behind a version bump. An automated ' +
+                  'dependency update has no issue to link, so the reference is ' +
+                  'not owed here; a version bump from one would still owe a ' +
+                  'changelog entry and is not checked, which is the cost of the ' +
+                  'skip and is stated rather than hidden.',
+              );
+            } else if (isOutside) {
+              warnings.push(
+                'The blocking tier was skipped because the author is outside ' +
+                  `this repository (author_association: ${pr.author_association || 'NONE'}). ` +
+                  'The two checks not made are the issue reference in the body ' +
+                  'and the changelog entry behind a version bump. The issue ' +
+                  'linkage is still wanted: whoever handles this contribution ' +
+                  'supplies the reference, and files the issue where none ' +
+                  'exists yet. Read this as "not their obligation", never as ' +
+                  '"linkage does not matter here".',
+              );
+            }
+
+            // --- Check 1: the body names an issue (FAIL) -----------------------
+            // Every change on this board starts as an issue, and the pull
+            // request is where that link is readable. A bare `#12`, a keyword
+            // form such as `Closes #12`, or a full issue URL all satisfy it.
+            // Lenient on purpose: a genuinely linked change must never be
+            // refused on phrasing.
+            const body = pr.body || '';
+            const hasIssueRef =
+              /(^|[^\w])#\d+\b/.test(body) ||
+              /github\.com\/[^/\s]+\/[^/\s]+\/issues\/\d+/i.test(body);
+            if (failTierApplies && !hasIssueRef) {
+              failures.push(
+                'The body carries no issue reference. Name the issue this ' +
+                  'change belongs to, for example `Closes #12` or `Part of #12`.',
+              );
+            }
+
+            // --- Check 1b: not adopted, the bracketed commit subject -----------
+            // The sibling board fails a commit whose subject carries no `[#N]`.
+            // That is a commit message convention rather than a fact about the
+            // pull request, and it is not this board's convention: the reference
+            // is written in the message body, as `Closes #45` or `Part of #1`,
+            // and the subject gains the pull request number when the merge
+            // squashes it. Adopting the bracketed form would refuse every commit
+            // already on the mainline, which is a change to how this board
+            // writes commits rather than a check on a change, and #26 asks for
+            // neither.
+
+            // --- Check 1c: not adopted, the commit message character set -------
+            // The sibling board holds every commit message to an explicit
+            // repertoire, which is what refuses a bidirectional control or a
+            // homoglyph in text that can only be repaired by rewriting history.
+            // `Reject Trojan Source Unicode` here reads tracked files and never
+            // git metadata, so that gap is real on this board and nothing below
+            // closes it. It is named here rather than left silent, and it is not
+            // part of what #26 asks for.
+
+            // --- Check 2: a version bump owes a changelog entry (FAIL) ---------
+            // Two packaging files carry a version, one per claimed server line,
+            // and either of them moving is a release change. The version field
+            // is not touched by anything else, so this stays silent on every
+            // pull request that is not one.
+            const PACKAGING_FILES = ['build.yaml', 'build-jf12.yaml'];
+            const bumped = files
+              .filter((f) => PACKAGING_FILES.includes(f.filename))
+              .filter((f) => f.patch && /^\+\s*version:/m.test(f.patch))
+              .map((f) => f.filename);
+            if (
+              failTierApplies &&
+              bumped.length > 0 &&
+              !changed.includes('CHANGELOG.md')
+            ) {
+              failures.push(
+                `\`version:\` changed in ${bumped.join(' and ')} but CHANGELOG.md ` +
+                  'was not touched. A version somebody can see in their plugin ' +
+                  'list with nothing saying what it changed is a number without ' +
+                  'a reason.',
+              );
+            }
+
+            // --- Check 3: the diff is large (WARN) -----------------------------
+            // Advisory and never red. Generated and lock files are left out so
+            // the count is of what a person wrote and a person has to read.
+            const isGenerated = (name) =>
+              name.endsWith('packages.lock.json') ||
+              name.endsWith('.min.js') ||
+              name.endsWith('.min.css');
+            const churn = files
+              .filter((f) => !isGenerated(f.filename))
+              .reduce((sum, f) => sum + f.additions + f.deletions, 0);
+            const WARN_AT = 400;
+            if (churn >= WARN_AT) {
+              warnings.push(
+                `This pull request changes ${churn} lines, excluding generated ` +
+                  `and lock files. Review quality falls off past about ${WARN_AT} ` +
+                  'lines, so this one is worth a closer look. It is not a limit ' +
+                  'and nothing here refuses it.',
+              );
+            }
+
+            // --- Check 4: the plugin moved and no test did (WARN) --------------
+            // Advisory. A comment pass, a documentation change inside a source
+            // file or a pure refactor legitimately moves no test, and failing
+            // those is the false positive that makes a check worthless.
+            const codeChanged = changed.some(
+              (n) => n.startsWith('Jellyfin.Plugin.Requests/') && n.endsWith('.cs'),
+            );
+            const testsChanged = changed.some((n) =>
+              n.startsWith('Jellyfin.Plugin.Requests.Tests/'),
+            );
+            if (codeChanged && !testsChanged) {
+              warnings.push(
+                'A .cs file under Jellyfin.Plugin.Requests/ changed and nothing ' +
+                  'under Jellyfin.Plugin.Requests.Tests/ did. Either the change ' +
+                  'is genuinely untestable, which is worth saying in the body, ' +
+                  'or a test is missing.',
+              );
+            }
+
+            // --- Report --------------------------------------------------------
+            for (const w of warnings) {
+              core.warning(w);
+            }
+            const summary = core.summary.addHeading('Pull request hygiene', 2);
+            if (failures.length === 0 && warnings.length === 0) {
+              summary.addRaw('Every check passed and nothing was skipped.');
+            } else {
+              if (failures.length) {
+                summary.addHeading('Refused', 3).addList(failures);
+              }
+              if (warnings.length) {
+                summary.addHeading('Advisory, nothing is refused', 3).addList(warnings);
+              }
+            }
+            await summary.write();
+
+            if (failures.length) {
+              core.setFailed(failures.join(' | '));
+            }

--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -43,9 +43,9 @@ This one:
 Thirteen contexts against three, and the gap is not the same as the gap in what
 runs. Most of the thirteen have a counterpart running here already and are
 simply not required, which is a repository setting rather than a file in this
-tree. What ran on the last change to land, at `1a18979`:
+tree. What ran on `db1a28b`, the head of the change that added the hygiene job:
 
-    $ gh api repos/iderex/jellyfin-plugin-requests/commits/1a18979/check-runs \
+    $ gh api repos/Flowfin/jellyfin-plugin-requests/commits/db1a28b/check-runs \
         --jq '.check_runs[].name' | sort -u
     Analyze (actions, none)
     Analyze (csharp, manual)
@@ -57,20 +57,21 @@ tree. What ran on the last change to land, at `1a18979`:
     CodeQL
     DCO sign-off
     dependency-review
+    Deterministic pull request hygiene checks
     floor 10.11.0.0
     floor 12.0.0.0
     lines
     Reject Trojan Source Unicode
     zizmor
 
-Four of the thirteen have no counterpart running here at all: the two packaging
-contexts, the pull request hygiene checks and the greppable invariant lint.
-Those are #108, #109, #26 and #28. The rest run and are not required, and the
-section below is the set that says which of them should be.
+Three of the thirteen have no counterpart running here at all: the two packaging
+contexts and the greppable invariant lint. Those are #108, #109 and #28. It was
+four until the hygiene job landed under #26. The rest run and are not required,
+and the section below is the set that says which of them should be.
 
 ## The set to require
 
-Thirteen contexts, named exactly as the checks name themselves. A required check
+Fourteen contexts, named exactly as the checks name themselves. A required check
 is matched literally: the ruleset holds a string, GitHub compares it to the name
 a check run reports, and nothing reconciles the two. So renaming a job does not
 rename a requirement, it removes one and leaves the ruleset asking for a name
@@ -86,6 +87,7 @@ name below was copied out of a run rather than out of a workflow file.
     Check formatting
     DCO sign-off
     dependency-review
+    Deterministic pull request hygiene checks
     floor 10.11.0.0
     floor 12.0.0.0
     lines
@@ -132,7 +134,7 @@ command is right:
     call / test
     Reject Trojan Source Unicode
 
-Three of the thirteen. The set above is not applied: a ruleset is a repository
+Three of the fourteen. The set above is not applied: a ruleset is a repository
 setting rather than a file in this tree, and nothing in this change touches one.
 #30 carries the application and the demonstration that a red check refuses a
 merge.
@@ -153,7 +155,12 @@ merge.
 - `Analyze (csharp)` there is `Analyze (csharp, manual)` here, and two more
   beside it, because the build mode is part of the matrix job's name and this
   repository scans three languages rather than one.
-- `Deterministic PR-hygiene checks` has no counterpart running here; #26.
+- `Deterministic PR-hygiene checks` there is
+  `Deterministic pull request hygiene checks` here, which is the same job under a
+  name written out, and its blocking tier reaches a different audience: the
+  inside set there is owner and member, and here it also holds collaborator,
+  because the value a workflow reads out of the event payload and the value the
+  API returns for the same pull request disagree on this board.
 - `Enforce greppable invariants` has no counterpart running here; #28.
 - `prettier` there is `Check formatting` here, which is the same workflow under
   a job name of its own.
@@ -167,42 +174,42 @@ merge.
 Named by file, because two files can produce one context and one file can
 produce several.
 
-| File there                  | Here            | Reasoning                                                                                                                                                                      |
-| --------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `build.yml`                 | adopted, #108   | It is the reusable packaging leg, and packaging on a pull request is what catches a broken package before release day instead of on it.                                        |
-| `codeql.yml`                | adopted, landed | `scan-codeql.yaml` names this repository's own language set and branch triggers rather than the default that would have covered the default branch and nothing else.           |
-| `dco.yml`                   | adopted, landed | It arrived with this tree, it runs on every pull request, and the record that it refuses a commit with no sign-off is below.                                                   |
-| `dependency-review.yml`     | adopted, landed | It arrived with this tree and refuses a newly introduced dependency carrying a published advisory, which is the one supply-chain failure a diff can be judged for.             |
-| `dotnet.yml`                | adopted, landed | It carries the build, test and floor legs there; here they are `gate.yaml` and `abi-floor.yaml`, because the shared workflows know nothing about this tree's multi-targeting.  |
-| `e2e-login.yml`             | declined        | There is no authentication flow here to drive end to end, and the risk it stands for, a packaged plugin that builds but does not load, is covered by the run in `testing.md`.  |
-| `fuzz.yml`                  | declined        | The untrusted input here is authenticated JSON from the server's own API rather than an anonymous credential, and round-trip tests over the persisted schema in #47 cover it.  |
-| `manifest-freshness.yml`    | adopted, #111   | A publish that reports success and leaves the manifest untouched ships nothing installable, and nothing else would notice.                                                     |
-| `nightly-betas.yml`         | declined        | Nothing is shipping yet and a nightly channel before a first release is a channel with nothing in it; nothing covers that risk here because there is no risk to cover yet.     |
-| `opengrep.yml`              | adopted, #28    | Several rules on this board are patterns a compiler cannot refuse and a document can only ask for.                                                                             |
-| `pr-hygiene.yml`            | adopted, #26    | It reasons about the change rather than about the code, which nothing else here does.                                                                                          |
-| `prettier.yml`              | adopted, landed | This plugin ships HTML, CSS and JavaScript inside the assembly and no .NET analyzer reaches any of it, and the markdown is where everything here is argued.                    |
-| `publish-beta.yml`          | declined        | It publishes to a beta channel this repository has not decided to have, and nothing covers that risk here because no channel exists to protect; #110 is where that is decided. |
-| `publish-failure-alert.yml` | adopted, #111   | A freshness check whose failure sits unread in a run log is not a check.                                                                                                       |
-| `publish-jf12-beta.yml`     | declined        | Same beta channel, second line, and the same absence of anything to protect.                                                                                                   |
-| `publish-jf12-stable.yml`   | adopted, #110   | The 12.0 line is claimed in `build-jf12.yaml` and a claimed line with no release path is a claim nobody can install.                                                           |
-| `publish.yml`               | adopted, #110   | The 10.11 line's release path, and the `publish.yaml` here is inherited and knows nothing about two lines.                                                                     |
-| `regenerate-manifest.yml`   | adopted, #110   | The manifest is regenerated by the release path rather than edited by hand, because a hand-edited manifest drifts against what was actually published.                         |
-| `scorecard.yml`             | adopted, landed | It arrived with this tree and its push trigger named a branch this repository does not have, so until #25 it did not run on the default branch once.                           |
-| `stryker-mutation.yml`      | adopted, landed | The transition table and the authorisation checks are exactly the small branchy code where line coverage says little and a surviving mutant is a missing negative test.        |
-| `unicode-guard.yml`         | adopted, landed | It arrived with this tree, it is the one inherited guard already in the required set, and the record that it refuses a bidirectional control character is below.               |
-| `wiki-lint.yml`             | declined        | There is no wiki here and the documentation lives in the tree, where the ordinary gate already reaches it.                                                                     |
-| `zizmor.yml`                | adopted, landed | It arrived with this tree, its push trigger named a branch this repository does not have, and it was red on the tree as it stood until the inherited callers were pinned.      |
+| File there                  | Here            | Reasoning                                                                                                                                                                                           |
+| --------------------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `build.yml`                 | adopted, #108   | It is the reusable packaging leg, and packaging on a pull request is what catches a broken package before release day instead of on it.                                                             |
+| `codeql.yml`                | adopted, landed | `scan-codeql.yaml` names this repository's own language set and branch triggers rather than the default that would have covered the default branch and nothing else.                                |
+| `dco.yml`                   | adopted, landed | It arrived with this tree, it runs on every pull request, and the record that it refuses a commit with no sign-off is below.                                                                        |
+| `dependency-review.yml`     | adopted, landed | It arrived with this tree and refuses a newly introduced dependency carrying a published advisory, which is the one supply-chain failure a diff can be judged for.                                  |
+| `dotnet.yml`                | adopted, landed | It carries the build, test and floor legs there; here they are `gate.yaml` and `abi-floor.yaml`, because the shared workflows know nothing about this tree's multi-targeting.                       |
+| `e2e-login.yml`             | declined        | There is no authentication flow here to drive end to end, and the risk it stands for, a packaged plugin that builds but does not load, is covered by the run in `testing.md`.                       |
+| `fuzz.yml`                  | declined        | The untrusted input here is authenticated JSON from the server's own API rather than an anonymous credential, and round-trip tests over the persisted schema in #47 cover it.                       |
+| `manifest-freshness.yml`    | adopted, #111   | A publish that reports success and leaves the manifest untouched ships nothing installable, and nothing else would notice.                                                                          |
+| `nightly-betas.yml`         | declined        | Nothing is shipping yet and a nightly channel before a first release is a channel with nothing in it; nothing covers that risk here because there is no risk to cover yet.                          |
+| `opengrep.yml`              | adopted, #28    | Several rules on this board are patterns a compiler cannot refuse and a document can only ask for.                                                                                                  |
+| `pr-hygiene.yml`            | adopted, landed | It reasons about the change rather than about the code, which nothing else here does; `pr-hygiene.yaml` carries the two blocking checks and the two advisory ones, and not its commit-message pair. |
+| `prettier.yml`              | adopted, landed | This plugin ships HTML, CSS and JavaScript inside the assembly and no .NET analyzer reaches any of it, and the markdown is where everything here is argued.                                         |
+| `publish-beta.yml`          | declined        | It publishes to a beta channel this repository has not decided to have, and nothing covers that risk here because no channel exists to protect; #110 is where that is decided.                      |
+| `publish-failure-alert.yml` | adopted, #111   | A freshness check whose failure sits unread in a run log is not a check.                                                                                                                            |
+| `publish-jf12-beta.yml`     | declined        | Same beta channel, second line, and the same absence of anything to protect.                                                                                                                        |
+| `publish-jf12-stable.yml`   | adopted, #110   | The 12.0 line is claimed in `build-jf12.yaml` and a claimed line with no release path is a claim nobody can install.                                                                                |
+| `publish.yml`               | adopted, #110   | The 10.11 line's release path, and the `publish.yaml` here is inherited and knows nothing about two lines.                                                                                          |
+| `regenerate-manifest.yml`   | adopted, #110   | The manifest is regenerated by the release path rather than edited by hand, because a hand-edited manifest drifts against what was actually published.                                              |
+| `scorecard.yml`             | adopted, landed | It arrived with this tree and its push trigger named a branch this repository does not have, so until #25 it did not run on the default branch once.                                                |
+| `stryker-mutation.yml`      | adopted, landed | The transition table and the authorisation checks are exactly the small branchy code where line coverage says little and a surviving mutant is a missing negative test.                             |
+| `unicode-guard.yml`         | adopted, landed | It arrived with this tree, it is the one inherited guard already in the required set, and the record that it refuses a bidirectional control character is below.                                    |
+| `wiki-lint.yml`             | declined        | There is no wiki here and the documentation lives in the tree, where the ordinary gate already reaches it.                                                                                          |
+| `zizmor.yml`                | adopted, landed | It arrived with this tree, its push trigger named a branch this repository does not have, and it was red on the tree as it stood until the inherited callers were pinned.                           |
 
 ## One row per workflow here with no counterpart there
 
-Nine files here map onto a file there and are placed by the table above:
+Ten files here map onto a file there and are placed by the table above:
 `dco.yml`, `dependency-review.yml`, `mutation.yaml`, `prettier.yml`,
-`publish.yaml`, `scan-codeql.yaml`, `scorecard.yml`, `unicode-guard.yml` and
-`zizmor.yml`. Three of the rows below are the rest, and nine plus three is what
-the directory holds:
+`pr-hygiene.yaml`, `publish.yaml`, `scan-codeql.yaml`, `scorecard.yml`,
+`unicode-guard.yml` and `zizmor.yml`. Three of the rows below are the rest, and
+ten plus three is what the directory holds:
 
     $ ls .github/workflows/ | wc -l
-    12
+    13
 
 Those three do have a counterpart there and are listed here anyway, because what
 they are is not what it is: `dotnet.yml` is one file there and three here, and


### PR DESCRIPTION
Closes #26.

Every other check on this board reasons about the code. Nothing looked at the
pull request itself: whether it names the issue it belongs to, and whether a
version bump also recorded what changed for somebody who has the plugin
installed. No analyzer, formatter, scan or build could catch either, because
neither is a fact about a file.

`.github/workflows/pr-hygiene.yaml` is this repository's own, one
`actions/github-script` step against the pull request API, rather than an
external review service reading every diff before I do. Nothing is
checked out, no untrusted value reaches a shell, and the job asks for
`contents: read` and `pull-requests: read` and no write.

Means: the input is pull request metadata that only the GitHub API holds, and the
step that reads it runs inside a workflow, so the means is JavaScript in a
`github-script` step. It adds no runtime the gate does not already start, the
action is pinned by digest, and the alternative that would have added one, an
external review service, is the thing this issue asks to be replaced.

## The tiers

Blocking: the issue reference in the body, and a changelog entry behind a version
bump in either packaging file. Both stay silent on a change that is not one.

Advisory, never red: diff size, and a plugin change with no test change. A
rename, a documentation move or a comment pass legitimately exceeds any cap and
legitimately moves no test. A merge blocked for either teaches people to split a
change badly, which is the opposite of what a size check is for.

The blocking tier is skipped for two audiences for two different reasons, and
both skips are written at the check and annotated on the run. An automated
dependency update has no issue to link, because the update is the whole change.
An author from outside this repository has no way to know the issue numbers this
board expects, and often no issue exists yet. What the bot skip costs is in the
same annotation: a version bump from a bot would still owe a changelog entry and
is not checked.

## The audience the tier reaches, which was wrong first

The inside set started as owner and member, copied from the sibling board, and on
this board it skipped the blocking tier for every pull request. The
`author_association` field is not one value. What a workflow reads out of the
event payload and what the API returns for the same pull request disagree here.
Run 31258684361, on the throwaway head carrying both blocking defects at once,
was green and said why:

    ##[warning]The blocking tier was skipped because the author is outside this
    repository (author_association: COLLABORATOR)

    gh api repos/Flowfin/jellyfin-plugin-requests/pulls/163 --jq '.author_association'
    MEMBER

The value that decides the check is the one the workflow reads, so collaborator
joined the set and the reason is written at the check. This was found by watching
the check run rather than by reading it.

## Evidence

Three runs, one per tier plus the clean case.

The blocking tier refuses. Throwaway head, no issue reference in the body and a
version moved in both packaging files with the changelog untouched, closed
without merging:

    gh api repos/Flowfin/jellyfin-plugin-requests/actions/runs/31258895376 --jq '.conclusion,.head_sha'
    failure
    d44c2ed...

    ##[error]The body carries no issue reference. Name the issue this change
    belongs to, for example `Closes #12` or `Part of #12`. | `version:` changed in
    build-jf12.yaml and build.yaml but CHANGELOG.md was not touched. A version
    somebody can see in their plugin list with nothing saying what it changed is a
    number without a reason.

The advisory tier annotates and stays green. Throwaway head, a .cs file under the
plugin with no test change and 513 changed lines, closed without merging:

    gh api repos/Flowfin/jellyfin-plugin-requests/actions/runs/31258897077 --jq '.conclusion,.head_sha'
    success
    9fc6ed9...

    ##[warning]This pull request changes 513 lines, excluding generated and lock
    files. Review quality falls off past about 400 lines, so this one is worth a
    closer look. It is not a limit and nothing here refuses it.
    ##[warning]A .cs file under Jellyfin.Plugin.Requests/ changed and nothing
    under Jellyfin.Plugin.Requests.Tests/ did. Either the change is genuinely
    untestable, which is worth saying in the body, or a test is missing.

A change that owes nothing produces neither. This pull request's own head:

    gh api repos/Flowfin/jellyfin-plugin-requests/actions/runs/31258879106 --jq '.conclusion,.head_sha'
    success
    db1a28b...

with no error and no warning annotation in its log.

Under those, a harness that extracts the script from the workflow file at run
time rather than copying it, so it cannot drift against what runs. Sixteen
scenarios, both directions of every leg:

    $ node hygiene-harness.js .
    ok    inside author, body names an issue, nothing else moved  [refused=false, advisory=0]
    ok    inside author, body names no issue  [refused=true, advisory=0]
    ok    inside author, body names an issue by URL  [refused=false, advisory=0]
    ok    version bumped in build.yaml, CHANGELOG.md untouched  [refused=true, advisory=0]
    ok    version bumped in build-jf12.yaml, CHANGELOG.md untouched  [refused=true, advisory=0]
    ok    version bumped and CHANGELOG.md touched  [refused=false, advisory=0]
    ok    packaging file touched without moving the version line  [refused=false, advisory=0]
    ok    large diff only, advisory  [refused=false, advisory=1]
    ok    large diff made of lock files only, not counted  [refused=false, advisory=0]
    ok    plugin code changed, no test change, advisory  [refused=false, advisory=1]
    ok    plugin code changed with a test change  [refused=false, advisory=0]
    ok    bot author with no issue reference and an unlogged version bump  [refused=false, advisory=1]
    ok    outside author with no issue reference  [refused=false, advisory=1]
    ok    collaborator is inside the blocking tier  [refused=true, advisory=0]
    ok    no association at all is outside the blocking tier  [refused=false, advisory=1]
    ok    member is inside the blocking tier  [refused=true, advisory=0]

    16/16 scenarios as expected

Each blocking leg proved to bite by removing it. Dropping `build-jf12.yaml` from
the packaging list:

    FAIL  version bumped in build-jf12.yaml, CHANGELOG.md untouched
            expected failed=true, got false (null)
            failure text missing "build-jf12.yaml": null
    14/15 scenarios as expected

Disabling the issue-reference refusal:

    FAIL  inside author, body names no issue
            expected failed=true, got false (null)
    FAIL  member is inside the blocking tier
            expected failed=true, got false (null)
    13/15 scenarios as expected

## What is not adopted from the sibling board

Its bracketed commit subject rule is a commit message convention rather than a
check on a change, and it is not this board's, which puts the reference in the
message body. Adopting it would refuse every commit already on the mainline.

Its commit message character set covers git metadata. `Reject Trojan Source
Unicode` here reads tracked files and never git metadata, so that gap is real on
this board, nothing closes it, and no issue holds it today. It is named at the
check rather than left silent, and it is outside what #26 asks for.

## Second commit, and a path outside the issue's scope

`docs/quality-parity.md` said the pull request hygiene checks had no counterpart
running here and named #26 beside the row. This change makes that false, so the
row, the counts, the required set and the directory count move with it. That file
is outside the `Scope:` line on #26, which names `.github/workflows/`, and it is
touched anyway because the sentence this change falsifies is in it. It is one
topic with the first commit rather than a second one.

The required set in that document is now fourteen names. Applying it is #30 and
is a repository setting rather than a file here, so nothing in this change
touches one, and the hygiene job holds no merge until somebody does.

## What the evidence does not cover

The harness is not tracked. Adding a JavaScript suite to a tree whose only test
project is .NET is a means decision this issue did not take, so what is tracked
is the workflow, and what a reader gets is the command and its output rather than
a check that re-runs it.

The bot skip is exercised by a fake author object in the harness and by no real
run. This account cannot open a pull request as a bot, so the live proof is the
next automated dependency update and does not exist yet. That is stated rather
than described as covered.

This change has had no second reader. The evidence above stands in place of one.
