### PR TITLE
Add the reason a decline must carry and the notes people write (#41)

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Model/MediaRequestTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Model/MediaRequestTests.cs
@@ -24,6 +24,8 @@ public class MediaRequestTests
     [
         "Availability",
         "AvailabilityCheckedAt",
+        "DeclineNote",
+        "DeclineReason",
         "DisplayTitle",
         "DisplayYear",
         "Id",
@@ -31,6 +33,7 @@ public class MediaRequestTests
         "ProviderIds",
         "RequestedAt",
         "RequestedByUserId",
+        "RequesterNote",
         "State",
         "StateChangedAt",
         "StateChangedByUserId"

--- a/Jellyfin.Plugin.Requests.Tests/Model/RequestLifecycleTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Model/RequestLifecycleTests.cs
@@ -174,11 +174,10 @@ public class RequestLifecycleTests
             var request = ARequest() with { State = cell.From };
 
             var refusal = Assert.Throws<IllegalRequestTransitionException>(
-                () => RequestLifecycle.Move(
+                () => MoveThroughTheRightDoor(
                     request,
                     cell.To,
-                    new DateTimeOffset(2026, 8, 9, 13, 0, 0, TimeSpan.Zero),
-                    movedByUserId: null));
+                    new DateTimeOffset(2026, 8, 9, 13, 0, 0, TimeSpan.Zero)));
 
             Assert.Equal(cell.From, refusal.From);
             Assert.Equal(cell.To, refusal.To);
@@ -272,6 +271,20 @@ public class RequestLifecycleTests
 
         Assert.Equal(expected, documented);
     }
+
+    /// <summary>
+    /// Makes a move through whichever of the two methods takes it. A decline needs a reason and so
+    /// has a door of its own, and a test walking the whole table has to knock on the right one or it
+    /// measures the wrong refusal.
+    /// </summary>
+    /// <param name="request">The request to move.</param>
+    /// <param name="to">The state to move it into.</param>
+    /// <param name="at">When the move happens.</param>
+    /// <returns>The moved request.</returns>
+    private static MediaRequest MoveThroughTheRightDoor(MediaRequest request, RequestState to, DateTimeOffset at)
+        => to == RequestState.Declined
+            ? RequestLifecycle.Decline(request, DeclineReason.NotWanted, note: null, at, declinedByUserId: null)
+            : RequestLifecycle.Move(request, to, at, movedByUserId: null);
 
     private static string Verdict(RequestTransition cell) => cell.IsLegal ? "allowed" : "refused";
 

--- a/Jellyfin.Plugin.Requests.Tests/Model/RequestNotesTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Model/RequestNotesTests.cs
@@ -1,0 +1,296 @@
+using System;
+using Jellyfin.Plugin.Requests.Model;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Model;
+
+/// <summary>
+/// The two pieces of free text a person writes on a request, and the reason a decline is required
+/// to carry.
+/// <para>
+/// Both notes are typed by a person and read back on a page, so what is asserted here is what the
+/// model does with text it did not write: it refuses what is too long instead of shortening it, it
+/// holds nothing where there was nothing, and it changes not one character of what is left.
+/// </para>
+/// </summary>
+public class RequestNotesTests
+{
+    /// <summary>
+    /// A note carrying every character a renderer might mistake for markup. Kept as one value so
+    /// the tests below all use the same payload, and so somebody widening it widens every one of
+    /// them at once.
+    /// </summary>
+    private const string LooksLikeMarkup = "<script>alert('hi')</script> & \"quoted\" 'apostrophed' <b>bold</b>";
+
+    /// <summary>
+    /// The operator making every decision below. One value, so a test says what it is about and not
+    /// who was holding the mouse.
+    /// </summary>
+    private static readonly Guid AnOperator = new("c5b1a739-4e82-4d16-9f70-3a2b6c8d4e51");
+
+    /// <summary>
+    /// A fresh request has neither note and no reason. The failure this stands for is a default of
+    /// empty string, which reads on a page as a note somebody wrote and left blank.
+    /// </summary>
+    [Fact]
+    public void ANewRequestCarriesNoNotesAndNoReason()
+    {
+        var request = ARequest();
+
+        Assert.Null(request.RequesterNote);
+        Assert.Null(request.DeclineReason);
+        Assert.Null(request.DeclineNote);
+    }
+
+    /// <summary>
+    /// A decline carries the reason it was given for, and the note beside it.
+    /// </summary>
+    [Fact]
+    public void ADeclineCarriesItsReasonAndWhateverTheOperatorWroteBesideIt()
+    {
+        var declined = RequestLifecycle.Decline(
+            ARequest(),
+            DeclineReason.NoRoomForIt,
+            "The disk is at ninety-five percent until the archive move finishes.",
+            At(14),
+            AnOperator);
+
+        Assert.Equal(RequestState.Declined, declined.State);
+        Assert.Equal(DeclineReason.NoRoomForIt, declined.DeclineReason);
+        Assert.Equal(
+            "The disk is at ninety-five percent until the archive move finishes.",
+            declined.DeclineNote,
+            StringComparer.Ordinal);
+        Assert.Equal(AnOperator, declined.StateChangedByUserId);
+    }
+
+    /// <summary>
+    /// A decline with no reason cannot be expressed through the place moves are made. This is what
+    /// makes the requirement a rule rather than a sentence in an issue: the door into declined takes
+    /// a reason, and the general one refuses that destination and says where to go instead.
+    /// </summary>
+    [Fact]
+    public void ADeclineWithNoReasonCannotBeMadeThroughMove()
+    {
+        var refusal = Assert.Throws<ArgumentException>(
+            () => RequestLifecycle.Move(ARequest(), RequestState.Declined, At(14), AnOperator));
+
+        Assert.Equal("to", refusal.ParamName, StringComparer.Ordinal);
+        Assert.Contains("Decline", refusal.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The escape hatch cannot be used to give no reason. A reason of Other says only that the list
+    /// did not cover it, so the text beside it is the whole reason and is required.
+    /// </summary>
+    /// <param name="note">What the operator wrote, or did not.</param>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AReasonOffTheListNeedsTheTextThatSaysWhy(string? note)
+    {
+        var refusal = Assert.Throws<ArgumentException>(
+            () => RequestLifecycle.Decline(ARequest(), DeclineReason.Other, note, At(14), AnOperator));
+
+        Assert.Equal("note", refusal.ParamName, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// The same reason with the text is accepted. Without this the test above would pass equally
+    /// well against a model that refused Other outright, which is a different rule.
+    /// </summary>
+    [Fact]
+    public void AReasonOffTheListIsAcceptedWithTheTextThatSaysWhy()
+    {
+        var declined = RequestLifecycle.Decline(
+            ARequest(),
+            DeclineReason.Other,
+            "The rights holder asked us to take it down.",
+            At(14),
+            AnOperator);
+
+        Assert.Equal(DeclineReason.Other, declined.DeclineReason);
+        Assert.Equal(
+            "The rights holder asked us to take it down.",
+            declined.DeclineNote,
+            StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// A reason describes the decline it was given for, and goes when the decline goes. A request
+    /// that has been approved carrying "there is no room for it" is a sentence that contradicts the
+    /// state next to it, and an operator reading the queue has no way to tell which one is current.
+    /// </summary>
+    [Fact]
+    public void TakingBackADeclineTakesTheReasonWithIt()
+    {
+        var declined = RequestLifecycle.Decline(
+            ARequest(),
+            DeclineReason.NoRoomForIt,
+            "The disk is full.",
+            At(14),
+            AnOperator);
+
+        var approved = RequestLifecycle.Move(declined, RequestState.Approved, At(15), AnOperator);
+
+        Assert.Equal(RequestState.Approved, approved.State);
+        Assert.Null(approved.DeclineReason);
+        Assert.Null(approved.DeclineNote);
+    }
+
+    /// <summary>
+    /// The requester's note survives a move untouched. It describes the asking rather than the
+    /// deciding, so nothing about a decision should reach it.
+    /// </summary>
+    [Fact]
+    public void TheRequesterNoteSurvivesEveryMove()
+    {
+        var request = ARequest() with { RequesterNote = "The 1974 one, not the remake." };
+
+        var declined = RequestLifecycle.Decline(request, DeclineReason.CannotBeObtained, null, At(14), AnOperator);
+        var approved = RequestLifecycle.Move(declined, RequestState.Approved, At(15), AnOperator);
+
+        Assert.Equal("The 1974 one, not the remake.", approved.RequesterNote, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Text exactly as long as the cap is accepted. The near miss this is here for is the
+    /// off-by-one: a check written with the wrong comparison refuses the last legal length, and
+    /// nothing else in the suite would notice.
+    /// </summary>
+    [Fact]
+    public void TextExactlyAsLongAsTheCapIsAccepted()
+    {
+        var atTheCap = new string('x', MediaRequest.NoteMaximumLength);
+
+        var request = ARequest() with { RequesterNote = atTheCap, DeclineNote = atTheCap };
+
+        Assert.Equal(MediaRequest.NoteMaximumLength, request.RequesterNote?.Length);
+        Assert.Equal(MediaRequest.NoteMaximumLength, request.DeclineNote?.Length);
+    }
+
+    /// <summary>
+    /// One character over is refused, and the refusal says which field, how long it may be and how
+    /// long it was. Refused rather than shortened: the person who wrote it is not told about a
+    /// truncation, the sentence that mattered is usually the last one, and what would be stored is
+    /// something nobody wrote.
+    /// </summary>
+    [Fact]
+    public void TextOneCharacterOverTheCapIsRefusedRatherThanShortened()
+    {
+        var tooLong = new string('x', MediaRequest.NoteMaximumLength + 1);
+
+        var onTheRequesterNote = Assert.Throws<RequestTextTooLongException>(
+            () => ARequest() with { RequesterNote = tooLong });
+
+        Assert.Equal("RequesterNote", onTheRequesterNote.Field, StringComparer.Ordinal);
+        Assert.Equal(MediaRequest.NoteMaximumLength, onTheRequesterNote.MaximumLength);
+        Assert.Equal(MediaRequest.NoteMaximumLength + 1, onTheRequesterNote.ActualLength);
+
+        var onTheDeclineNote = Assert.Throws<RequestTextTooLongException>(
+            () => ARequest() with { DeclineNote = tooLong });
+
+        Assert.Equal("DeclineNote", onTheDeclineNote.Field, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// A decline whose note is too long does not half happen. The refusal comes from the record, so
+    /// the request the caller handed in is the request they still have, and nothing was declined
+    /// with the reason and then failed to keep the text.
+    /// </summary>
+    [Fact]
+    public void ADeclineWithTooLongANoteLeavesTheRequestWhereItWas()
+    {
+        var request = ARequest();
+
+        Assert.Throws<RequestTextTooLongException>(
+            () => RequestLifecycle.Decline(
+                request,
+                DeclineReason.Other,
+                new string('x', MediaRequest.NoteMaximumLength + 1),
+                At(14),
+                AnOperator));
+
+        Assert.Equal(RequestState.Open, request.State);
+        Assert.Null(request.DeclineReason);
+    }
+
+    /// <summary>
+    /// Nothing and whitespace are the same as no note. Two representations of one fact mean every
+    /// reader has to test for both, and one of them eventually will not, which is how an empty box
+    /// with a heading above it ends up on a page.
+    /// </summary>
+    /// <param name="text">The text as it arrives.</param>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t\n")]
+    public void TextWithNothingInItIsHeldAsNoNote(string? text)
+    {
+        var request = ARequest() with { RequesterNote = text, DeclineNote = text };
+
+        Assert.Null(request.RequesterNote);
+        Assert.Null(request.DeclineNote);
+    }
+
+    /// <summary>
+    /// The model changes not one character of what a person typed, markup included. Two failures
+    /// are refused at once here. Escaping at the model would double-escape at the surface that
+    /// escapes properly, so a note would read with visible ampersands in it. Stripping at the model
+    /// would silently alter what somebody wrote and would leave the surface believing its input is
+    /// safe, which is the belief that puts unescaped text on a page.
+    /// <para>
+    /// What this does not do is refuse a surface rendering the text as markup. That needs a surface,
+    /// and there is none in the tree; #41 carries the condition and the surfaces are #61, #66 and
+    /// #69. Storing the payload unchanged is what makes such a test possible to write there.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void ANoteIsHeldAsTextAndNeverTouched()
+    {
+        var declined = RequestLifecycle.Decline(
+            ARequest() with { RequesterNote = LooksLikeMarkup },
+            DeclineReason.Other,
+            LooksLikeMarkup,
+            At(14),
+            AnOperator);
+
+        Assert.Equal(LooksLikeMarkup, declined.RequesterNote, StringComparer.Ordinal);
+        Assert.Equal(LooksLikeMarkup, declined.DeclineNote, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Both notes are plain strings and nothing on the record is typed as markup. A property typed
+    /// as anything that claims to be already-safe markup is how a surface is told it may skip
+    /// escaping, and the record has no way to make that claim true.
+    /// </summary>
+    [Fact]
+    public void TheNotesAreStringsRatherThanAnythingClaimingToBeMarkup()
+    {
+        Assert.Equal(typeof(string), typeof(MediaRequest).GetProperty(nameof(MediaRequest.RequesterNote))?.PropertyType);
+        Assert.Equal(typeof(string), typeof(MediaRequest).GetProperty(nameof(MediaRequest.DeclineNote))?.PropertyType);
+    }
+
+    private static DateTimeOffset At(int hour) => new(2026, 8, 9, hour, 0, 0, TimeSpan.Zero);
+
+    /// <summary>
+    /// A request with only the fields that have no default, in the state a new one is created in.
+    /// </summary>
+    /// <returns>A newly asked-for request.</returns>
+    private static MediaRequest ARequest()
+    {
+        var asked = At(13);
+
+        return new MediaRequest
+        {
+            Id = new Guid("9c3e6a41-2b7d-4f05-8e19-6d4a7b2c5f83"),
+            RequestedByUserId = new Guid("18f5d92c-7a34-4b60-8d2e-5c9f1a3b7e06"),
+            RequestedAt = asked,
+            StateChangedAt = asked,
+            Kind = RequestedItemKind.Movie,
+            DisplayTitle = "The Conversation"
+        };
+    }
+}

--- a/Jellyfin.Plugin.Requests/Model/DeclineReason.cs
+++ b/Jellyfin.Plugin.Requests/Model/DeclineReason.cs
@@ -1,0 +1,59 @@
+namespace Jellyfin.Plugin.Requests.Model;
+
+/// <summary>
+/// Why a request was declined, from a short list.
+/// <para>
+/// A reason is required on every decline, decided on #113. A decline with no reason reads as
+/// arbitrary to the person who asked, and the thing they do next is ask for the same title again,
+/// because nothing told them what was wrong with the first attempt.
+/// </para>
+/// <para>
+/// The list is short on purpose. It is chosen by an operator making the same decision for the tenth
+/// time that evening, and a list long enough to need reading is a list that gets whatever is at the
+/// top. Anything the list does not cover is <see cref="Other"/>, which requires the free text beside
+/// it, so the escape hatch cannot be used to give no reason at all.
+/// </para>
+/// <para>
+/// These are the values a surface offers and a notification reads. Adding one is cheap; removing one
+/// is not, because requests already declined carry it.
+/// </para>
+/// </summary>
+public enum DeclineReason
+{
+    /// <summary>
+    /// Not one of the reasons below. The free text beside it says what happened, and a decline
+    /// carrying this value without that text is refused.
+    /// </summary>
+    Other = 0,
+
+    /// <summary>
+    /// The server already has it. Usually a search that missed, or a title under a different name,
+    /// and the person who asked can go and watch it now.
+    /// </summary>
+    AlreadyInTheLibrary = 1,
+
+    /// <summary>
+    /// Somebody already asked for this and that request is the live one. Points at a request rather
+    /// than at a refusal, which is what separates it from the reasons below.
+    /// </summary>
+    AlreadyRequested = 2,
+
+    /// <summary>
+    /// Nothing can be found to fetch. The title exists and this server has no way to get it, which
+    /// is a different answer from not wanting it.
+    /// </summary>
+    CannotBeObtained = 3,
+
+    /// <summary>
+    /// The operator does not want it on this server. The honest reason for a decision that is
+    /// somebody's choice rather than a fact about availability, and one an operator should be able
+    /// to give without dressing it as something else.
+    /// </summary>
+    NotWanted = 4,
+
+    /// <summary>
+    /// There is no room for it. Separate from <see cref="NotWanted"/> because it is a fact about the
+    /// disk rather than a judgement about the title, and asking again later is reasonable.
+    /// </summary>
+    NoRoomForIt = 5
+}

--- a/Jellyfin.Plugin.Requests/Model/MediaRequest.cs
+++ b/Jellyfin.Plugin.Requests/Model/MediaRequest.cs
@@ -34,6 +34,22 @@ namespace Jellyfin.Plugin.Requests.Model;
 public sealed record MediaRequest
 {
     /// <summary>
+    /// The longest a piece of free text on a request may be. One number for both notes, because two
+    /// numbers that happen to be equal are two numbers that can drift apart for no reason anybody
+    /// wrote down.
+    /// <para>
+    /// Five hundred characters is a short paragraph. Both fields are read whole, in a queue row and
+    /// in whatever tells the requester what happened, and neither surface has anywhere to put an
+    /// essay. The cap is refused rather than applied, so nothing is ever stored that the person who
+    /// typed it did not write.
+    /// </para>
+    /// </summary>
+    public const int NoteMaximumLength = 500;
+
+    private readonly string? _requesterNote;
+    private readonly string? _declineNote;
+
+    /// <summary>
     /// Gets this request's own identifier, which is not the identifier of anything it refers to.
     /// Where it comes from is the injected identifier source in #34, so a test does not get a
     /// different value on every run.
@@ -105,6 +121,63 @@ public sealed record MediaRequest
     public Guid? StateChangedByUserId { get; init; }
 
     /// <summary>
+    /// Gets what the person who asked wanted to say about it, or <see langword="null"/> where they
+    /// said nothing. Sometimes this carries the only information that makes the request decidable:
+    /// which of two films with one title, or that it is for somebody's birthday on Friday.
+    /// <para>
+    /// Free text written by a person, so it is untrusted wherever it is shown. It is stored exactly
+    /// as it was typed and nothing here escapes it, because escaping belongs at the one place that
+    /// renders it and text escaped twice is text with visible ampersands in it.
+    /// </para>
+    /// <para>
+    /// Text that is only whitespace is held as <see langword="null"/>. "No note" and "an empty note"
+    /// are the same fact, and keeping two representations of it means every reader has to test for
+    /// both and one of them eventually will not.
+    /// </para>
+    /// </summary>
+    /// <exception cref="RequestTextTooLongException">
+    /// Where the text is longer than <see cref="NoteMaximumLength"/>.
+    /// </exception>
+    public string? RequesterNote
+    {
+        get => _requesterNote;
+        init => _requesterNote = Note(value, nameof(RequesterNote));
+    }
+
+    /// <summary>
+    /// Gets why this request was declined, or <see langword="null"/> where it is not declined. A
+    /// decline always carries one: <see cref="RequestLifecycle.Decline"/> is the only way into
+    /// <see cref="RequestState.Declined"/> and it requires a reason, decided on #113.
+    /// <para>
+    /// It is cleared when a request leaves <see cref="RequestState.Declined"/>, because a reason
+    /// standing on an approved request is a sentence that is no longer true. What the request used
+    /// to say is the append-only history in #43, and until that exists the earlier reason is gone
+    /// rather than kept somewhere else.
+    /// </para>
+    /// </summary>
+    public DeclineReason? DeclineReason { get; init; }
+
+    /// <summary>
+    /// Gets what the operator wrote alongside <see cref="DeclineReason"/>, or
+    /// <see langword="null"/> where they wrote nothing. Required beside
+    /// <see cref="Model.DeclineReason.Other"/>, which says nothing on its own, and optional beside
+    /// every other value.
+    /// <para>
+    /// Free text written by a person, under the same rules as
+    /// <see cref="RequesterNote"/>: untrusted where it is shown, stored as typed, whitespace held
+    /// as <see langword="null"/>, and cleared when the request stops being declined.
+    /// </para>
+    /// </summary>
+    /// <exception cref="RequestTextTooLongException">
+    /// Where the text is longer than <see cref="NoteMaximumLength"/>.
+    /// </exception>
+    public string? DeclineNote
+    {
+        get => _declineNote;
+        init => _declineNote = Note(value, nameof(DeclineNote));
+    }
+
+    /// <summary>
     /// Gets whether the server holds what was asked for. Separate from <see cref="State"/> on
     /// purpose: approval is a decision and availability is an observation, and the pair
     /// approved-and-absent is the ordinary case rather than a contradiction.
@@ -117,4 +190,22 @@ public sealed record MediaRequest
     /// operator asking why a request still says absent needs to know whether anything checked.
     /// </summary>
     public DateTimeOffset? AvailabilityCheckedAt { get; init; }
+
+    /// <summary>
+    /// Refuses a note that is too long and flattens an empty one to nothing.
+    /// </summary>
+    /// <param name="text">The text as it arrived.</param>
+    /// <param name="field">The property being written, for the refusal to name.</param>
+    /// <returns>The text, or <see langword="null"/> where there was nothing in it.</returns>
+    private static string? Note(string? text, string field)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return null;
+        }
+
+        return text.Length > NoteMaximumLength
+            ? throw new RequestTextTooLongException(field, NoteMaximumLength, text.Length)
+            : text;
+    }
 }

--- a/Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs
+++ b/Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs
@@ -6,7 +6,7 @@ using System.Linq;
 namespace Jellyfin.Plugin.Requests.Model;
 
 /// <summary>
-/// The moves a request may make, as a table, and the one place a move is made.
+/// The moves a request may make, as a table, and the two methods that make one.
 /// <para>
 /// It is a table rather than a chain of conditionals because the same question gets asked by the
 /// API, by the administrator page, by the bridge and by whatever detects fulfilment, and four
@@ -76,12 +76,12 @@ public static class RequestLifecycle
     }
 
     /// <summary>
-    /// Moves a request, or refuses to.
+    /// Moves a request into any state except <see cref="RequestState.Declined"/>, or refuses to.
     /// <para>
-    /// This is the only place in the plugin that changes a request's state. The record is immutable
-    /// and a caller could still write <c>with { State = ... }</c>, so this being the one place is
-    /// held by review and by the callers that exist rather than by anything that refuses the
-    /// alternative; that gap is named in <c>docs/lifecycle.md</c>.
+    /// This and <see cref="Decline"/> are the only places in the plugin that change a request's
+    /// state. The record is immutable and a caller could still write <c>with { State = ... }</c>, so
+    /// that being true is held by review and by the callers that exist rather than by anything that
+    /// refuses the alternative; that gap is named in <c>docs/lifecycle.md</c>.
     /// </para>
     /// </summary>
     /// <param name="request">The request to move.</param>
@@ -96,6 +96,10 @@ public static class RequestLifecycle
     /// <returns>A new request in the new state.</returns>
     /// <exception cref="ArgumentNullException">Where no request was given.</exception>
     /// <exception cref="IllegalRequestTransitionException">Where the table refuses the move.</exception>
+    /// <exception cref="ArgumentException">
+    /// Where the state asked for is <see cref="RequestState.Declined"/>, which needs a reason and so
+    /// has a door of its own.
+    /// </exception>
     public static MediaRequest Move(
         MediaRequest request,
         RequestState to,
@@ -104,6 +108,77 @@ public static class RequestLifecycle
     {
         ArgumentNullException.ThrowIfNull(request);
 
+        if (to == RequestState.Declined)
+        {
+            throw new ArgumentException(
+                "A decline carries a reason, so it is made with Decline rather than with Move. A decline with no reason reads as arbitrary to the person who asked, decided on #113.",
+                nameof(to));
+        }
+
+        return Moved(request, to, at, movedByUserId) with
+        {
+            // A reason describes the decline it was given for. Carried onto a request that is no
+            // longer declined it is a sentence that is no longer true, and the surfaces would show
+            // it beside a state it contradicts. What the request used to say is #43.
+            DeclineReason = null,
+            DeclineNote = null
+        };
+    }
+
+    /// <summary>
+    /// Declines a request, with the reason a decline is required to carry.
+    /// <para>
+    /// It is a method of its own rather than a parameter on <see cref="Move"/> because the reason is
+    /// mandatory for exactly one destination. A nullable parameter that is required for one value of
+    /// another parameter is a rule a caller reads in prose; two doors is a rule the compiler carries.
+    /// </para>
+    /// </summary>
+    /// <param name="request">The request to decline.</param>
+    /// <param name="reason">Why it is being declined.</param>
+    /// <param name="note">
+    /// What the operator wants to say about it. Required beside <see cref="DeclineReason.Other"/>,
+    /// which says nothing on its own, and optional beside every other reason.
+    /// </param>
+    /// <param name="at">
+    /// When the decline happened, from the injected clock rather than the machine's.
+    /// </param>
+    /// <param name="declinedByUserId">The Jellyfin user who declined it.</param>
+    /// <returns>A new request, declined, carrying the reason.</returns>
+    /// <exception cref="ArgumentNullException">Where no request was given.</exception>
+    /// <exception cref="IllegalRequestTransitionException">Where the table refuses the move.</exception>
+    /// <exception cref="ArgumentException">
+    /// Where the reason is <see cref="DeclineReason.Other"/> and no note says what happened.
+    /// </exception>
+    /// <exception cref="RequestTextTooLongException">Where the note is too long.</exception>
+    public static MediaRequest Decline(
+        MediaRequest request,
+        DeclineReason reason,
+        string? note,
+        DateTimeOffset at,
+        Guid? declinedByUserId)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (reason == DeclineReason.Other && string.IsNullOrWhiteSpace(note))
+        {
+            throw new ArgumentException(
+                "A decline for a reason not on the list has to say what the reason was. Other with nothing beside it is a decline with no reason, which is the thing a required reason exists to prevent.",
+                nameof(note));
+        }
+
+        return Moved(request, RequestState.Declined, at, declinedByUserId) with
+        {
+            DeclineReason = reason,
+            DeclineNote = note
+        };
+    }
+
+    private static MediaRequest Moved(
+        MediaRequest request,
+        RequestState to,
+        DateTimeOffset at,
+        Guid? movedByUserId)
+    {
         var cell = Cell(request.State, to);
 
         if (!cell.IsLegal)

--- a/Jellyfin.Plugin.Requests/Model/RequestTextTooLongException.cs
+++ b/Jellyfin.Plugin.Requests/Model/RequestTextTooLongException.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Globalization;
+
+namespace Jellyfin.Plugin.Requests.Model;
+
+/// <summary>
+/// Thrown when a piece of free text on a request is longer than the model allows.
+/// <para>
+/// The cap is refused rather than applied. Truncating is the tempting alternative and it is worse:
+/// the person who wrote the text is not told, the sentence that mattered is usually the last one,
+/// and what is stored is something nobody wrote. A refusal gives a surface something to say.
+/// </para>
+/// <para>
+/// The field, the cap and the length that arrived are carried as values, so an API layer can turn
+/// this into a message naming the field and the number without parsing English out of a string.
+/// </para>
+/// </summary>
+public sealed class RequestTextTooLongException : ArgumentException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequestTextTooLongException"/> class for a named
+    /// field.
+    /// </summary>
+    /// <param name="field">The property the text was being written to.</param>
+    /// <param name="maximumLength">The longest the text may be.</param>
+    /// <param name="actualLength">How long the text was.</param>
+    public RequestTextTooLongException(string field, int maximumLength, int actualLength)
+        : base(Describe(field, maximumLength, actualLength), field)
+    {
+        Field = field;
+        MaximumLength = maximumLength;
+        ActualLength = actualLength;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequestTextTooLongException"/> class. Present
+    /// because the analyzers ask every exception for the three ordinary constructors; the
+    /// constructor above is the one this type exists for.
+    /// </summary>
+    public RequestTextTooLongException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequestTextTooLongException"/> class with a
+    /// message of the caller's own. See the note on the parameterless constructor.
+    /// </summary>
+    /// <param name="message">The message.</param>
+    public RequestTextTooLongException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequestTextTooLongException"/> class with a
+    /// message and an inner exception. See the note on the parameterless constructor.
+    /// </summary>
+    /// <param name="message">The message.</param>
+    /// <param name="innerException">The inner exception.</param>
+    public RequestTextTooLongException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    /// Gets the property the text was being written to, or <see langword="null"/> where this was
+    /// built by one of the constructors that names no field.
+    /// </summary>
+    public string? Field { get; }
+
+    /// <summary>
+    /// Gets the longest the text may be.
+    /// </summary>
+    public int MaximumLength { get; }
+
+    /// <summary>
+    /// Gets how long the text that was refused was.
+    /// </summary>
+    public int ActualLength { get; }
+
+    private static string Describe(string field, int maximumLength, int actualLength)
+        => string.Format(
+            CultureInfo.InvariantCulture,
+            "{0} may be at most {1} characters and {2} were given. The text is refused rather than shortened, because a truncated note is something nobody wrote.",
+            field,
+            maximumLength,
+            actualLength);
+}

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -13,8 +13,12 @@ against that table and fails if either side changes without the other.
 `Approved` means an operator said yes. It does not mean the server has the media, and the gap
 between the two is the ordinary case rather than an edge one.
 
-`Declined` means an operator said no. A reason is required, which was decided on #113 and is built
-in #41.
+`Declined` means an operator said no. A reason is required, decided on #113.
+`RequestLifecycle.Decline` is the only way into this state and it takes one, so a decline with no
+reason cannot be made. The short list is `DeclineReason`, and anything it does not cover is `Other`,
+which requires the free text beside it, so the escape hatch cannot be used to give no reason at all.
+Leaving `Declined` clears the reason, because a reason standing on an approved request is a sentence
+that is no longer true.
 
 `Fulfilled` means the thing that was asked for is in the library and the person who asked can watch
 it.
@@ -98,12 +102,12 @@ asked for and got an answer. A library that no longer holds the media is an obse
 
 ## What is not enforced
 
-`RequestLifecycle.Move` is the one place in the plugin that changes a state, and it refuses a move
-this table refuses. Nothing stops a caller writing `with { State = ... }` on the record instead: the
-record is immutable, and immutability makes a move produce a new value rather than making it go
-through here. There are no callers yet, so the property holds today by there being nothing to hold
-it against. The invariant lint in #28 is where a rule refusing that shape would live, and this
-paragraph is what it does not yet do.
+`RequestLifecycle.Move` and `RequestLifecycle.Decline` are the two places in the plugin that change
+a state, and both refuse a move this table refuses. Nothing stops a caller writing
+`with { State = ... }` on the record instead: the record is immutable, and immutability makes a move
+produce a new value rather than making it go through here. There are no callers yet, so the property
+holds today by there being nothing to hold it against. The invariant lint in #28 is where a rule
+refusing that shape would live, and this paragraph is what it does not yet do.
 
 The history of the moves a request has made is #43, and it is not built here. `StateChangedAt` and
 `StateChangedByUserId` on the record are the current move only, and a request that has been approved


### PR DESCRIPTION
Part of #41. It does not close it, and the last section says exactly which of the four conditions is left and why.

## What this changes

A decline carried no reason, because the record had no field for one. Ombi keeps a `DeniedReason` for the same purpose, and the failure without it is not subtle: the person who asked sees only that the answer was no, so they ask for the same title again.

`DeclineReason` is the short list decided on #113: `AlreadyInTheLibrary`, `AlreadyRequested`, `CannotBeObtained`, `NotWanted`, `NoRoomForIt`, and `Other`. It is short because it is read by an operator making the same decision for the tenth time that evening, and a list long enough to need reading is a list that gets whatever is at the top. `Other` requires the free text beside it, so the escape hatch cannot be used to give no reason at all.

The requirement is a rule rather than a sentence in an issue. `RequestLifecycle.Decline` is the only way into `Declined` and it takes a reason. `RequestLifecycle.Move` refuses that destination and its message says where to go instead. A nullable reason parameter on `Move` would have been one door, and the rule would then be prose a caller has to read; two doors is a rule the compiler carries.

Leaving `Declined` clears the reason and the note. A request reading "there is no room for it" beside a state of `Approved` is a sentence that contradicts the thing next to it, and an operator has no way to tell which is current. What the request used to say is the append-only history in #43, and until that lands the earlier reason is gone rather than kept somewhere else. That is a loss and it is written on the field.

`MediaRequest` gains `RequesterNote`, `DeclineReason` and `DeclineNote`.

## The cap

Five hundred characters, one number for both notes, refused rather than applied. Two numbers that happen to be equal are two numbers that can drift for no reason anybody wrote down, and both fields are read whole in a queue row and in whatever tells the requester what happened.

Refused rather than truncated, because truncating tells the person who wrote it nothing, the sentence that mattered is usually the last one, and what gets stored is something nobody wrote. `RequestTextTooLongException` carries the field, the cap and the length that arrived, so an API layer can build a message from values rather than by parsing English out of a string.

Text with nothing but whitespace in it is held as nothing. "No note" and "an empty note" are the same fact, and two representations of it mean every reader has to test for both, which is how an empty box under a heading ends up on a page.

## The means

C# in the model project and the existing xunit suite, no package, no runtime, no new apparatus. The cap is enforced in the `init` accessor with a backing field, which is what makes it unrepresentable rather than checked by whoever remembers: `with { RequesterNote = ... }` goes through it too, and there is no second door. A validation attribute was the alternative and was not taken, because attributes are evaluated by whoever chooses to evaluate them and this record is read by code that has no validator anywhere near it.

## What was run

    dotnet test Jellyfin.Plugin.Requests.sln --nologo
    Bestanden!   : Fehler:     0, erfolgreich:    94, uebersprungen:     0, gesamt:    94 - Jellyfin.Plugin.Requests.Tests.dll (net9.0)
    Bestanden!   : Fehler:     0, erfolgreich:    94, uebersprungen:     0, gesamt:    94 - Jellyfin.Plugin.Requests.Tests.dll (net10.0)

Ninety-four, from seventy-six before this change. The runner on this machine is German; the numbers are the numbers.

    dotnet build Jellyfin.Plugin.Requests.sln --nologo -warnaserror
    0 Warnung(en)
    0 Fehler

    npx --yes prettier@3.6.2 --check "docs/lifecycle.md"
    All matched files use Prettier code style!

## Each guard watched failing

The cap made to truncate instead of refusing:

    Fehler ...RequestNotesTests.ADeclineWithTooLongANoteLeavesTheRequestWhereItWas
    Fehler ...RequestNotesTests.TextOneCharacterOverTheCapIsRefusedRatherThanShortened
    Fehler!      : Fehler:     2, erfolgreich:    92, gesamt:    94

The refusal of `Declined` removed from `Move`, so a decline can be made with no reason:

    Fehler ...RequestNotesTests.ADeclineWithNoReasonCannotBeMadeThroughMove
    Fehler!      : Fehler:     1, erfolgreich:    93, gesamt:    94

The clearing removed, so a reason survives onto an approved request:

    Fehler ...RequestNotesTests.TakingBackADeclineTakesTheReasonWithIt
    Fehler!      : Fehler:     1, erfolgreich:    93, gesamt:    94

`Other` no longer requiring its text:

    Fehler ...RequestNotesTests.AReasonOffTheListNeedsTheTextThatSaysWhy(note: "")
    Fehler ...RequestNotesTests.AReasonOffTheListNeedsTheTextThatSaysWhy(note: "   ")
    Fehler ...RequestNotesTests.AReasonOffTheListNeedsTheTextThatSaysWhy(note: null)
    Fehler!      : Fehler:     3, erfolgreich:    91, gesamt:    94

Whitespace kept as an empty note rather than as nothing:

    Fehler ...RequestNotesTests.TextWithNothingInItIsHeldAsNoNote(text: "")
    Fehler ...RequestNotesTests.TextWithNothingInItIsHeldAsNoNote(text: "   ")
    Fehler ...RequestNotesTests.TextWithNothingInItIsHeldAsNoNote(text: "\t\n")
    Fehler!      : Fehler:     3, erfolgreich:    91, gesamt:    94

Each was reverted before the next.

## Why this does not close #41

The third condition, that both are capped and the cap is refused at the model rather than truncated silently, is met.

The first two conditions each have two halves. The field exists, it is carried on the request every surface reads, and it survives a move: that half is here. That the requester can see the decline reason, and that an operator can see the requester's note, is a statement about a surface, and there is no surface in the tree. Nothing in the plugin serves anything:

    git grep -lnE "ControllerBase|ApiController|HttpGet|HttpPost" -- Jellyfin.Plugin.Requests ; echo "exit=$?"
    exit=1

and the one page in the tree is the template configuration page, which shows nothing about a request:

    git ls-files Jellyfin.Plugin.Requests | grep -E "[.](html|js|css)$"
    Jellyfin.Plugin.Requests/Configuration/configPage.html

Those halves belong to #61, #66 and #69.

The fourth condition, that rendering either as markup rather than text is refused by a test, cannot be met inside this issue's declared scope for the same reason: nothing renders anything, so there is nothing for such a test to catch. What is here instead is the model half, which is what makes that test writable later: `ANoteIsHeldAsTextAndNeverTouched` puts a payload of script tags, ampersands and quotation marks through both fields and asserts it comes back byte for byte, so the model neither escapes (which would double-escape at a surface that escapes properly) nor strips (which would silently alter what somebody wrote and leave the surface believing its input is safe). `TheNotesAreStringsRatherThanAnythingClaimingToBeMarkup` refuses a property typed as already-safe markup, which is how a surface gets told it may skip escaping.

## What is not covered

The invariant lint was not run on this machine. It is a Linux binary the workflow downloads by digest and there is no Windows build of it here, so the patterns of all nine rules were read against the changed files by hand and none matches. The gate on this pull request is what judges it.

`docs/lifecycle.md` is edited although this issue's declared scope is the model code and the test project. Two sentences there described the decline reason as not yet built and named `Move` as the only place a state changes, and both became false with this change. Leaving them would have been leaving the document lying about the code it documents.

This change had no second reader.


