### PR TITLE
Decide how a user reaches this plugin, and write down what it costs (#65)

### DIFF
--- a/docs/surface.md
+++ b/docs/surface.md
@@ -1,0 +1,110 @@
+# How a user reaches this plugin
+
+## The decision
+
+Three surfaces, and they are not alternatives to each other.
+
+The **API** is the floor. Everything else in this repository is built on it and it reaches anything
+somebody scripts. On its own it reaches nobody else, so it is not an answer to this question.
+
+A **channel** is the surface for clients this project cannot change. It puts a browsable folder tree
+beside the user's libraries, on every client that renders channels, and it needs no change to any
+client and no cooperation from anybody.
+
+A **page served by the plugin** is the surface for browsers. It is one page, it is opened by a user
+who is already signed in, and it can show and do things a folder tree cannot.
+
+Writing placeholder items into a real library is rejected outright. See below.
+
+## What was rejected, and why
+
+### Placeholder items in a real library
+
+Rejected. It reaches everything a channel reaches, by writing rows that are not media into somebody's
+film library. That is not a cost this plugin pays, it is one the operator pays forever: the rows are
+in their library, they appear in their searches and their collections, and removing the plugin does
+not obviously remove them. A plugin that leaves debris in the thing it was installed to help is not
+worth the reach it buys.
+
+### The API on its own
+
+Rejected as an answer and kept as the floor. A user who has asked for something and wants to know
+what happened is not going to write a script. Milestone 8 exists because that user has no way to ask
+and no way to look, and an interface only a programmer can use leaves them exactly where they were.
+
+### The channel on its own
+
+Rejected. A channel renders a folder tree, and a folder tree is a poor shape for the two things a
+browser can do well: showing a decline reason as a sentence, and cancelling something. The page costs
+one page and the channel does not replace it.
+
+### The page on its own
+
+Rejected, and this is the one worth spelling out because it is the cheap answer. It costs one page
+and it strands every user who is not at a browser, which on a media server is most of them. This
+milestone is called the user surface every client can reach; building the browser surface and calling
+the rest future work is how that title stops being true without anybody deciding it should.
+
+## What the channel costs
+
+It is the expensive choice and it is chosen with its costs open.
+
+The plugin takes a place in the server's library database, because that is how the server holds what
+a channel returns. That is a second thing an uninstall has to clean up, which is #98.
+
+The rendering is per user, and a request is personal data. A user's requests must not be visible to
+another user through anything this plugin puts in that database. That is #67, it is the failure that
+matters most on this milestone, and it is not treated here as a detail of the implementation:
+
+**If per-user isolation cannot be shown on a running server of each claimed line, the channel falls
+back to a shape that carries no per-user data at all.** That is #67's own third condition and it is
+repeated here because this page is where the decision lives. A channel that leaks one user's requests
+to another is worse than no channel, and the fallback is the answer rather than a softer test.
+
+What a channel renders is items, and a request is not an item of media. The rows will be titles a
+person asked for, with their state, and pressing play on one does nothing. That is a real awkwardness
+and it is the price of reaching a client nobody here can change. It is not the same defect as writing
+placeholders into a real library, because a channel's folder is the plugin's own and disappears with
+it.
+
+## What is not reached
+
+Nothing here is softened, and the parts that are claims rather than measurements say so.
+
+**No cell of the reach matrix has been checked against a real client in this repository.** The matrix
+is #72 and it does not exist yet. Until it does, which client families render a channel, and how,
+is a claim taken from the plan rather than a thing anybody here has run. Do not read the section
+above as a measurement of reach.
+
+**A client with no browser cannot open the page.** That is what the page is: a document served over
+HTTP to a signed-in session. A client that draws its own interface and offers no way to open a URL
+gets nothing from #69.
+
+**A client that does not render channels gets nothing from the channel**, and there is no fallback
+for it inside this plugin beyond the API.
+
+**On a server with no browsing sibling installed, there is no way to ask for anything from a
+television client at all.** This is the sharpest one and it is certain rather than a claim about
+clients. This plugin ships no way to find a title the server does not have, decided on #113, because
+the sibling discover plugin owns the catalogue and this plugin calls no metadata source, decided in
+#92. So on such a server the channel can show a user what they have already asked for and can offer
+nothing to ask with. The gesture that creates a request arrives from the sibling, which is #68 and
+#89.
+
+## What the rest of this milestone follows from
+
+Every issue after #65 in milestone 8 is read against the decision above.
+
+- #66, the user's view of their own requests on a client this project has never touched, is the
+  channel rendering.
+- #67, proving one user cannot see another's requests through the surface, is the channel's
+  per-user rendering, with the fallback stated above.
+- #68, what gesture creates a request from this side, is unchanged: the gesture arrives through the
+  seam and this plugin draws nothing anybody clicks.
+- #69, serving a page for browsers, is the page.
+- #70, what a user sees when the answer is no or not yet, is written once and rendered by both.
+- #71, never revealing a title a user is not allowed to see, applies to both.
+- #72, the reach matrix, is the measurement this page says it does not have.
+- #73, the localisation catalogue, covers the strings both surfaces show.
+
+None of them assumes a surface other than these, and none is closed as not wanted.


### PR DESCRIPTION
Closes #65.

## What this changes

Milestone 8 turned on a decision nobody had taken, and #65 names the way it goes wrong: build the easy surface and call the rest future work. `docs/surface.md` takes the decision and carries what each option costs.

Three surfaces, and they are not alternatives to each other. The **API** is the floor: everything is built on it and on its own it reaches only somebody who writes a script. A **channel** is the surface for clients this project cannot change, because it needs no change to any client. A **page served by the plugin** is the browser surface, and it can show a decline reason as a sentence and offer a cancellation, which a folder tree does badly.

## What was rejected

**Placeholder items written into a real library.** Rejected outright. It reaches everything a channel reaches by putting rows that are not media into somebody's film library, and that is not a cost this plugin pays but one the operator pays forever, in their searches, their collections and after an uninstall.

**The API alone.** Rejected as an answer, kept as the floor. The user this milestone exists for is not going to write a script.

**The channel alone.** Rejected: a folder tree is a poor shape for a sentence and for a cancellation, and the page costs one page.

**The page alone.** Rejected, and the document spells this one out because it is the cheap answer. One page, and every user who is not at a browser is stranded, which on a media server is most of them.

## The channel's costs are open rather than assumed away

A place in the server's library database, which is a second thing #98's uninstall has to clean. A per-user rendering of personal data. Items that are not media and do nothing when played, which is a real awkwardness and is the price of reaching a client nobody here can change.

The condition #67 already carries is repeated where the decision lives, because that is the page a later reader opens: if per-user isolation cannot be shown on a running server of each claimed line, the channel falls back to a shape carrying no per-user data at all. A channel that shows one user another's requests is worse than no channel.

## The negative disclosure

The document separates what is claimed from what was measured, and the claims are named as claims.

No cell of the reach matrix has been checked against a real client in this repository. The matrix is #72 and it does not exist. Which client families render a channel, and how, is taken from the plan rather than run by anybody here, and the page says so in those words so the reach argument cannot be read as a measurement.

What is certain is stated as certain. A client with no browser cannot open the page. A client that does not render channels gets nothing from the channel. And the sharpest one: on a server with no browsing sibling installed there is no way to ask for anything from a television client at all, because this plugin ships no title search, decided on #113, and calls no metadata source, decided in #92.

## The means

Markdown in `docs/`, which is where every argument in this tree is written, and the only file this issue's scope names. Nothing is added: no language, no runtime, no dependency, and no code, because a decision is not code and writing one as a configuration value would be pretending it is revisited per install.

## Against the three conditions

**The decision is in `docs/surface.md` with the rejected options and the cost that rejected each.** Four rejections, each with its cost, and the two chosen surfaces with theirs.

**The decision names which clients the chosen surface does not reach, without softening it.** The section above, including the case where a television client can ask for nothing at all.

**Every issue after this one in this milestone matches the decision or is closed.** Read one at a time, and the last section of the document records the reading: #66 is the channel rendering, #67 is its per-user isolation with the fallback above, #68 is unchanged because the gesture arrives through the seam and this plugin draws nothing anybody clicks, #69 is the page, #70 is written once and rendered by both, #71 applies to both, #72 is the measurement this page says it does not have, and #73 covers the strings both show. None assumes a surface other than these, so none needed changing and none is closed as not wanted.

## What was run

    npx --yes prettier@3.6.2 --check "docs/surface.md"
    Checking formatting...
    All matched files use Prettier code style!

No file outside `docs/surface.md` is touched:

    git diff --name-only origin/master...HEAD
    docs/surface.md

Nothing in this change is code, so there is no test to add and none was added. The suite is unmoved at a hundred and four on each claimed line.

## What is not covered

The document is a decision and a set of costs, not a measurement of reach. #72 is the measurement, and until it lands nothing in this repository has opened a real client.

Nothing here refuses a later change to the decision. It is a document, and this tree's own rule is that a sentence in a document is not a rule. What makes it hard to drift from is that the eight issues after it now read against it and the last section names them.

This change had no second reader.
