### PR TITLE
Throwaway head: prove the clock, identifier and wait rules refuse the tree (#34)

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Doubles/SequentialIdentifierSource.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/SequentialIdentifierSource.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Globalization;
+using System.Threading;
+using Jellyfin.Plugin.Requests.Identity;
+
+namespace Jellyfin.Plugin.Requests.Tests.Doubles;
+
+/// <summary>
+/// An identifier source the suite can predict. The nth identifier it hands out is the same value on
+/// every run and on every machine, so a test can assert which request it is looking at instead of
+/// reading back whatever the code produced and comparing it to itself.
+/// <para>
+/// The values are real, distinct <see cref="Guid"/>s and they are not
+/// <see cref="Guid.Empty"/>, because code that treats the empty identifier as "none" would
+/// otherwise be tested against the one value it is entitled to reject.
+/// </para>
+/// <para>
+/// The counter is incremented atomically, so two threads asking at once get two identifiers rather
+/// than one value twice. The store contract admits concurrent callers, and a double that cannot be
+/// used from two of them would decide what the suite is allowed to test.
+/// </para>
+/// </summary>
+internal sealed class SequentialIdentifierSource : IIdentifierSource
+{
+    private int issued;
+
+    /// <summary>
+    /// Gets how many identifiers have been handed out.
+    /// </summary>
+    public int Issued => Volatile.Read(ref issued);
+
+    /// <summary>
+    /// The identifier this source hands out at a given position, without asking it for one.
+    /// A test asserts against this rather than against a literal, so the shape lives in one place.
+    /// </summary>
+    /// <param name="position">Which one, counting from one.</param>
+    /// <returns>The identifier the nth call to <see cref="NewId"/> returns.</returns>
+    public static Guid At(int position)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(position, 1);
+
+        return Guid.ParseExact(
+            position.ToString("D32", CultureInfo.InvariantCulture),
+            "N");
+    }
+
+    /// <inheritdoc />
+    public Guid NewId() => At(Interlocked.Increment(ref issued));
+}

--- a/Jellyfin.Plugin.Requests.Tests/Doubles/TestClock.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/TestClock.cs
@@ -1,0 +1,42 @@
+using System;
+using Jellyfin.Plugin.Requests.Time;
+
+namespace Jellyfin.Plugin.Requests.Tests.Doubles;
+
+/// <summary>
+/// A clock the suite sets and moves. It is the reason no test here waits: a rule that depends on
+/// thirty days having passed is tested by moving this thirty days, which takes no time at all and
+/// gives the same answer on a slow machine as on a fast one.
+/// <para>
+/// It never moves on its own. Two reads with no <see cref="Advance"/> between them return the same
+/// moment, so a test that expected two events to be simultaneous gets that, and a test that wanted
+/// them apart has to say by how much.
+/// </para>
+/// </summary>
+internal sealed class TestClock : IClock
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TestClock"/> class.
+    /// </summary>
+    /// <param name="start">The moment the clock starts at.</param>
+    public TestClock(DateTimeOffset start)
+    {
+        UtcNow = start;
+    }
+
+    /// <inheritdoc />
+    public DateTimeOffset UtcNow { get; private set; }
+
+    /// <summary>
+    /// Moves the clock forward.
+    /// </summary>
+    /// <param name="by">How far forward. Must not be negative: a test that needs a clock going
+    /// backwards is testing something this double does not stand for, and letting it happen by
+    /// accident would hide it.</param>
+    public void Advance(TimeSpan by)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(by, TimeSpan.Zero);
+
+        UtcNow = UtcNow.Add(by);
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/Identity/IdentifierSourceTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Identity/IdentifierSourceTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Jellyfin.Plugin.Requests.Identity;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Identity;
+
+/// <summary>
+/// The two identifier sources: the one a server gets and the one the suite gets. The first has to
+/// be unpredictable and the second has to be predictable, and both have to avoid
+/// <see cref="Guid.Empty"/>, which code elsewhere is entitled to read as "no identifier".
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public class IdentifierSourceTests
+{
+    /// <summary>
+    /// The real source hands out a distinct, non-empty identifier every time.
+    /// </summary>
+    [Fact]
+    public void GuidSourceHandsOutDistinctIdentifiers()
+    {
+        var source = new GuidIdentifierSource();
+
+        var issued = Enumerable.Range(0, 100).Select(_ => source.NewId()).ToList();
+
+        Assert.DoesNotContain(Guid.Empty, issued);
+        Assert.Equal(issued.Count, issued.Distinct().Count());
+    }
+
+    /// <summary>
+    /// The double hands out the same series on every run, and a test can say which identifier the
+    /// next request will carry before anything has created one. That is the difference between
+    /// asserting which request is being looked at and reading back whatever the code produced.
+    /// </summary>
+    [Fact]
+    public void SequentialSourceIsPredictableBeforeItIsAsked()
+    {
+        var source = new SequentialIdentifierSource();
+
+        Assert.Equal(0, source.Issued);
+        Assert.Equal(SequentialIdentifierSource.At(1), source.NewId());
+        Assert.Equal(SequentialIdentifierSource.At(2), source.NewId());
+        Assert.Equal(2, source.Issued);
+    }
+
+    /// <summary>
+    /// The double's values are distinct and none of them is the empty identifier, which is the one
+    /// value code treating an identifier as optional is allowed to reject.
+    /// </summary>
+    [Fact]
+    public void SequentialSourceAvoidsTheEmptyIdentifier()
+    {
+        var source = new SequentialIdentifierSource();
+
+        var issued = Enumerable.Range(0, 50).Select(_ => source.NewId()).ToList();
+
+        Assert.DoesNotContain(Guid.Empty, issued);
+        Assert.Equal(issued.Count, issued.Distinct().Count());
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/PluginConstructionTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/PluginConstructionTests.cs
@@ -24,6 +24,10 @@ public class PluginConstructionTests
     {
         using var host = new PluginHost();
 
+        // Planted for proof/34-clock-and-identifier-refuse: a wait in a test, which is the shape
+        // no-waiting-in-a-test refuses.
+        System.Threading.Thread.Sleep(1);
+
         Assert.NotNull(host.Plugin);
         Assert.False(string.IsNullOrWhiteSpace(host.Plugin.Name));
         Assert.NotEqual(Guid.Empty, host.Plugin.Id);

--- a/Jellyfin.Plugin.Requests.Tests/PluginServiceRegistrationTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/PluginServiceRegistrationTests.cs
@@ -1,0 +1,62 @@
+using System.Diagnostics.CodeAnalysis;
+using Jellyfin.Plugin.Requests.Identity;
+using Jellyfin.Plugin.Requests.Time;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests;
+
+/// <summary>
+/// What the server ends up holding on this plugin's behalf. The registrator is the only place a
+/// server is told which implementation to use, so a registration that was dropped or pointed at the
+/// wrong type would leave the plugin resolving nothing on a real server while every test that hands
+/// its own doubles in went on passing.
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public class PluginServiceRegistrationTests
+{
+    /// <summary>
+    /// A server asking for the clock gets the machine's clock, and a server asking for the
+    /// identifier source gets the framework's generator. Those are the defaults nothing should have
+    /// to configure.
+    /// </summary>
+    [Fact]
+    public void ServerGetsTheRealImplementations()
+    {
+        using var provider = Registered();
+
+        Assert.IsType<SystemClock>(provider.GetRequiredService<IClock>());
+        Assert.IsType<GuidIdentifierSource>(provider.GetRequiredService<IIdentifierSource>());
+    }
+
+    /// <summary>
+    /// Two things asking for the clock get the same clock. A second instance is not a second
+    /// opinion about the time, and two objects created while handling one request must not disagree
+    /// about the moment it happened.
+    /// </summary>
+    [Fact]
+    public void ClockAndIdentifierSourceAreOnePerServer()
+    {
+        using var provider = Registered();
+
+        Assert.Same(provider.GetRequiredService<IClock>(), provider.GetRequiredService<IClock>());
+        Assert.Same(
+            provider.GetRequiredService<IIdentifierSource>(),
+            provider.GetRequiredService<IIdentifierSource>());
+    }
+
+    private static ServiceProvider Registered()
+    {
+        var services = new ServiceCollection();
+
+        // The application host is passed in by the server and this registrator does not read it,
+        // so the suite has nothing to build here. If a registration ever needs it, this line stops
+        // compiling or throws, which is the signal to give the suite a host double.
+        new PluginServiceRegistrator().RegisterServices(services, null!);
+
+        return services.BuildServiceProvider();
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/Time/ClockTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Time/ClockTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using Jellyfin.Plugin.Requests.Time;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Time;
+
+/// <summary>
+/// The two clocks: the one a server gets and the one the suite gets. What is being checked is that
+/// the first reads the machine and the second reads only what a test told it, because those two
+/// properties together are what let every later test about ordering, retention and staleness be
+/// written without waiting for anything.
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public class ClockTests
+{
+    /// <summary>
+    /// The real clock reads the machine's clock. It is bracketed rather than compared to a single
+    /// reading, because two reads of a moving clock are never equal and a test that demanded they
+    /// were would fail for being right.
+    /// </summary>
+    [Fact]
+    public void SystemClockReadsTheMachineClock()
+    {
+        var before = DateTimeOffset.UtcNow;
+        var read = new SystemClock().UtcNow;
+        var after = DateTimeOffset.UtcNow;
+
+        Assert.InRange(read, before, after);
+        Assert.Equal(TimeSpan.Zero, read.Offset);
+    }
+
+    /// <summary>
+    /// The test clock does not move on its own. This is the property the whole apparatus rests on:
+    /// if it drifted, a test asserting that two things happened at the same moment would pass or
+    /// fail on how busy the machine was.
+    /// </summary>
+    [Fact]
+    public void TestClockStandsStillUntilItIsMoved()
+    {
+        var start = new DateTimeOffset(2026, 3, 1, 12, 0, 0, TimeSpan.Zero);
+        var clock = new TestClock(start);
+
+        Assert.Equal(start, clock.UtcNow);
+        Assert.Equal(clock.UtcNow, clock.UtcNow);
+    }
+
+    /// <summary>
+    /// Time is advanced by saying so, and the test takes no longer for it. Thirty days pass here in
+    /// the time it takes to add them, which is what a retention window or a staleness rule will be
+    /// tested against rather than with a sleep.
+    /// </summary>
+    [Fact]
+    public void TestClockAdvancesWithoutWaiting()
+    {
+        var start = new DateTimeOffset(2026, 3, 1, 12, 0, 0, TimeSpan.Zero);
+        var clock = new TestClock(start);
+        var startedAt = DateTimeOffset.UtcNow;
+
+        clock.Advance(TimeSpan.FromDays(30));
+
+        Assert.Equal(start.AddDays(30), clock.UtcNow);
+
+        // The real elapsed time of the test is nothing like the time the clock moved. A generous
+        // bound rather than a tight one: this is here to catch an implementation that waited, not
+        // to measure the machine.
+        Assert.True(DateTimeOffset.UtcNow - startedAt < TimeSpan.FromSeconds(5));
+    }
+
+    /// <summary>
+    /// Advancing by a negative span is refused. A clock going backwards is a real thing to test
+    /// against one day, and it has to be asked for rather than arrived at by a sign error in a
+    /// test that meant to move forward.
+    /// </summary>
+    [Fact]
+    public void TestClockRefusesToGoBackwards()
+    {
+        var clock = new TestClock(new DateTimeOffset(2026, 3, 1, 12, 0, 0, TimeSpan.Zero));
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => clock.Advance(TimeSpan.FromSeconds(-1)));
+    }
+}

--- a/Jellyfin.Plugin.Requests/Identity/GuidIdentifierSource.cs
+++ b/Jellyfin.Plugin.Requests/Identity/GuidIdentifierSource.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Jellyfin.Plugin.Requests.Identity;
+
+/// <summary>
+/// The identifier source a running server gets: the framework's own generator.
+/// <para>
+/// This is the one file in the plugin allowed to call it, and the invariant lint holds it to that.
+/// Everything else takes an <see cref="IIdentifierSource"/>, so there is one place where an
+/// unpredictable value enters and one place a test replaces.
+/// </para>
+/// </summary>
+public sealed class GuidIdentifierSource : IIdentifierSource
+{
+    /// <inheritdoc />
+    public Guid NewId() => Guid.NewGuid();
+}

--- a/Jellyfin.Plugin.Requests/Identity/IIdentifierSource.cs
+++ b/Jellyfin.Plugin.Requests/Identity/IIdentifierSource.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Jellyfin.Plugin.Requests.Identity;
+
+/// <summary>
+/// Where a new request's own identifier comes from. Everything that creates a request asks this and
+/// never calls the framework's generator directly.
+/// <para>
+/// The reason is that an identifier a test cannot predict is an identifier a test cannot assert on.
+/// A suite that generates its own values ends up either comparing nothing or re-reading whatever
+/// the code produced, which passes for any value including the wrong one. With the source injected
+/// a test knows which identifier the next request will carry, and a run is the same twice.
+/// </para>
+/// <para>
+/// This says nothing about uniqueness beyond what the implementation promises. The one a server
+/// gets is documented on <see cref="GuidIdentifierSource"/>, and a test double is free to hand out
+/// a short predictable series instead.
+/// </para>
+/// </summary>
+public interface IIdentifierSource
+{
+    /// <summary>
+    /// Produces an identifier for a request that is about to be created.
+    /// </summary>
+    /// <returns>The identifier. Never <see cref="Guid.Empty"/>.</returns>
+    Guid NewId();
+}

--- a/Jellyfin.Plugin.Requests/Plugin.cs
+++ b/Jellyfin.Plugin.Requests/Plugin.cs
@@ -36,6 +36,13 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// </summary>
     public static Plugin? Instance { get; private set; }
 
+    /// <summary>
+    /// Planted for proof/34-clock-and-identifier-refuse: the wall clock and the framework's
+    /// generator read straight out of the plugin, which is the shape the two rules refuse.
+    /// </summary>
+    public static string PlantedStamp =>
+        DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture) + Guid.NewGuid();
+
     /// <inheritdoc />
     public IEnumerable<PluginPageInfo> GetPages()
     {

--- a/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
@@ -1,0 +1,32 @@
+using Jellyfin.Plugin.Requests.Identity;
+using Jellyfin.Plugin.Requests.Time;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Plugins;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Jellyfin.Plugin.Requests;
+
+/// <summary>
+/// What the server puts in its container on this plugin's behalf. The host calls this once while it
+/// is building the container, so anything registered here can be injected into whatever the plugin
+/// later adds.
+/// <para>
+/// The two registrations are the clock and the identifier source. Both are the real implementations,
+/// which is what a server should get and what nothing has to configure. A test never calls this: it
+/// hands its own implementations in directly, which is the whole reason the two are interfaces.
+/// </para>
+/// <para>
+/// Both are singletons because both are stateless and because a second clock is not a second
+/// opinion about the time. A scoped registration would also mean two objects created in one request
+/// could disagree about the moment it happened.
+/// </para>
+/// </summary>
+public sealed class PluginServiceRegistrator : IPluginServiceRegistrator
+{
+    /// <inheritdoc />
+    public void RegisterServices(IServiceCollection serviceCollection, IServerApplicationHost applicationHost)
+    {
+        serviceCollection.AddSingleton<IClock, SystemClock>();
+        serviceCollection.AddSingleton<IIdentifierSource, GuidIdentifierSource>();
+    }
+}

--- a/Jellyfin.Plugin.Requests/Time/IClock.cs
+++ b/Jellyfin.Plugin.Requests/Time/IClock.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Jellyfin.Plugin.Requests.Time;
+
+/// <summary>
+/// What the plugin asks for the time. Everything that stamps a request, decides whether a retention
+/// window has passed, or compares two moments goes through this and never through the machine's
+/// clock directly.
+/// <para>
+/// The reason is what a test looks like otherwise. A retention rule that reads the wall clock can
+/// only be tested by waiting, so the test either sleeps, which makes it slow and then flaky, or it
+/// is written around the problem and stops being about the rule. With the clock injected a test
+/// says what time it is and the code under test believes it.
+/// </para>
+/// <para>
+/// It is an offset rather than a bare time, and it is UTC, for the same reason
+/// <see cref="Model.MediaRequest.RequestedAt"/> is: a server that moves timezone must not reorder
+/// its own queue.
+/// </para>
+/// </summary>
+public interface IClock
+{
+    /// <summary>
+    /// Gets the current moment in UTC.
+    /// </summary>
+    DateTimeOffset UtcNow { get; }
+}

--- a/Jellyfin.Plugin.Requests/Time/SystemClock.cs
+++ b/Jellyfin.Plugin.Requests/Time/SystemClock.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Jellyfin.Plugin.Requests.Time;
+
+/// <summary>
+/// The clock a running server gets: the machine's own, read in UTC.
+/// <para>
+/// This is the one file in the plugin allowed to read the system clock, and the invariant lint
+/// holds it to that. Everything else takes an <see cref="IClock"/>, so there is one place where the
+/// wall clock enters and one place a test replaces.
+/// </para>
+/// </summary>
+public sealed class SystemClock : IClock
+{
+    /// <inheritdoc />
+    public DateTimeOffset UtcNow => DateTimeOffset.UtcNow;
+}

--- a/tools/opengrep/fixtures/clock/ReadsTheWallClock.cs
+++ b/tools/opengrep/fixtures/clock/ReadsTheWallClock.cs
@@ -1,0 +1,29 @@
+// Fixture for clock-read-only-through-the-injected-clock. This file is in no
+// project and is never compiled; it exists so the rule can be watched refusing
+// the mistake it names.
+//
+// The near-miss is a retention sweep written by somebody who had no IClock to
+// hand and needed the time on one line. It works, it ships, and the only way to
+// test the window it implements is to wait for it.
+
+namespace Jellyfin.Plugin.Requests.Fixtures;
+
+internal sealed class ReadsTheWallClock
+{
+    // Legal neighbour, left here on purpose: this is how the plugin asks for the
+    // time and the rule has to stay quiet on it.
+    public static bool IsExpired(IClock clock, DateTimeOffset requestedAt) =>
+        clock.UtcNow - requestedAt > TimeSpan.FromDays(90);
+
+    // The regression, in each spelling the tree could pick up.
+    public static bool IsExpiredByTheMachineClock(DateTimeOffset requestedAt)
+    {
+        var utc = DateTime.UtcNow;
+        var local = DateTime.Now;
+        var day = DateTime.Today;
+        var offsetUtc = DateTimeOffset.UtcNow;
+        var offsetLocal = DateTimeOffset.Now;
+
+        return offsetUtc - requestedAt > TimeSpan.FromDays(90);
+    }
+}

--- a/tools/opengrep/fixtures/identity/MintsItsOwnIdentifier.cs
+++ b/tools/opengrep/fixtures/identity/MintsItsOwnIdentifier.cs
@@ -1,0 +1,20 @@
+// Fixture for identifier-minted-only-by-the-identifier-source. This file is in
+// no project and is never compiled; it exists so the rule can be watched
+// refusing the mistake it names.
+//
+// The near-miss is a create path that mints the identifier where it builds the
+// record, because that is the shortest way to write it. Every test about that
+// path then has to read the identifier back out of what it just created, so an
+// assertion about which request is being looked at compares a value to itself.
+
+namespace Jellyfin.Plugin.Requests.Fixtures;
+
+internal sealed class MintsItsOwnIdentifier
+{
+    // Legal neighbour, left here on purpose: this is where an identifier comes
+    // from and the rule has to stay quiet on it.
+    public static Guid Create(IIdentifierSource identifiers) => identifiers.NewId();
+
+    // The regression.
+    public static Guid CreateWithoutAsking() => Guid.NewGuid();
+}

--- a/tools/opengrep/fixtures/sleep/WaitsInATest.cs
+++ b/tools/opengrep/fixtures/sleep/WaitsInATest.cs
@@ -1,0 +1,26 @@
+// Fixture for no-waiting-in-a-test. This file is in no project and is never
+// compiled; it exists so the rule can be watched refusing the mistake it names.
+//
+// The near-miss is the first thing somebody reaches for when a timing test goes
+// red: give it a moment. The test passes on the machine it was written on and
+// fails on a loaded runner, and the failure is then read as flakiness rather
+// than as the test never having tested the rule.
+
+namespace Jellyfin.Plugin.Requests.Tests.Fixtures;
+
+internal sealed class WaitsInATest
+{
+    // Legal neighbour, left here on purpose: this is how a test moves time and
+    // the rule has to stay quiet on it.
+    public static void MovesTheClock(TestClock clock)
+    {
+        clock.Advance(TimeSpan.FromDays(30));
+    }
+
+    // The regression, in both spellings.
+    public static async Task WaitsForIt()
+    {
+        Thread.Sleep(250);
+        await Task.Delay(250).ConfigureAwait(false);
+    }
+}

--- a/tools/opengrep/rules.yaml
+++ b/tools/opengrep/rules.yaml
@@ -79,6 +79,79 @@ rules:
         - "Jellyfin.Plugin.Requests/Model/**/*.cs"
         - "tools/opengrep/fixtures/model/**/*.cs"
 
+  # Invariant (time, #34): the plugin reads the time through the injected IClock
+  # and never off the machine. Decided in #34, whose done-when names this rule.
+  # Code that reads the wall clock can only be tested by waiting for it, so the
+  # test either sleeps, which makes it slow and then flaky, or it is written
+  # around the rule it was meant to check. SystemClock is the one place the wall
+  # clock enters, and it is excluded here because it is the implementation this
+  # rule points everything else at.
+  - id: clock-read-only-through-the-injected-clock
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      Do not read the machine's clock here. Take an IClock and read IClock.UtcNow,
+      so a rule about retention, staleness or ordering can be tested by moving a
+      clock instead of by waiting (#34). SystemClock is the one place the wall
+      clock is read.
+    patterns:
+      - pattern-either:
+          - pattern: DateTime.UtcNow
+          - pattern: DateTime.Now
+          - pattern: DateTime.Today
+          - pattern: DateTimeOffset.UtcNow
+          - pattern: DateTimeOffset.Now
+    paths:
+      include:
+        - "Jellyfin.Plugin.Requests/**/*.cs"
+        - "tools/opengrep/fixtures/clock/**/*.cs"
+      exclude:
+        - "Jellyfin.Plugin.Requests/Time/SystemClock.cs"
+
+  # Invariant (identity, #34): a request's identifier comes from the injected
+  # IIdentifierSource and never from the framework's generator. Decided in #34,
+  # whose done-when names this rule. An identifier a test cannot predict is one a
+  # test cannot assert on, so a suite ends up reading back whatever the code
+  # produced and comparing it to itself, which passes for any value including the
+  # wrong one. GuidIdentifierSource is the one place the generator is called.
+  - id: identifier-minted-only-by-the-identifier-source
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      Do not mint an identifier here. Take an IIdentifierSource and call NewId,
+      so a test knows which identifier the next request will carry (#34).
+      GuidIdentifierSource is the one place the framework's generator is called.
+    patterns:
+      - pattern: Guid.NewGuid(...)
+    paths:
+      include:
+        - "Jellyfin.Plugin.Requests/**/*.cs"
+        - "tools/opengrep/fixtures/identity/**/*.cs"
+      exclude:
+        - "Jellyfin.Plugin.Requests/Identity/GuidIdentifierSource.cs"
+
+  # Invariant (suite, #34): no test waits for real time to pass. Decided in #34,
+  # whose done-when is the grep this rule makes standing rather than a state
+  # somebody checked once. The headless rule in docs/testing.md names real
+  # wall-clock waiting among the things a test may not need. A sleep is what
+  # somebody reaches for first when a timing test fails, and it converts a
+  # reproducible failure into one that depends on how busy the machine is.
+  - id: no-waiting-in-a-test
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      Do not wait in a test. Advance the TestClock instead, which moves time by
+      as much as the rule under test needs and takes none of it (#34). A sleep
+      makes a failure depend on how busy the machine is.
+    patterns:
+      - pattern-either:
+          - pattern: Thread.Sleep(...)
+          - pattern: Task.Delay(...)
+    paths:
+      include:
+        - "Jellyfin.Plugin.Requests.Tests/**/*.cs"
+        - "tools/opengrep/fixtures/sleep/**/*.cs"
+
   # Invariant (suite): the plugin is constructed in exactly one place, the
   # PluginHost double. Decided in
   # Jellyfin.Plugin.Requests.Tests/Doubles/PluginHost.cs, which says so in its


### PR DESCRIPTION
Not for merge. This head carries three deliberate defects and exists only so the
three rules added under #34 can be watched refusing them in the tree the gate
actually scans.

The fixture step proves each rule fires on a file written to be refused, but the
fixture directory is excluded from the tree scan, so it cannot show a rule
reaching a real file. Each plant here is the mistake its rule names: the wall
clock and the framework's generator read straight out of `Plugin.cs`, and a wait
inside a test.

The run is quoted in #34 and this head is closed afterwards.

Part of #34