### PR TITLE
Ship a bill of materials with every package (#109)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -334,7 +334,30 @@ jobs:
         with:
           dotnet-target: "net9.0"
 
-      - name: Check both release inputs exist
+      - name: Write the bill of materials
+        id: bom
+        env:
+          ARTIFACT: ${{ steps.jprm.outputs.artifact }}
+          SOURCE_REPOSITORY: ${{ github.repository }}
+          SOURCE_COMMIT: ${{ github.sha }}
+          PACKAGE_VERSION: ${{ needs.gate.outputs.version }}
+        # What ships in the package, listed from the package rather than from the
+        # project, so it can be checked by anybody who downloads the archive and runs
+        # the same script on it. The attestation minted in the next job says where the
+        # archive came from; this says what is in it, and neither answers the other's
+        # question.
+        #
+        # Written here rather than in the release job because a failure has to happen
+        # before anything is published. A release that exists is never touched again,
+        # so a step that reds after the release is created leaves a version people can
+        # install with an asset missing and no way to repair it.
+        run: |
+          set -euo pipefail
+          bom="${ARTIFACT%.zip}.cdx.json"
+          scripts/bill-of-materials.sh "${ARTIFACT}" "${bom}"
+          echo "path=${bom}" >> "$GITHUB_OUTPUT"
+
+      - name: Check every release input exists
         env:
           ARTIFACT: ${{ steps.jprm.outputs.artifact }}
         # if-no-files-found on the upload below fires only when no pattern matches at
@@ -342,13 +365,13 @@ jobs:
         # release one asset short. Named here, one file at a time.
         run: |
           set -euo pipefail
-          for file in "${ARTIFACT}" "${ARTIFACT}.meta.json"; do
+          for file in "${ARTIFACT}" "${ARTIFACT}.meta.json" "${ARTIFACT%.zip}.cdx.json"; do
             if [ ! -f "${file}" ]; then
-              echo "::error::The packaging step did not produce ${file}. Both the archive and the metadata written beside it are release assets."
+              echo "::error::The packaging step did not produce ${file}. The archive, the metadata written beside it and the bill of materials are all release assets."
               exit 1
             fi
           done
-          ls -l "${ARTIFACT}" "${ARTIFACT}.meta.json"
+          ls -l "${ARTIFACT}" "${ARTIFACT}.meta.json" "${ARTIFACT%.zip}.cdx.json"
 
       - name: Hand the package to the later jobs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -356,12 +379,15 @@ jobs:
           name: build-artifact
           retention-days: 30
           if-no-files-found: error
-          # The archive and the metadata the packager writes beside it. The metadata
-          # travels with the release so a catalog can be built from the package that
-          # was actually shipped instead of from a file read back out of the tree.
+          # The archive, the metadata the packager writes beside it, and the bill of
+          # materials. The metadata travels with the release so a catalog can be built
+          # from the package that was actually shipped instead of from a file read back
+          # out of the tree, and the bill of materials travels with it so what is in
+          # that package can be checked without trusting this run.
           path: |
             ${{ steps.jprm.outputs.artifact }}
             ${{ steps.jprm.outputs.artifact }}.meta.json
+            ${{ steps.bom.outputs.path }}
 
   attest:
     name: Attest build provenance

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -30,30 +30,84 @@ serialising them by hand is what keeps the release order readable.
 ## What the run produces
 
 The workflow builds the plugin from the tagged commit, creates the GitHub release
-for the tag, and attaches four files:
+for the tag, and attaches five files:
 
 - the plugin archive
 - the packaging metadata written beside it, `<archive>.zip.meta.json`
+- the bill of materials, `<archive>.cdx.json`
 - one `.md5` file, the checksum of the archive
 - one `.sha256` file for the same archive
 
 The `.md5` is the value a Jellyfin catalog serves as the plugin checksum. There is
 exactly one per release so that no generator can pair a checksum with the wrong
-file. Both the archive and the metadata are checked for existence by name before the
-release job runs, so a release with three of the four files is not a state this route
-can reach.
+file. The archive, the metadata and the bill of materials are each checked for
+existence by name before the release job runs, so a release with four of the five
+files is not a state this route can reach.
 
 The run also signs a build provenance statement for the archive, in a separate job
-that downloads the archive and runs no build tooling. A downloaded archive can be
-checked against it:
+that downloads the archive and runs no build tooling.
+
+Nothing here writes a plugin catalog. A GitHub release is the whole output. If this
+repository previously published through the Jellyfin meta plugins workflow, that path
+is gone and no catalog is fed until a manifest generator is added.
+
+## The bill of materials
+
+`scripts/bill-of-materials.sh` writes it, in the build job, before anything is
+published. It is a CycloneDX document listing every file the archive carries with the
+SHA-256 of the bytes that get written on install, and it is derived from the archive
+rather than from the project.
+
+Two things it does not carry, both on purpose. It reads no version out of a DLL,
+because that needs a .NET toolchain and the version a catalog serves is already in
+the archive's own `meta.json`. It is not the compile-time dependency graph either:
+`packages.lock.json` at the source commit is that graph, and a package in it appears
+in the bill of materials only if the build copied it into the archive. For
+`0.1.0.0` the archive holds two files and nothing third-party ships, so the list is
+two entries long. That is a fact about the package rather than a gap in the script.
+
+## Checking a release
+
+Both checks are for somebody who downloaded the archive and wants to know what they
+have, and neither needs anything from this repository beyond the script.
+
+Where the archive came from:
 
 ```
 gh attestation verify <archive>.zip --repo <owner>/<repository>
 ```
 
-Nothing here writes a plugin catalog. A GitHub release is the whole output. If this
-repository previously published through the Jellyfin meta plugins workflow, that path
-is gone and no catalog is fed until a manifest generator is added.
+What is inside it. The document is reproducible, so regenerating it from the download
+and comparing is the check. There is no timestamp and no serial number in it, and the
+components are sorted, so two runs over the same archive produce the same bytes:
+
+```
+SOURCE_REPOSITORY=<owner>/<repository> \
+SOURCE_COMMIT=<the commit in the shipped document> \
+PACKAGE_VERSION=<version> \
+  scripts/bill-of-materials.sh <archive>.zip regenerated.cdx.json
+diff regenerated.cdx.json <archive>.cdx.json
+```
+
+A recorded run of the first command against `0.1.0.0-stable`, which is the release
+that exists at the time of writing:
+
+```
+gh release download 0.1.0.0-stable --repo Flowfin/jellyfin-plugin-requests \
+  --pattern 'requests_0.1.0.0.zip'
+gh attestation verify requests_0.1.0.0.zip --repo Flowfin/jellyfin-plugin-requests
+echo "exit=$?"
+exit=0
+```
+
+The command prints its result only to a terminal, so a run whose output is captured
+to a file or a pipe shows the exit status and nothing else. Reading the statement
+itself rather than the verdict takes `--format json`. Pointed at a repository that did
+not build the archive it exits 1 with an HTTP 404, which is the failing direction of
+the same command.
+
+`0.1.0.0-stable` was built before the bill of materials existed and carries no
+`.cdx.json`, so the second check has nothing to run against until the next release.
 
 ## What fails the run
 
@@ -72,7 +126,10 @@ is gone and no catalog is fed until a manifest generator is added.
   cannot restore against a reviewed dependency graph. Create one with
   `dotnet restore <project> -p:RestorePackagesWithLockFile=true` and commit it.
 - The version stamped into the assembly is not the version in `build.yaml`.
-- The build produced no archive, or more than one, or no packaging metadata.
+- The build produced no archive, or more than one, or no packaging metadata, or no
+  bill of materials.
+- The archive cannot be read, or carries no files at all, so nothing can describe
+  what ships in it.
 - A release already exists for the tag.
 
 All of these fail before anything is published.

--- a/scripts/bill-of-materials.sh
+++ b/scripts/bill-of-materials.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Write a CycloneDX bill of materials for a built plugin archive.
+#
+# Somebody installing a binary from a catalogue is trusting whoever built it. The provenance
+# attestation says which source and which workflow run produced the archive. This says what is
+# inside it. They answer different questions and neither one replaces the other.
+#
+# The document is derived from the archive and from nothing else. Every entry is a file the archive
+# carries, named as the archive names it, with the SHA-256 of the bytes that get written on install.
+# Nothing is read out of the source tree, which is what makes regenerating this from a downloaded
+# archive a check rather than a restatement: the two documents either agree or the download is not
+# the package that was built.
+#
+# What it deliberately does not carry. No assembly version is read out of a DLL, because that needs
+# a .NET toolchain and the version a catalogue serves is already in the archive's own meta.json. No
+# compile-time dependency graph is included either: packages.lock.json at the source commit is that
+# graph, and a package in it appears here only if the build copied it into the archive. A short list
+# is therefore a fact about the package rather than a gap in this script.
+#
+# The archive is read rather than unpacked, and the names in it are never taken apart by the shell.
+# An earlier draft extracted it and walked the files line by line, which needed a rule refusing an
+# entry name that carries a newline, and that rule could not be shown to bite: the unpacker on one
+# of the machines this is run from rewrites such a name before anything here sees it. A guard nobody
+# can watch fail is worse than the case it was written for, so the pipeline that needed it is gone.
+#
+# The output is reproducible. There is no timestamp and no random serial number, so the same archive
+# always produces the same bytes and two documents can be compared with `diff`.
+#
+# usage: scripts/bill-of-materials.sh <archive.zip> <output.json>
+#   SOURCE_REPOSITORY=Flowfin/jellyfin-plugin-requests \
+#   SOURCE_COMMIT=c44552645f0dba120c49599deedbc0244b59dcec \
+#   PACKAGE_VERSION=0.1.0.0 \
+#     scripts/bill-of-materials.sh requests_0.1.0.0.zip requests_0.1.0.0.cdx.json
+
+set -euo pipefail
+
+archive=${1:?path to the built plugin archive, for example requests_0.1.0.0.zip}
+output=${2:?path to write the bill of materials to}
+
+: "${SOURCE_REPOSITORY:?owner and name of the repository the archive was built from}"
+: "${SOURCE_COMMIT:?the commit the archive was built from}"
+: "${PACKAGE_VERSION:?the plugin version this archive carries}"
+
+if [ ! -f "$archive" ]; then
+    echo "bill-of-materials: $archive does not exist, so there is nothing to describe." >&2
+    exit 1
+fi
+
+# python3 is already what scripts/verify-plugin-loads.sh reaches for, so this adds no runtime the
+# tree did not already carry. It reads the archive, hashes each entry and writes the JSON through a
+# real encoder: escaping a name is the one part of this a shell gets wrong quietly, and an entry
+# name is the input least under this script's control.
+ARCHIVE_NAME="$(basename "$archive")" python3 - "$archive" "$output" <<'PY'
+import hashlib
+import json
+import os
+import sys
+import zipfile
+
+source, destination = sys.argv[1], sys.argv[2]
+
+try:
+    archive = zipfile.ZipFile(source)
+except zipfile.BadZipFile as problem:
+    sys.exit(
+        "bill-of-materials: %s is not a readable archive (%s). The packaging step produced "
+        "something this cannot describe." % (source, problem)
+    )
+
+components = []
+with archive:
+    # Sorted by name so the order of the components does not depend on the order the packaging
+    # step happened to write them in.
+    for entry in sorted(archive.infolist(), key=lambda item: item.filename):
+        if entry.is_dir():
+            continue
+        digest = hashlib.sha256(archive.read(entry)).hexdigest()
+        components.append(
+            {
+                "type": "file",
+                "bom-ref": "archive:" + entry.filename,
+                "name": entry.filename,
+                "hashes": [{"alg": "SHA-256", "content": digest}],
+                "properties": [{"name": "size-in-bytes", "value": str(entry.file_size)}],
+            }
+        )
+
+if not components:
+    sys.exit(
+        "bill-of-materials: %s carries no files. A package with nothing in it is not a package."
+        % source
+    )
+
+document = {
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.6",
+    "version": 1,
+    "metadata": {
+        "component": {
+            "type": "application",
+            "bom-ref": os.environ["ARCHIVE_NAME"],
+            "name": os.environ["ARCHIVE_NAME"],
+            "version": os.environ["PACKAGE_VERSION"],
+            "externalReferences": [
+                {
+                    "type": "vcs",
+                    "url": "https://github.com/" + os.environ["SOURCE_REPOSITORY"],
+                    "comment": "built from commit " + os.environ["SOURCE_COMMIT"],
+                }
+            ],
+        },
+        "tools": {
+            "components": [
+                {"type": "application", "name": "scripts/bill-of-materials.sh"}
+            ]
+        },
+    },
+    "components": components,
+}
+
+with open(destination, "w", encoding="utf-8", newline="\n") as handle:
+    json.dump(document, handle, indent=2, sort_keys=True)
+    handle.write("\n")
+
+print(
+    "bill-of-materials: wrote %s describing %d file(s) from %s."
+    % (destination, len(components), source)
+)
+PY


### PR DESCRIPTION
Closes nothing on its own. This is the first of the three conditions on #109 and it leaves the other two where they are.

## What this changes

The release path already attested where an archive came from. It said nothing about what is inside it, so somebody installing from a catalogue could check the provenance and still not see which files they were about to write into their server.

`scripts/bill-of-materials.sh` reads a built archive and writes a CycloneDX document listing every file it carries with the SHA-256 of the bytes that get written on install. `publish.yaml` runs it in the build job and refuses to continue without it. That placement is the point: a release that exists is never touched again on this route, so a step that reds after the release is created leaves an installable version with an asset missing and no way to repair it.

The document is derived from the archive and from nothing in the source tree. It carries no timestamp and no serial number and its components are sorted, so regenerating it from a download and comparing with `diff` is a check rather than a restatement.

## The means

Bash calling `python3`, which is what `scripts/verify-plugin-loads.sh` already reaches for, so this adds no language, runtime or dependency the tree did not carry. The archive is read through `zipfile` and the JSON written by an encoder rather than by `printf`, because escaping an entry name is the part a shell gets wrong quietly and an entry name is the input least under this script's control. A third-party scanner action was the alternative and was not taken: it would put an unpinnable dependency in the one path that produces the bytes people install, for a package whose whole content is two files.

## What was run

Against the archive of the release that exists, `requests_0.1.0.0.zip` from `0.1.0.0-stable`:

    SOURCE_REPOSITORY=Flowfin/jellyfin-plugin-requests \
    SOURCE_COMMIT=c44552645f0dba120c49599deedbc0244b59dcec \
    PACKAGE_VERSION=0.1.0.0 \
      scripts/bill-of-materials.sh requests_0.1.0.0.zip bom-a.json
    bill-of-materials: wrote bom-a.json describing 2 file(s) from requests_0.1.0.0.zip.

Two entries, `Jellyfin.Plugin.Requests.dll` and `meta.json`, which is the whole archive:

    unzip -l requests_0.1.0.0.zip
      Length      Date    Time    Name
      900  2026-08-08 09:39   meta.json
    22528  2026-08-08 09:39   Jellyfin.Plugin.Requests.dll

Reproducible, which is what makes the comparison a check:

    scripts/bill-of-materials.sh requests_0.1.0.0.zip bom-b.json
    diff bom-a.json bom-b.json ; echo "exit=$?"
    exit=0

Each refusal watched failing, one at a time:

    scripts/bill-of-materials.sh empty.zip out.json ; echo "exit=$?"
    bill-of-materials: empty.zip carries no files. A package with nothing in it is not a package.
    exit=1

    scripts/bill-of-materials.sh notzip.zip out.json ; echo "exit=$?"
    bill-of-materials: notzip.zip is not a readable archive (File is not a zip file). The packaging step produced something this cannot describe.
    exit=1

    scripts/bill-of-materials.sh nope.zip out.json ; echo "exit=$?"
    bill-of-materials: nope.zip does not exist, so there is nothing to describe.
    exit=1

    ( unset PACKAGE_VERSION; scripts/bill-of-materials.sh requests_0.1.0.0.zip out.json ) ; echo "exit=$?"
    scripts/bill-of-materials.sh: line 42: PACKAGE_VERSION: the plugin version this archive carries
    exit=1

The recorded attestation run that `docs/RELEASING.md` now carries, and its failing direction:

    gh attestation verify requests_0.1.0.0.zip --repo Flowfin/jellyfin-plugin-requests ; echo "exit=$?"
    exit=0

    gh attestation verify requests_0.1.0.0.zip --repo Flowfin/jellyfin-plugin-sso ; echo "exit=$?"
    Error: HTTP 404: Not Found (.../repos/Flowfin/jellyfin-plugin-sso/attestations/sha256:c028b70f...)
    exit=1

The command prints its verdict only to a terminal, so the first run shows an exit status and no text. That is written into `docs/RELEASING.md` beside the command, because a reader who captures the output to a file and sees nothing would otherwise read silence as failure.

Formatting, on the files this touches, with the repository's own version and its `.editorconfig` beside them:

    npx --yes prettier@3.6.2 --check "**/*.md"
    Checking formatting...
    All matched files use Prettier code style!

## What was not run, and is not claimed

**The workflow steps have not executed.** `publish.yaml` runs on a tag push and on nothing else, and pushing a tag cuts a release. So the two changed steps are unproven: the script beneath them is proven by the runs above, and the wiring is not. What would prove it is the next release, and the failure it would produce is a red build job before anything is published rather than a broken release.

**An earlier draft carried a guard that was removed rather than shipped.** It unpacked the archive and walked the files line by line, which needed a rule refusing an entry name carrying a newline. That rule could not be shown to bite, because the unpacker on one of the platforms this runs on rewrites such a name before anything sees it. Reading the archive instead removes the whole class, so there is no unproven guard left in the script.

**No second reader.** This has been read by nobody but its author, and the evidence above stands in place of one.

## What #109 still waits on

Its first condition is met from the next release onward and not for `0.1.0.0-stable`, which was built before this existed and carries no `.cdx.json`. Its second condition is met and is checkable today, shown above. Its third asks for a recorded run of a verification command against a real release: the attestation half is recorded here and in `docs/RELEASING.md`, and the bill of materials half has nothing to run against until a release carries one.
