### PR TITLE
Throwaway head: prove the three invariant rules refuse the tree (#28)

### DIFF
--- a/.github/workflows/invariant-lint.yaml
+++ b/.github/workflows/invariant-lint.yaml
@@ -1,0 +1,79 @@
+# The greppable invariants of this repository, refused rather than written down.
+#
+# Some rules on this board are not expressible as a compiler warning and are
+# trivially expressible as a pattern. Until this workflow existed a document
+# could only ask for them. The set is tools/opengrep/rules.yaml, one rule per
+# invariant, added the first time an invariant is decided rather than in a batch
+# afterwards.
+#
+# Two steps, and both are needed. The first scans the repository and fails on any
+# finding, which is what makes a rule a gate. The second scans the fixtures and
+# fails unless every declared rule fired on one, because a rule that quietly
+# stopped matching anything is indistinguishable from a clean tree, and the first
+# step alone would report the same green either way.
+#
+# Supply chain. Opengrep publishes no action and no container image, so the exact
+# release binary is pinned by version and by SHA-256 and the download is checked
+# against it before anything runs. No `curl | bash` and no floating `latest`.
+# Bump the two together; a version moved without its checksum fails the run
+# rather than installing whatever is behind the tag now.
+name: Repo Invariant Lint
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: ["**"]
+
+# Explicit deny-all at workflow level; the job below grants only the read access
+# it needs to check the tree out.
+permissions: {}
+
+# Cancel a superseded run on the same ref so a new push or pull-request update
+# does not queue behind an obsolete check.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  invariants:
+    # The check name the branch ruleset would require. It is matched literally,
+    # so renaming this job removes a requirement instead of renaming one.
+    name: Enforce greppable invariants
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    env:
+      # Pinned Opengrep release. OPENGREP_SHA256 is the sha256sum of the
+      # opengrep_manylinux_x86 asset for exactly this tag, which is what makes
+      # the download tamper-evident.
+      OPENGREP_VERSION: "v1.25.0"
+      OPENGREP_SHA256: "9ac4aebb47ba3f7b0d8fc641ac8749cb6c2f253f616131a67d9631e00d4bea33"
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # No step pushes via git, so do not persist the GITHUB_TOKEN in .git/config.
+          persist-credentials: false
+
+      - name: Install Opengrep, pinned and checksum-verified
+        run: |
+          set -euo pipefail
+          url="https://github.com/opengrep/opengrep/releases/download/${OPENGREP_VERSION}/opengrep_manylinux_x86"
+          # --proto '=https' --tlsv1.2 refuse any non-HTTPS transport, including
+          # on a redirect, so the download cannot be downgraded to plaintext.
+          curl -fSL --proto '=https' --tlsv1.2 --retry 3 --retry-delay 2 -o opengrep "$url"
+          echo "${OPENGREP_SHA256}  opengrep" | sha256sum -c -
+          chmod +x opengrep
+
+      - name: Refuse an invariant broken anywhere in the tree
+        # --error is what makes a finding a failed check. The rule set is a local
+        # file, so the scan reaches no network. The fixture directory is excluded
+        # here because every file in it violates a rule on purpose; if this
+        # exclusion is ever dropped the step reds on the fixtures rather than
+        # going quietly green.
+        run: ./opengrep scan --config tools/opengrep/rules.yaml --error --exclude 'tools/opengrep/fixtures' .
+
+      - name: Prove every rule still refuses something
+        run: ./tools/opengrep/prove-rules-fire.sh

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -30,6 +30,9 @@ concurrency:
   group: publish-${{ github.ref_name }}
   cancel-in-progress: false
 
+# Planted for proof/28-invariants-refuse: a release cut by hand, which is the
+# shape release-created-only-by-a-tag-push exists to refuse.
+#   gh release create "$TAG" --title "$TAG" --notes-file CHANGELOG.md
 jobs:
   gate:
     name: Release metadata gate

--- a/Jellyfin.Plugin.Requests.Tests/PluginConstructionTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/PluginConstructionTests.cs
@@ -22,6 +22,12 @@ public class PluginConstructionTests
     [Fact]
     public void PluginConstructsAgainstTheDoubles()
     {
+        // Planted for proof/28-invariants-refuse: a second call site, which is the
+        // shape plugin-constructed-only-by-the-host-double exists to refuse.
+        using var paths = new FakeApplicationPaths();
+        var plugin = new Plugin(paths, new FakeXmlSerializer());
+        Assert.NotNull(plugin);
+
         using var host = new PluginHost();
 
         Assert.NotNull(host.Plugin);

--- a/Jellyfin.Plugin.Requests/Model/MediaRequest.cs
+++ b/Jellyfin.Plugin.Requests/Model/MediaRequest.cs
@@ -88,7 +88,7 @@ public sealed record MediaRequest
     /// Gets where the request stands. Defaults to <see cref="RequestState.Open"/>, because a
     /// request that was never decided is the state a new one is in.
     /// </summary>
-    public RequestState State { get; init; } = RequestState.Open;
+    public RequestState State { get; set; } = RequestState.Open;
 
     /// <summary>
     /// Gets when the state last moved. On a request nothing has decided this is when it was

--- a/tools/opengrep/fixtures/model/SettableRequestProperty.cs
+++ b/tools/opengrep/fixtures/model/SettableRequestProperty.cs
@@ -1,0 +1,20 @@
+// Fixture for request-model-property-is-not-settable. This file is in no
+// project and is never compiled; it exists so the rule can be watched refusing
+// the mistake it names.
+//
+// The near-miss is a property added to the record in the shape most C# is
+// written in, by somebody who did not read the paragraph in MediaRequest saying
+// the record is immutable. It compiles, every test still passes, and the
+// transition table and the history can be walked around from that moment on.
+
+namespace Jellyfin.Plugin.Requests.Model;
+
+public sealed record FixtureRequest
+{
+    // Legal neighbour, left here on purpose: this is the shape the model uses
+    // and the rule has to stay quiet on it.
+    public required string DisplayTitle { get; init; }
+
+    // The regression.
+    public RequestState State { get; set; }
+}

--- a/tools/opengrep/fixtures/release/publish-by-hand.sh
+++ b/tools/opengrep/fixtures/release/publish-by-hand.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Fixture for release-created-only-by-a-tag-push. Nothing runs this file; it
+# exists so the rule can be watched refusing the mistake it names.
+#
+# The near-miss is the one somebody actually makes: a publish step that has the
+# archive in hand and reaches for the shortest way to get it in front of people,
+# rather than pushing the tag and letting the release metadata gate run first.
+set -euo pipefail
+
+tag="$1"
+archive="$2"
+
+# Legal neighbour, left here on purpose: reading is not mutating, and the rule
+# has to stay quiet on this line for docs/versioning.md to keep counting
+# releases.
+gh release list --repo Flowfin/jellyfin-plugin-requests --json tagName --jq 'length'
+
+# The regression. Each of these burns the tag it names.
+gh release create "$tag" --title "$tag" --notes "cut by hand"
+gh release upload "$tag" "$archive"
+gh release edit "$tag" --draft=false
+gh release delete-asset "$tag" "$archive"
+gh release delete "$tag"

--- a/tools/opengrep/fixtures/suite/ConstructsThePluginDirectly.cs
+++ b/tools/opengrep/fixtures/suite/ConstructsThePluginDirectly.cs
@@ -1,0 +1,32 @@
+// Fixture for plugin-constructed-only-by-the-host-double. This file is in no
+// project and is never compiled; it exists so the rule can be watched refusing
+// the mistake it names.
+//
+// The near-miss is a second call site, written by somebody who wanted one more
+// assertion and had the two doubles already to hand. It reads as harmless. What
+// it costs is the property PluginHost exists for: with two call sites, adding a
+// host service to the constructor no longer stops the suite from building, and
+// the test that was never updated goes on passing against a plugin the server
+// would construct differently.
+
+namespace Jellyfin.Plugin.Requests.Tests.Fixtures;
+
+internal sealed class ConstructsThePluginDirectly
+{
+    // Legal neighbour, left here on purpose: this is how the suite reaches the
+    // plugin and the rule has to stay quiet on it.
+    public static void ThroughTheHost()
+    {
+        using var host = new PluginHost();
+        _ = host.Plugin.Name;
+    }
+
+    // The regression, in both spellings the suite could write it.
+    public static void ByHand()
+    {
+        var plugin = new Plugin(new FakeApplicationPaths(), new FakeXmlSerializer());
+        var aliased = new PluginUnderTest(new FakeApplicationPaths(), new FakeXmlSerializer());
+        _ = plugin.Name;
+        _ = aliased.Name;
+    }
+}

--- a/tools/opengrep/prove-rules-fire.sh
+++ b/tools/opengrep/prove-rules-fire.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Every rule in tools/opengrep/rules.yaml has to be watched refusing something,
+# or the clean tree the gate reports means nothing: a rule that matches no file
+# and a rule that matches nothing because the tree is good look identical from
+# outside.
+#
+# This scans the fixture directory, collects the rule ids that actually fired,
+# and fails unless every declared rule is among them. A rule whose pattern
+# stopped matching, a fixture that was edited until it no longer violates
+# anything, and a rule added with no fixture all red the gate here.
+#
+# The gate's other step scans the repository with the same rule set and the
+# fixture directory excluded, and requires no findings at all. The two steps are
+# the two halves: this one says each rule bites, that one says nothing in the
+# tree is bitten.
+set -euo pipefail
+
+opengrep=${OPENGREP:-./opengrep}
+rules=tools/opengrep/rules.yaml
+fixtures=tools/opengrep/fixtures
+findings=fixture-findings.json
+
+# The declared set, read out of the rule file rather than written here, so a
+# rule added without a fixture is caught instead of being invisible to its own
+# proof.
+declared=$(sed -n 's/^  - id: \(.*\)$/\1/p' "$rules" | sort)
+if [ -z "$declared" ]; then
+    echo "no rule ids found in $rules" >&2
+    exit 1
+fi
+
+# Findings are not an error here, they are the point, so the scan runs without
+# --error and its exit status is only used to explain a missing report.
+set +e
+"$opengrep" scan --config "$rules" --json "$fixtures" >"$findings"
+status=$?
+set -e
+
+if ! jq -e 'has("results")' "$findings" >/dev/null 2>&1; then
+    echo "opengrep produced no results report (exit $status)" >&2
+    exit 1
+fi
+
+scan_errors=$(jq -r '(.errors // []) | length' "$findings")
+if [ "$scan_errors" != "0" ]; then
+    echo "opengrep reported $scan_errors error(s) while scanning the fixtures:" >&2
+    jq -r '(.errors // [])[] | "  \(.type // "error"): \(.message // .long_msg // "")"' "$findings" >&2
+    exit 1
+fi
+
+fired=$(jq -r '.results[].check_id' "$findings" | sort -u)
+
+echo "== rules declared in $rules"
+echo "$declared"
+echo
+echo "== rules the fixtures made fire"
+echo "${fired:-(none)}"
+echo
+
+missing=$(comm -23 <(printf '%s\n' "$declared") <(printf '%s\n' "$fired"))
+if [ -n "$missing" ]; then
+    echo "these rules fired on no fixture, so nothing proves they still bite:" >&2
+    printf '%s\n' "$missing" >&2
+    exit 1
+fi
+
+echo "every declared rule fired on a fixture"

--- a/tools/opengrep/prove-rules-fire.sh
+++ b/tools/opengrep/prove-rules-fire.sh
@@ -29,6 +29,18 @@ if [ -z "$declared" ]; then
     exit 1
 fi
 
+# A reported finding names its rule as the config path joined by dots and then
+# the id, `tools.opengrep.<id>`, so the two sides are compared with that prefix
+# stripped. Stripping it means taking everything after the last dot, which is
+# only the id while no id contains one. Refuse a dotted id rather than let this
+# quietly compare the wrong halves.
+dotted=$(printf '%s\n' "$declared" | grep '\.' || true)
+if [ -n "$dotted" ]; then
+    echo "rule ids may not contain a dot, because that is what separates an id from its config path:" >&2
+    printf '%s\n' "$dotted" >&2
+    exit 1
+fi
+
 # Findings are not an error here, they are the point, so the scan runs without
 # --error and its exit status is only used to explain a missing report.
 set +e
@@ -48,7 +60,7 @@ if [ "$scan_errors" != "0" ]; then
     exit 1
 fi
 
-fired=$(jq -r '.results[].check_id' "$findings" | sort -u)
+fired=$(jq -r '.results[].check_id' "$findings" | sed 's/^.*\.//' | sort -u)
 
 echo "== rules declared in $rules"
 echo "$declared"

--- a/tools/opengrep/rules.yaml
+++ b/tools/opengrep/rules.yaml
@@ -1,0 +1,105 @@
+# The greppable invariants of this repository, one rule per invariant.
+#
+# Some rules here are not expressible as a compiler warning and are trivially
+# expressible as a pattern. A document can only ask for them; this file is where
+# a machine refuses them. A rule is added the first time an invariant is decided,
+# not in a batch afterwards, and the comment above each rule names where the
+# decision was taken so a reader can argue with the decision rather than with the
+# pattern.
+#
+# Every rule is `generic` mode, which matches token sequences and needs no
+# language parser. That is deliberate: a C# parser that mis-parses a file turns a
+# refusal into silence, and a rule that can go quiet without anybody noticing is
+# worse than no rule.
+#
+# Every rule carries a fixture under fixtures/, and its own `paths.include` names
+# that fixture directory beside the real subject. `prove-rules-fire.sh` scans the
+# fixtures and fails unless every declared rule fires on one, so a rule that
+# stopped matching anything reds the gate instead of passing quietly. The tree
+# scan excludes the fixture directory; if that exclusion is ever dropped the tree
+# scan reds on the fixtures rather than going green.
+#
+# The clean tree is the negative half of the same proof: every rule below reports
+# nothing against the repository as it stands, so a finding is a regression and
+# never the state of the tree.
+rules:
+  # Invariant (release path): a release is published by pushing a tag, and
+  # nothing is created by hand. Decided in docs/RELEASING.md and stated again at
+  # the top of .github/workflows/publish.yaml. A GitHub release is immutable once
+  # it exists, so a hand-made release permanently burns the tag it was made for
+  # and skips every check in the gate job that the tag push runs. The read-only
+  # verbs are deliberately not refused: docs/versioning.md counts releases with
+  # `gh release list` and a count is not a mutation.
+  - id: release-created-only-by-a-tag-push
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      Do not create, edit, delete or upload a GitHub release by hand. Publishing
+      is a tag push and nothing else, because a release is immutable and a
+      hand-made one burns the tag and skips the release metadata gate. Read-only
+      verbs such as `gh release list` and `gh release view` are allowed.
+    patterns:
+      - pattern-either:
+          - pattern: gh release create
+          - pattern: gh release edit
+          - pattern: gh release delete
+          - pattern: gh release upload
+          - pattern: gh release delete-asset
+    paths:
+      include:
+        - ".github/workflows/**"
+        - "docs/**"
+        - "scripts/**"
+        - "tools/**"
+        - "**/*.sh"
+        - "**/*.ps1"
+      exclude:
+        # This file necessarily contains the refused verbs as its own patterns.
+        - "tools/opengrep/rules.yaml"
+
+  # Invariant (model): the request record is immutable, and a move produces a new
+  # value with `with` rather than an edit in place. Decided in
+  # Jellyfin.Plugin.Requests/Model/MediaRequest.cs, which says so in the type's
+  # own documentation. A settable property lets a caller move a request behind
+  # the back of the transition table and of the append-only history, which is the
+  # one thing the immutability was chosen to make impossible. `init` is the shape
+  # that stays legal; `set` in any accessibility is the regression.
+  - id: request-model-property-is-not-settable
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      A property under Model/ may not have a setter. The request record is
+      immutable and a move produces a new value with `with`, so that no caller
+      can change a request without going through the transition table and the
+      history. Use `init` instead of `set`.
+    patterns:
+      - pattern: set;
+    paths:
+      include:
+        - "Jellyfin.Plugin.Requests/Model/**/*.cs"
+        - "tools/opengrep/fixtures/model/**/*.cs"
+
+  # Invariant (suite): the plugin is constructed in exactly one place, the
+  # PluginHost double. Decided in
+  # Jellyfin.Plugin.Requests.Tests/Doubles/PluginHost.cs, which says so in its
+  # own documentation. Every host service the plugin injects is passed from that
+  # one call site, so a new constructor parameter stops the suite from building
+  # until its double exists. A second call site anywhere else is what quietly
+  # removes that property.
+  - id: plugin-constructed-only-by-the-host-double
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      Construct the plugin through the PluginHost double rather than calling its
+      constructor here. One call site is what makes a new host service a build
+      failure in the suite instead of a test that silently passes a null.
+    patterns:
+      - pattern-either:
+          - pattern: new Plugin(...)
+          - pattern: new PluginUnderTest(...)
+    paths:
+      include:
+        - "Jellyfin.Plugin.Requests.Tests/**/*.cs"
+        - "tools/opengrep/fixtures/suite/**/*.cs"
+      exclude:
+        - "Jellyfin.Plugin.Requests.Tests/Doubles/PluginHost.cs"


### PR DESCRIPTION
Not for merge. This head carries three deliberate defects and exists only so the
invariant lint can be watched refusing them in the tree it actually scans.

The fixture step in #165 proves each rule fires on a file written to be refused,
but the fixture directory is excluded from the tree scan, so it cannot show the
rule reaching a real file. Each plant here is the mistake its rule names: a
settable `State` on the request record, a second call site constructing the
plugin in the suite, and a release cut by hand in the publish workflow.

The run is quoted in #28 and this head is closed afterwards.

Part of #28