### PR TITLE
Make the legal moves a table rather than a rule people remember (#39)

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj
+++ b/Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj
@@ -47,6 +47,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- The lifecycle document, next to the suite, so the transition table printed for a reader is
+         compared against the table the code reads rather than against a copy of it in a test. -->
+    <None Include="../docs/lifecycle.md" Link="docs/lifecycle.md" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- The project, not a built assembly: a stale copy in a bin directory would pass a suite that
          is testing last week's plugin. -->
     <ProjectReference Include="..\Jellyfin.Plugin.Requests\Jellyfin.Plugin.Requests.csproj" />

--- a/Jellyfin.Plugin.Requests.Tests/Model/RequestLifecycleTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Model/RequestLifecycleTests.cs
@@ -1,0 +1,344 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using Jellyfin.Plugin.Requests.Model;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Model;
+
+/// <summary>
+/// The transition table, cell by cell, and the two things that make it a table rather than a
+/// comment: a move it refuses throws instead of happening, and the table printed in the
+/// documentation is the one the code reads.
+/// <para>
+/// The expected verdicts below are written out by hand rather than derived from
+/// <see cref="RequestLifecycle.Table"/>. Derived ones would compare the table with itself and pass
+/// for whatever it happened to say, including the day somebody widens a cell by accident.
+/// </para>
+/// </summary>
+public class RequestLifecycleTests
+{
+    /// <summary>
+    /// Every ordered pair of states has a cell and no pair has two. This is what makes adding a
+    /// value to the enumeration a visible piece of work: a sixth state arrives with eleven missing
+    /// cells and reds here, instead of quietly being a state nothing can leave or reach.
+    /// </summary>
+    [Fact]
+    public void EveryOrderedPairOfStatesHasExactlyOneCell()
+    {
+        var states = Enum.GetValues<RequestState>();
+        var missing = new List<string>();
+        var duplicated = new List<string>();
+
+        foreach (var from in states)
+        {
+            foreach (var to in states)
+            {
+                var cells = RequestLifecycle.Table.Count(cell => cell.From == from && cell.To == to);
+
+                if (cells == 0)
+                {
+                    missing.Add(Pair(from, to));
+                }
+                else if (cells > 1)
+                {
+                    duplicated.Add(Pair(from, to));
+                }
+            }
+        }
+
+        Assert.Empty(missing);
+        Assert.Empty(duplicated);
+        Assert.Equal(states.Length * states.Length, RequestLifecycle.Table.Count);
+    }
+
+    /// <summary>
+    /// Every cell of the table, legal and refused, asserted against a verdict written here rather
+    /// than read from the table. Twenty-five lines is the whole rule, and a change to any cell is a
+    /// change to this list with a reason in the commit that made it.
+    /// </summary>
+    /// <param name="from">The state being moved out of.</param>
+    /// <param name="to">The state being moved into.</param>
+    /// <param name="expected">Whether that move is allowed.</param>
+    [Theory]
+
+    // From open: an operator decides, or the library turns out to hold it already. Nothing has been
+    // sent anywhere, so it cannot have failed, and it is already open.
+    [InlineData(RequestState.Open, RequestState.Open, false)]
+    [InlineData(RequestState.Open, RequestState.Approved, true)]
+    [InlineData(RequestState.Open, RequestState.Declined, true)]
+    [InlineData(RequestState.Open, RequestState.Fulfilled, true)]
+    [InlineData(RequestState.Open, RequestState.Failed, false)]
+
+    // From approved: it arrives, it does not arrive, or the approval is taken back by declining it.
+    // Not back to open, because undeciding hides that somebody decided.
+    [InlineData(RequestState.Approved, RequestState.Open, false)]
+    [InlineData(RequestState.Approved, RequestState.Approved, false)]
+    [InlineData(RequestState.Approved, RequestState.Declined, true)]
+    [InlineData(RequestState.Approved, RequestState.Fulfilled, true)]
+    [InlineData(RequestState.Approved, RequestState.Failed, true)]
+
+    // From declined: an operator may change their mind, which is one move. Straight to fulfilled is
+    // refused, because a declined title appearing in the library is an availability observation.
+    [InlineData(RequestState.Declined, RequestState.Open, false)]
+    [InlineData(RequestState.Declined, RequestState.Approved, true)]
+    [InlineData(RequestState.Declined, RequestState.Declined, false)]
+    [InlineData(RequestState.Declined, RequestState.Fulfilled, false)]
+    [InlineData(RequestState.Declined, RequestState.Failed, false)]
+
+    // Fulfilled is terminal. The wrong file is a new request, and a library that no longer holds it
+    // is an observation rather than a decision being undone.
+    [InlineData(RequestState.Fulfilled, RequestState.Open, false)]
+    [InlineData(RequestState.Fulfilled, RequestState.Approved, false)]
+    [InlineData(RequestState.Fulfilled, RequestState.Declined, false)]
+    [InlineData(RequestState.Fulfilled, RequestState.Fulfilled, false)]
+    [InlineData(RequestState.Fulfilled, RequestState.Failed, false)]
+
+    // From failed: try again, give up, or it arrives after all. A failure with no way out would be
+    // the state this one was added to remove.
+    [InlineData(RequestState.Failed, RequestState.Open, false)]
+    [InlineData(RequestState.Failed, RequestState.Approved, true)]
+    [InlineData(RequestState.Failed, RequestState.Declined, true)]
+    [InlineData(RequestState.Failed, RequestState.Fulfilled, true)]
+    [InlineData(RequestState.Failed, RequestState.Failed, false)]
+    public void TheTableSaysWhatThisListSays(RequestState from, RequestState to, bool expected)
+    {
+        Assert.Equal(expected, RequestLifecycle.IsLegal(from, to));
+    }
+
+    /// <summary>
+    /// A move the table allows produces a new request in the new state, with the time and the mover
+    /// recorded, and changes nothing else. The last part is what stops a move from quietly
+    /// rewriting the title snapshot or the identifiers a later fulfilment check matches on.
+    /// </summary>
+    [Fact]
+    public void AnAllowedMoveChangesTheStateTheTimeAndTheMoverAndNothingElse()
+    {
+        var request = ARequest();
+        var movedAt = new DateTimeOffset(2026, 8, 9, 11, 30, 0, TimeSpan.Zero);
+        var operatorId = new Guid("2d8f4b16-3a5c-4d97-8e21-7c6b5a4f3e29");
+
+        var moved = RequestLifecycle.Move(request, RequestState.Approved, movedAt, operatorId);
+
+        Assert.Equal(RequestState.Approved, moved.State);
+        Assert.Equal(movedAt, moved.StateChangedAt);
+        Assert.Equal(operatorId, moved.StateChangedByUserId);
+
+        // Everything the move is not about, compared as one value: the record's generated equality
+        // covers every field, so a field added later is covered here without this test being
+        // edited.
+        Assert.Equal(
+            request,
+            moved with
+            {
+                State = request.State,
+                StateChangedAt = request.StateChangedAt,
+                StateChangedByUserId = request.StateChangedByUserId
+            });
+    }
+
+    /// <summary>
+    /// The plugin moving a request on its own records no mover. A request the library check
+    /// fulfilled and one an operator fulfilled read differently, and reading the plugin's own move
+    /// as somebody's decision is what would make an operator answer for a decision they did not
+    /// take.
+    /// </summary>
+    [Fact]
+    public void TheMoverIsAbsentWhereNoPersonMovedIt()
+    {
+        var request = ARequest();
+
+        var moved = RequestLifecycle.Move(
+            request,
+            RequestState.Fulfilled,
+            new DateTimeOffset(2026, 8, 9, 12, 0, 0, TimeSpan.Zero),
+            movedByUserId: null);
+
+        Assert.Equal(RequestState.Fulfilled, moved.State);
+        Assert.Null(moved.StateChangedByUserId);
+    }
+
+    /// <summary>
+    /// A refused move throws, and the refusal names both states. Both halves matter: a refusal that
+    /// returns the request unchanged is a move that silently did not happen, and a refusal reading
+    /// only "invalid transition" sends whoever finds it in a log back into the code to work out
+    /// which pair it meant.
+    /// </summary>
+    [Fact]
+    public void ARefusedMoveThrowsAndTheRefusalNamesBothStates()
+    {
+        foreach (var cell in RequestLifecycle.Table.Where(entry => !entry.IsLegal))
+        {
+            var request = ARequest() with { State = cell.From };
+
+            var refusal = Assert.Throws<IllegalRequestTransitionException>(
+                () => RequestLifecycle.Move(
+                    request,
+                    cell.To,
+                    new DateTimeOffset(2026, 8, 9, 13, 0, 0, TimeSpan.Zero),
+                    movedByUserId: null));
+
+            Assert.Equal(cell.From, refusal.From);
+            Assert.Equal(cell.To, refusal.To);
+            Assert.Contains(cell.From.ToString(), refusal.Message, StringComparison.Ordinal);
+            Assert.Contains(cell.To.ToString(), refusal.Message, StringComparison.Ordinal);
+            Assert.Contains(cell.Why, refusal.Message, StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>
+    /// Every cell says why. A refused cell with no reason is an absence with extra steps, and the
+    /// question a reader arrives with is why a move they expected is not allowed.
+    /// </summary>
+    [Fact]
+    public void EveryCellCarriesAReason()
+    {
+        var silent = RequestLifecycle.Table
+            .Where(cell => string.IsNullOrWhiteSpace(cell.Why) || !cell.Why.EndsWith('.'))
+            .Select(cell => Pair(cell.From, cell.To))
+            .ToArray();
+
+        Assert.Empty(silent);
+    }
+
+    /// <summary>
+    /// The grid printed in <c>docs/lifecycle.md</c> is the table in the code, cell for cell. This
+    /// and the test below it are the condition on #39 that the two cannot drift: the document is
+    /// not generated at build time, and what stands in place of generation is a comparison that
+    /// reds in both directions, so a cell changed in either place fails until it is changed in the
+    /// other.
+    /// <para>
+    /// The grid is a five by five matrix whose rows are the state being left and whose columns are
+    /// the state being entered. Only the padding inside the pipes is ignored, because the
+    /// formatting gate owns that and this suite should not have a second opinion about it.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void TheDocumentedGridIsTheTableInTheCode()
+    {
+        var rows = MarkedSection("grid").Where(line => line.StartsWith('|')).ToArray();
+        var header = SplitRow(rows[0]);
+
+        // The row of dashes under the header is the table's own furniture. Everything else is a
+        // row of the matrix, so a row that was deleted from the document fails the comparison at
+        // the end rather than being skipped here.
+        var body = rows.Skip(2).Select(SplitRow).ToArray();
+
+        var documented = new List<string>();
+
+        foreach (var row in body)
+        {
+            for (var column = 1; column < row.Length; column++)
+            {
+                documented.Add(string.Concat(row[0], " ", header[column], " ", row[column]));
+            }
+        }
+
+        var expected = RequestLifecycle.Table
+            .Select(cell => string.Concat(
+                cell.From.ToString(),
+                " ",
+                cell.To.ToString(),
+                " ",
+                Verdict(cell)))
+            .ToArray();
+
+        Assert.Equal(expected, documented);
+    }
+
+    /// <summary>
+    /// The reasons printed in <c>docs/lifecycle.md</c> are the reasons in the code, one bullet per
+    /// cell, in the table's own order. The grid above says what the answer is and this says why,
+    /// and the why is the half a reader actually arrives for.
+    /// </summary>
+    [Fact]
+    public void TheDocumentedReasonsAreTheReasonsInTheCode()
+    {
+        var expected = RequestLifecycle.Table
+            .Select(cell => string.Format(
+                CultureInfo.InvariantCulture,
+                "- **{0} to {1}**: {2}. {3}",
+                cell.From,
+                cell.To,
+                Verdict(cell),
+                cell.Why))
+            .ToArray();
+
+        var documented = MarkedSection("reasons")
+            .Where(line => line.StartsWith("- **", StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.Equal(expected, documented);
+    }
+
+    private static string Verdict(RequestTransition cell) => cell.IsLegal ? "allowed" : "refused";
+
+    private static string[] SplitRow(string row)
+        => [.. row.Trim('|').Split('|').Select(cell => cell.Trim())];
+
+    /// <summary>
+    /// Reads the lines the document marks off for one section.
+    /// </summary>
+    /// <param name="name">The name in the marker comments.</param>
+    /// <returns>The trimmed lines between the markers.</returns>
+    private static string[] MarkedSection(string name)
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "docs", "lifecycle.md");
+        Assert.True(File.Exists(path), FormattableString.Invariant($"{path} was not copied next to the suite."));
+
+        var opening = FormattableString.Invariant($"<!-- {name} begins -->");
+        var closing = FormattableString.Invariant($"<!-- {name} ends -->");
+        var inside = false;
+        var lines = new List<string>();
+
+        foreach (var line in File.ReadLines(path))
+        {
+            var trimmed = line.Trim();
+
+            if (trimmed.Equals(opening, StringComparison.Ordinal))
+            {
+                inside = true;
+                continue;
+            }
+
+            if (trimmed.Equals(closing, StringComparison.Ordinal))
+            {
+                inside = false;
+                continue;
+            }
+
+            if (inside && trimmed.Length > 0)
+            {
+                lines.Add(trimmed);
+            }
+        }
+
+        Assert.False(inside, FormattableString.Invariant($"The document opens {name} and never closes it."));
+        Assert.NotEmpty(lines);
+        return [.. lines];
+    }
+
+    private static string Pair(RequestState from, RequestState to)
+        => string.Format(CultureInfo.InvariantCulture, "{0} to {1}", from, to);
+
+    /// <summary>
+    /// A request with only the fields that have no default, in the state a new one is created in.
+    /// </summary>
+    /// <returns>A newly asked-for request.</returns>
+    private static MediaRequest ARequest()
+    {
+        var asked = new DateTimeOffset(2026, 8, 9, 10, 0, 0, TimeSpan.Zero);
+
+        return new MediaRequest
+        {
+            Id = new Guid("41d7c0b2-9e3a-4f58-b6d1-8c2f5a0e7b93"),
+            RequestedByUserId = new Guid("7a4e2f18-6b0c-4d39-95e7-1f8a3c6d2b40"),
+            RequestedAt = asked,
+            StateChangedAt = asked,
+            Kind = RequestedItemKind.Series,
+            DisplayTitle = "Tinker Tailor Soldier Spy"
+        };
+    }
+}

--- a/Jellyfin.Plugin.Requests/Model/IllegalRequestTransitionException.cs
+++ b/Jellyfin.Plugin.Requests/Model/IllegalRequestTransitionException.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Globalization;
+
+namespace Jellyfin.Plugin.Requests.Model;
+
+/// <summary>
+/// Thrown when something asks for a move <see cref="RequestLifecycle.Table"/> refuses.
+/// <para>
+/// The two states are carried as values as well as being named in the message, so a caller can act
+/// on them without reading English out of a string, and a log line says which move was attempted
+/// rather than that one was. A refusal that says only "invalid state transition" sends whoever
+/// reads it back to the code to work out which pair it meant.
+/// </para>
+/// </summary>
+public sealed class IllegalRequestTransitionException : InvalidOperationException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IllegalRequestTransitionException"/> class for
+    /// a named pair of states.
+    /// </summary>
+    /// <param name="from">The state the move was out of.</param>
+    /// <param name="to">The state the move was into.</param>
+    /// <param name="why">The reason the table gives for refusing this pair.</param>
+    public IllegalRequestTransitionException(RequestState from, RequestState to, string why)
+        : base(Describe(from, to, why))
+    {
+        From = from;
+        To = to;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IllegalRequestTransitionException"/> class.
+    /// Present because the analyzers ask every exception for the three ordinary constructors; the
+    /// constructor above is the one this type exists for, and it is the only one that can say which
+    /// move was refused.
+    /// </summary>
+    public IllegalRequestTransitionException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IllegalRequestTransitionException"/> class with
+    /// a message of the caller's own. See the note on the parameterless constructor.
+    /// </summary>
+    /// <param name="message">The message.</param>
+    public IllegalRequestTransitionException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IllegalRequestTransitionException"/> class with
+    /// a message and an inner exception. See the note on the parameterless constructor.
+    /// </summary>
+    /// <param name="message">The message.</param>
+    /// <param name="innerException">The inner exception.</param>
+    public IllegalRequestTransitionException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    /// Gets the state the refused move was out of, or <see cref="RequestState.Open"/> where this
+    /// was built by one of the constructors that names no pair.
+    /// </summary>
+    public RequestState From { get; }
+
+    /// <summary>
+    /// Gets the state the refused move was into, or <see cref="RequestState.Open"/> where this was
+    /// built by one of the constructors that names no pair.
+    /// </summary>
+    public RequestState To { get; }
+
+    private static string Describe(RequestState from, RequestState to, string why)
+        => string.Format(
+            CultureInfo.InvariantCulture,
+            "A request cannot move from {0} to {1}. {2}",
+            from,
+            to,
+            why);
+}

--- a/Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs
+++ b/Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace Jellyfin.Plugin.Requests.Model;
+
+/// <summary>
+/// The moves a request may make, as a table, and the one place a move is made.
+/// <para>
+/// It is a table rather than a chain of conditionals because the same question gets asked by the
+/// API, by the administrator page, by the bridge and by whatever detects fulfilment, and four
+/// copies of a rule are four chances for one of them to be a version behind. A table can be read
+/// by a person, printed into the documentation and tested cell by cell, including the cells that
+/// must refuse.
+/// </para>
+/// <para>
+/// Every ordered pair of states has a cell, including a state paired with itself, so adding a value
+/// to <see cref="RequestState"/> is a set of entries here rather than a silent widening. The three
+/// cells people disagree about are answered as follows, and each answer is in the table's own
+/// <see cref="RequestTransition.Why"/> beside the cell rather than only here.
+/// </para>
+/// <para>
+/// Nothing returns to <see cref="RequestState.Open"/>. Undeciding is not a decision, and a request
+/// that reads as undecided after somebody decided it hides the decision from the next person to
+/// look at the queue. An approval given by mistake is repaired by declining it, and both moves stay
+/// in the history.
+/// </para>
+/// <para>
+/// A decline can be taken back. An operator changing their mind is ordinary, and the alternative is
+/// asking the person who was refused to ask again, which loses the connection between the two and
+/// depends on that person still being there.
+/// </para>
+/// <para>
+/// <see cref="RequestState.Fulfilled"/> is the end. A file that turns out to be the wrong one is a
+/// new request for the right one, and a library that stops holding the media is an observation
+/// rather than a decision being undone, which is what <see cref="LibraryAvailability"/> and
+/// <see cref="MediaRequest.AvailabilityCheckedAt"/> are for.
+/// </para>
+/// </summary>
+public static class RequestLifecycle
+{
+    /// <summary>
+    /// Gets every ordered pair of states, whether the move is allowed, and why. This is the source
+    /// the grid and the reasons in <c>docs/lifecycle.md</c> are written from, and
+    /// <c>TheDocumentedGridIsTheTableInTheCode</c> and
+    /// <c>TheDocumentedReasonsAreTheReasonsInTheCode</c> refuse the two disagreeing.
+    /// </summary>
+    public static IReadOnlyList<RequestTransition> Table { get; } = BuildTable();
+
+    /// <summary>
+    /// Whether a request may move between two states.
+    /// </summary>
+    /// <param name="from">The state being moved out of.</param>
+    /// <param name="to">The state being moved into.</param>
+    /// <returns><see langword="true"/> where the table allows the move.</returns>
+    public static bool IsLegal(RequestState from, RequestState to) => Cell(from, to).IsLegal;
+
+    /// <summary>
+    /// Looks up one cell of the table.
+    /// </summary>
+    /// <param name="from">The state being moved out of.</param>
+    /// <param name="to">The state being moved into.</param>
+    /// <returns>The cell for that pair.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Where either value is not one the table has a cell for, which can only happen if a value was
+    /// added to <see cref="RequestState"/> without adding its rows here.
+    /// </exception>
+    public static RequestTransition Cell(RequestState from, RequestState to)
+    {
+        var cell = Table.FirstOrDefault(entry => entry.From == from && entry.To == to);
+
+        return cell ?? throw new ArgumentOutOfRangeException(
+            nameof(to),
+            $"The transition table has no cell for {from} to {to}. A state was added to RequestState without its rows.");
+    }
+
+    /// <summary>
+    /// Moves a request, or refuses to.
+    /// <para>
+    /// This is the only place in the plugin that changes a request's state. The record is immutable
+    /// and a caller could still write <c>with { State = ... }</c>, so this being the one place is
+    /// held by review and by the callers that exist rather than by anything that refuses the
+    /// alternative; that gap is named in <c>docs/lifecycle.md</c>.
+    /// </para>
+    /// </summary>
+    /// <param name="request">The request to move.</param>
+    /// <param name="to">The state to move it into.</param>
+    /// <param name="at">
+    /// When the move happened, from the injected clock rather than the machine's.
+    /// </param>
+    /// <param name="movedByUserId">
+    /// The Jellyfin user who moved it, or <see langword="null"/> where the plugin moved it on its
+    /// own after looking at the library.
+    /// </param>
+    /// <returns>A new request in the new state.</returns>
+    /// <exception cref="ArgumentNullException">Where no request was given.</exception>
+    /// <exception cref="IllegalRequestTransitionException">Where the table refuses the move.</exception>
+    public static MediaRequest Move(
+        MediaRequest request,
+        RequestState to,
+        DateTimeOffset at,
+        Guid? movedByUserId)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var cell = Cell(request.State, to);
+
+        if (!cell.IsLegal)
+        {
+            throw new IllegalRequestTransitionException(cell.From, cell.To, cell.Why);
+        }
+
+        return request with
+        {
+            State = to,
+            StateChangedAt = at,
+            StateChangedByUserId = movedByUserId
+        };
+    }
+
+    private static ReadOnlyCollection<RequestTransition> BuildTable()
+    {
+        const string NotAMove =
+            "A move to the state it is already in is not a move, and appending a history entry saying nothing happened makes the history harder to read rather than more complete.";
+        const string NoUndeciding =
+            "Nothing returns to open. A request reading as undecided after somebody decided it hides that decision from the next person to look at the queue.";
+        const string FulfilledIsTheEnd =
+            "Fulfilled is the end of this request. A file that turns out to be the wrong one is a new request for the right one, and a library that stops holding it is an availability observation rather than a decision being undone.";
+        const string NothingWasSent =
+            "Nothing was ever sent onward, so there is nothing that could have failed.";
+
+        var table = new List<RequestTransition>
+        {
+            Refused(RequestState.Open, RequestState.Open, NotAMove),
+            Legal(RequestState.Open, RequestState.Approved, "An operator says yes."),
+            Legal(RequestState.Open, RequestState.Declined, "An operator says no."),
+            Legal(
+                RequestState.Open,
+                RequestState.Fulfilled,
+                "The library already holds what was asked for, so there is nothing left for anybody to decide."),
+            Refused(RequestState.Open, RequestState.Failed, NothingWasSent),
+
+            Refused(RequestState.Approved, RequestState.Open, NoUndeciding),
+            Refused(RequestState.Approved, RequestState.Approved, NotAMove),
+            Legal(
+                RequestState.Approved,
+                RequestState.Declined,
+                "An operator takes an approval back, and the reason says why. This is the repair for an approval given by mistake."),
+            Legal(RequestState.Approved, RequestState.Fulfilled, "It arrived and the person who asked can watch it."),
+            Legal(
+                RequestState.Approved,
+                RequestState.Failed,
+                "It was sent onward and did not arrive, so it stops looking like an operator forgot about it."),
+
+            Refused(RequestState.Declined, RequestState.Open, NoUndeciding),
+            Legal(
+                RequestState.Declined,
+                RequestState.Approved,
+                "An operator changes their mind. One request carrying both moves beats asking the person who was refused to ask again."),
+            Refused(RequestState.Declined, RequestState.Declined, NotAMove),
+            Refused(
+                RequestState.Declined,
+                RequestState.Fulfilled,
+                "A declined request whose title later appears in the library is an availability observation and not a decision. Approving it first is the move that says a person changed the answer."),
+            Refused(RequestState.Declined, RequestState.Failed, NothingWasSent),
+
+            Refused(RequestState.Fulfilled, RequestState.Open, FulfilledIsTheEnd),
+            Refused(RequestState.Fulfilled, RequestState.Approved, FulfilledIsTheEnd),
+            Refused(RequestState.Fulfilled, RequestState.Declined, FulfilledIsTheEnd),
+            Refused(RequestState.Fulfilled, RequestState.Fulfilled, NotAMove),
+            Refused(RequestState.Fulfilled, RequestState.Failed, FulfilledIsTheEnd),
+
+            Refused(RequestState.Failed, RequestState.Open, NoUndeciding),
+            Legal(RequestState.Failed, RequestState.Approved, "An operator sends it onward again."),
+            Legal(
+                RequestState.Failed,
+                RequestState.Declined,
+                "An operator gives up on it, and the reason says why. Without this a failure has no ending."),
+            Legal(
+                RequestState.Failed,
+                RequestState.Fulfilled,
+                "It arrived after all, by this route or by somebody putting it in the library by hand."),
+            Refused(RequestState.Failed, RequestState.Failed, NotAMove)
+        };
+
+        return new ReadOnlyCollection<RequestTransition>(table);
+    }
+
+    private static RequestTransition Legal(RequestState from, RequestState to, string why)
+        => new() { From = from, To = to, IsLegal = true, Why = why };
+
+    private static RequestTransition Refused(RequestState from, RequestState to, string why)
+        => new() { From = from, To = to, IsLegal = false, Why = why };
+}

--- a/Jellyfin.Plugin.Requests/Model/RequestState.cs
+++ b/Jellyfin.Plugin.Requests/Model/RequestState.cs
@@ -6,15 +6,18 @@ namespace Jellyfin.Plugin.Requests.Model;
 /// are separate because an approved request that has not arrived yet is the ordinary case rather
 /// than an edge one.
 /// <para>
-/// Which moves between these values are legal is a table rather than a set of conditionals, and it
-/// is #39. Whether four values are enough, or whether a cancelled or failed value is also needed,
-/// is decision 3 on #113; adding one is an entry here and a row there.
+/// Which moves between these values are legal is <see cref="RequestLifecycle.Table"/>, which is
+/// data rather than a set of conditionals. Adding a value here is an entry there, and the table has
+/// a cell for every pair whether it is legal or not, so a new value cannot be added without saying
+/// what may reach it and what it may reach.
 /// </para>
 /// </summary>
 public enum RequestState
 {
     /// <summary>
-    /// Asked for, and nothing has been decided. The state a request is created in.
+    /// Asked for, and nothing has been decided. The state a request is created in, and the only
+    /// state nothing moves back to: undecided is a fact about a request nobody has looked at, and
+    /// once somebody has looked, the honest record of that is the decision they made.
     /// </summary>
     Open = 0,
 
@@ -24,12 +27,21 @@ public enum RequestState
     Approved = 1,
 
     /// <summary>
-    /// An operator said no. The reason, where there is one, is #41.
+    /// An operator said no. The reason is #41 and is required, decided on #113.
     /// </summary>
     Declined = 2,
 
     /// <summary>
     /// The thing that was asked for is in the library and the person who asked can watch it.
     /// </summary>
-    Fulfilled = 3
+    Fulfilled = 3,
+
+    /// <summary>
+    /// Approved, sent onward, and it did not arrive. This exists because the alternative is a
+    /// request that sits in <see cref="Approved"/> forever looking like an operator forgot, when
+    /// what happened is that the thing doing the fetching gave up. Added on the decision recorded
+    /// on #113; a cancelled value was considered there and refused, because a user withdrawing is
+    /// a second road to "finished" that carries nothing an operator acts on differently.
+    /// </summary>
+    Failed = 4
 }

--- a/Jellyfin.Plugin.Requests/Model/RequestTransition.cs
+++ b/Jellyfin.Plugin.Requests/Model/RequestTransition.cs
@@ -1,0 +1,36 @@
+namespace Jellyfin.Plugin.Requests.Model;
+
+/// <summary>
+/// One cell of <see cref="RequestLifecycle.Table"/>: an ordered pair of states, whether moving
+/// between them is allowed, and the sentence that says why.
+/// <para>
+/// A refused cell is a row here rather than an absence, because an absence cannot carry a reason.
+/// The question a reader arrives with is almost never "is this allowed" but "why is this not
+/// allowed", and a table of only the legal moves answers the first and leaves the second to
+/// whoever remembers the argument.
+/// </para>
+/// </summary>
+public sealed record RequestTransition
+{
+    /// <summary>
+    /// Gets the state being moved out of.
+    /// </summary>
+    public required RequestState From { get; init; }
+
+    /// <summary>
+    /// Gets the state being moved into.
+    /// </summary>
+    public required RequestState To { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether this move is allowed.
+    /// </summary>
+    public required bool IsLegal { get; init; }
+
+    /// <summary>
+    /// Gets the reason this cell reads the way it does, in one sentence. This is printed in
+    /// <c>docs/lifecycle.md</c> and is the text a person reads when a move they expected to work
+    /// was refused, so it says why rather than restating the verdict.
+    /// </summary>
+    public required string Why { get; init; }
+}

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -1,0 +1,110 @@
+# The request lifecycle
+
+A request is in one of five states, and which moves between them are allowed is a table rather than
+a chain of conditionals. The table is data, in
+[`RequestLifecycle.Table`](../Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs), and everything
+below is printed from it: `RequestLifecycleTests` compares the grid and the reasons on this page
+against that table and fails if either side changes without the other.
+
+## The five states
+
+`Open` is where a request starts. Nothing has been decided and nobody has necessarily looked at it.
+
+`Approved` means an operator said yes. It does not mean the server has the media, and the gap
+between the two is the ordinary case rather than an edge one.
+
+`Declined` means an operator said no. A reason is required, which was decided on #113 and is built
+in #41.
+
+`Fulfilled` means the thing that was asked for is in the library and the person who asked can watch
+it.
+
+`Failed` means it was approved, sent onward, and did not arrive. Without it, a request that the
+external service accepted and then dropped sits in `Approved` forever looking like an operator
+forgot about it. It was added on the decision recorded on #113, which also refused a `Cancelled`
+state: a user withdrawing a request is a second road to "finished" that an operator does nothing
+different about.
+
+State says nothing about whether the server holds the media. That is `LibraryAvailability`, it is a
+separate field on the record, and several of the refusals below only make sense because it exists.
+
+## The table
+
+Rows are the state being left, columns are the state being entered.
+
+<!-- grid begins -->
+
+| From      | Open    | Approved | Declined | Fulfilled | Failed  |
+| --------- | ------- | -------- | -------- | --------- | ------- |
+| Open      | refused | allowed  | allowed  | allowed   | refused |
+| Approved  | refused | refused  | allowed  | allowed   | allowed |
+| Declined  | refused | allowed  | refused  | refused   | refused |
+| Fulfilled | refused | refused  | refused  | refused   | refused |
+| Failed    | refused | allowed  | allowed  | allowed   | refused |
+
+<!-- grid ends -->
+
+Ten of the twenty-five moves are allowed. Every pair has a cell, including a state paired with
+itself, so a sixth state is eleven new cells rather than a silent widening.
+
+## Why each cell reads the way it does
+
+<!-- reasons begins -->
+
+- **Open to Open**: refused. A move to the state it is already in is not a move, and appending a history entry saying nothing happened makes the history harder to read rather than more complete.
+- **Open to Approved**: allowed. An operator says yes.
+- **Open to Declined**: allowed. An operator says no.
+- **Open to Fulfilled**: allowed. The library already holds what was asked for, so there is nothing left for anybody to decide.
+- **Open to Failed**: refused. Nothing was ever sent onward, so there is nothing that could have failed.
+- **Approved to Open**: refused. Nothing returns to open. A request reading as undecided after somebody decided it hides that decision from the next person to look at the queue.
+- **Approved to Approved**: refused. A move to the state it is already in is not a move, and appending a history entry saying nothing happened makes the history harder to read rather than more complete.
+- **Approved to Declined**: allowed. An operator takes an approval back, and the reason says why. This is the repair for an approval given by mistake.
+- **Approved to Fulfilled**: allowed. It arrived and the person who asked can watch it.
+- **Approved to Failed**: allowed. It was sent onward and did not arrive, so it stops looking like an operator forgot about it.
+- **Declined to Open**: refused. Nothing returns to open. A request reading as undecided after somebody decided it hides that decision from the next person to look at the queue.
+- **Declined to Approved**: allowed. An operator changes their mind. One request carrying both moves beats asking the person who was refused to ask again.
+- **Declined to Declined**: refused. A move to the state it is already in is not a move, and appending a history entry saying nothing happened makes the history harder to read rather than more complete.
+- **Declined to Fulfilled**: refused. A declined request whose title later appears in the library is an availability observation and not a decision. Approving it first is the move that says a person changed the answer.
+- **Declined to Failed**: refused. Nothing was ever sent onward, so there is nothing that could have failed.
+- **Fulfilled to Open**: refused. Fulfilled is the end of this request. A file that turns out to be the wrong one is a new request for the right one, and a library that stops holding it is an availability observation rather than a decision being undone.
+- **Fulfilled to Approved**: refused. Fulfilled is the end of this request. A file that turns out to be the wrong one is a new request for the right one, and a library that stops holding it is an availability observation rather than a decision being undone.
+- **Fulfilled to Declined**: refused. Fulfilled is the end of this request. A file that turns out to be the wrong one is a new request for the right one, and a library that stops holding it is an availability observation rather than a decision being undone.
+- **Fulfilled to Fulfilled**: refused. A move to the state it is already in is not a move, and appending a history entry saying nothing happened makes the history harder to read rather than more complete.
+- **Fulfilled to Failed**: refused. Fulfilled is the end of this request. A file that turns out to be the wrong one is a new request for the right one, and a library that stops holding it is an availability observation rather than a decision being undone.
+- **Failed to Open**: refused. Nothing returns to open. A request reading as undecided after somebody decided it hides that decision from the next person to look at the queue.
+- **Failed to Approved**: allowed. An operator sends it onward again.
+- **Failed to Declined**: allowed. An operator gives up on it, and the reason says why. Without this a failure has no ending.
+- **Failed to Fulfilled**: allowed. It arrived after all, by this route or by somebody putting it in the library by hand.
+- **Failed to Failed**: refused. A move to the state it is already in is not a move, and appending a history entry saying nothing happened makes the history harder to read rather than more complete.
+
+<!-- reasons ends -->
+
+## The three cells people disagree about
+
+**Can a declined request be reopened?** It can be approved, and it cannot go back to open. An
+operator changing their mind is ordinary, and the alternative is asking the person who was refused
+to ask again, which loses the connection between the two attempts and depends on that person still
+being around. Going back to `Open` is different: it would erase the fact that somebody decided, and
+the queue would show the request as untouched.
+
+**Can an approval be taken back?** Yes, by declining it. That leaves both moves in the history, so
+an operator dealing with a complaint can see that the request was approved on Tuesday and declined
+on Wednesday, which is what happened.
+
+**Can a fulfilled request return to an earlier state?** No. A file that turns out to be the wrong
+one is a request for the right one, and it is a new request because the old one describes what was
+asked for and got an answer. A library that no longer holds the media is an observation, which the
+`Availability` field on the record already carries with the time it was made.
+
+## What is not enforced
+
+`RequestLifecycle.Move` is the one place in the plugin that changes a state, and it refuses a move
+this table refuses. Nothing stops a caller writing `with { State = ... }` on the record instead: the
+record is immutable, and immutability makes a move produce a new value rather than making it go
+through here. There are no callers yet, so the property holds today by there being nothing to hold
+it against. The invariant lint in #28 is where a rule refusing that shape would live, and this
+paragraph is what it does not yet do.
+
+The history of the moves a request has made is #43, and it is not built here. `StateChangedAt` and
+`StateChangedByUserId` on the record are the current move only, and a request that has been approved
+and then declined carries no trace of the approval until that issue lands.


### PR DESCRIPTION
Closes #39.

## What this changes

`RequestState` had four values and nothing anywhere said which moves between them were allowed. The next thing to move a request would have written that rule, and so would the one after it, and a rule written four times is four chances for one copy to be a version behind. The concrete failure is cheap to reach: an approval taken back by moving the request to `Open`, which leaves the queue showing it as undecided and quietly removes the fact that somebody decided.

`Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs` holds the table as data. Every ordered pair of states has a cell, including a state paired with itself, and each cell carries whether the move is allowed and one sentence saying why. A refused cell is a row rather than an absence, because an absence cannot carry a reason, and the question a reader arrives with is almost never "is this allowed" but "why is this not allowed".

`RequestLifecycle.Move` is the one place a state changes. It looks the pair up and throws `IllegalRequestTransitionException` where the table refuses it. The exception names both states in its message and carries them as values, so a caller can act on the pair without reading English out of a string and a log line says which move was attempted rather than that one was.

`RequestState` gains `Failed`. That is the decision recorded on #113: without it, an approved request that the external service accepted and then dropped sits in `Approved` forever looking like an operator forgot about it. The same decision refused a `Cancelled` value and none is added.

`docs/lifecycle.md` is new. It carries the five states, the grid, the reason for all twenty-five cells, and the three cells the issue says people disagree about.

## The three cells the issue names

A **declined** request can be approved and cannot go back to `Open`. An operator changing their mind is ordinary, and the alternative is asking the person who was refused to ask again, which loses the connection between the two attempts and depends on that person still being around. Going back to `Open` is a different thing and is refused everywhere: it erases that somebody decided.

An **approval** is taken back by declining it, which leaves both moves visible rather than one.

**Fulfilled** is terminal. A file that turns out to be the wrong one is a new request for the right one, and a library that stops holding the media is an observation rather than a decision being undone, which is what `Availability` and `AvailabilityCheckedAt` on the record already carry.

Ten of the twenty-five moves are allowed.

## The means

C# in the existing model project, tested by the existing xunit suite, documented in the existing `docs/`. No language, runtime, package or apparatus is added: the table is a list of records and the documentation check is `File.ReadLines` against a file the test project already knows how to copy next to the suite, in the same shape `PackagingMetadataTests` reads the packaging metadata. A source generator writing the document at build time was the alternative and was not taken, because it adds a build-time dependency and a generated file to review for a page whose whole content is twenty-five rows that a test can compare.

## The third condition, exactly

The issue asks that the documentation render the table from the same source the code uses, so the two cannot drift. The document is **not** generated at build time. What stands in place of generation is `TheDocumentedGridIsTheTableInTheCode` and `TheDocumentedReasonsAreTheReasonsInTheCode`, which read the page next to the suite and compare it with `RequestLifecycle.Table` in both directions, so a cell changed in either place fails until it is changed in the other. Only the padding inside the pipes is ignored, because the formatting gate owns that.

## What was run

The suite, on both claimed target frameworks:

    dotnet test Jellyfin.Plugin.Requests.sln --nologo
    Bestanden!   : Fehler:     0, erfolgreich:    76, uebersprungen:     0, gesamt:    76 - Jellyfin.Plugin.Requests.Tests.dll (net9.0)
    Bestanden!   : Fehler:     0, erfolgreich:    76, uebersprungen:     0, gesamt:    76 - Jellyfin.Plugin.Requests.Tests.dll (net10.0)

Seventy-six, from thirty-five before this change. The runner on this machine is German; the numbers are the numbers.

The build with warnings as errors, which is what the gate runs:

    dotnet build Jellyfin.Plugin.Requests.sln --nologo -warnaserror
    0 Warnung(en)
    0 Fehler

The formatter, at the version the gate pins:

    npx --yes prettier@3.6.2 --check "docs/lifecycle.md"
    Checking formatting...
    All matched files use Prettier code style!

## Each guard watched failing

One cell widened in the code and nowhere else, `Declined` to `Fulfilled` changed from refused to allowed:

    Fehler ...RequestLifecycleTests.TheTableSaysWhatThisListSays(from: Declined, to: Fulfilled, expected: False)
    Fehler ...RequestLifecycleTests.TheDocumentedGridIsTheTableInTheCode
    Fehler ...RequestLifecycleTests.TheDocumentedReasonsAreTheReasonsInTheCode
    Fehler!      : Fehler:     3, erfolgreich:    73, gesamt:    76

One cell changed in the document and nowhere else, the `Declined` to `Fulfilled` cell of the grid set to `allowed`:

    Fehler ...RequestLifecycleTests.TheDocumentedGridIsTheTableInTheCode
    Fehler!      : Fehler:     1, erfolgreich:    75, gesamt:    76

One cell deleted from the table, `Failed` to `Failed`:

    Fehler ...RequestLifecycleTests.TheTableSaysWhatThisListSays(from: Failed, to: Failed, expected: False)
    Fehler ...RequestLifecycleTests.TheDocumentedGridIsTheTableInTheCode
    Fehler ...RequestLifecycleTests.TheDocumentedReasonsAreTheReasonsInTheCode
    Fehler ...RequestLifecycleTests.EveryOrderedPairOfStatesHasExactlyOneCell
    Fehler!      : Fehler:     4, erfolgreich:    72, gesamt:    76

The refusal removed from `Move`, so an illegal move happens instead of throwing:

    Fehler ...RequestLifecycleTests.ARefusedMoveThrowsAndTheRefusalNamesBothStates
    Fehler!      : Fehler:     1, erfolgreich:    75, gesamt:    76

Each was reverted before the next.

## What is not covered

`RequestLifecycle.Move` is the only place a state changes, and nothing refuses a caller writing `with { State = ... }` on the record instead. There are no callers yet, so the property holds today by there being nothing to hold it against. A rule refusing that shape belongs to the invariant lint in #28, it is not added here because `tools/` is outside this issue's declared scope, and `docs/lifecycle.md` says so on the page rather than only here.

The history of the moves a request has made is #43 and is not built here. `StateChangedAt` and `StateChangedByUserId` remain the current move only, and a request approved and then declined carries no trace of the approval until that issue lands.

The decline reason the `Declined` cells talk about is #41 and does not exist yet, so the table allows a decline that says nothing.

The invariant lint was not run on this machine. It is a Linux binary the workflow downloads by digest and there is no Windows build of it here, so what was done instead is narrower: the patterns of all nine rules were read against the added files by hand and none matches. The gate on this pull request is what actually judges it.

This change had no second reader.
