### PR TITLE
Measure coverage in the gated run and hold it to a floor (#36)

### DIFF
--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -90,4 +90,86 @@ jobs:
       - name: Test every claimed target framework
         # --no-build, so the assemblies under test are the ones the step above
         # produced and not a second build made with different settings.
-        run: dotnet test Jellyfin.Plugin.Requests.sln --configuration Release --no-build
+        #
+        # Coverage is collected here rather than in a run of its own, because a
+        # second run would be a second build of the same tree and would report a
+        # number for code the gate did not test. The collector ships with
+        # Microsoft.NET.Test.Sdk, so this adds nothing to the dependency graph.
+        # Both target frameworks run and the collector writes one merged report,
+        # so a line reached on either line counts as reached.
+        run: >-
+          dotnet test Jellyfin.Plugin.Requests.sln --configuration Release --no-build
+          --collect "Code Coverage;Format=cobertura" --results-directory coverage
+
+      - name: Hold the plugin's line coverage to its floor
+        # The floor is a ratchet against drift and not a target. What it catches
+        # is a change that adds code nobody tested; what it cannot catch is a
+        # test that executes a line without asserting anything about it. The rule
+        # in docs/testing.md carries that half, and this number is the cheap one.
+        #
+        # The percentage is covered lines over recorded lines for the plugin's own
+        # package, which is what the report holds and what the reader can
+        # recompute. The test project's own coverage is not counted: a suite
+        # measuring itself says nothing.
+        env:
+          # Measured at 79.50% on b1d401b, the commit this step landed against.
+          # Raise it when the number rises; never lower it to make a run pass.
+          COVERAGE_FLOOR: "75"
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import glob
+          import os
+          import sys
+          import xml.etree.ElementTree as ET
+
+          floor = float(os.environ["COVERAGE_FLOOR"])
+          reports = sorted(glob.glob("coverage/**/*.cobertura.xml", recursive=True))
+          if not reports:
+              # Fail closed. A run that collected nothing must not read as a run
+              # that collected everything and found it fine.
+              sys.exit("no coverage report was produced, so nothing was measured")
+
+          covered = total = 0
+          per_file = {}
+          for report in reports:
+              for package in ET.parse(report).getroot().iter("package"):
+                  if package.get("name") != "Jellyfin.Plugin.Requests":
+                      continue
+                  for klass in package.iter("class"):
+                      name = klass.get("filename", "").replace("\\", "/").split("/")[-1]
+                      hit, seen = per_file.get(name, (0, 0))
+                      for line in klass.iter("line"):
+                          seen += 1
+                          total += 1
+                          if int(line.get("hits", "0")) > 0:
+                              hit += 1
+                              covered += 1
+                      per_file[name] = (hit, seen)
+
+          if total == 0:
+              sys.exit("the report holds no lines for the plugin's own package")
+
+          rate = 100.0 * covered / total
+          lines = [
+              "## Line coverage of the plugin",
+              "",
+              f"**{rate:.2f}%** of {total} recorded lines, floor {floor:.2f}%.",
+              "",
+              "| File | Covered | Recorded |",
+              "| --- | ---: | ---: |",
+          ]
+          for name in sorted(per_file):
+              hit, seen = per_file[name]
+              lines.append(f"| {name} | {hit} | {seen} |")
+
+          summary = os.environ.get("GITHUB_STEP_SUMMARY")
+          if summary:
+              with open(summary, "a", encoding="utf-8") as handle:
+                  handle.write("\n".join(lines) + "\n")
+
+          print(f"::notice title=Line coverage::{rate:.2f}% of {total} lines, floor {floor:.2f}%")
+          print(f"line coverage {rate:.2f}% over {total} lines, floor {floor:.2f}%")
+          if rate < floor:
+              sys.exit(f"line coverage {rate:.2f}% is below the floor of {floor:.2f}%")
+          PY

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -100,6 +100,62 @@ makes visible today, and the conditions above are what decide the next one. A te
 condition not yet met by any proposal gets its own entry here when the proposal arrives, together
 with what replaces it.
 
+## Coverage, and the rule it does not replace
+
+Full unit-test coverage is a claim somebody has to be able to check, so the gate collects the number
+on every run and refuses a run below a floor.
+
+### What is measured
+
+The `test` job of `gate.yaml` collects coverage in the same run that tests, because a second run
+would be a second build and would report a number for code the gate did not test. The collector
+ships with `Microsoft.NET.Test.Sdk`, so nothing was added to the dependency graph for it. Both
+claimed target frameworks run and the collector writes one merged report, so a line reached on
+either server line counts as reached.
+
+The number is covered lines over recorded lines, for the plugin's own package only. The suite's
+coverage of itself is not counted: a suite measuring itself says nothing.
+
+The floor is 75%, and it is in `gate.yaml` beside the step that reads it. It is a ratchet rather
+than a target: raise it when the number rises, and never lower it to make a run pass. A run below
+it fails `call / test`, which is a required check, and the number is written to the run's summary
+and printed as an annotation on the pull request either way, so a change that adds untested code is
+visible while it is being reviewed rather than afterwards.
+
+A run that produced no report fails as well. A run that collected nothing must not read as a run
+that collected everything and found it fine.
+
+To read the same number on a checkout:
+
+    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release --collect "Code Coverage;Format=cobertura" --results-directory coverage
+
+which was 79.50%, 128 of 161 recorded lines, on `b1d401b`.
+
+### The rule the percentage cannot carry
+
+A percentage says lines were executed. It does not say anything was asserted about them, and the
+lines that matter here are a small fraction of the total: a transition table has few lines and every
+one of them is a decision somebody can get wrong.
+
+So the rule beside the floor is this. **Every state transition, every authorisation refusal and
+every error path named in an issue on this board has a test that reaches it, and the test's name
+says which one.** The percentage catches drift; this catches the cases that matter.
+
+It is checkable by reading a test name against the issue that named the case, and it is meant to be
+checked that way rather than by a tool. An example of the shape, from the store contract in #45:
+
+    git grep -n 'AWriteAgainstAnOvertakenRevisionIsRefused' -- Jellyfin.Plugin.Requests.Tests/
+    Jellyfin.Plugin.Requests.Tests/Storage/RequestStoreContract.cs:129:    public async Task AWriteAgainstAnOvertakenRevisionIsRefusedAndSaysWhatTheStoreHolds()
+
+The issue named a refusal, the test names the same refusal, and a reader holding both can see in one
+line that the case is covered. A test called `ReplaceTest` would satisfy the percentage and fail
+this rule, which is the whole difference between the two.
+
+Nothing refuses a missing case. No check reads an issue, so this rule is read by a person, and a
+transition added with no test reaches the mainline as long as the percentage holds. What the floor
+does catch is the change large enough to move the number, which is not the same thing and is not
+offered as if it were.
+
 ## Does the plugin load on a real server
 
 A plugin that builds is not a plugin that loads. An ABI mismatch, an embedded resource path that


### PR DESCRIPTION
Closes #36.

The plan asks for full unit-test coverage. Nothing could check that, so the claim
sat where a reader had to take it on trust.

## What lands

Coverage is collected in the `test` job of `gate.yaml`, in the same run that
tests. A run of its own would be a second build of the same tree and would report
a number for code the gate did not test. The collector ships with
`Microsoft.NET.Test.Sdk`, so nothing was added to the dependency graph for it,
and both claimed target frameworks run into one merged report, so a line reached
on either server line counts as reached.

The number is covered lines over recorded lines for the plugin's own package. The
suite's coverage of itself is not counted, because a suite measuring itself says
nothing.

It is reported twice on the pull request, as a run summary table with a row per
file and as a `::notice` annotation carrying the percentage, so a change that adds
untested code is visible while it is being reviewed.

The floor is 75%, written beside the step that reads it, measured against 79.50%
on `b1d401b`. Below it `call / test` goes red, and that check is already required,
so this needed no new context and no change to the required set.

A run that produced no report fails too. A run that collected nothing must not
read as one that collected everything and found it fine.

## The rule the percentage cannot carry

A percentage says lines were executed, not that anything was asserted about them,
and the lines that matter here are few: a transition table has one line per
decision somebody can get wrong.

So `docs/testing.md` carries the rule beside the floor. Every state transition,
every authorisation refusal and every error path named in an issue on this board
has a test that reaches it, and the test's name says which one. The document
shows the shape with a case that already exists rather than describing it:

    git grep -n 'AWriteAgainstAnOvertakenRevisionIsRefused' -- Jellyfin.Plugin.Requests.Tests/
    Jellyfin.Plugin.Requests.Tests/Storage/RequestStoreContract.cs:129:    public async Task AWriteAgainstAnOvertakenRevisionIsRefusedAndSaysWhatTheStoreHolds()

A test called `ReplaceTest` satisfies the percentage and fails this rule, which is
the difference the two halves exist for.

## That it bites

The step's script was extracted from the workflow rather than copied, so the
harness cannot drift against what runs, and then run against the report this tree
produces:

    COVERAGE_FLOOR=75 python floor.py
    line coverage 79.50% over 161 lines, floor 75.00%
    exit=0

    COVERAGE_FLOOR=85 python floor.py
    line coverage 79.50% is below the floor of 85.00%
    exit=1

    COVERAGE_FLOOR=75 python floor.py     # in a directory holding no report
    no coverage report was produced, so nothing was measured
    exit=1

## What this does not do

Nothing refuses a missing case. No check reads an issue, so the rule above is read
by a person, and a transition added with no test reaches the mainline as long as
the percentage holds. `docs/testing.md` says that where the rule is rather than in
a footnote.

The floor is a ratchet and not a target. It catches the change big enough to move
the number and nothing smaller.

This board has no second reader tonight. The commands above stand in place of one.