### PR TITLE
Refuse a browser driver, a trust store write and a suite path of its own (#115)

### DIFF
--- a/tools/opengrep/fixtures/display/ReferencesABrowserAutomationPackage.xml
+++ b/tools/opengrep/fixtures/display/ReferencesABrowserAutomationPackage.xml
@@ -1,0 +1,31 @@
+<!--
+  Fixture for no-browser-automation-package. This file is in no build and is
+  never restored; it exists so the rule can be watched refusing the mistake it
+  names. It carries the .xml extension rather than .csproj on purpose, so the
+  dependency bot does not try to resolve the packages below.
+
+  The near-miss is the reference somebody adds while the page is being built,
+  reasonably, because the page is the one part of this plugin that has no
+  in-process test and a driver is the obvious way to get one. Nothing about the
+  reference needs a display. The first test written against it downloads a
+  browser per machine, and the suite stops being `dotnet test` on a checkout.
+-->
+<Project>
+
+  <ItemGroup>
+    <!-- Legal neighbours, left here on purpose: these are what the test project
+         actually references and the rule has to stay quiet on them. -->
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- The regression, in each family a driver arrives from. -->
+    <PackageReference Include="Microsoft.Playwright" Version="1.49.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.27.0" />
+    <PackageReference Include="PuppeteerSharp" Version="20.0.5" />
+    <PackageReference Include="WebDriverManager" Version="2.17.5" />
+  </ItemGroup>
+
+</Project>

--- a/tools/opengrep/fixtures/runpath/WritesOutsideTheRunDirectory.cs
+++ b/tools/opengrep/fixtures/runpath/WritesOutsideTheRunDirectory.cs
@@ -1,0 +1,33 @@
+// Fixture for suite-writes-only-under-the-run-directory. This file is in no
+// project and is never compiled; it exists so the rule can be watched refusing
+// the mistake it names.
+//
+// The near-miss is a test that wants somewhere to put a file and asks the
+// machine for it, which is what every example on the subject does. It never goes
+// through a double, so the assertions in TestRunDirectoryTests say nothing about
+// it, it passes, and it leaves a file beside everything else the same user's
+// processes wrote. On a shared machine that is somebody else's disk, and the
+// suite is the only thing that knows the file is rubbish.
+
+namespace Jellyfin.Plugin.Requests.Tests.Fixtures;
+
+internal sealed class WritesOutsideTheRunDirectory
+{
+    // Legal neighbour, left here on purpose: this is how a test gets somewhere to
+    // write, and the rule has to stay quiet on it.
+    public static string SomewhereToWrite()
+    {
+        return TestRunDirectory.CreateSubdirectory();
+    }
+
+    // The regression, in the spellings that reach a shared location.
+    public static string AskTheMachine()
+    {
+        Directory.SetCurrentDirectory(Environment.CurrentDirectory);
+        var working = Directory.GetCurrentDirectory();
+        var scratch = Path.GetTempPath();
+        var scratchFile = Path.GetTempFileName();
+        var documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+        return Path.Combine(scratch, scratchFile, documents, working);
+    }
+}

--- a/tools/opengrep/fixtures/truststore/TrustsATestCertificate.cs
+++ b/tools/opengrep/fixtures/truststore/TrustsATestCertificate.cs
@@ -1,0 +1,31 @@
+// Fixture for no-certificate-store-access. This file is in no project and is
+// never compiled; it exists so the rule can be watched refusing the mistake it
+// names.
+//
+// The near-miss is the one that arrives with the first test against a real
+// HTTPS endpoint: the endpoint is a self-signed one the test starts itself, the
+// handshake fails, and the shortest way past that is to put the certificate
+// where the machine will believe it. It works, the test goes green, and every
+// other program on that machine trusts the certificate afterwards, including
+// long after the run that installed it.
+
+namespace Jellyfin.Plugin.Requests.Tests.Fixtures;
+
+internal sealed class TrustsATestCertificate
+{
+    // Legal neighbour, left here on purpose: reading a certificate out of bytes
+    // the test brought with it touches no store, and the rule has to stay quiet
+    // on it.
+    public static X509Certificate2 LoadFromBytes(byte[] pkcs12)
+    {
+        return X509CertificateLoader.LoadPkcs12(pkcs12, password: null);
+    }
+
+    // The regression.
+    public static void Trust(X509Certificate2 certificate)
+    {
+        using var store = new X509Store(StoreName.Root, StoreLocation.CurrentUser);
+        store.Open(OpenFlags.ReadWrite);
+        store.Add(certificate);
+    }
+}

--- a/tools/opengrep/fixtures/truststore/trust-a-development-certificate.sh
+++ b/tools/opengrep/fixtures/truststore/trust-a-development-certificate.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Fixture for no-certificate-store-access, in its command-line spelling. Nothing
+# runs this file; it exists so the rule can be watched refusing the mistake it
+# names.
+#
+# The near-miss is the setup step somebody adds to make a suite pass on their own
+# machine, copied out of an ASP.NET getting-started page where it is the right
+# advice. Both lines below raise a consent prompt on the machine that runs them,
+# which is what makes this a rule about the person sitting at the machine rather
+# than about the test.
+set -euo pipefail
+
+# Legal neighbours, left here on purpose: the suite is this and nothing else, and
+# the rule has to stay quiet on both.
+dotnet restore Jellyfin.Plugin.Requests.sln
+dotnet test Jellyfin.Plugin.Requests.sln --configuration Release
+
+# The regression, in both spellings the platforms use.
+dotnet dev-certs https --trust
+certutil -addstore -user Root test-certificate.cer

--- a/tools/opengrep/rules.yaml
+++ b/tools/opengrep/rules.yaml
@@ -176,3 +176,116 @@ rules:
         - "tools/opengrep/fixtures/suite/**/*.cs"
       exclude:
         - "Jellyfin.Plugin.Requests.Tests/Doubles/PluginHost.cs"
+
+  # Invariant (headless, #115): no browser automation package is referenced
+  # anywhere in this repository. Decided in docs/testing.md, whose first refusal
+  # is a browser-driven test of the administrator page and whose replacement is
+  # the endpoints tested in process. A package reference is how a display
+  # requirement arrives: nothing about the reference itself needs a display, and
+  # the first test written against it downloads a browser per machine and turns
+  # the suite into something a machine without one cannot run. The lock files are
+  # named beside the project files so a driver arriving as somebody else's
+  # dependency is refused too.
+  #
+  # What it does not reach: the four families below are the ones a .NET driver
+  # comes from today, matched case-sensitively against the canonical package
+  # identifier, which is the casing every file this rule reads carries. A fifth
+  # family is a fifth pattern here, and nothing finds one for you.
+  - id: no-browser-automation-package
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      Do not reference a browser automation package. A browser-driven test needs
+      a display or a per-machine browser download, which docs/testing.md refuses;
+      test the endpoints the page calls in process instead (#115).
+    patterns:
+      - pattern-either:
+          - pattern: Playwright
+          - pattern: Selenium
+          - pattern: Puppeteer
+          - pattern: WebDriver
+    paths:
+      include:
+        - "**/*.csproj"
+        - "**/*.props"
+        - "**/*.targets"
+        - "**/packages.lock.json"
+        - "tools/opengrep/fixtures/display/**"
+
+  # Invariant (headless, #115): nothing in this tree reaches into a certificate
+  # store. Decided in docs/testing.md, which refuses a test needing an elevation
+  # or consent prompt and names a write to a machine trust store as one form of
+  # it. A trust store is shared with every other program on the machine and
+  # outlives the run that changed it, so this is the one refusal whose cost is
+  # paid by somebody who never ran the suite. X509Store is the whole managed
+  # entry point, because a store cannot be opened without constructing one;
+  # StoreName and StoreLocation are only ever its arguments and are left out
+  # rather than listed, so this rule cannot red on a storage type that happens to
+  # carry one of those words. `dotnet dev-certs` and `certutil` are the two
+  # command-line spellings of the same write.
+  - id: no-certificate-store-access
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      Do not open or write a certificate store. It raises a consent prompt and
+      changes what every other program on the machine trusts, long after the run
+      ends, which docs/testing.md refuses (#115). Reach the client through an
+      in-process handler instead of trusting a certificate.
+    patterns:
+      - pattern-either:
+          - pattern: X509Store
+          - pattern: dotnet dev-certs
+          - pattern: certutil
+    paths:
+      include:
+        - "**/*.cs"
+        - "**/*.sh"
+        - "**/*.ps1"
+        - ".github/workflows/**"
+        - "tools/opengrep/fixtures/truststore/**"
+
+  # Invariant (headless, #115): the suite names no location outside the directory
+  # the run owns. Decided in Jellyfin.Plugin.Requests.Tests/Doubles/TestRunDirectory.cs,
+  # which is that directory and says so. The suite already asserts that every
+  # double is rooted under it, and a test that never went through a double is
+  # invisible to those assertions: it asks the machine for a temporary path, a
+  # known folder or the working directory, and writes beside everything else that
+  # uses them. Walking the machine's temporary root at the end of a run is the
+  # other way to catch that and is deliberately not done, because that root is
+  # shared with every process running as the same user and such a check reds for
+  # a file nobody in this repository created. This is the half that names a
+  # source line instead. TestRunDirectoryTests is excluded with the directory
+  # itself, because the assertion that the run's directory sits directly under
+  # the machine's temporary root has to name that root to make it.
+  #
+  # What it does not reach, and deliberately. AppContext.BaseDirectory is not
+  # refused: it is the test host's own output directory, it is where the
+  # packaging metadata is copied to be read, and nothing in the suite writes
+  # through it. A rooted path written as a literal is not refused either, because
+  # a pattern for one matches every version string and every URL in the suite,
+  # and a rule that reds on those is a rule somebody switches off. This catches
+  # the four calls that ask the machine where to put something, which is how a
+  # test that never went through a double actually gets written.
+  - id: suite-writes-only-under-the-run-directory
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      Do not ask the machine for a location here. Take a subdirectory of
+      TestRunDirectory, which is the one directory a run owns and removes, so a
+      test cannot write beside everything else on a shared machine (#115).
+    patterns:
+      - pattern-either:
+          - pattern: Path.GetTempPath(...)
+          - pattern: Path.GetTempFileName(...)
+          - pattern: Environment.GetFolderPath(...)
+          - pattern: Environment.SpecialFolder
+          - pattern: Environment.CurrentDirectory
+          - pattern: Directory.GetCurrentDirectory(...)
+          - pattern: Directory.SetCurrentDirectory(...)
+    paths:
+      include:
+        - "Jellyfin.Plugin.Requests.Tests/**/*.cs"
+        - "tools/opengrep/fixtures/runpath/**/*.cs"
+      exclude:
+        - "Jellyfin.Plugin.Requests.Tests/Doubles/TestRunDirectory.cs"
+        - "Jellyfin.Plugin.Requests.Tests/TestRunDirectoryTests.cs"


### PR DESCRIPTION
Part of #115.

The headless rule is written in `docs/testing.md` and that document says of itself that nothing refuses any of it. Three of the four mechanisms #115 names are now rules in the invariant lint, so breaking the rule reds the gate rather than arriving later as a suite the next machine cannot run.

`no-browser-automation-package` refuses a reference to Playwright, Selenium, Puppeteer or WebDriver in a project file, a props or targets file, or a lock file. That reference is how a display requirement arrives: nothing about the reference itself needs a display, and the first test written against it downloads a browser per machine. The lock files are read alongside the project files so a driver arriving as somebody else's dependency is refused too.

`no-certificate-store-access` refuses `X509Store` in any C# in the tree and `dotnet dev-certs` or `certutil` in any script or workflow. This is the refusal whose cost is paid by somebody who never ran the suite. A trust store is shared with every program on the machine and outlives the run that changed it, and the write raises a consent prompt at whoever is sitting there. `StoreName` and `StoreLocation` are deliberately not patterns: they are only ever arguments to the constructor, and a rule matching them would red on a storage type that happens to carry one of those words.

`suite-writes-only-under-the-run-directory` refuses `Path.GetTempPath`, `Path.GetTempFileName`, `Environment.GetFolderPath`, `Environment.SpecialFolder`, `Environment.CurrentDirectory`, `Directory.GetCurrentDirectory` and `Directory.SetCurrentDirectory` anywhere in the test project except `TestRunDirectory` and its own tests. The suite already asserts that every double is rooted under the one directory a run owns, and a test that never went through a double is invisible to those assertions. The call that asks the machine for a location is how such a test gets written, and that call is what this refuses.

Each rule carries a fixture holding the mistake next to the legal neighbour it sits nearest to, which is what `prove-rules-fire.sh` reads. A rule that stopped matching, or a fixture edited until it no longer violates anything, fails that step rather than passing quietly. The fixture for the package reference carries an `.xml` extension rather than `.csproj` so the dependency bot does not try to resolve packages that exist only to be refused.

The tree is clean under all three, measured on the commit this branch is based on:

    git grep -nEi "playwright|selenium|puppeteer|webdriver|chromedriver" origin/master ; echo "exit=$?"
    exit=1

    git grep -nE "X509Store|dev-certs|certutil" origin/master ; echo "exit=$?"
    exit=1

    git grep -nE "GetTempPath|GetTempFileName|GetFolderPath|CurrentDirectory|SpecialFolder" origin/master -- Jellyfin.Plugin.Requests.Tests
    origin/master:Jellyfin.Plugin.Requests.Tests/Doubles/TestRunDirectory.cs:29:        Path.GetTempPath(),
    origin/master:Jellyfin.Plugin.Requests.Tests/TestRunDirectoryTests.cs:52:            Path.GetFullPath(Path.GetTempPath()).TrimEnd(Path.DirectorySeparatorChar),

Those two lines are the two files the rule excludes, and the second is excluded because the assertion that the run's directory sits directly under the machine's temporary root has to name that root in order to make it.

That each rule bites is not asserted from this machine. Opengrep publishes no build that runs here, so the proof is the `Prove every rule still refuses something` step of `Repo Invariant Lint` on this branch, which scans the fixtures and fails unless every declared rule fired on one. Read that step's output rather than this paragraph.

What this does not cover.

The fourth mechanism, the network one, is not here and cannot be built yet. It asks for outbound calls to be refused at the handler the plugin resolves, and the plugin resolves no handler because it makes no outbound call. It waits on the first outbound client, which is #78 or #80, and on the double in #35.

The run directory rule is the source-text half of its mechanism and not the whole of it. Walking the machine's temporary root at the end of a run is the other half and stays deliberately absent: that root is shared with every process running as the same user, so such a check reds for a file nobody in this repository created, which is the guard that gets switched off rather than fixed. A test that computes a shared path some other way, without naming one of the seven calls, still passes.

`AppContext.BaseDirectory` is not refused. It is the test host's own output directory, it is where the packaging metadata is copied to be read, and nothing in the suite writes through it. A rooted path written as a literal is not refused either, because a pattern for one matches every version string and every URL in the suite.

The four package families are the ones a .NET browser driver comes from today, matched case-sensitively against the canonical package identifier. A fifth family is a fifth pattern here and nothing finds one for you.

`docs/testing.md` still says that nothing refuses the headless rule. That sentence is now narrower than the tree: it holds for the network mechanism and for a display requirement arriving some other way, and no longer for the three above. Correcting it is an edit to the file #32 landed, which is outside the scope this issue declares, so it is named here rather than made.

#115 stays open on the network mechanism and on the half of the run directory mechanism described above.

There was no second reader for this change. The evidence above stands in place of one: the commands are quoted so a reader can run them, and what is not proven is named rather than left out.
