### PR TITLE
Say which parts of the headless rule are refused and which are not (#3)

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -34,9 +34,26 @@ document.
 A refused test is not dropped. Each one below names what replaces it, and a proposal that fits a
 refusal is answered with that replacement rather than with a no.
 
-Nothing refuses any of this. The rule is written here and read by a person; no check reads a test
-for a display, a prompt or a socket, and a test breaking every line above builds and passes exactly
-like one that does not. #115 is where that gap is held.
+Three of the ways this rule gets broken are refused, and the rest of it is read by a person. The
+refusals are rules in the invariant lint, and each names the line above it stands for:
+
+    git grep -n "^  - id: no-browser-automation-package\|^  - id: no-certificate-store-access\|^  - id: suite-writes-only-under-the-run-directory" tools/opengrep/rules.yaml
+
+`no-browser-automation-package` refuses a reference to Playwright, Selenium, Puppeteer or WebDriver
+in the project, props, targets and lock files, which is how a display requirement arrives.
+`no-certificate-store-access` refuses `X509Store` in any C# here and `dotnet dev-certs` or
+`certutil` in any script or workflow, which is the elevation form that outlives the run.
+`suite-writes-only-under-the-run-directory` refuses the seven calls that ask the machine for a
+location, anywhere in the test project except the run directory itself and its own tests.
+
+What is still read by a person and refused by nothing. A test that opens a socket passes: the
+mechanism for that refuses outbound calls at the handler the plugin resolves, and the plugin
+resolves no handler because it makes no outbound call. A display requirement arriving as something
+other than a package reference passes. A test that reaches a shared location without naming one of
+the seven calls passes, because the check is over source text and not over what a run did. A test
+needing a running server or a container engine passes. So a test breaking most of the lines above
+still builds and runs exactly like one that does not, and the three rules narrow that rather than
+closing it. #115 is where the rest of the gap is held.
 
 ### The refusals, and what replaces each
 


### PR DESCRIPTION
Part of #3.

`docs/testing.md` said that nothing refuses any of the headless rule. Since 15b2c797b9a56701832cbaca9dc6ed7c9fcd1111 three of the ways that rule gets broken are refused by rules in the invariant lint, so the sentence understated the tree. A reader deciding whether a proposed test is allowed was being told that nothing would catch them, which is the wrong direction for a sentence to be wrong in.

The paragraph now names the three rules, says which line of the rule above it each one stands for, and cites the command that lists them rather than restating the list:

    git grep -n "^  - id: no-browser-automation-package\|^  - id: no-certificate-store-access\|^  - id: suite-writes-only-under-the-run-directory" tools/opengrep/rules.yaml
    tools/opengrep/rules.yaml:194:  - id: no-browser-automation-package
    tools/opengrep/rules.yaml:226:  - id: no-certificate-store-access
    tools/opengrep/rules.yaml:269:  - id: suite-writes-only-under-the-run-directory

The negative half is longer than the positive one and is still a negative. Four ways to break the rule are named as passing: a socket, because the mechanism for it refuses at a handler the plugin does not resolve; a display requirement arriving as anything other than a package reference; a shared location reached without naming one of the seven refused calls, because the check is over source text and not over what a run did; and a test needing a running server or a container engine. The paragraph says all four rather than reporting the three refusals and stopping there.

No claim in it was made positive. What changed is that a sentence saying "nothing" now says which three things and lists what is still uncovered.

This closes nothing. #3 stays open on its first condition, which is every issue in the milestone being closed, and #115 holds the rest of the gap this paragraph describes.

There was no second reader for this change. The command above is quoted so the list can be checked against the file that decides it.
