### PR TITLE
Write down the assemblies this plugin may reference, and refuse an addition (#94)

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/SiblingIndependenceTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/SiblingIndependenceTests.cs
@@ -101,9 +101,22 @@ public class SiblingIndependenceTests
         Assert.Empty(siblings);
     }
 
+    /// <summary>
+    /// The assemblies the built plugin references, by name, sorted.
+    /// <para>
+    /// One name is dropped. `netstandard` is a type-forwarding facade that the Release build carries
+    /// and the Debug build does not, measured on this tree: the same command against the two
+    /// configurations differs by that name and by nothing else. Keeping it would make the list
+    /// depend on which configuration ran, and the list has to be one list, because the whole value
+    /// of the comparison is that it is exact. The facade contains no code and forwards to the
+    /// framework, so it cannot be a sibling plugin arriving under another name.
+    /// </para>
+    /// </summary>
+    /// <returns>The reference names.</returns>
     private static string[] ReferencedAssemblyNames()
         => [.. typeof(PluginUnderTest).Assembly
             .GetReferencedAssemblies()
             .Select(reference => reference.Name ?? string.Empty)
+            .Where(name => !string.Equals(name, "netstandard", StringComparison.Ordinal))
             .OrderBy(name => name, StringComparer.Ordinal)];
 }

--- a/Jellyfin.Plugin.Requests.Tests/SiblingIndependenceTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/SiblingIndependenceTests.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+using PluginUnderTest = global::Jellyfin.Plugin.Requests.Plugin;
+
+namespace Jellyfin.Plugin.Requests.Tests;
+
+/// <summary>
+/// What this plugin is allowed to depend on.
+/// <para>
+/// Two plugins that install separately and reference each other at build time fail on the first
+/// server that installs one of them. This board carries the harder side of that, because
+/// implementing somebody else's interface means having the type, and the moment a sibling assembly
+/// is referenced the package stops being installable on its own.
+/// </para>
+/// <para>
+/// The package is one assembly and a metadata file, so the assembly's own reference list is the
+/// package's dependency list. That is what is read here.
+/// </para>
+/// </summary>
+public class SiblingIndependenceTests
+{
+    /// <summary>
+    /// Every assembly the plugin references, written out. An addition fails this test, which is the
+    /// whole point: a reference arrives by somebody writing a `using`, and nothing else in the tree
+    /// would say so. Adding a line here is the deliberate act, and the commit that adds it is where
+    /// the reason lives.
+    /// <para>
+    /// The framework assemblies are in the list rather than filtered out by a name prefix. A filter
+    /// would have to decide what counts as the framework, and the shape of that mistake is a filter
+    /// wide enough to let a sibling through under a name nobody predicted.
+    /// </para>
+    /// </summary>
+    private static readonly string[] AllowedReferences =
+    [
+        "MediaBrowser.Common",
+        "MediaBrowser.Controller",
+        "MediaBrowser.Model",
+        "Microsoft.Extensions.DependencyInjection.Abstractions",
+        "System.Collections",
+        "System.Linq",
+        "System.Runtime"
+    ];
+
+    /// <summary>
+    /// The plugin references exactly the assemblies written above and nothing else. This is the
+    /// second condition on #94: the set is written down, and an addition fails until somebody adds
+    /// it here.
+    /// </summary>
+    [Fact]
+    public void ThePluginReferencesExactlyTheAssembliesWrittenDown()
+    {
+        // Joined rather than compared as two sequences, because a collection failure prints the
+        // difference with the middle elided and the whole list is what somebody repairing this
+        // needs to read.
+        Assert.Equal(
+            string.Join(" | ", AllowedReferences),
+            string.Join(" | ", ReferencedAssemblyNames()),
+            StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// No assembly the plugin references is another Jellyfin plugin. The exact list above would
+    /// already catch this and would catch it as "an unexpected reference", saying nothing about why
+    /// the reference is unwelcome. This one names the reason, and it also refuses the case where
+    /// somebody adds the reference to the list and to the project in one change.
+    /// <para>
+    /// The sibling discover plugin is the one this board is about, and the check is over the shape
+    /// rather than over that one name, because a second sibling would arrive under a third.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void NothingThePluginReferencesIsAnotherJellyfinPlugin()
+    {
+        var siblings = ReferencedAssemblyNames()
+            .Where(name => name.StartsWith("Jellyfin.Plugin.", StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.Empty(siblings);
+    }
+
+    /// <summary>
+    /// The suite runs with no sibling plugin loaded, which is its ordinary state and is the third
+    /// condition on #94. Written as an assertion rather than left as a fact about the day somebody
+    /// looked: a test project that grows a package reference to a sibling in order to test the seam
+    /// is exactly how the ordinary state stops being ordinary, and it would fail here.
+    /// </summary>
+    [Fact]
+    public void NoSiblingPluginIsLoadedWhileTheSuiteRuns()
+    {
+        var siblings = AppDomain.CurrentDomain
+            .GetAssemblies()
+            .Select(assembly => assembly.GetName().Name ?? string.Empty)
+            .Where(name => name.StartsWith("Jellyfin.Plugin.", StringComparison.Ordinal))
+            .Where(name => !name.StartsWith("Jellyfin.Plugin.Requests", StringComparison.Ordinal))
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Empty(siblings);
+    }
+
+    private static string[] ReferencedAssemblyNames()
+        => [.. typeof(PluginUnderTest).Assembly
+            .GetReferencedAssemblies()
+            .Select(reference => reference.Name ?? string.Empty)
+            .OrderBy(name => name, StringComparer.Ordinal)];
+}


### PR DESCRIPTION
Part of #94. Two of its four conditions are met, one is met from a narrower subject than it names, and one needs a run by hand. The last section says which is which.

## What this changes

A reference to a sibling plugin arrives by somebody writing a `using`, not by anybody deciding, and the first server that installs one plugin without the other is where it surfaces. Nothing in this tree said which assemblies this plugin may depend on.

`SiblingIndependenceTests` writes the list out and compares it. Six framework and server assemblies today, and an addition fails the test until somebody adds a line, which puts the reason in the commit that adds it.

The framework assemblies are in the list rather than filtered out by a name prefix. A filter would have to decide what counts as the framework, and the shape of that mistake is a filter wide enough to let a sibling through under a name nobody predicted.

Two narrower assertions sit beside the list. `NothingThePluginReferencesIsAnotherJellyfinPlugin` names the reason a reference is unwelcome, which the exact list cannot, and refuses the change that adds the reference and the allowlist line in one go. `NoSiblingPluginIsLoadedWhileTheSuiteRuns` asserts the suite's ordinary state rather than leaving it as a fact about the day somebody looked: a test project that grows a package reference to a sibling in order to test the seam is exactly how that state stops being ordinary.

## The means

The existing xunit suite and reflection over the built assembly. No package, no runtime, no new apparatus. The alternative was reading the project file or the lockfile, and it was not taken: both describe what the build was asked for, and `GetReferencedAssemblies` describes what the assembly that ships actually carries, which is the thing an operator installs. The two differ exactly when a package reference is declared and unused, which is the case where the project file would report a dependency the package does not have.

## What was run

    dotnet test Jellyfin.Plugin.Requests.sln --nologo
    Bestanden!   : Fehler:     0, erfolgreich:   107, uebersprungen:     0, gesamt:   107 - Jellyfin.Plugin.Requests.Tests.dll (net9.0)
    Bestanden!   : Fehler:     0, erfolgreich:   107, uebersprungen:     0, gesamt:   107 - Jellyfin.Plugin.Requests.Tests.dll (net10.0)

A hundred and seven, from a hundred and four. The runner on this machine is German; the numbers are the numbers.

    dotnet build Jellyfin.Plugin.Requests.sln --nologo -warnaserror
    0 Warnung(en)
    0 Fehler

The list is the same on both claimed target frameworks, which is why it is one list rather than one per line.

## Each guard watched failing

A real new dependency added to the plugin, one line using `System.Text.Json`:

    Fehler ...SiblingIndependenceTests.ThePluginReferencesExactlyTheAssembliesWrittenDown
    Actual:   MediaBrowser.Common | MediaBrowser.Controller | MediaBrowser.Model | Microsoft.Extensions.DependencyInjection.Abstractions | System.Collections | System.Linq | System.Runtime | System.Text.Json
    Fehler!      : Fehler:     1, erfolgreich:   106, gesamt:   107

The subject pointed at an assembly that does reference an assembly named `Jellyfin.Plugin.*`, which is the test assembly referencing the plugin. This is a demonstration that the predicate refuses such a reference when one is present, and it is not the same thing as a sibling being added, because building a real sibling to reference would mean adding a project to this tree:

    Fehler ...SiblingIndependenceTests.NothingThePluginReferencesIsAnotherJellyfinPlugin
    Fehler ...SiblingIndependenceTests.ThePluginReferencesExactlyTheAssembliesWrittenDown
    Fehler!      : Fehler:     2, erfolgreich:   105, gesamt:   107

The loaded-assembly check with its exclusion of this plugin's own name removed, so the plugin assembly itself is what it finds. Same bound as above: it shows the detection works against a loaded `Jellyfin.Plugin.*` assembly, not that a sibling was installed:

    Fehler ...SiblingIndependenceTests.NoSiblingPluginIsLoadedWhileTheSuiteRuns
    Fehler!      : Fehler:     1, erfolgreich:   106, gesamt:   107

Each was reverted before the next, and the suite was green again after the last.

## Why this does not close #94

**The set of assemblies this plugin may reference is written down and an addition fails until it is added there.** Met, and watched failing.

**The suite runs with no sibling plugin present, which is its ordinary state.** Met, and now asserted rather than assumed, with the bound on the proof stated above.

**The built package's dependency list is asserted to contain no sibling plugin assembly, from the package.** Met from the assembly rather than from the package, and the difference is not nothing. The package is one assembly and one metadata file, so its dependency list is that assembly's reference list, which is what this reads. What is not read here is the archive: nothing in this change opens a built zip and asserts what is in it. The route that could is `scripts/bill-of-materials.sh`, which already describes an archive file by file and runs in the release job, and the assertion belongs there rather than in a suite that has no archive to open. That is not built here because the release path is M14 and outside this issue's declared scope.

**The first-load procedure from #20 boots a server with only this plugin installed.** Not shown by anything in this change. `docs/testing.md` records a run of `scripts/verify-plugin-loads.sh` on a server of each claimed line whose plugin list is the server's own bundled metadata plugins and `Requests`, with no sibling. That record is evidence about `e574918`, which predates #107 and reports version `1.0.0.0`, so it is a run from an earlier tree rather than a statement about this one. Re-running it is by hand on one machine and nothing produces it as a side effect of a merge. #20 is where that condition lives.

## One thing this got wrong first

The check was written against a Debug build and the gate builds Release. The Release build carries a type-forwarding facade named `netstandard` that the Debug build does not, so the first push went red on the gate with exactly one difference:

    Actual:   MediaBrowser.Common | ... | System.Runtime | netstandard

The facade is dropped by name rather than added to the list. The list has to be one list, because the whole value of the comparison is that it is exact, and a list that is right in one configuration and wrong in the other is neither. The facade holds no code and forwards to the framework, so nothing arrives through it. Both configurations were then run here, and the guard was watched failing again in Release with the same real new dependency:

    dotnet test Jellyfin.Plugin.Requests.sln --nologo --configuration Release
    Bestanden!   : Fehler:     0, erfolgreich:   107, gesamt:   107 - (net9.0)
    Bestanden!   : Fehler:     0, erfolgreich:   107, gesamt:   107 - (net10.0)

## What is not covered

The invariant lint was not run on this machine. It is a Linux binary the workflow downloads by digest and there is no Windows build of it here, so the patterns of all ten rules were read against the added file by hand and none matches. The gate on this pull request is what judges it.

The contract type the seam needs is #117, and nothing here decides it. This change asserts the current answer, which is that there is no shared type at all, and it will red on the day one arrives as a reference. That is the intended behaviour rather than an oversight: whatever #117 concludes, the allowlist is where the conclusion is written down.

This change had no second reader.

