### PR TITLE
Throwaway head: prove the advisory tier annotates and stays green

### DIFF
--- a/Jellyfin.Plugin.Requests/Plugin.cs
+++ b/Jellyfin.Plugin.Requests/Plugin.cs
@@ -1,4 +1,5 @@
 using System;
+// Throwaway edit: a comment-only change to the plugin, so the advisory tier fires.
 using System.Collections.Generic;
 using System.Globalization;
 using Jellyfin.Plugin.Requests.Configuration;

--- a/docs/throwaway-size-probe.md
+++ b/docs/throwaway-size-probe.md
@@ -1,0 +1,512 @@
+# Size probe
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+
+A throwaway file. It exists to push this pull request past the advisory size
+threshold so the annotation can be watched happening on a run that stays green.
+


### PR DESCRIPTION
Part of #26, and a throwaway pull request that was closed without merging.

Its body carries an issue reference and it moves no version, so the blocking tier
had nothing to say. It changes a .cs file under the plugin with no matching test
change, and it is over the advisory size threshold. Both advisory checks
annotated and the run stayed green, which is what the tier is for:

    gh api repos/Flowfin/jellyfin-plugin-requests/actions/runs/31258897077 --jq '"\(.id)  \(.name)  \(.head_sha[0:7])  \(.conclusion)"'
    31258897077  PR hygiene  9fc6ed9  success

    ##[warning]This pull request changes 513 lines, excluding generated and lock
    files. Review quality falls off past about 400 lines, so this one is worth a
    closer look. It is not a limit and nothing here refuses it.
    ##[warning]A .cs file under Jellyfin.Plugin.Requests/ changed and nothing
    under Jellyfin.Plugin.Requests.Tests/ did. Either the change is genuinely
    untestable, which is worth saying in the body, or a test is missing.

Closed unmerged. The run identifier is what the change carrying the check quotes.
