### PR TITLE
Keep every move a request made, and refuse an edit to one (#43)

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Model/MediaRequestTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Model/MediaRequestTests.cs
@@ -28,6 +28,7 @@ public class MediaRequestTests
         "DeclineReason",
         "DisplayTitle",
         "DisplayYear",
+        "History",
         "Id",
         "Kind",
         "ProviderIds",
@@ -188,9 +189,34 @@ public class MediaRequestTests
             return true;
         }
 
-        // The one collection on the record, and only in the shape it is declared in: a read-only
-        // map of string to string carries no behaviour a caller could reach through.
-        return underlying == typeof(IReadOnlyDictionary<string, string>);
+        // The two collections on the record, and only in the shapes they are declared in. A
+        // read-only map of string to string carries no behaviour a caller could reach through, and
+        // a read-only list of history entries carries only entries whose own fields are checked by
+        // TheHistoryEntryIsAPlainValueToo below. Neither gives a reader anything to resolve a title
+        // through, which is the property this test is about.
+        return underlying == typeof(IReadOnlyDictionary<string, string>)
+            || underlying == typeof(IReadOnlyList<RequestHistoryEntry>);
+    }
+
+    /// <summary>
+    /// The history entry is held to the same rule as the record that carries it. Without this, the
+    /// widening above would have let a field of any type at all onto the record by way of an entry,
+    /// which is the hole a reader of the widened line would not see.
+    /// </summary>
+    [Fact]
+    public void TheHistoryEntryIsAPlainValueToo()
+    {
+        var offending = typeof(RequestHistoryEntry)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(property => !IsAPlainValue(property.PropertyType))
+            .Select(property => string.Format(
+                CultureInfo.InvariantCulture,
+                "{0} is {1}",
+                property.Name,
+                property.PropertyType.Name))
+            .ToArray();
+
+        Assert.Empty(offending);
     }
 
     private static string[] PublicFieldNames()

--- a/Jellyfin.Plugin.Requests.Tests/Model/RequestHistoryTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Model/RequestHistoryTests.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Linq;
+using Jellyfin.Plugin.Requests.Model;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Model;
+
+/// <summary>
+/// The history a request carries. The state says what is true now; this says what happened, which is
+/// the question an operator dealing with a complaint actually has.
+/// </summary>
+public class RequestHistoryTests
+{
+    private static readonly Guid FirstOperator = new("a1f4c827-9d3b-4e06-8175-2c6e5b9a4d31");
+
+    private static readonly Guid SecondOperator = new("6b09e13d-5f78-4a2c-90b4-8e1d7c3a5029");
+
+    /// <summary>
+    /// A request nobody has decided has an empty history. Being created is not a move, and an entry
+    /// saying it was created would put a row in every history that says nothing an operator asked
+    /// about.
+    /// </summary>
+    [Fact]
+    public void ARequestNothingHasDecidedHasNoHistory()
+    {
+        Assert.Empty(ARequest().History);
+    }
+
+    /// <summary>
+    /// A request walked through its whole life, with one entry per move and no others. This is the
+    /// first condition on #43, and it is written as one walk rather than as a move per test because
+    /// the failure it stands for is an entry appended twice or not at all somewhere in the middle of
+    /// a sequence, which a test of a single move cannot see.
+    /// </summary>
+    [Fact]
+    public void EveryMoveAppendsExactlyOneEntryAndNothingElseDoes()
+    {
+        var request = ARequest();
+
+        var approved = RequestLifecycle.Move(request, RequestState.Approved, At(9), FirstOperator);
+        var failed = RequestLifecycle.Move(approved, RequestState.Failed, At(10), movedByUserId: null);
+        var declined = RequestLifecycle.Decline(failed, DeclineReason.CannotBeObtained, "Nothing has it.", At(11), SecondOperator);
+        var approvedAgain = RequestLifecycle.Move(declined, RequestState.Approved, At(12), FirstOperator);
+        var fulfilled = RequestLifecycle.Move(approvedAgain, RequestState.Fulfilled, At(13), movedByUserId: null);
+
+        Assert.Equal(
+            [
+                "Open to Approved",
+                "Approved to Failed",
+                "Failed to Declined",
+                "Declined to Approved",
+                "Approved to Fulfilled"
+            ],
+            fulfilled.History.Select(entry => $"{entry.From} to {entry.To}").ToArray());
+
+        Assert.Equal([1, 2, 3, 4, 5], new[] { approved, failed, declined, approvedAgain, fulfilled }.Select(step => step.History.Count).ToArray());
+    }
+
+    /// <summary>
+    /// An entry carries when the move happened and who made it, and says so where nobody did. A
+    /// history that cannot tell an operator's decision from the plugin's own would make somebody
+    /// answer for a decision they never took.
+    /// </summary>
+    [Fact]
+    public void AnEntryCarriesTheTimeAndTheMoverIncludingWhereThereWasNone()
+    {
+        var approved = RequestLifecycle.Move(ARequest(), RequestState.Approved, At(9), FirstOperator);
+        var fulfilled = RequestLifecycle.Move(approved, RequestState.Fulfilled, At(13), movedByUserId: null);
+
+        Assert.Equal(At(9), fulfilled.History[0].At);
+        Assert.Equal(FirstOperator, fulfilled.History[0].ByUserId);
+
+        Assert.Equal(At(13), fulfilled.History[1].At);
+        Assert.Null(fulfilled.History[1].ByUserId);
+    }
+
+    /// <summary>
+    /// The reason a decline was given for survives the decline being taken back. This is the whole
+    /// reason an entry holds more than a pair of states: the reason on the request is the current
+    /// one and is cleared the moment somebody changes their mind, and an operator answering a
+    /// complaint about a refusal that was later reversed has nowhere else to read it.
+    /// </summary>
+    [Fact]
+    public void AReasonSurvivesTheDeclineBeingTakenBack()
+    {
+        var declined = RequestLifecycle.Decline(
+            ARequest(),
+            DeclineReason.NoRoomForIt,
+            "The disk is full until the archive move finishes.",
+            At(9),
+            FirstOperator);
+
+        var approved = RequestLifecycle.Move(declined, RequestState.Approved, At(10), SecondOperator);
+
+        Assert.Null(approved.DeclineReason);
+        Assert.Equal(DeclineReason.NoRoomForIt, approved.History[0].Reason);
+        Assert.Equal(
+            "The disk is full until the archive move finishes.",
+            approved.History[0].Note,
+            StringComparer.Ordinal);
+        Assert.Null(approved.History[1].Reason);
+    }
+
+    /// <summary>
+    /// A refused move appends nothing. A history that grew on an attempt would read as a request
+    /// that moved and came back, and the thing that actually happened is that nothing happened.
+    /// </summary>
+    [Fact]
+    public void ARefusedMoveAppendsNothing()
+    {
+        var fulfilled = RequestLifecycle.Move(
+            RequestLifecycle.Move(ARequest(), RequestState.Approved, At(9), FirstOperator),
+            RequestState.Fulfilled,
+            At(10),
+            FirstOperator);
+
+        Assert.Throws<IllegalRequestTransitionException>(
+            () => RequestLifecycle.Move(fulfilled, RequestState.Approved, At(11), FirstOperator));
+
+        Assert.Equal(2, fulfilled.History.Count);
+    }
+
+    /// <summary>
+    /// A move that fails at the cap appends nothing either. The entry is built before the record is,
+    /// so this is the case where a history could grow for a move that never happened.
+    /// </summary>
+    [Fact]
+    public void ADeclineRefusedForItsNoteLengthAppendsNothing()
+    {
+        var request = ARequest();
+
+        Assert.Throws<RequestTextTooLongException>(
+            () => RequestLifecycle.Decline(
+                request,
+                DeclineReason.Other,
+                new string('x', MediaRequest.NoteMaximumLength + 1),
+                At(9),
+                FirstOperator));
+
+        Assert.Empty(request.History);
+    }
+
+    /// <summary>
+    /// Moving a request does not touch the history of the value it was made from. The record is
+    /// immutable and a move produces a new value, so a caller still holding the earlier one is
+    /// holding what they read, and a shared list grown in place would take that away.
+    /// </summary>
+    [Fact]
+    public void MovingARequestLeavesTheEarlierValuesHistoryAlone()
+    {
+        var request = ARequest();
+        var approved = RequestLifecycle.Move(request, RequestState.Approved, At(9), FirstOperator);
+
+        _ = RequestLifecycle.Move(approved, RequestState.Fulfilled, At(10), FirstOperator);
+
+        Assert.Empty(request.History);
+        Assert.Single(approved.History);
+    }
+
+    /// <summary>
+    /// Entries are oldest first, and stay that way. The order is what makes a history readable as a
+    /// sequence of events rather than as a set of them, and a page that shows it will show it in the
+    /// order the list is in.
+    /// </summary>
+    [Fact]
+    public void EntriesAreOldestFirst()
+    {
+        var fulfilled = RequestLifecycle.Move(
+            RequestLifecycle.Move(ARequest(), RequestState.Approved, At(9), FirstOperator),
+            RequestState.Fulfilled,
+            At(13),
+            FirstOperator);
+
+        Assert.Equal(
+            fulfilled.History.Select(entry => entry.At).OrderBy(at => at).ToArray(),
+            fulfilled.History.Select(entry => entry.At).ToArray());
+    }
+
+    /// <summary>
+    /// The note on an entry is capped by the same rule as the note on the request. A copy of a
+    /// capped value that is not capped is the cap not being enforced, one indirection away.
+    /// </summary>
+    [Fact]
+    public void TheNoteOnAnEntryIsCappedToo()
+    {
+        var refusal = Assert.Throws<RequestTextTooLongException>(
+            () => new RequestHistoryEntry
+            {
+                From = RequestState.Open,
+                To = RequestState.Declined,
+                At = At(9),
+                Note = new string('x', MediaRequest.NoteMaximumLength + 1)
+            });
+
+        Assert.Equal("Note", refusal.Field, StringComparer.Ordinal);
+    }
+
+    private static DateTimeOffset At(int hour) => new(2026, 8, 9, hour, 0, 0, TimeSpan.Zero);
+
+    /// <summary>
+    /// A request with only the fields that have no default, in the state a new one is created in.
+    /// </summary>
+    /// <returns>A newly asked-for request.</returns>
+    private static MediaRequest ARequest()
+    {
+        var asked = At(8);
+
+        return new MediaRequest
+        {
+            Id = new Guid("e70b4c19-8a5d-4236-91f7-0c3b6e2a8d54"),
+            RequestedByUserId = new Guid("3f8c1d05-2e69-4b74-a018-9d5e7c4b6a12"),
+            RequestedAt = asked,
+            StateChangedAt = asked,
+            Kind = RequestedItemKind.Movie,
+            DisplayTitle = "Sorcerer"
+        };
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/Model/RequestLifecycleTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Model/RequestLifecycleTests.cs
@@ -128,14 +128,16 @@ public class RequestLifecycleTests
 
         // Everything the move is not about, compared as one value: the record's generated equality
         // covers every field, so a field added later is covered here without this test being
-        // edited.
+        // edited. The four the move is about are put back first. The history is one of them because
+        // a move appends to it, which RequestHistoryTests is about.
         Assert.Equal(
             request,
             moved with
             {
                 State = request.State,
                 StateChangedAt = request.StateChangedAt,
-                StateChangedByUserId = request.StateChangedByUserId
+                StateChangedByUserId = request.StateChangedByUserId,
+                History = request.History
             });
     }
 

--- a/Jellyfin.Plugin.Requests/Model/MediaRequest.cs
+++ b/Jellyfin.Plugin.Requests/Model/MediaRequest.cs
@@ -178,6 +178,24 @@ public sealed record MediaRequest
     }
 
     /// <summary>
+    /// Gets every move this request has made, oldest first. Empty on a request nothing has decided,
+    /// because being created is not a move.
+    /// <para>
+    /// Append-only. <see cref="RequestLifecycle"/> is the only thing that adds to it and it never
+    /// removes or rewrites an entry, which is what makes the list worth reading at all. Nothing in
+    /// the type system says so, because a list that could refuse a removal would be a type of its
+    /// own; what says so is the lint rule <c>history-is-only-appended-to</c>, which refuses an
+    /// assignment to this property anywhere but the one place that appends.
+    /// </para>
+    /// <para>
+    /// This is where a decline reason survives being taken back. The reason on the request is the
+    /// current one and is cleared when the request stops being declined; the entry that carried it
+    /// stays.
+    /// </para>
+    /// </summary>
+    public IReadOnlyList<RequestHistoryEntry> History { get; init; } = [];
+
+    /// <summary>
     /// Gets whether the server holds what was asked for. Separate from <see cref="State"/> on
     /// purpose: approval is a decision and availability is an observation, and the pair
     /// approved-and-absent is the ordinary case rather than a contradiction.
@@ -192,12 +210,14 @@ public sealed record MediaRequest
     public DateTimeOffset? AvailabilityCheckedAt { get; init; }
 
     /// <summary>
-    /// Refuses a note that is too long and flattens an empty one to nothing.
+    /// Refuses a note that is too long and flattens an empty one to nothing. Internal because
+    /// <see cref="RequestHistoryEntry"/> holds a copy of the same text and has to hold it under the
+    /// same rule; two implementations of one cap is one of them being raised alone.
     /// </summary>
     /// <param name="text">The text as it arrived.</param>
     /// <param name="field">The property being written, for the refusal to name.</param>
     /// <returns>The text, or <see langword="null"/> where there was nothing in it.</returns>
-    private static string? Note(string? text, string field)
+    internal static string? Note(string? text, string field)
     {
         if (string.IsNullOrWhiteSpace(text))
         {

--- a/Jellyfin.Plugin.Requests/Model/RequestHistoryEntry.cs
+++ b/Jellyfin.Plugin.Requests/Model/RequestHistoryEntry.cs
@@ -1,0 +1,66 @@
+using System;
+
+namespace Jellyfin.Plugin.Requests.Model;
+
+/// <summary>
+/// One move a request made, kept forever.
+/// <para>
+/// The state on a request answers what is true now. An operator dealing with a complaint needs what
+/// happened: who approved it, when, who declined the earlier one and for what reason, and whether a
+/// person did it at all. <see cref="MediaRequest.State"/> and
+/// <see cref="MediaRequest.StateChangedByUserId"/> answer only the last of those, and answering the
+/// rest from them is guessing.
+/// </para>
+/// <para>
+/// An entry carries the reason and the note the move was made with, so a decline that is later taken
+/// back leaves its reason here rather than nowhere. That is the one thing the current-value fields
+/// cannot do: they are overwritten by the next move by definition.
+/// </para>
+/// </summary>
+public sealed record RequestHistoryEntry
+{
+    private readonly string? _note;
+
+    /// <summary>
+    /// Gets the state the request was in before this move.
+    /// </summary>
+    public required RequestState From { get; init; }
+
+    /// <summary>
+    /// Gets the state it was in after it.
+    /// </summary>
+    public required RequestState To { get; init; }
+
+    /// <summary>
+    /// Gets when the move happened, from the injected clock rather than the machine's.
+    /// </summary>
+    public required DateTimeOffset At { get; init; }
+
+    /// <summary>
+    /// Gets the Jellyfin user who made the move, or <see langword="null"/> where the plugin made it
+    /// on its own after looking at the library. The distinction matters in a complaint: an operator
+    /// should not have to answer for a decision nobody took.
+    /// </summary>
+    public Guid? ByUserId { get; init; }
+
+    /// <summary>
+    /// Gets the reason the move was made with, where it was a decline, and <see langword="null"/>
+    /// otherwise. This is why an entry is worth more than a pair of states: the reason on the
+    /// request is overwritten the moment somebody changes their mind, and this copy is not.
+    /// </summary>
+    public DeclineReason? Reason { get; init; }
+
+    /// <summary>
+    /// Gets the free text written alongside the reason, or <see langword="null"/> where there was
+    /// none. Untrusted where it is shown, and capped by the same rule as the note on the request
+    /// itself, because a cap the copy does not carry is no cap at all.
+    /// </summary>
+    /// <exception cref="RequestTextTooLongException">
+    /// Where the text is longer than <see cref="MediaRequest.NoteMaximumLength"/>.
+    /// </exception>
+    public string? Note
+    {
+        get => _note;
+        init => _note = MediaRequest.Note(value, nameof(Note));
+    }
+}

--- a/Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs
+++ b/Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs
@@ -115,14 +115,11 @@ public static class RequestLifecycle
                 nameof(to));
         }
 
-        return Moved(request, to, at, movedByUserId) with
-        {
-            // A reason describes the decline it was given for. Carried onto a request that is no
-            // longer declined it is a sentence that is no longer true, and the surfaces would show
-            // it beside a state it contradicts. What the request used to say is #43.
-            DeclineReason = null,
-            DeclineNote = null
-        };
+        // A reason describes the decline it was given for. Carried onto a request that is no longer
+        // declined it is a sentence that is no longer true, and the surfaces would show it beside a
+        // state it contradicts. The entry that carried it stays in the history, so taking a decline
+        // back loses the current reason and not the record of it.
+        return Moved(request, to, at, movedByUserId, reason: null, note: null);
     }
 
     /// <summary>
@@ -166,18 +163,28 @@ public static class RequestLifecycle
                 nameof(note));
         }
 
-        return Moved(request, RequestState.Declined, at, declinedByUserId) with
-        {
-            DeclineReason = reason,
-            DeclineNote = note
-        };
+        return Moved(request, RequestState.Declined, at, declinedByUserId, reason, note);
     }
 
+    /// <summary>
+    /// The one place a request changes state, and therefore the one place the history grows. Both
+    /// public methods above go through here, so "every transition appends exactly one entry" is a
+    /// property of the code's shape rather than a thing two call sites have to remember.
+    /// </summary>
+    /// <param name="request">The request to move.</param>
+    /// <param name="to">The state to move it into.</param>
+    /// <param name="at">When the move happened.</param>
+    /// <param name="movedByUserId">Who moved it, or nothing where the plugin did.</param>
+    /// <param name="reason">The decline reason, where this is a decline.</param>
+    /// <param name="note">The text written beside the reason.</param>
+    /// <returns>A new request in the new state, one entry longer.</returns>
     private static MediaRequest Moved(
         MediaRequest request,
         RequestState to,
         DateTimeOffset at,
-        Guid? movedByUserId)
+        Guid? movedByUserId,
+        DeclineReason? reason,
+        string? note)
     {
         var cell = Cell(request.State, to);
 
@@ -186,11 +193,28 @@ public static class RequestLifecycle
             throw new IllegalRequestTransitionException(cell.From, cell.To, cell.Why);
         }
 
+        var entry = new RequestHistoryEntry
+        {
+            From = cell.From,
+            To = cell.To,
+            At = at,
+            ByUserId = movedByUserId,
+            Reason = reason,
+            Note = note
+        };
+
         return request with
         {
             State = to,
             StateChangedAt = at,
-            StateChangedByUserId = movedByUserId
+            StateChangedByUserId = movedByUserId,
+            DeclineReason = reason,
+            DeclineNote = note,
+
+            // A new list rather than an addition to the old one. The request handed in is a value
+            // somebody else may still be holding, and growing its list underneath them would move a
+            // history they had already read.
+            History = [.. request.History, entry]
         };
     }
 

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -18,7 +18,8 @@ between the two is the ordinary case rather than an edge one.
 reason cannot be made. The short list is `DeclineReason`, and anything it does not cover is `Other`,
 which requires the free text beside it, so the escape hatch cannot be used to give no reason at all.
 Leaving `Declined` clears the reason, because a reason standing on an approved request is a sentence
-that is no longer true.
+that is no longer true. The entry that carried it stays in the history, so taking a decline back
+loses the current reason and not the record of it.
 
 `Fulfilled` means the thing that was asked for is in the library and the person who asked can watch
 it.
@@ -109,6 +110,22 @@ produce a new value rather than making it go through here. There are no callers 
 holds today by there being nothing to hold it against. The invariant lint in #28 is where a rule
 refusing that shape would live, and this paragraph is what it does not yet do.
 
-The history of the moves a request has made is #43, and it is not built here. `StateChangedAt` and
-`StateChangedByUserId` on the record are the current move only, and a request that has been approved
-and then declined carries no trace of the approval until that issue lands.
+## The history
+
+Every move appends one entry to `History`, oldest first, and both methods above go through the one
+private helper that appends, so one entry per move is a property of the code's shape rather than
+something two call sites remember. An entry holds the pair of states, when it happened, who did it
+or nothing where the plugin did, and the reason and note a decline was made with.
+
+`StateChangedAt` and `StateChangedByUserId` on the record stay what they were: the current move only.
+Where they and the last entry disagree, the entry is the one to trust, because it was written when
+the move happened and they are overwritten by the next one.
+
+Nothing edits or removes an entry. The lint rule `history-is-only-appended-to` refuses an assignment
+to `History` anywhere in the plugin except the one place that appends, and it carries a fixture, so
+the rule going quiet reds the gate rather than passing. What it does not reach is the test project
+and anything outside this repository.
+
+A request that survives a restart with its history intact is not shown by any of this, and that is
+the third condition on #43. There is no store on a disk yet, so there is nothing to restart and no
+schema to migrate.

--- a/tools/opengrep/fixtures/history/RewritesTheHistory.cs
+++ b/tools/opengrep/fixtures/history/RewritesTheHistory.cs
@@ -1,0 +1,29 @@
+// Fixture for history-is-only-appended-to. This file is in no project and is
+// never compiled; it exists so the rule can be watched refusing the mistake it
+// names.
+//
+// The near-miss is not somebody deliberately destroying a record. It is a
+// tidy-up: a request whose history has an entry in it that reads badly, and a
+// helper written to produce the same request "without that step", by somebody
+// who reached for `with` because that is how every other field on this record
+// is changed. It compiles, it is one line, and from that moment the history
+// answers "what happened" with whatever the last writer preferred.
+
+namespace Jellyfin.Plugin.Requests.Storage;
+
+using System.Linq;
+using Jellyfin.Plugin.Requests.Model;
+
+internal static class FixtureHistoryTidyUp
+{
+    // Legal neighbour, left here on purpose: reading the history is fine and the
+    // rule has to stay quiet on it.
+    public static int MoveCount(MediaRequest request) => request.History.Count;
+
+    // The regression.
+    public static MediaRequest WithoutTheDeclines(MediaRequest request)
+        => request with
+        {
+            History = [.. request.History.Where(entry => entry.To != RequestState.Declined)]
+        };
+}

--- a/tools/opengrep/rules.yaml
+++ b/tools/opengrep/rules.yaml
@@ -289,3 +289,28 @@ rules:
       exclude:
         - "Jellyfin.Plugin.Requests.Tests/Doubles/TestRunDirectory.cs"
         - "Jellyfin.Plugin.Requests.Tests/TestRunDirectoryTests.cs"
+
+  # Invariant (model, #43): the history on a request is only ever appended to.
+  # Decided in #43, whose second done-condition names this rule. Entries are
+  # never edited or removed, and that is the only thing that makes the list
+  # worth reading: a history somebody can tidy answers "what happened" with
+  # whatever the last writer preferred. Nothing in the type system says so,
+  # because IReadOnlyList refuses a removal and says nothing about an
+  # assignment, and `with { History = ... }` is exactly how a caller would
+  # replace one. RequestLifecycle is the one place that appends, so it is the
+  # one place excluded.
+  - id: history-is-only-appended-to
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      Do not assign to History here. A request's history is append-only and
+      RequestLifecycle is the only thing that grows it, so that a move cannot be
+      rewritten out of the record after the fact (#43).
+    patterns:
+      - pattern: History =
+    paths:
+      include:
+        - "Jellyfin.Plugin.Requests/**/*.cs"
+        - "tools/opengrep/fixtures/history/**/*.cs"
+      exclude:
+        - "Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs"


### PR DESCRIPTION
Part of #43. Two of its three conditions are met and the third has no subject yet; the last section says which and why.

## What this changes

The record answered what is true now and nothing else. An operator dealing with a complaint needs what happened, and `StateChangedAt` and `StateChangedByUserId` answer only the last move. The sharpest version of the gap arrived with #41: a decline that is later taken back clears its reason, so until now a request that had been refused and then approved carried no trace of the refusal at all.

`MediaRequest.History` is every move the request made, oldest first. Empty on a request nothing has decided, because being created is not a move and an entry saying so would put a row in every history that answers nothing anybody asked.

`RequestHistoryEntry` holds the pair of states, when it happened, who did it or nothing where the plugin did, and the reason and note a decline was made with. The last part is why an entry is worth more than a pair of states: the reason on the request is the current one and is overwritten by the next move, and this copy is not.

The append goes in the one private helper both public methods already went through. One entry per move is then a property of the shape of the code rather than something two call sites remember, and a third way to move a request would have to be written past it on purpose.

The list is rebuilt rather than added to. The request handed in is a value somebody else may still be holding, and growing its list underneath them would move a history they had already read.

## What refuses an edit

`history-is-only-appended-to` refuses an assignment to `History` anywhere in the plugin except `RequestLifecycle`. That is the shape the regression actually takes: `IReadOnlyList` already refuses a removal and says nothing at all about an assignment, and `with { History = ... }` is how a caller would replace one, because it is how every other field on this record is changed.

The fixture is a helper that filters the declines out of a history, written as a tidy-up rather than as vandalism, which is the version somebody would actually land. It sits beside a legal neighbour that reads the history, so the rule staying quiet on a read is proven too.

## The means

C# in the model project, and one more rule in the opengrep ruleset the tree already carries. No package, no runtime, no second apparatus. The alternative for the append-only property was a collection type of its own that refuses a removal, and it was not taken: it would refuse the removal nobody can express anyway, and say nothing about the assignment that is the real hole, so the cost would buy the wrong half.

`tools/` is outside this issue's declared scope, which is the model code, the storage code and the test project. The second done-condition names the invariant lint by name, so the rule is where that condition asks for it rather than where the scope line allows, and it is disclosed here rather than left to be noticed in the diff.

## What was run

    dotnet test Jellyfin.Plugin.Requests.sln --nologo
    Bestanden!   : Fehler:     0, erfolgreich:   104, uebersprungen:     0, gesamt:   104 - Jellyfin.Plugin.Requests.Tests.dll (net9.0)
    Bestanden!   : Fehler:     0, erfolgreich:   104, uebersprungen:     0, gesamt:   104 - Jellyfin.Plugin.Requests.Tests.dll (net10.0)

A hundred and four, from ninety-four before this change. The runner on this machine is German; the numbers are the numbers.

    dotnet build Jellyfin.Plugin.Requests.sln --nologo -warnaserror
    0 Warnung(en)
    0 Fehler

    npx --yes prettier@3.6.2 --check "docs/lifecycle.md"
    All matched files use Prettier code style!

## Each guard watched failing

The append removed, so a move records nothing:

    Fehler ...RequestHistoryTests.MovingARequestLeavesTheEarlierValuesHistoryAlone
    Fehler ...RequestHistoryTests.AReasonSurvivesTheDeclineBeingTakenBack
    Fehler ...RequestHistoryTests.EveryMoveAppendsExactlyOneEntryAndNothingElseDoes
    Fehler ...RequestHistoryTests.ARefusedMoveAppendsNothing
    Fehler ...RequestHistoryTests.AnEntryCarriesTheTimeAndTheMoverIncludingWhereThereWasNone
    Fehler!      : Fehler:     5, erfolgreich:    99, gesamt:   104

One of the two doors made to stop appending, which is the failure the shared helper exists to make impossible:

    Fehler ...RequestHistoryTests.AReasonSurvivesTheDeclineBeingTakenBack
    Fehler ...RequestHistoryTests.EveryMoveAppendsExactlyOneEntryAndNothingElseDoes
    Fehler!      : Fehler:     2, erfolgreich:   102, gesamt:   104

The entry no longer carrying the reason, so a decline is recorded as having happened for nothing:

    Fehler ...RequestHistoryTests.AReasonSurvivesTheDeclineBeingTakenBack
    Fehler!      : Fehler:     1, erfolgreich:   103, gesamt:   104

Each was reverted before the next, and the suite was green again after the last.

## Why this does not close #43

The first condition is met: every transition appends exactly one entry, proven by `EveryMoveAppendsExactlyOneEntryAndNothingElseDoes`, which walks one request open to approved to failed to declined to approved to fulfilled and asserts the five entries and the count after each step. `ARefusedMoveAppendsNothing` and `ADeclineRefusedForItsNoteLengthAppendsNothing` cover the other direction, an entry for a move that did not happen.

The second condition is met, with the bound named above: the rule reaches the plugin project, not the test project.

The third is not, and it cannot be here. It asks that the history survive a plugin restart and a schema migration. Nothing in this tree writes anything to a disk:

    git grep -ln "IRequestStore" ; echo "exit=$?"
    Jellyfin.Plugin.Requests.Tests/Doubles/InMemoryRequestStore.cs
    Jellyfin.Plugin.Requests.Tests/Storage/InMemoryRequestStoreTests.cs
    Jellyfin.Plugin.Requests.Tests/Storage/RequestStoreContract.cs
    Jellyfin.Plugin.Requests/Storage/IRequestStore.cs
    Jellyfin.Plugin.Requests/Storage/RequestConcurrencyException.cs
    Jellyfin.Plugin.Requests/Storage/StoredRequest.cs
    docs/storage.md
    exit=0

The only implementation of the contract is the in-memory double the suite uses. There is no restart to survive and no schema to migrate, so the condition has no subject rather than being unmet. It follows #46 for the store on a disk and #47 for the version rule and the migration.

## What is not covered

The invariant lint was not run on this machine. It is a Linux binary the workflow downloads by digest and there is no Windows build of it here, so the new rule was not watched firing locally. What the gate on this pull request runs is `prove-rules-fire.sh`, which fails unless every declared rule fires on a fixture, and the tree scan, which fails if any rule finds something in the repository. Both are the evidence for this rule, and if either is red this is not merged.

The history is not shown anywhere, because nothing shows anything. #63 and the administrator surface in M7 are where it is read.

This change had no second reader.
