### PR TITLE
Write down the storage medium and what the other two would have cost (#44)

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -1,0 +1,112 @@
+# Storage
+
+## The decision
+
+Requests are kept in a file this plugin writes itself, in the plugin's own data directory, serialised
+with the JSON support the runtime already provides.
+
+Three media were plausible. The two that were not chosen are below with the cost that decided each,
+so the next person can see this was a choice and can argue with the cost rather than with the
+outcome.
+
+## What was rejected, and why
+
+### The plugin configuration file
+
+The cheapest option, and wrong for a reason that has nothing to do with size.
+
+The dashboard rewrites the configuration file wholesale when an administrator saves any setting. It
+reads the whole document when the page loads and writes the whole document back on save, so anything
+added to that file between the two is overwritten. A request created while an administrator had the
+settings page open would be lost, and nothing would report it: the save succeeds, the file is valid,
+and the request is simply not in it.
+
+The second cost is shape rather than correctness. A settings file is a small document a person edits
+by hand when something has gone wrong. An unbounded list of records inside one is a file nobody can
+read at the moment they most need to.
+
+### A database file of the plugin's own
+
+The obvious answer, and the one that costs the most here, because this plugin claims two server
+lines.
+
+The database library is supplied by the host, and the two lines supply different major versions of
+it. Compiling against the host's copy means compiling against a different API per line. Shipping the
+plugin's own copy instead means shipping native components inside the package, and a native
+component that resolves on one line and not on the other is the failure class this repository
+already spends two ABI floor jobs on: it builds, it packages, it installs, and it throws at first
+use on one of the two lines.
+
+That cost is real rather than hypothetical for this tree. `build.yaml` and `build-jf12.yaml` claim
+`10.11` and `12.0` separately, and `docs/testing.md` records a run where a package built for one line
+was installed on the other and the server reported `Status=NotSupported`.
+
+## What the chosen medium costs
+
+The crash safety, the indexing and the concurrency are this plugin's to write. That is the whole of
+what a database would have supplied.
+
+At the size a request queue reaches, hundreds to a few thousand records, that is a small amount of
+code and it is the same code on both server lines, which is what the other two options could not
+offer. `IRequestStore` already states the concurrency the callers may rely on, so the promises exist
+before the implementation does.
+
+What is not decided here, and where it is:
+
+- What happens to a write interrupted halfway is #46.
+- The on-disk shape, its version, and the rules for changing it are #47.
+- Filtering, sorting and paging for the surfaces are #48.
+- How long a finished request is kept is #49, and the number itself is decision 5 on #113.
+
+## It adds no package reference
+
+The chosen medium needs nothing that is not already in the runtime. The plugin project's package
+references are the two Jellyfin assemblies and nothing else, and neither is added by this decision:
+
+    git grep -n 'PackageReference Include' -- Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.csproj Directory.Build.props
+    Directory.Build.props:54:        <PackageReference Include="SerilogAnalyzer" Version="0.15.0" PrivateAssets="All" />
+    Directory.Build.props:55:        <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
+    Directory.Build.props:56:        <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" PrivateAssets="All" />
+    Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.csproj:23:    <PackageReference Include="Jellyfin.Controller" Version="$(JellyfinVersion)">
+    Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.csproj:26:    <PackageReference Include="Jellyfin.Model" Version="$(JellyfinVersion)">
+
+The three analyzers are `PrivateAssets="All"` and are build-time only. The two Jellyfin references
+differ in version between the lines, which is what `JellyfinVersion` is for and what makes the point:
+the set of references is the same on both lines and this decision keeps it that way, where a
+database library would have made it differ.
+
+## The record fits without knowing where it is kept
+
+`MediaRequest` is a value with no behaviour and no dependencies, and `IRequestStore` names no file,
+no database and no serialisation. Nothing in either has to change for this medium, and nothing in
+either would have to change for a different one.
+
+That was measured rather than assumed. A request carrying every field, including a title with a
+comma, an accent and a quote in it, was serialised with `System.Text.Json` and read back, against the
+plugin as the tree has it:
+
+    every field back: True
+    no provider ids, no year, no mover: True
+
+    {"Id":"00000000-0000-0000-0000-000000000001","RequestedByUserId":"00000000-0000-0000-0000-000000000002","RequestedAt":"2026-03-01T12:00:00+00:00","Kind":1,"DisplayTitle":"A title with a comma, an accent \u00E9 and a quote \u0022","DisplayYear":1999,"ProviderIds":{"Tmdb":"603","Imdb":"tt0133093"},"State":1,"StateChangedAt":"2026-03-02T09:30:00+00:00","StateChangedByUserId":"00000000-0000-0000-0000-000000000003","Availability":2,"AvailabilityCheckedAt":"2026-03-03T00:00:00+00:00"}
+
+The second line is the case a store will meet constantly and is easy to get wrong: a request typed by
+hand carries no provider identifiers, no release year and nobody who moved it, and all three come
+back as the absence they were rather than as a default.
+
+One thing came out of that run which whoever writes the store needs, because it is not what the type
+looks like. The generated equality on the record is not value equality:
+
+    record == record: False
+    same value, two dictionaries, == says: False
+
+`ProviderIds` is an `IReadOnlyDictionary`, and a record compares that member by reference. So two
+requests holding the same values compare unequal whenever the dictionaries are two objects, which is
+every time one of them came off disk. A store deciding whether a write changed anything, or a test
+asserting that what was read is what was written, cannot use `==` for it and has to compare the
+dictionary itself. Nothing in the tree does that today; this is written here so the first thing that
+needs to does not discover it as a bug.
+
+The harness for those runs is not tracked. It is a console project referencing the plugin, and adding
+one to a tree whose only test project is the suite is a means decision this issue did not take. The
+round trip belongs in the suite when the store exists, which is #46.


### PR DESCRIPTION
Closes #44.

Three media were plausible and nothing in the tree said which one this plugin
uses. The first thing to write a store would have taken the decision by accident,
and nobody afterwards could have told a choice from a default.

## The decision

A file this plugin writes itself, in the plugin's own data directory, serialised
with the JSON support the runtime already provides. `docs/storage.md` carries it
with both rejected options and the cost that decided each.

- The configuration file is rewritten wholesale by the dashboard on any save, so
  a request created while an administrator had the settings page open is
  overwritten, and nothing reports it: the save succeeds and the file is valid.
- A database file is supplied by the host at a different major version on each
  claimed line, and shipping the plugin's own copy means shipping native
  components. That is the failure class this tree already spends two ABI floor
  jobs on, and `docs/testing.md` records a run of exactly that shape.

The cost of the answer is stated beside it: the crash safety, the indexing and
the concurrency are this plugin's to write, and that is the whole of what a
database would have supplied.

## The two conditions that could be measured

It adds no package reference. The plugin project references the two Jellyfin
assemblies and nothing else, and the three analyzers are build-time only:

    git grep -n 'PackageReference Include' -- Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.csproj Directory.Build.props
    Directory.Build.props:54:        <PackageReference Include="SerilogAnalyzer" Version="0.15.0" PrivateAssets="All" />
    Directory.Build.props:55:        <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
    Directory.Build.props:56:        <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" PrivateAssets="All" />
    Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.csproj:23:    <PackageReference Include="Jellyfin.Controller" Version="$(JellyfinVersion)">
    Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.csproj:26:    <PackageReference Include="Jellyfin.Model" Version="$(JellyfinVersion)">

The record fits the medium without knowing about it. A request carrying every
field, with a comma, an accent and a quote in the title, went through
`System.Text.Json` against the plugin as the tree has it and came back field for
field. So did the ordinary case a store will meet constantly: a request typed by
hand, with no provider identifiers, no release year and nobody who moved it, all
three returning as the absence they were rather than as a default.

    every field back: True
    no provider ids, no year, no mover: True

## What that run also found

    record == record: False
    same value, two dictionaries, == says: False

`ProviderIds` is an `IReadOnlyDictionary` and a record compares that member by
reference, so two requests holding the same values are unequal whenever the
dictionaries are two objects, which is every time one came off disk. A store
deciding whether a write changed anything cannot use `==` for it. Nothing in the
tree relies on that today, which is why this is a note in the document rather
than a fix.

## What this does not do

No store lands here. No done-when asks for one, and what is not decided in the
document is named in it with the issue that holds each: the interrupted write is
#46, the on-disk shape and its version #47, the query paths #48, and the
retention window #49 with its number as decision 5 on #113.

The harness that produced the round-trip output is not tracked. It is a console
project referencing the plugin, and adding one to a tree whose only test project
is the suite is a means decision this issue did not take. The round trip belongs
in the suite when the store exists, which is #46. What is tracked is the command
and its output.

This board has no second reader tonight. The output above stands in place of one.