### PR TITLE
Make a write survive being interrupted (#46)

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Doubles/InterruptingProviderIds.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/InterruptingProviderIds.cs
@@ -1,0 +1,49 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Jellyfin.Plugin.Requests.Tests.Doubles;
+
+/// <summary>
+/// A request's provider identifiers that cannot be read. Put on one request in a store that already
+/// holds others, it stops a write in the middle of the bytes rather than before them: the records
+/// ahead of it are already in the stream and on the disk when it throws.
+/// <para>
+/// This is what makes the interruption real rather than reconstructed. The alternative is to write
+/// a half file by hand and assert the store copes with it, which proves the loader and says nothing
+/// about whether a write can actually be stopped where the proof assumes it can.
+/// </para>
+/// </summary>
+internal sealed class InterruptingProviderIds : IReadOnlyDictionary<string, string>
+{
+    /// <inheritdoc />
+    public IEnumerable<string> Keys => throw new WriteInterruptedException();
+
+    /// <inheritdoc />
+    public IEnumerable<string> Values => throw new WriteInterruptedException();
+
+    /// <summary>
+    /// Gets a count that reads as an ordinary one, so nothing decides to skip this property before
+    /// reaching the point where the interruption happens.
+    /// </summary>
+    public int Count => 1;
+
+    /// <inheritdoc />
+    public string this[string key] => throw new WriteInterruptedException();
+
+    /// <inheritdoc />
+    public bool ContainsKey(string key) => throw new WriteInterruptedException();
+
+    /// <inheritdoc />
+    [SuppressMessage(
+        "Design",
+        "CA1065:Do not raise exceptions in unexpected locations",
+        Justification = "Throwing here is the whole point: this double exists to stop a write in the middle of serialising a record.")]
+    public IEnumerator<KeyValuePair<string, string>> GetEnumerator() => throw new WriteInterruptedException();
+
+    /// <inheritdoc />
+    public bool TryGetValue(string key, [MaybeNullWhen(false)] out string value) => throw new WriteInterruptedException();
+
+    /// <inheritdoc />
+    IEnumerator IEnumerable.GetEnumerator() => throw new WriteInterruptedException();
+}

--- a/Jellyfin.Plugin.Requests.Tests/Doubles/WriteInterruptedException.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/WriteInterruptedException.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace Jellyfin.Plugin.Requests.Tests.Doubles;
+
+/// <summary>
+/// Thrown from inside a request while it is being serialised, so a write stops in the middle of
+/// putting bytes on a disk. It stands for the server being killed at that moment, and it is thrown
+/// by <see cref="InterruptingProviderIds"/> rather than by anything the store can see coming.
+/// </summary>
+internal sealed class WriteInterruptedException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WriteInterruptedException"/> class.
+    /// </summary>
+    public WriteInterruptedException()
+        : base("The write was interrupted part way through the record being serialised.")
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WriteInterruptedException"/> class.
+    /// </summary>
+    /// <param name="message">What happened.</param>
+    public WriteInterruptedException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WriteInterruptedException"/> class.
+    /// </summary>
+    /// <param name="message">What happened.</param>
+    /// <param name="innerException">What it happened because of.</param>
+    public WriteInterruptedException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/SiblingIndependenceTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/SiblingIndependenceTests.cs
@@ -41,7 +41,18 @@ public class SiblingIndependenceTests
         "Microsoft.Extensions.DependencyInjection.Abstractions",
         "System.Collections",
         "System.Linq",
-        "System.Runtime"
+        "System.Runtime",
+
+        // The store keeps requests as JSON, so the serialiser the framework already ships is what
+        // reads and writes the file. It is part of the runtime the server provides on both claimed
+        // lines rather than a package this plugin carries, and choosing a serialiser from outside
+        // would have been a package in the install and a second thing to hold at a version.
+        "System.Text.Json",
+
+        // The store's calls are asynchronous and it holds one lock across a write, so the
+        // cancellation token, the task and the lock all come from here. It arrives with the store
+        // rather than with any decision of its own.
+        "System.Threading"
     ];
 
     /// <summary>

--- a/Jellyfin.Plugin.Requests.Tests/Storage/FileRequestStoreDurabilityTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Storage/FileRequestStoreDurabilityTests.cs
@@ -47,23 +47,33 @@ public sealed class FileRequestStoreDurabilityTests : IDisposable
     /// directory, including the three absences a hand-typed request arrives with. The comparison is
     /// field by field because <c>docs/storage.md</c> measured that the record's generated equality
     /// compares the provider identifiers by reference, which two dictionaries never satisfy once one
-    /// of them has come off a disk.
+    /// of them has come off a disk. The history is compared the same way and for the same reason: it
+    /// is held as an interface, so the generated equality compares the list itself and never its
+    /// entries, and a list that has been read back is a different list whatever it holds.
+    /// <para>
+    /// The state here is reached by making the move rather than by writing the state onto the
+    /// record, so the request carries a history and the round trip has one to lose. A request whose
+    /// history is empty would let a store that drops the field entirely pass this.
+    /// </para>
     /// </summary>
     /// <returns>A task that completes when the assertions have run.</returns>
     [Fact]
     public async Task EveryFieldComesBackFromAStoreOpenedFreshOverTheSameDirectory()
     {
         var directory = ADirectory();
-        var full = ARequest(1) with
-        {
-            DisplayTitle = "A title with a comma, an accent é and a quote \"",
-            DisplayYear = 1999,
-            ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tmdb"] = "603", ["Imdb"] = "tt0133093" },
-            State = RequestState.Approved,
-            StateChangedByUserId = new Guid("2b7b4f1d-4f0e-4a63-9a3d-0f5a1c9e77aa"),
-            Availability = LibraryAvailability.Partial,
-            AvailabilityCheckedAt = new DateTimeOffset(2026, 3, 3, 0, 0, 0, TimeSpan.Zero)
-        };
+        var approvedBy = new Guid("2b7b4f1d-4f0e-4a63-9a3d-0f5a1c9e77aa");
+        var full = RequestLifecycle.Move(
+            ARequest(1) with
+            {
+                DisplayTitle = "A title with a comma, an accent é and a quote \"",
+                DisplayYear = 1999,
+                ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tmdb"] = "603", ["Imdb"] = "tt0133093" },
+                Availability = LibraryAvailability.Partial,
+                AvailabilityCheckedAt = new DateTimeOffset(2026, 3, 3, 0, 0, 0, TimeSpan.Zero)
+            },
+            RequestState.Approved,
+            new DateTimeOffset(2026, 8, 8, 9, 0, 0, TimeSpan.Zero),
+            RequestCaller.Administrator(approvedBy));
 
         var bare = ARequest(2);
 
@@ -76,10 +86,21 @@ public sealed class FileRequestStoreDurabilityTests : IDisposable
         var readBare = await reading.GetAsync(bare.Id, CancellationToken.None).ConfigureAwait(true);
 
         Assert.NotNull(readFull);
-        Assert.Equal(full with { ProviderIds = readFull.Value.Request.ProviderIds }, readFull.Value.Request);
+        Assert.Equal(
+            full with
+            {
+                ProviderIds = readFull.Value.Request.ProviderIds,
+                History = readFull.Value.Request.History
+            },
+            readFull.Value.Request);
         Assert.Equal(
             full.ProviderIds.OrderBy(pair => pair.Key, StringComparer.Ordinal),
             readFull.Value.Request.ProviderIds.OrderBy(pair => pair.Key, StringComparer.Ordinal));
+
+        // Entry by entry, and the entries are records of values, so this compares what each move
+        // said and not which list it is in. The approval above is the one entry there is to lose.
+        Assert.Equal(full.History, readFull.Value.Request.History);
+        Assert.Single(readFull.Value.Request.History);
 
         Assert.NotNull(readBare);
         Assert.Null(readBare.Value.Request.DisplayYear);

--- a/Jellyfin.Plugin.Requests.Tests/Storage/FileRequestStoreDurabilityTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Storage/FileRequestStoreDurabilityTests.cs
@@ -1,0 +1,476 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Storage;
+
+/// <summary>
+/// What the durable store owes beyond the contract every store keeps: after an interruption at any
+/// point the store loads, at most the record being written is lost, and bytes that are not the
+/// document this store writes are refused rather than partly read.
+/// <para>
+/// Each proof here is made against real bytes on a real disk, read back by the loader that ships.
+/// The interruption is a write actually stopped in the middle rather than a half file written by
+/// hand, and the truncation legs walk every byte offset rather than a few chosen ones, because the
+/// offsets somebody picks by hand are the ones they already believed were safe.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class FileRequestStoreDurabilityTests : IDisposable
+{
+    /// <summary>
+    /// Enough requests that the serialiser has flushed part of the document to the disk before the
+    /// interrupted record is reached. With a handful of records the whole document fits in the
+    /// serialiser's buffer, nothing has reached the file when the write stops, and the leg would
+    /// prove the easy half of the property while looking like it proved both.
+    /// </summary>
+    private const int EnoughToHaveReachedTheDisk = 60;
+
+    private readonly List<FileRequestStore> _stores = [];
+    private readonly List<string> _directories = [];
+
+    /// <summary>
+    /// Every field of a request comes back as itself from a store opened fresh over the same
+    /// directory, including the three absences a hand-typed request arrives with. The comparison is
+    /// field by field because <c>docs/storage.md</c> measured that the record's generated equality
+    /// compares the provider identifiers by reference, which two dictionaries never satisfy once one
+    /// of them has come off a disk.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task EveryFieldComesBackFromAStoreOpenedFreshOverTheSameDirectory()
+    {
+        var directory = ADirectory();
+        var full = ARequest(1) with
+        {
+            DisplayTitle = "A title with a comma, an accent é and a quote \"",
+            DisplayYear = 1999,
+            ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tmdb"] = "603", ["Imdb"] = "tt0133093" },
+            State = RequestState.Approved,
+            StateChangedByUserId = new Guid("2b7b4f1d-4f0e-4a63-9a3d-0f5a1c9e77aa"),
+            Availability = LibraryAvailability.Partial,
+            AvailabilityCheckedAt = new DateTimeOffset(2026, 3, 3, 0, 0, 0, TimeSpan.Zero)
+        };
+
+        var bare = ARequest(2);
+
+        var writing = NewStore(directory);
+        await writing.AddAsync(full, CancellationToken.None).ConfigureAwait(true);
+        await writing.AddAsync(bare, CancellationToken.None).ConfigureAwait(true);
+
+        var reading = NewStore(directory);
+        var readFull = await reading.GetAsync(full.Id, CancellationToken.None).ConfigureAwait(true);
+        var readBare = await reading.GetAsync(bare.Id, CancellationToken.None).ConfigureAwait(true);
+
+        Assert.NotNull(readFull);
+        Assert.Equal(full with { ProviderIds = readFull.Value.Request.ProviderIds }, readFull.Value.Request);
+        Assert.Equal(
+            full.ProviderIds.OrderBy(pair => pair.Key, StringComparer.Ordinal),
+            readFull.Value.Request.ProviderIds.OrderBy(pair => pair.Key, StringComparer.Ordinal));
+
+        Assert.NotNull(readBare);
+        Assert.Null(readBare.Value.Request.DisplayYear);
+        Assert.Null(readBare.Value.Request.StateChangedByUserId);
+        Assert.Null(readBare.Value.Request.AvailabilityCheckedAt);
+        Assert.Empty(readBare.Value.Request.ProviderIds);
+    }
+
+    /// <summary>
+    /// A write stopped in the middle of the bytes. The caller is told, the file the loader reads has
+    /// not moved, and what is lost is the one record the write was adding and nothing else. The
+    /// store keeps working afterwards, which is the half a store that refuses to open ever again
+    /// would fail.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AWriteStoppedInTheMiddleReachesTheCallerAndCostsOnlyTheRecordItWasWriting()
+    {
+        var directory = ADirectory();
+        var store = NewStore(directory);
+
+        for (var ordinal = 1; ordinal <= EnoughToHaveReachedTheDisk; ordinal++)
+        {
+            await store.AddAsync(ABulkyRequest(ordinal), CancellationToken.None).ConfigureAwait(true);
+        }
+
+        var before = await File.ReadAllBytesAsync(store.FilePath, CancellationToken.None).ConfigureAwait(true);
+        var interrupted = ABulkyRequest(EnoughToHaveReachedTheDisk + 1) with { ProviderIds = new InterruptingProviderIds() };
+
+        var thrown = await Assert.ThrowsAnyAsync<Exception>(
+            () => store.AddAsync(interrupted, CancellationToken.None)).ConfigureAwait(true);
+
+        Assert.True(IsOrCarries<WriteInterruptedException>(thrown), thrown.ToString());
+
+        // The file the loader reads is byte for byte the one it was before the write started. This
+        // is the assertion the whole design is for, and it is made before anything else so that a
+        // store writing in place fails here rather than somewhere further down.
+        var after = await File.ReadAllBytesAsync(store.FilePath, CancellationToken.None).ConfigureAwait(true);
+        Assert.True(before.SequenceEqual(after));
+
+        var live = await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true);
+        Assert.Equal(EnoughToHaveReachedTheDisk, live.Count);
+        Assert.Null(await store.GetAsync(interrupted.Id, CancellationToken.None).ConfigureAwait(true));
+
+        var reopened = NewStore(directory);
+        var reloaded = await reopened.GetAllAsync(CancellationToken.None).ConfigureAwait(true);
+        Assert.Equal(EnoughToHaveReachedTheDisk, reloaded.Count);
+        Assert.Null(await reopened.GetAsync(interrupted.Id, CancellationToken.None).ConfigureAwait(true));
+
+        // The write had already put bytes on the disk when it stopped, so this was an interruption
+        // in the middle of a document rather than one before it started. An unclosed array is what a
+        // reader of that file would find, and nothing reads it.
+        var half = await File.ReadAllBytesAsync(store.PendingFilePath, CancellationToken.None).ConfigureAwait(true);
+        Assert.NotEmpty(half);
+        Assert.NotEqual((byte)']', half[^1]);
+
+        var added = await reopened.AddAsync(ABulkyRequest(EnoughToHaveReachedTheDisk + 2), CancellationToken.None).ConfigureAwait(true);
+        Assert.Equal(1, added.Revision);
+
+        var again = NewStore(directory);
+        Assert.Equal(EnoughToHaveReachedTheDisk + 1, (await again.GetAllAsync(CancellationToken.None).ConfigureAwait(true)).Count);
+    }
+
+    /// <summary>
+    /// The half file an interruption leaves, at every byte offset it could have stopped at. For each
+    /// one the store loads and holds exactly the set it held before the write, so the record being
+    /// written is the whole of what an interruption can cost.
+    /// <para>
+    /// Every offset rather than a sample, because the offsets a person chooses are the ones they
+    /// already expect to be safe, and the interesting one is whichever byte happens to sit at the
+    /// end of a buffer.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ThePendingFileStoppedAtEveryOffsetLeavesTheSetTheStoreHeldBeforeTheWrite()
+    {
+        var directory = ADirectory();
+        var seeding = NewStore(directory);
+        var kept = new List<Guid>();
+
+        for (var ordinal = 1; ordinal <= 3; ordinal++)
+        {
+            var request = ARequest(ordinal);
+            kept.Add(request.Id);
+            await seeding.AddAsync(request, CancellationToken.None).ConfigureAwait(true);
+        }
+
+        var before = await File.ReadAllBytesAsync(seeding.FilePath, CancellationToken.None).ConfigureAwait(true);
+
+        var fourth = ARequest(4);
+        await seeding.AddAsync(fourth, CancellationToken.None).ConfigureAwait(true);
+        var wholeWrite = await File.ReadAllBytesAsync(seeding.FilePath, CancellationToken.None).ConfigureAwait(true);
+
+        var offsets = 0;
+
+        for (var stopped = 0; stopped <= wholeWrite.Length; stopped++)
+        {
+            await File.WriteAllBytesAsync(seeding.FilePath, before, CancellationToken.None).ConfigureAwait(true);
+            await File.WriteAllBytesAsync(seeding.PendingFilePath, wholeWrite[..stopped], CancellationToken.None).ConfigureAwait(true);
+
+            var store = new FileRequestStore(directory);
+
+            try
+            {
+                var held = await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true);
+
+                Assert.Equal(3, held.Count);
+                Assert.Equal(kept.Order(), held.Select(stored => stored.Request.Id).Order());
+                Assert.DoesNotContain(held, stored => stored.Request.Id == fourth.Id);
+            }
+            finally
+            {
+                store.Dispose();
+            }
+
+            offsets++;
+        }
+
+        Assert.Equal(wholeWrite.Length + 1, offsets);
+    }
+
+    /// <summary>
+    /// The pending file is ignored rather than merely unreadable. Left behind whole, and holding a
+    /// set that differs from the one the store keeps, it still changes nothing about what loads.
+    /// <para>
+    /// The truncation leg above cannot say this on its own: a loader that read the pending file and
+    /// fell back to the other one whenever it failed to parse would pass every offset of it and
+    /// would take this file as the truth.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ACompletePendingFileIsIgnoredRatherThanRead()
+    {
+        var directory = ADirectory();
+        var seeding = NewStore(directory);
+        await seeding.AddAsync(ARequest(1), CancellationToken.None).ConfigureAwait(true);
+
+        var one = await File.ReadAllBytesAsync(seeding.FilePath, CancellationToken.None).ConfigureAwait(true);
+
+        var fourth = ARequest(4);
+        await seeding.AddAsync(fourth, CancellationToken.None).ConfigureAwait(true);
+        var two = await File.ReadAllBytesAsync(seeding.FilePath, CancellationToken.None).ConfigureAwait(true);
+
+        await File.WriteAllBytesAsync(seeding.FilePath, one, CancellationToken.None).ConfigureAwait(true);
+        await File.WriteAllBytesAsync(seeding.PendingFilePath, two, CancellationToken.None).ConfigureAwait(true);
+
+        var store = NewStore(directory);
+        var held = await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Single(held);
+        Assert.DoesNotContain(held, stored => stored.Request.Id == fourth.Id);
+    }
+
+    /// <summary>
+    /// The file the loader reads, cut short anywhere before its end. Every one of those is refused,
+    /// naming the file, rather than loading the records that did parse.
+    /// <para>
+    /// A partial read is the failure this stands against and it is quiet: the plugin comes up with a
+    /// shorter queue, nothing reports anything, and the first write afterwards puts the shorter
+    /// queue over the file that still held the rest.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task TheStoreFileCutShortAnywhereIsRefusedRatherThanPartlyRead()
+    {
+        var directory = ADirectory();
+        var seeding = NewStore(directory);
+
+        for (var ordinal = 1; ordinal <= 3; ordinal++)
+        {
+            await seeding.AddAsync(ARequest(ordinal), CancellationToken.None).ConfigureAwait(true);
+        }
+
+        var whole = await File.ReadAllBytesAsync(seeding.FilePath, CancellationToken.None).ConfigureAwait(true);
+        var refusals = 0;
+
+        for (var cut = 0; cut < whole.Length; cut++)
+        {
+            await File.WriteAllBytesAsync(seeding.FilePath, whole[..cut], CancellationToken.None).ConfigureAwait(true);
+
+            var store = new FileRequestStore(directory);
+
+            try
+            {
+                var refused = await Assert.ThrowsAsync<RequestStoreLoadException>(
+                    () => store.GetAllAsync(CancellationToken.None)).ConfigureAwait(true);
+
+                Assert.Equal(store.FilePath, refused.FilePath);
+            }
+            finally
+            {
+                store.Dispose();
+            }
+
+            refusals++;
+        }
+
+        Assert.Equal(whole.Length, refusals);
+
+        await File.WriteAllBytesAsync(seeding.FilePath, whole, CancellationToken.None).ConfigureAwait(true);
+        var reopened = NewStore(directory);
+        Assert.Equal(3, (await reopened.GetAllAsync(CancellationToken.None).ConfigureAwait(true)).Count);
+    }
+
+    /// <summary>
+    /// Bytes that parse but are not a set of requests this store could have written. Each is refused
+    /// with the file named, because each one leaves the store unable to say what it holds, and
+    /// answering anyway is the partial read under a different name.
+    /// <para>
+    /// What is deliberately not claimed here: a value changed inside a string is still a document
+    /// this store could have written, and nothing in it would notice. Noticing would need a checksum
+    /// over the bytes, which this store does not carry.
+    /// </para>
+    /// </summary>
+    /// <param name="damage">Which of the shapes the file is replaced by.</param>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Theory]
+    [InlineData("garbage")]
+    [InlineData("null")]
+    [InlineData("null-entry")]
+    [InlineData("no-request")]
+    [InlineData("revision-below-one")]
+    [InlineData("one-identifier-twice")]
+    public async Task BytesThatAreNotASetOfRequestsAreRefusedWithTheFileNamed(string damage)
+    {
+        var directory = ADirectory();
+        var seeding = NewStore(directory);
+        await seeding.AddAsync(ARequest(1), CancellationToken.None).ConfigureAwait(true);
+
+        var written = await File.ReadAllTextAsync(seeding.FilePath, Encoding.UTF8, CancellationToken.None).ConfigureAwait(true);
+        var entry = written[1..^1];
+
+        var damaged = damage switch
+        {
+            "garbage" => "this is not the document this store writes",
+            "null" => "null",
+            "null-entry" => "[null]",
+            "no-request" => "[{\"Revision\":1}]",
+            "revision-below-one" => written.Replace("\"Revision\":1", "\"Revision\":0", StringComparison.Ordinal),
+            _ => string.Format(CultureInfo.InvariantCulture, "[{0},{0}]", entry)
+        };
+
+        Assert.NotEqual(written, damaged);
+        await File.WriteAllTextAsync(seeding.FilePath, damaged, Encoding.UTF8, CancellationToken.None).ConfigureAwait(true);
+
+        var store = new FileRequestStore(directory);
+
+        try
+        {
+            var refused = await Assert.ThrowsAsync<RequestStoreLoadException>(
+                () => store.GetAllAsync(CancellationToken.None)).ConfigureAwait(true);
+
+            Assert.Equal(store.FilePath, refused.FilePath);
+            Assert.Contains(store.FilePath, refused.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            store.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// A write the file system refuses. The caller is told, the store goes on reporting what it
+    /// actually holds rather than what it was asked to hold, and the next write works once the
+    /// obstruction is gone.
+    /// <para>
+    /// This is not a full disk and does not claim to be one: filling a volume needs a volume to
+    /// fill, and making one needs the elevation the headless rule in <c>docs/testing.md</c> refuses.
+    /// What is proven instead is the property a full disk is one instance of. The write path catches
+    /// nothing, so every failure the file system raises reaches the caller by construction, and the
+    /// runtime reports an exhausted disk as one of those.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AWriteTheFileSystemRefusesReachesTheCallerAndDropsNothingQuietly()
+    {
+        var directory = ADirectory();
+        var store = NewStore(directory);
+        await store.AddAsync(ARequest(1), CancellationToken.None).ConfigureAwait(true);
+        await store.AddAsync(ARequest(2), CancellationToken.None).ConfigureAwait(true);
+
+        var before = await File.ReadAllBytesAsync(store.FilePath, CancellationToken.None).ConfigureAwait(true);
+
+        // Somewhere the write cannot put its file. What the platform raises differs between them and
+        // neither is caught anywhere in the write path.
+        Directory.CreateDirectory(store.PendingFilePath);
+
+        var third = ARequest(3);
+        var refused = await Assert.ThrowsAnyAsync<Exception>(
+            () => store.AddAsync(third, CancellationToken.None)).ConfigureAwait(true);
+
+        Assert.True(refused is IOException or UnauthorizedAccessException, refused.ToString());
+
+        Assert.Equal(2, (await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true)).Count);
+        Assert.Null(await store.GetAsync(third.Id, CancellationToken.None).ConfigureAwait(true));
+
+        var after = await File.ReadAllBytesAsync(store.FilePath, CancellationToken.None).ConfigureAwait(true);
+        Assert.True(before.SequenceEqual(after));
+
+        var reopened = NewStore(directory);
+        Assert.Equal(2, (await reopened.GetAllAsync(CancellationToken.None).ConfigureAwait(true)).Count);
+
+        Directory.Delete(store.PendingFilePath);
+        var added = await store.AddAsync(third, CancellationToken.None).ConfigureAwait(true);
+        Assert.Equal(1, added.Revision);
+        Assert.Equal(3, (await NewStore(directory).GetAllAsync(CancellationToken.None).ConfigureAwait(true)).Count);
+    }
+
+    /// <summary>
+    /// Removes every store this test made and the directory each one wrote in.
+    /// </summary>
+    public void Dispose()
+    {
+        foreach (var store in _stores)
+        {
+            store.Dispose();
+        }
+
+        foreach (var directory in _directories)
+        {
+            TestRunDirectory.Remove(directory);
+        }
+    }
+
+    /// <summary>
+    /// Whether an exception is the one named or carries it underneath. The serialiser is free to
+    /// wrap what a record throws, and the assertion is about what stopped the write rather than
+    /// about how many layers it arrived through.
+    /// </summary>
+    /// <typeparam name="T">The exception looked for.</typeparam>
+    /// <param name="thrown">What the caller was given.</param>
+    /// <returns>Whether it is there.</returns>
+    private static bool IsOrCarries<T>(Exception thrown)
+        where T : Exception
+    {
+        for (var carried = thrown; carried is not null; carried = carried.InnerException)
+        {
+            if (carried is T)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// A request with a predictable identifier, so a leg can say which records survived rather than
+    /// only how many.
+    /// </summary>
+    /// <param name="ordinal">Which one.</param>
+    /// <returns>A newly asked-for request.</returns>
+    private static MediaRequest ARequest(int ordinal)
+    {
+        var asked = new DateTimeOffset(2026, 8, 8, 8, 0, 0, TimeSpan.Zero);
+
+        return new MediaRequest
+        {
+            Id = new Guid(string.Format(CultureInfo.InvariantCulture, "00000000-0000-0000-0000-{0:D12}", ordinal)),
+            RequestedByUserId = new Guid("b31d0f9a-5c2e-4a71-8f6b-0d4c3e2a1b58"),
+            RequestedAt = asked,
+            StateChangedAt = asked,
+            Kind = RequestedItemKind.Movie,
+            DisplayTitle = string.Format(CultureInfo.InvariantCulture, "The Conversation {0}", ordinal)
+        };
+    }
+
+    /// <summary>
+    /// The same request with a title long enough that a set of them outgrows the serialiser's
+    /// buffer, which is what puts bytes on the disk before an interruption can happen.
+    /// </summary>
+    /// <param name="ordinal">Which one.</param>
+    /// <returns>A newly asked-for request.</returns>
+    private static MediaRequest ABulkyRequest(int ordinal)
+        => ARequest(ordinal) with { DisplayTitle = new string('t', 400) };
+
+    private string ADirectory()
+    {
+        var directory = TestRunDirectory.CreateSubdirectory();
+        _directories.Add(directory);
+        return directory;
+    }
+
+    private FileRequestStore NewStore(string directory)
+    {
+        var store = new FileRequestStore(directory);
+        _stores.Add(store);
+        return store;
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/Storage/FileRequestStoreTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Storage/FileRequestStoreTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+
+namespace Jellyfin.Plugin.Requests.Tests.Storage;
+
+/// <summary>
+/// The conformance suite run against the store this plugin ships. It adds no assertion of its own,
+/// for the reason the in-memory one gives: a promise only one implementation keeps is not a
+/// contract. What the durable store owes on top of the contract is
+/// <see cref="FileRequestStoreDurabilityTests"/>.
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "The rule exempts a class that declares a test method and this one only inherits them, so it reads as an unused public type. xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class FileRequestStoreTests : RequestStoreContract, IDisposable
+{
+    private readonly List<FileRequestStore> _stores = [];
+    private readonly List<string> _directories = [];
+
+    /// <summary>
+    /// Removes every store this test made and the directory each one wrote in.
+    /// </summary>
+    public void Dispose()
+    {
+        foreach (var store in _stores)
+        {
+            store.Dispose();
+        }
+
+        foreach (var directory in _directories)
+        {
+            TestRunDirectory.Remove(directory);
+        }
+    }
+
+    /// <inheritdoc />
+    protected override IRequestStore NewStore()
+    {
+        var directory = TestRunDirectory.CreateSubdirectory();
+        _directories.Add(directory);
+
+        var store = new FileRequestStore(directory);
+        _stores.Add(store);
+        return store;
+    }
+}

--- a/Jellyfin.Plugin.Requests/Storage/FileRequestStore.cs
+++ b/Jellyfin.Plugin.Requests/Storage/FileRequestStore.cs
@@ -1,0 +1,376 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Model;
+
+namespace Jellyfin.Plugin.Requests.Storage;
+
+/// <summary>
+/// The store this plugin ships: every request in one file in the plugin's own data directory,
+/// serialised with the JSON support the runtime already provides. The medium and the two that were
+/// rejected are in <c>docs/storage.md</c>.
+/// <para>
+/// <b>What an interruption may cost.</b> A server is stopped, a container is killed, a disk fills.
+/// After any of those the store loads, and at most the one record being written is lost. That is a
+/// property of how a write is made rather than of how carefully the caller shuts down: nothing is
+/// ever written into the file the loader reads. A write serialises the whole set into
+/// <see cref="PendingFileName"/>, flushes it to the disk, and only then replaces
+/// <see cref="FileName"/> with it in one step. So the file the loader reads is a file some write
+/// finished, and a process that dies at any moment leaves either the set before the write or the
+/// set after it.
+/// </para>
+/// <para>
+/// Two things that step rests on are the platform's and not this file's, and neither is measured
+/// here. The replace is atomic because the runtime maps it onto the operating system's own rename,
+/// and a rename is not durable until the directory entry reaches the disk, for which the runtime
+/// offers no call. What that leaves is a window in which a completed write can be lost by a power
+/// cut, which is the ordinary bound for this medium. It does not widen what an interruption can
+/// cost: whichever of the two sets survives, it is a whole one.
+/// </para>
+/// <para>
+/// <b>A leftover pending file is ignored, never read.</b> It is the wreckage of an interrupted
+/// write, it is the one file that can be half a document, and the loader does not look at it. It is
+/// not deleted on load either, because loading is a read: the next write truncates it.
+/// </para>
+/// <para>
+/// <b>What is not survivable.</b> If the file the loader reads cannot be parsed as a set of
+/// requests, the store refuses to open with <see cref="RequestStoreLoadException"/> rather than
+/// returning the part of it that did parse. A short read that looks like a successful one is how a
+/// queue silently loses records and then has the loss written back over the file that still held
+/// them.
+/// </para>
+/// <para>
+/// <b>Reads do not wait for writes.</b> The set is held in memory as one value that is replaced
+/// whole, so a reader takes the current one and never blocks and never sees half of a change. It is
+/// replaced only after the disk has taken the same set, so what the plugin reports and what survives
+/// a restart cannot disagree.
+/// </para>
+/// </summary>
+public sealed class FileRequestStore : IRequestStore, IDisposable
+{
+    /// <summary>
+    /// The file the loader reads. It is only ever created by replacing it whole.
+    /// </summary>
+    public const string FileName = "requests.json";
+
+    /// <summary>
+    /// The file a write is built in before it replaces <see cref="FileName"/>. This is the only file
+    /// that can be found half written, and nothing ever reads it.
+    /// </summary>
+    public const string PendingFileName = "requests.json.writing";
+
+    private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions
+    {
+        WriteIndented = false
+    };
+
+    private readonly string _directoryPath;
+    private readonly string _filePath;
+    private readonly string _pendingFilePath;
+
+    /// <summary>
+    /// Held for the whole of a write, so no two writes are building the pending file at once and no
+    /// write decides against a set another write has already replaced.
+    /// </summary>
+    private readonly SemaphoreSlim _writes = new SemaphoreSlim(1, 1);
+
+    /// <summary>
+    /// What the store holds, or null before the first call has read the file. Replaced whole and
+    /// never edited, which is what lets a reader take it without waiting for anything.
+    /// </summary>
+    private Dictionary<Guid, StoredRequest>? _held;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileRequestStore"/> class.
+    /// </summary>
+    /// <param name="directoryPath">
+    /// The directory the file lives in. Nothing is created until the first write, so constructing a
+    /// store against a directory that does not exist yet is not an error.
+    /// </param>
+    public FileRequestStore(string directoryPath)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(directoryPath);
+
+        _directoryPath = directoryPath;
+        _filePath = Path.Combine(directoryPath, FileName);
+        _pendingFilePath = Path.Combine(directoryPath, PendingFileName);
+    }
+
+    /// <summary>
+    /// Gets the file the requests are kept in.
+    /// </summary>
+    public string FilePath => _filePath;
+
+    /// <summary>
+    /// Gets the file a write is built in before it replaces <see cref="FilePath"/>.
+    /// </summary>
+    public string PendingFilePath => _pendingFilePath;
+
+    /// <inheritdoc />
+    public async Task<StoredRequest?> GetAsync(Guid id, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var held = await HeldAsync(cancellationToken).ConfigureAwait(false);
+        return held.TryGetValue(id, out var stored) ? stored : null;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<StoredRequest>> GetAllAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var held = await HeldAsync(cancellationToken).ConfigureAwait(false);
+        return held.Values.ToArray();
+    }
+
+    /// <inheritdoc />
+    public async Task<StoredRequest> AddAsync(MediaRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        await _writes.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            var held = LoadedWhileHoldingTheWriteLock();
+
+            if (held.ContainsKey(request.Id))
+            {
+                throw new DuplicateRequestException(request.Id);
+            }
+
+            var stored = new StoredRequest(request, 1);
+            var next = new Dictionary<Guid, StoredRequest>(held) { [request.Id] = stored };
+
+            await PersistAsync(next, cancellationToken).ConfigureAwait(false);
+            Volatile.Write(ref _held, next);
+            return stored;
+        }
+        finally
+        {
+            _writes.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<StoredRequest> ReplaceAsync(MediaRequest request, long expectedRevision, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        await _writes.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            var held = LoadedWhileHoldingTheWriteLock();
+            var current = held.TryGetValue(request.Id, out var stored) ? stored : (StoredRequest?)null;
+
+            if (current is null || current.Value.Revision != expectedRevision)
+            {
+                throw new RequestConcurrencyException(request.Id, expectedRevision, current);
+            }
+
+            var written = new StoredRequest(request, expectedRevision + 1);
+            var next = new Dictionary<Guid, StoredRequest>(held) { [request.Id] = written };
+
+            await PersistAsync(next, cancellationToken).ConfigureAwait(false);
+            Volatile.Write(ref _held, next);
+            return written;
+        }
+        finally
+        {
+            _writes.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> RemoveAsync(Guid id, long expectedRevision, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        await _writes.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            var held = LoadedWhileHoldingTheWriteLock();
+
+            if (!held.TryGetValue(id, out var stored))
+            {
+                return false;
+            }
+
+            if (stored.Revision != expectedRevision)
+            {
+                throw new RequestConcurrencyException(id, expectedRevision, stored);
+            }
+
+            var next = new Dictionary<Guid, StoredRequest>(held);
+            next.Remove(id);
+
+            await PersistAsync(next, cancellationToken).ConfigureAwait(false);
+            Volatile.Write(ref _held, next);
+            return true;
+        }
+        finally
+        {
+            _writes.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _writes.Dispose();
+    }
+
+    /// <summary>
+    /// Reads the file into a set, refusing anything it cannot read whole.
+    /// </summary>
+    /// <param name="filePath">The file to read.</param>
+    /// <returns>What the file holds, and an empty set where there is no file yet.</returns>
+    private static Dictionary<Guid, StoredRequest> Read(string filePath)
+    {
+        if (!File.Exists(filePath))
+        {
+            return [];
+        }
+
+        PersistedRequest?[]? persisted;
+
+        try
+        {
+            using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            persisted = JsonSerializer.Deserialize<PersistedRequest?[]>(stream, SerializerOptions);
+        }
+        catch (JsonException reason)
+        {
+            throw new RequestStoreLoadException(
+                filePath,
+                "it is not the document this store writes, which is what an interruption in the middle of the file would leave if a write were made in place.",
+                reason);
+        }
+
+        if (persisted is null)
+        {
+            throw new RequestStoreLoadException(filePath, "it holds a JSON null where the list of requests should be.");
+        }
+
+        var held = new Dictionary<Guid, StoredRequest>();
+
+        foreach (var entry in persisted)
+        {
+            if (entry?.Request is null)
+            {
+                throw new RequestStoreLoadException(filePath, "one of the entries carries no request.");
+            }
+
+            if (entry.Revision < 1)
+            {
+                throw new RequestStoreLoadException(filePath, "one of the entries carries a revision below the one an added request starts at.");
+            }
+
+            if (!held.TryAdd(entry.Request.Id, new StoredRequest(entry.Request, entry.Revision)))
+            {
+                throw new RequestStoreLoadException(filePath, "two entries carry one identifier, so which of them the store holds is not decidable.");
+            }
+        }
+
+        return held;
+    }
+
+    /// <summary>
+    /// The set, reading the file on the first call that needs it. A caller that finds it already
+    /// read takes it without waiting for anything, which is what
+    /// <see cref="IRequestStore.GetAsync"/> promises.
+    /// </summary>
+    /// <param name="cancellationToken">Cancels the wait for the first read.</param>
+    /// <returns>What the store holds.</returns>
+    private async Task<Dictionary<Guid, StoredRequest>> HeldAsync(CancellationToken cancellationToken)
+    {
+        var held = Volatile.Read(ref _held);
+
+        if (held is not null)
+        {
+            return held;
+        }
+
+        await _writes.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            return LoadedWhileHoldingTheWriteLock();
+        }
+        finally
+        {
+            _writes.Release();
+        }
+    }
+
+    /// <summary>
+    /// The set, read from the file if this is the first call. The caller has to be holding
+    /// <see cref="_writes"/>, which is what stops two of them reading the file at once and what
+    /// stops a write deciding against a set that was read before another write replaced it.
+    /// </summary>
+    /// <returns>What the store holds.</returns>
+    private Dictionary<Guid, StoredRequest> LoadedWhileHoldingTheWriteLock()
+    {
+        var held = _held;
+
+        if (held is not null)
+        {
+            return held;
+        }
+
+        held = Read(_filePath);
+        Volatile.Write(ref _held, held);
+        return held;
+    }
+
+    /// <summary>
+    /// Puts a set on the disk, whole or not at all.
+    /// <para>
+    /// Every failure here reaches the caller. There is no catch in this method and none around its
+    /// call sites, so a disk that is full, a directory that cannot be written to and a file the
+    /// platform refuses to replace are all reported rather than absorbed, and the in-memory set is
+    /// left as it was because it is only replaced after this returns.
+    /// </para>
+    /// </summary>
+    /// <param name="held">The set to write.</param>
+    /// <param name="cancellationToken">Cancels the write.</param>
+    /// <returns>A task that completes when the set is on the disk.</returns>
+    private async Task PersistAsync(Dictionary<Guid, StoredRequest> held, CancellationToken cancellationToken)
+    {
+        var persisted = held.Values
+            .Select(stored => new PersistedRequest { Revision = stored.Revision, Request = stored.Request })
+            .ToArray();
+
+        Directory.CreateDirectory(_directoryPath);
+
+        // Write-through, so the bytes are asked to reach the device rather than a cache the replace
+        // below would then overtake. What that is worth against a power cut is the platform's
+        // answer and is not measured by this repository's suite; what the suite does measure is the
+        // property that does not depend on it, which is that the file the loader reads is never a
+        // partial one.
+        var pending = new FileStream(
+            _pendingFilePath,
+            FileMode.Create,
+            FileAccess.Write,
+            FileShare.None,
+            bufferSize: 4096,
+            FileOptions.WriteThrough);
+
+        await using (pending.ConfigureAwait(false))
+        {
+            await JsonSerializer.SerializeAsync(pending, persisted, SerializerOptions, cancellationToken).ConfigureAwait(false);
+            await pending.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        File.Move(_pendingFilePath, _filePath, overwrite: true);
+    }
+}

--- a/Jellyfin.Plugin.Requests/Storage/PersistedRequest.cs
+++ b/Jellyfin.Plugin.Requests/Storage/PersistedRequest.cs
@@ -1,0 +1,29 @@
+using Jellyfin.Plugin.Requests.Model;
+
+namespace Jellyfin.Plugin.Requests.Storage;
+
+/// <summary>
+/// One entry as it is written to disk: the request, and the revision the store held it at.
+/// <para>
+/// It exists so that what is serialised is a shape this file controls rather than whatever
+/// <see cref="StoredRequest"/> happens to look like. The two carry the same two values today, and a
+/// change to the public type is not automatically a change to the bytes on somebody's disk.
+/// </para>
+/// <para>
+/// This is the whole of the on-disk shape as #46 needed it, and no more. Giving it a version field
+/// and stating what may be changed about it without stranding an existing install is #47.
+/// </para>
+/// </summary>
+internal sealed record PersistedRequest
+{
+    /// <summary>
+    /// Gets the revision the store held this request at.
+    /// </summary>
+    public long Revision { get; init; }
+
+    /// <summary>
+    /// Gets the request. Null only in a file that has been damaged, which the loader refuses rather
+    /// than reads around.
+    /// </summary>
+    public MediaRequest? Request { get; init; }
+}

--- a/Jellyfin.Plugin.Requests/Storage/RequestStoreLoadException.cs
+++ b/Jellyfin.Plugin.Requests/Storage/RequestStoreLoadException.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Globalization;
+
+namespace Jellyfin.Plugin.Requests.Storage;
+
+/// <summary>
+/// The persisted requests could not be read, so the store refuses to open rather than reporting
+/// whatever part of the file it managed to parse.
+/// <para>
+/// The alternative is the failure this type exists against. A loader that swallows a parse error and
+/// returns the records it read before it stopped hands the plugin a queue that is quietly shorter
+/// than the one on disk, and the first write afterwards persists that shorter queue over the longer
+/// one. Nobody sees a failure and the requests are gone. Refusing is loud, keeps the file, and
+/// leaves an operator something to look at.
+/// </para>
+/// <para>
+/// This says the bytes could not be read as a set of requests. It does not say they are the bytes
+/// this store wrote: a value changed inside a string is still well-formed and this store carries
+/// nothing that would notice.
+/// </para>
+/// </summary>
+public class RequestStoreLoadException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequestStoreLoadException"/> class.
+    /// </summary>
+    /// <param name="filePath">The file that could not be read.</param>
+    /// <param name="detail">What is wrong with it, in a sentence an operator can act on.</param>
+    public RequestStoreLoadException(string filePath, string detail)
+        : base(Describe(filePath, detail))
+    {
+        FilePath = filePath;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequestStoreLoadException"/> class.
+    /// </summary>
+    /// <param name="filePath">The file that could not be read.</param>
+    /// <param name="detail">What is wrong with it, in a sentence an operator can act on.</param>
+    /// <param name="innerException">What the reader threw.</param>
+    public RequestStoreLoadException(string filePath, string detail, Exception innerException)
+        : base(Describe(filePath, detail), innerException)
+    {
+        FilePath = filePath;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequestStoreLoadException"/> class.
+    /// </summary>
+    public RequestStoreLoadException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequestStoreLoadException"/> class.
+    /// </summary>
+    /// <param name="message">What happened.</param>
+    public RequestStoreLoadException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequestStoreLoadException"/> class.
+    /// </summary>
+    /// <param name="message">What happened.</param>
+    /// <param name="innerException">What it happened because of.</param>
+    public RequestStoreLoadException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    /// Gets the file that could not be read, or <see langword="null"/> where this was constructed
+    /// without one.
+    /// </summary>
+    public string? FilePath { get; }
+
+    private static string Describe(string filePath, string detail)
+        => string.Format(
+            CultureInfo.InvariantCulture,
+            "The stored requests in {0} could not be read: {1} Nothing has been changed on disk.",
+            filePath,
+            detail);
+}


### PR DESCRIPTION
Part of #46. The store this plugin ships, and the proofs that an interruption cannot cost more than the record being written.

There was no store on disk before this. `IRequestStore` stated what every store must promise and a dictionary in the test project was the only thing keeping those promises, so nothing on this board could survive a restart.

## How a write is made

Nothing is ever written into the file the loader reads. A write serialises the whole set into `requests.json.writing`, asks for it write-through, and only then replaces `requests.json` with it in one step. The file the loader reads is therefore always one that some write finished, and a process killed at any moment leaves either the set before the write or the set after it. A leftover pending file is the wreckage of an interrupted write, it is the one file that can be half a document, and the loader does not look at it.

Two things that rests on are the platform's and are not measured here. The replace is atomic because the runtime maps it onto the operating system's own rename, and a rename is not durable until the directory entry reaches the disk, for which the runtime offers no call. That leaves a window in which a completed write can be lost to a power cut, which is the ordinary bound for this medium. It does not widen what an interruption can cost: whichever set survives, it is a whole one. Both sentences are in the type's own documentation rather than only here.

Where an interruption is not survivable the store refuses rather than guessing. A `requests.json` that cannot be read as a set of requests raises `RequestStoreLoadException` naming the file, instead of returning the part that parsed. A short read that looks like a successful one is how a queue loses records quietly and then has the loss written back over the file that still held them.

Reads take an in-memory set that is replaced whole, and only after the disk has taken the same set. A reader never waits for a writer, never sees half a change, and what the plugin reports cannot disagree with what survives a restart.

## The interruption is real

A record whose provider identifiers throw while they are being serialised stops a write in the middle of the bytes, with the records ahead of it already on the disk. The alternative, writing a half file by hand, proves the loader and says nothing about whether a write can be stopped where the proof assumes it can. The leg asserts that the pending file is non-empty and that its last byte is not the closing bracket, so what it interrupted was a document in progress rather than one that had not started.

The truncation legs walk every byte offset rather than a sample, because the offsets a person picks are the ones they already expect to be safe.

## The suite

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release
    Bestanden!: Fehler: 0, erfolgreich: 166, gesamt: 166 (net9.0)
    Bestanden!: Fehler: 0, erfolgreich: 166, gesamt: 166 (net10.0)

The new store derives `RequestStoreContract`, so it is judged by the same set the in-memory one is, with no assertion of its own added there.

## Both guards were proved to bite

Writing straight to `requests.json` instead of building the pending file and replacing:

    AWriteStoppedInTheMiddleReachesTheCallerAndCostsOnlyTheRecordItWasWriting [FAIL]
       Assert.True() Failure   Expected: True   Actual: False
    AWriteTheFileSystemRefusesReachesTheCallerAndDropsNothingQuietly [FAIL]
       Assert.ThrowsAny() Failure: No exception was thrown
    Fehler: 2, erfolgreich: 68, gesamt: 70

Catching the parse failure and returning an empty set, which is the one-line mistake somebody makes:

    TheStoreFileCutShortAnywhereIsRefusedRatherThanPartlyRead [FAIL]
       Assert.Throws() Failure: No exception was thrown
    BytesThatAreNotASetOfRequestsAreRefusedWithTheFileNamed(damage: "garbage") [FAIL]
       Assert.Throws() Failure: No exception was thrown
    Fehler: 2, erfolgreich: 68, gesamt: 70

Neither near-miss is committed. The first failing assertion in each is the property the guard exists for, and not a test that could no longer find a file.

## Coverage

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release \
      --collect "Code Coverage;Format=cobertura" --results-directory coverage
    rate 90.42% of 866 lines
      FileRequestStore.cs: 228/228
      PersistedRequest.cs: 6/8

The floor is 75. The reader is the gate's own, run over that report.

## Brought up to the mainline

This branch was opened against an older mainline and two changes that landed since refuse what was
written here. Both are repaired in a commit of their own on top, and the numbers above are from the
merged tree rather than from the tree this was first written against.

The reference allowlist from #94 does not name the two assemblies the store brings. `System.Text.Json`
is the serialiser the file is written with and `System.Threading` is the lock, the token and the task
the store's calls are made of. Both are part of the runtime the server provides on each claimed line
rather than packages this plugin carries, and both are added with the reason beside them, which is
the act that allowlist exists to require.

The append-only history from #43 did not exist when the round-trip proof was written. That proof
compared whole records, and the record holds the history behind an interface, so the generated
equality compares the list itself and never its entries: a list read back off a disk is a different
list whatever it holds. The history is now compared entry by entry, as the provider identifiers
already were and for the same measured reason.

The request in that proof also reaches its state by making the move rather than by writing the state
onto the record, so there is a history for the round trip to lose. With an empty one a store that
dropped the field entirely would have passed. Dropping it on the way to the file fails the proof:

    EveryFieldComesBackFromAStoreOpenedFreshOverTheSameDirectory [FAIL]
    Fehler: 1, erfolgreich: 165, gesamt: 166

That near-miss is not committed.

## What this does not do

Nothing is registered with the host, so no caller reaches this store yet. The surfaces that would are M6 and M7.

The on-disk shape carries no version field and no rules for changing it. That is #47, and what is here is the minimum a write needs and no more.

The third condition of #46, a full disk, is not met by this and the issue stays open on it. Filling a volume needs a volume to make, and making one needs the elevation `docs/testing.md` refuses. What is proven instead is the property an exhausted disk is one instance of: the write path catches nothing, so a failure the file system raises reaches the caller and the store goes on reporting what it actually holds. The detail is in the issue.

A byte changed inside a string is still a document this store could have written and nothing here would notice. Noticing needs a checksum over the bytes, which this store does not carry.

## Review

This section was produced by an automated re-run, not by a second person. No second reader has read this change. The evidence above stands in place of one: every number carries the command that produced it, and both guards carry the run that shows them refusing.

