### PR TITLE
Throwaway head: prove the hygiene check refuses

### DIFF
--- a/build-jf12.yaml
+++ b/build-jf12.yaml
@@ -10,7 +10,7 @@ name: "Requests"
 # PackagingMetadataTests.BothPackagesClaimTheSameIdentity refuses them diverging on it.
 guid: "0f9c9107-b31b-459e-81fa-6d35dac25e79"
 imageUrl: "https://raw.githubusercontent.com/Flowfin/jellyfin-plugin-requests/master/img/logo.png"
-version: "0.1.0.0"
+version: "0.2.0.0"
 # The 12.0 line's floor and the runtime it provides.
 targetAbi: "12.0.0.0"
 framework: "net10.0"

--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@
 name: "Requests"
 guid: "0f9c9107-b31b-459e-81fa-6d35dac25e79"
 imageUrl: "https://raw.githubusercontent.com/Flowfin/jellyfin-plugin-requests/master/img/logo.png"
-version: "0.1.0.0"
+version: "0.2.0.0"
 # Packaging metadata for the Jellyfin 10.11 line. The oldest server of that line this package claims
 # to load on, and the runtime that line provides. The project compiles against a newer 10.11.x SDK,
 # so a floor build against this number is what would show that every API the plugin calls also exists


### PR DESCRIPTION
A throwaway pull request, opened to be refused and closed without merging. It is
not a change anybody wants, and it was not merged.

Its body carries no issue reference on purpose, which is the first blocking leg
of the hygiene check. Its head moves the version in both packaging files and
leaves the changelog alone, which is the second.

Both fired in one run, and the run is red:

    gh api repos/Flowfin/jellyfin-plugin-requests/actions/runs/31258895376 --jq '"\(.id)  \(.name)  \(.head_sha[0:7])  \(.conclusion)"'
    31258895376  PR hygiene  d44c2ed  failure

    ##[error]The body carries no issue reference. Name the issue this change
    belongs to, for example `Closes #12` or `Part of #12`. | `version:` changed
    in build-jf12.yaml and build.yaml but CHANGELOG.md was not touched. A version
    somebody can see in their plugin list with nothing saying what it changed is
    a number without a reason.

The first run on this head, 31258684361, was green, and that is why this head
exists twice. The blocking tier was skipped for an inside author because the
value the workflow reads out of the event payload is not the value the API
returns. That is fixed on the branch this was opened against, and the run above
is the same head after the fix.

Closed unmerged. The run identifier is what the change carrying the check quotes.
