### PR TITLE
Say who may make each move, and refuse everyone else (#40)

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Model/RequestAuthorityTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Model/RequestAuthorityTests.cs
@@ -1,0 +1,314 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Jellyfin.Plugin.Requests.Model;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Model;
+
+/// <summary>
+/// Who may make each move, and what happens to everybody else. Legality and authority are two
+/// questions about one move: approving a request that is open is a legal transition, and an ordinary
+/// user approving their own is the thing this is here to refuse.
+/// <para>
+/// Everything below calls the model directly, with no endpoint and no page in between. That is the
+/// second condition on #40: a check that only exists at a calling surface is one the next calling
+/// surface will not have.
+/// </para>
+/// </summary>
+public class RequestAuthorityTests
+{
+    private static readonly Guid Requester = new("7a4e2f18-6b0c-4d39-95e7-1f8a3c6d2b40");
+
+    private static readonly Guid Operator = new("2d8f4b16-3a5c-4d97-8e21-7c6b5a4f3e29");
+
+    private static readonly Guid Stranger = new("9c3b7e05-1d42-4a86-b0f9-5e2c8a7d6134");
+
+    private static readonly DateTimeOffset MovedAt = new(2026, 8, 9, 14, 0, 0, TimeSpan.Zero);
+
+    /// <summary>
+    /// Every cell says who may make it, asserted against a list written here rather than read back
+    /// from the table. A derived expectation would agree with whatever the table said, including on
+    /// the day a cell is widened by accident, and a permission widened by accident is the failure
+    /// this whole issue is about.
+    /// </summary>
+    /// <param name="from">The state being moved out of.</param>
+    /// <param name="to">The state being moved into.</param>
+    /// <param name="expected">The callers that cell admits.</param>
+    [Theory]
+
+    // A decision is an administrator's. An observation is the plugin's. A refused cell admits
+    // nobody, which is what makes an illegal move and a move nobody may make one row rather than
+    // two rules that can drift apart.
+    [InlineData(RequestState.Open, RequestState.Open, RequestActor.None)]
+    [InlineData(RequestState.Open, RequestState.Approved, RequestActor.Administrator)]
+    [InlineData(RequestState.Open, RequestState.Declined, RequestActor.Administrator)]
+    [InlineData(RequestState.Open, RequestState.Fulfilled, RequestActor.Plugin)]
+    [InlineData(RequestState.Open, RequestState.Failed, RequestActor.None)]
+
+    [InlineData(RequestState.Approved, RequestState.Open, RequestActor.None)]
+    [InlineData(RequestState.Approved, RequestState.Approved, RequestActor.None)]
+    [InlineData(RequestState.Approved, RequestState.Declined, RequestActor.Administrator)]
+    [InlineData(RequestState.Approved, RequestState.Fulfilled, RequestActor.Plugin)]
+    [InlineData(RequestState.Approved, RequestState.Failed, RequestActor.Plugin)]
+
+    [InlineData(RequestState.Declined, RequestState.Open, RequestActor.None)]
+    [InlineData(RequestState.Declined, RequestState.Approved, RequestActor.Administrator)]
+    [InlineData(RequestState.Declined, RequestState.Declined, RequestActor.None)]
+    [InlineData(RequestState.Declined, RequestState.Fulfilled, RequestActor.None)]
+    [InlineData(RequestState.Declined, RequestState.Failed, RequestActor.None)]
+
+    [InlineData(RequestState.Fulfilled, RequestState.Open, RequestActor.None)]
+    [InlineData(RequestState.Fulfilled, RequestState.Approved, RequestActor.None)]
+    [InlineData(RequestState.Fulfilled, RequestState.Declined, RequestActor.None)]
+    [InlineData(RequestState.Fulfilled, RequestState.Fulfilled, RequestActor.None)]
+    [InlineData(RequestState.Fulfilled, RequestState.Failed, RequestActor.None)]
+
+    [InlineData(RequestState.Failed, RequestState.Open, RequestActor.None)]
+    [InlineData(RequestState.Failed, RequestState.Approved, RequestActor.Administrator)]
+    [InlineData(RequestState.Failed, RequestState.Declined, RequestActor.Administrator)]
+    [InlineData(RequestState.Failed, RequestState.Fulfilled, RequestActor.Plugin)]
+    [InlineData(RequestState.Failed, RequestState.Failed, RequestActor.None)]
+    public void EveryCellAdmitsWhatThisListSays(RequestState from, RequestState to, RequestActor expected)
+    {
+        Assert.Equal(expected, RequestLifecycle.Cell(from, to).Permitted);
+    }
+
+    /// <summary>
+    /// A refused cell admits nobody and a legal cell admits somebody. Either half failing is a cell
+    /// that says two things at once: a move nobody may make is a refusal written twice, and a legal
+    /// move nobody may make is a row that can never be exercised and that a reader will take for a
+    /// working one.
+    /// </summary>
+    [Fact]
+    public void ARefusedCellAdmitsNobodyAndALegalCellAdmitsSomebody()
+    {
+        var disagreeing = RequestLifecycle.Table
+            .Where(cell => cell.IsLegal != (cell.Permitted != RequestActor.None))
+            .Select(cell => string.Format(CultureInfo.InvariantCulture, "{0} to {1}", cell.From, cell.To))
+            .ToArray();
+
+        Assert.Empty(disagreeing);
+    }
+
+    /// <summary>
+    /// What a caller turns out to be depends on the request, and the five cases are the whole rule.
+    /// The one worth naming is the fourth: an ordinary user holds nothing at all on somebody else's
+    /// request, so a surface that hands the wrong request to the wrong session is refused here
+    /// rather than at whatever was supposed to have filtered it.
+    /// </summary>
+    [Fact]
+    public void ACallerIsWhatTheRequestMakesThem()
+    {
+        var request = ARequest();
+
+        Assert.Equal(RequestActor.Plugin, RequestCaller.Plugin.RolesOn(request));
+        Assert.Equal(RequestActor.Administrator, RequestCaller.Administrator(Operator).RolesOn(request));
+        Assert.Equal(RequestActor.Requester, RequestCaller.User(Requester).RolesOn(request));
+        Assert.Equal(RequestActor.None, RequestCaller.User(Stranger).RolesOn(request));
+        Assert.Equal(
+            RequestActor.Administrator | RequestActor.Requester,
+            RequestCaller.Administrator(Requester).RolesOn(request));
+    }
+
+    /// <summary>
+    /// The sentence the issue leads with. An ordinary user asking for something may not then approve
+    /// it, and the move they are attempting is one the table allows, so nothing about the states
+    /// refuses it and only the caller does.
+    /// </summary>
+    [Fact]
+    public void AUserCannotApproveTheirOwnRequest()
+    {
+        var request = ARequest();
+
+        Assert.True(RequestLifecycle.IsLegal(RequestState.Open, RequestState.Approved));
+
+        var refusal = Assert.Throws<RequestMoveNotPermittedException>(
+            () => RequestLifecycle.Move(request, RequestState.Approved, MovedAt, RequestCaller.User(Requester)));
+
+        Assert.Equal(RequestState.Open, refusal.From);
+        Assert.Equal(RequestState.Approved, refusal.To);
+        Assert.Equal(RequestActor.Administrator, refusal.Permitted);
+    }
+
+    /// <summary>
+    /// An administrator who asked for something themselves may still decide it. They hold both roles
+    /// on that one request, and the cell admits one of them. Whether a server should allow that is a
+    /// configuration question left to M12, and it is answered by building the caller with
+    /// <see cref="RequestCaller.User"/> for that call rather than by changing the table.
+    /// </summary>
+    [Fact]
+    public void AnAdministratorMayDecideOnTheirOwnRequest()
+    {
+        var theirs = ARequest() with { RequestedByUserId = Operator };
+
+        var approved = RequestLifecycle.Move(theirs, RequestState.Approved, MovedAt, RequestCaller.Administrator(Operator));
+
+        Assert.Equal(RequestState.Approved, approved.State);
+        Assert.Equal(Operator, approved.StateChangedByUserId);
+
+        Assert.Throws<RequestMoveNotPermittedException>(
+            () => RequestLifecycle.Move(theirs, RequestState.Approved, MovedAt, RequestCaller.User(Operator)));
+    }
+
+    /// <summary>
+    /// Nobody but the plugin says a request is fulfilled, and nobody but an administrator decides
+    /// one. This walks every legal cell against every kind of caller there is, so a permission that
+    /// widened shows up here whichever cell it widened, rather than only in the cells somebody
+    /// thought to write a test for.
+    /// </summary>
+    [Fact]
+    public void EveryLegalCellIsMadeByTheCallersItAdmitsAndByNoOthers()
+    {
+        var wrong = new List<string>();
+
+        foreach (var cell in RequestLifecycle.Table.Where(entry => entry.IsLegal))
+        {
+            var request = ARequest() with { State = cell.From };
+
+            foreach (var (caller, holds) in EveryKindOfCaller())
+            {
+                var admitted = (cell.Permitted & holds) != RequestActor.None;
+                var moved = TryMove(request, cell.To, caller);
+
+                if (moved != admitted)
+                {
+                    wrong.Add(string.Format(
+                        CultureInfo.InvariantCulture,
+                        "{0} to {1} by {2}: {3}",
+                        cell.From,
+                        cell.To,
+                        holds,
+                        moved ? "allowed and should not be" : "refused and should not be"));
+                }
+            }
+        }
+
+        Assert.Empty(wrong);
+    }
+
+    /// <summary>
+    /// A move the table refuses is refused for being refused, whoever asks. The distinction is worth
+    /// a test because the two exceptions are read differently: telling an operator that a fulfilled
+    /// request "may not be approved by you" would send them looking for a permission to grant, and
+    /// there is none, because that move is refused to everybody.
+    /// </summary>
+    [Fact]
+    public void ARefusedMoveIsRefusedBeforeAnybodysAuthorityIsLookedAt()
+    {
+        var fulfilled = ARequest() with { State = RequestState.Fulfilled };
+
+        Assert.Throws<IllegalRequestTransitionException>(
+            () => RequestLifecycle.Move(fulfilled, RequestState.Approved, MovedAt, RequestCaller.User(Stranger)));
+    }
+
+    /// <summary>
+    /// The refusal says enough to act on and nothing about the request it was thrown for. This is
+    /// the third condition on #40: a refusal is the one message a caller can make the plugin produce
+    /// about a request they were not allowed to touch, so the title, the identifiers and the text a
+    /// person typed must not be in it.
+    /// </summary>
+    [Fact]
+    public void TheRefusalNamesTheMoveAndNothingAboutTheRequest()
+    {
+        var request = ARequest() with { RequesterNote = "The one Clouzot made, not the remake." };
+
+        var refusal = Assert.Throws<RequestMoveNotPermittedException>(
+            () => RequestLifecycle.Move(request, RequestState.Approved, MovedAt, RequestCaller.User(Stranger)));
+
+        // Enough to act on: which move, and who makes it.
+        Assert.Contains("Open", refusal.Message, StringComparison.Ordinal);
+        Assert.Contains("Approved", refusal.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(RequestActor.Administrator), refusal.Message, StringComparison.Ordinal);
+
+        // And nothing that would tell the caller about a request they may not see. The requester's
+        // identifier is checked as well as the title, because an identifier handed back is how a
+        // caller learns whose request it is without ever being shown a name.
+        foreach (var secret in new[]
+        {
+            request.DisplayTitle,
+            request.RequesterNote!,
+            request.Id.ToString(),
+            request.RequestedByUserId.ToString()
+        })
+        {
+            Assert.DoesNotContain(secret, refusal.Message, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    /// <summary>
+    /// A caller who is refused leaves nothing behind. A refusal that had already appended to the
+    /// history would put a move in the record that nobody was allowed to make, which is worse than
+    /// the move itself: the record is what an operator answers a complaint from.
+    /// </summary>
+    [Fact]
+    public void ARefusedCallerChangesNothing()
+    {
+        var request = ARequest();
+
+        Assert.Throws<RequestMoveNotPermittedException>(
+            () => RequestLifecycle.Move(request, RequestState.Approved, MovedAt, RequestCaller.User(Requester)));
+
+        Assert.Equal(RequestState.Open, request.State);
+        Assert.Empty(request.History);
+    }
+
+    /// <summary>
+    /// Every kind of caller there is, with what each of them holds on the request below. A fifth
+    /// kind would be a fourth value in <see cref="RequestActor"/>, which is a change to the
+    /// enumeration and to this list together.
+    /// </summary>
+    /// <returns>Each caller and the roles it holds on a request asked for by <c>Requester</c>.</returns>
+    private static IEnumerable<(RequestCaller Caller, RequestActor Holds)> EveryKindOfCaller()
+    {
+        yield return (RequestCaller.Plugin, RequestActor.Plugin);
+        yield return (RequestCaller.Administrator(Operator), RequestActor.Administrator);
+        yield return (RequestCaller.User(Requester), RequestActor.Requester);
+        yield return (RequestCaller.User(Stranger), RequestActor.None);
+    }
+
+    /// <summary>
+    /// Makes a move through whichever of the two doors takes it, and says whether it was made. Only
+    /// the authority refusal is turned into <see langword="false"/>; anything else is a defect in
+    /// the walk rather than an answer, and it is left to throw.
+    /// </summary>
+    /// <param name="request">The request to move.</param>
+    /// <param name="to">The state to move it into.</param>
+    /// <param name="by">The caller making the move.</param>
+    /// <returns><see langword="true"/> where the move was made.</returns>
+    private static bool TryMove(MediaRequest request, RequestState to, RequestCaller by)
+    {
+        try
+        {
+            _ = to == RequestState.Declined
+                ? RequestLifecycle.Decline(request, DeclineReason.NotWanted, note: null, MovedAt, by)
+                : RequestLifecycle.Move(request, to, MovedAt, by);
+
+            return true;
+        }
+        catch (RequestMoveNotPermittedException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// A request asked for by <c>Requester</c>, in the state a new one is created in.
+    /// </summary>
+    /// <returns>A newly asked-for request.</returns>
+    private static MediaRequest ARequest()
+    {
+        var asked = new DateTimeOffset(2026, 8, 9, 10, 0, 0, TimeSpan.Zero);
+
+        return new MediaRequest
+        {
+            Id = new Guid("41d7c0b2-9e3a-4f58-b6d1-8c2f5a0e7b93"),
+            RequestedByUserId = Requester,
+            RequestedAt = asked,
+            StateChangedAt = asked,
+            Kind = RequestedItemKind.Movie,
+            DisplayTitle = "Wages of Fear"
+        };
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/Model/RequestHistoryTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Model/RequestHistoryTests.cs
@@ -15,6 +15,10 @@ public class RequestHistoryTests
 
     private static readonly Guid SecondOperator = new("6b09e13d-5f78-4a2c-90b4-8e1d7c3a5029");
 
+    private static readonly RequestCaller ByFirstOperator = RequestCaller.Administrator(FirstOperator);
+
+    private static readonly RequestCaller BySecondOperator = RequestCaller.Administrator(SecondOperator);
+
     /// <summary>
     /// A request nobody has decided has an empty history. Being created is not a move, and an entry
     /// saying it was created would put a row in every history that says nothing an operator asked
@@ -37,11 +41,11 @@ public class RequestHistoryTests
     {
         var request = ARequest();
 
-        var approved = RequestLifecycle.Move(request, RequestState.Approved, At(9), FirstOperator);
-        var failed = RequestLifecycle.Move(approved, RequestState.Failed, At(10), movedByUserId: null);
-        var declined = RequestLifecycle.Decline(failed, DeclineReason.CannotBeObtained, "Nothing has it.", At(11), SecondOperator);
-        var approvedAgain = RequestLifecycle.Move(declined, RequestState.Approved, At(12), FirstOperator);
-        var fulfilled = RequestLifecycle.Move(approvedAgain, RequestState.Fulfilled, At(13), movedByUserId: null);
+        var approved = RequestLifecycle.Move(request, RequestState.Approved, At(9), ByFirstOperator);
+        var failed = RequestLifecycle.Move(approved, RequestState.Failed, At(10), RequestCaller.Plugin);
+        var declined = RequestLifecycle.Decline(failed, DeclineReason.CannotBeObtained, "Nothing has it.", At(11), BySecondOperator);
+        var approvedAgain = RequestLifecycle.Move(declined, RequestState.Approved, At(12), ByFirstOperator);
+        var fulfilled = RequestLifecycle.Move(approvedAgain, RequestState.Fulfilled, At(13), RequestCaller.Plugin);
 
         Assert.Equal(
             [
@@ -64,8 +68,8 @@ public class RequestHistoryTests
     [Fact]
     public void AnEntryCarriesTheTimeAndTheMoverIncludingWhereThereWasNone()
     {
-        var approved = RequestLifecycle.Move(ARequest(), RequestState.Approved, At(9), FirstOperator);
-        var fulfilled = RequestLifecycle.Move(approved, RequestState.Fulfilled, At(13), movedByUserId: null);
+        var approved = RequestLifecycle.Move(ARequest(), RequestState.Approved, At(9), ByFirstOperator);
+        var fulfilled = RequestLifecycle.Move(approved, RequestState.Fulfilled, At(13), RequestCaller.Plugin);
 
         Assert.Equal(At(9), fulfilled.History[0].At);
         Assert.Equal(FirstOperator, fulfilled.History[0].ByUserId);
@@ -88,9 +92,9 @@ public class RequestHistoryTests
             DeclineReason.NoRoomForIt,
             "The disk is full until the archive move finishes.",
             At(9),
-            FirstOperator);
+            ByFirstOperator);
 
-        var approved = RequestLifecycle.Move(declined, RequestState.Approved, At(10), SecondOperator);
+        var approved = RequestLifecycle.Move(declined, RequestState.Approved, At(10), BySecondOperator);
 
         Assert.Null(approved.DeclineReason);
         Assert.Equal(DeclineReason.NoRoomForIt, approved.History[0].Reason);
@@ -109,13 +113,13 @@ public class RequestHistoryTests
     public void ARefusedMoveAppendsNothing()
     {
         var fulfilled = RequestLifecycle.Move(
-            RequestLifecycle.Move(ARequest(), RequestState.Approved, At(9), FirstOperator),
+            RequestLifecycle.Move(ARequest(), RequestState.Approved, At(9), ByFirstOperator),
             RequestState.Fulfilled,
             At(10),
-            FirstOperator);
+            RequestCaller.Plugin);
 
         Assert.Throws<IllegalRequestTransitionException>(
-            () => RequestLifecycle.Move(fulfilled, RequestState.Approved, At(11), FirstOperator));
+            () => RequestLifecycle.Move(fulfilled, RequestState.Approved, At(11), ByFirstOperator));
 
         Assert.Equal(2, fulfilled.History.Count);
     }
@@ -135,7 +139,7 @@ public class RequestHistoryTests
                 DeclineReason.Other,
                 new string('x', MediaRequest.NoteMaximumLength + 1),
                 At(9),
-                FirstOperator));
+                ByFirstOperator));
 
         Assert.Empty(request.History);
     }
@@ -149,9 +153,9 @@ public class RequestHistoryTests
     public void MovingARequestLeavesTheEarlierValuesHistoryAlone()
     {
         var request = ARequest();
-        var approved = RequestLifecycle.Move(request, RequestState.Approved, At(9), FirstOperator);
+        var approved = RequestLifecycle.Move(request, RequestState.Approved, At(9), ByFirstOperator);
 
-        _ = RequestLifecycle.Move(approved, RequestState.Fulfilled, At(10), FirstOperator);
+        _ = RequestLifecycle.Move(approved, RequestState.Fulfilled, At(10), RequestCaller.Plugin);
 
         Assert.Empty(request.History);
         Assert.Single(approved.History);
@@ -166,10 +170,10 @@ public class RequestHistoryTests
     public void EntriesAreOldestFirst()
     {
         var fulfilled = RequestLifecycle.Move(
-            RequestLifecycle.Move(ARequest(), RequestState.Approved, At(9), FirstOperator),
+            RequestLifecycle.Move(ARequest(), RequestState.Approved, At(9), ByFirstOperator),
             RequestState.Fulfilled,
             At(13),
-            FirstOperator);
+            RequestCaller.Plugin);
 
         Assert.Equal(
             fulfilled.History.Select(entry => entry.At).OrderBy(at => at).ToArray(),

--- a/Jellyfin.Plugin.Requests.Tests/Model/RequestLifecycleTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Model/RequestLifecycleTests.cs
@@ -120,7 +120,11 @@ public class RequestLifecycleTests
         var movedAt = new DateTimeOffset(2026, 8, 9, 11, 30, 0, TimeSpan.Zero);
         var operatorId = new Guid("2d8f4b16-3a5c-4d97-8e21-7c6b5a4f3e29");
 
-        var moved = RequestLifecycle.Move(request, RequestState.Approved, movedAt, operatorId);
+        var moved = RequestLifecycle.Move(
+            request,
+            RequestState.Approved,
+            movedAt,
+            RequestCaller.Administrator(operatorId));
 
         Assert.Equal(RequestState.Approved, moved.State);
         Assert.Equal(movedAt, moved.StateChangedAt);
@@ -156,7 +160,7 @@ public class RequestLifecycleTests
             request,
             RequestState.Fulfilled,
             new DateTimeOffset(2026, 8, 9, 12, 0, 0, TimeSpan.Zero),
-            movedByUserId: null);
+            RequestCaller.Plugin);
 
         Assert.Equal(RequestState.Fulfilled, moved.State);
         Assert.Null(moved.StateChangedByUserId);
@@ -278,6 +282,12 @@ public class RequestLifecycleTests
     /// Makes a move through whichever of the two methods takes it. A decline needs a reason and so
     /// has a door of its own, and a test walking the whole table has to knock on the right one or it
     /// measures the wrong refusal.
+    /// <para>
+    /// The caller is the plugin, and which caller it is does not change what this measures: a
+    /// refused cell is refused before anybody's authority is looked at, which is
+    /// <c>ALegalMoveIsStillRefusedToACallerTheCellDoesNotAdmit</c>'s neighbour in
+    /// <c>RequestAuthorityTests</c>.
+    /// </para>
     /// </summary>
     /// <param name="request">The request to move.</param>
     /// <param name="to">The state to move it into.</param>
@@ -285,8 +295,8 @@ public class RequestLifecycleTests
     /// <returns>The moved request.</returns>
     private static MediaRequest MoveThroughTheRightDoor(MediaRequest request, RequestState to, DateTimeOffset at)
         => to == RequestState.Declined
-            ? RequestLifecycle.Decline(request, DeclineReason.NotWanted, note: null, at, declinedByUserId: null)
-            : RequestLifecycle.Move(request, to, at, movedByUserId: null);
+            ? RequestLifecycle.Decline(request, DeclineReason.NotWanted, note: null, at, RequestCaller.Plugin)
+            : RequestLifecycle.Move(request, to, at, RequestCaller.Plugin);
 
     private static string Verdict(RequestTransition cell) => cell.IsLegal ? "allowed" : "refused";
 

--- a/Jellyfin.Plugin.Requests.Tests/Model/RequestNotesTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Model/RequestNotesTests.cs
@@ -29,6 +29,12 @@ public class RequestNotesTests
     private static readonly Guid AnOperator = new("c5b1a739-4e82-4d16-9f70-3a2b6c8d4e51");
 
     /// <summary>
+    /// That operator as a caller. Every decision below is a decision, so every one of them is made
+    /// by an administrator; who may make which move is <c>RequestAuthorityTests</c>.
+    /// </summary>
+    private static readonly RequestCaller ByTheOperator = RequestCaller.Administrator(AnOperator);
+
+    /// <summary>
     /// A fresh request has neither note and no reason. The failure this stands for is a default of
     /// empty string, which reads on a page as a note somebody wrote and left blank.
     /// </summary>
@@ -53,7 +59,7 @@ public class RequestNotesTests
             DeclineReason.NoRoomForIt,
             "The disk is at ninety-five percent until the archive move finishes.",
             At(14),
-            AnOperator);
+            ByTheOperator);
 
         Assert.Equal(RequestState.Declined, declined.State);
         Assert.Equal(DeclineReason.NoRoomForIt, declined.DeclineReason);
@@ -73,7 +79,7 @@ public class RequestNotesTests
     public void ADeclineWithNoReasonCannotBeMadeThroughMove()
     {
         var refusal = Assert.Throws<ArgumentException>(
-            () => RequestLifecycle.Move(ARequest(), RequestState.Declined, At(14), AnOperator));
+            () => RequestLifecycle.Move(ARequest(), RequestState.Declined, At(14), ByTheOperator));
 
         Assert.Equal("to", refusal.ParamName, StringComparer.Ordinal);
         Assert.Contains("Decline", refusal.Message, StringComparison.Ordinal);
@@ -91,7 +97,7 @@ public class RequestNotesTests
     public void AReasonOffTheListNeedsTheTextThatSaysWhy(string? note)
     {
         var refusal = Assert.Throws<ArgumentException>(
-            () => RequestLifecycle.Decline(ARequest(), DeclineReason.Other, note, At(14), AnOperator));
+            () => RequestLifecycle.Decline(ARequest(), DeclineReason.Other, note, At(14), ByTheOperator));
 
         Assert.Equal("note", refusal.ParamName, StringComparer.Ordinal);
     }
@@ -108,7 +114,7 @@ public class RequestNotesTests
             DeclineReason.Other,
             "The rights holder asked us to take it down.",
             At(14),
-            AnOperator);
+            ByTheOperator);
 
         Assert.Equal(DeclineReason.Other, declined.DeclineReason);
         Assert.Equal(
@@ -130,9 +136,9 @@ public class RequestNotesTests
             DeclineReason.NoRoomForIt,
             "The disk is full.",
             At(14),
-            AnOperator);
+            ByTheOperator);
 
-        var approved = RequestLifecycle.Move(declined, RequestState.Approved, At(15), AnOperator);
+        var approved = RequestLifecycle.Move(declined, RequestState.Approved, At(15), ByTheOperator);
 
         Assert.Equal(RequestState.Approved, approved.State);
         Assert.Null(approved.DeclineReason);
@@ -148,8 +154,8 @@ public class RequestNotesTests
     {
         var request = ARequest() with { RequesterNote = "The 1974 one, not the remake." };
 
-        var declined = RequestLifecycle.Decline(request, DeclineReason.CannotBeObtained, null, At(14), AnOperator);
-        var approved = RequestLifecycle.Move(declined, RequestState.Approved, At(15), AnOperator);
+        var declined = RequestLifecycle.Decline(request, DeclineReason.CannotBeObtained, null, At(14), ByTheOperator);
+        var approved = RequestLifecycle.Move(declined, RequestState.Approved, At(15), ByTheOperator);
 
         Assert.Equal("The 1974 one, not the remake.", approved.RequesterNote, StringComparer.Ordinal);
     }
@@ -210,7 +216,7 @@ public class RequestNotesTests
                 DeclineReason.Other,
                 new string('x', MediaRequest.NoteMaximumLength + 1),
                 At(14),
-                AnOperator));
+                ByTheOperator));
 
         Assert.Equal(RequestState.Open, request.State);
         Assert.Null(request.DeclineReason);
@@ -255,7 +261,7 @@ public class RequestNotesTests
             DeclineReason.Other,
             LooksLikeMarkup,
             At(14),
-            AnOperator);
+            ByTheOperator);
 
         Assert.Equal(LooksLikeMarkup, declined.RequesterNote, StringComparer.Ordinal);
         Assert.Equal(LooksLikeMarkup, declined.DeclineNote, StringComparer.Ordinal);

--- a/Jellyfin.Plugin.Requests/Model/RequestActor.cs
+++ b/Jellyfin.Plugin.Requests/Model/RequestActor.cs
@@ -1,0 +1,74 @@
+using System;
+
+namespace Jellyfin.Plugin.Requests.Model;
+
+/// <summary>
+/// What a caller is, as far as moving a request is concerned. Three kinds of caller reach the
+/// lifecycle and no more: the person who asked, an administrator of the server, and the plugin
+/// itself acting on something it observed.
+/// <para>
+/// It is a set rather than a single value because one caller can be two of them at once. An
+/// administrator who asked for something themselves is both the requester and an administrator on
+/// that request and only an administrator on everybody else's, and a rule that made a caller choose
+/// one label would have to guess which. <see cref="RequestCaller.RolesOn"/> is where a caller and a
+/// request produce this set, and <see cref="RequestTransition.Permitted"/> is the set a cell admits;
+/// a move is permitted where the two sets share a value.
+/// </para>
+/// <para>
+/// The values say what a caller <b>is</b> and never what it may do. What each one may do is per
+/// cell, in <see cref="RequestLifecycle.Table"/>, so widening a permission is an edit to one row of
+/// a table that a test reads back rather than a condition added somewhere a reader has to find.
+/// </para>
+/// </summary>
+[Flags]
+public enum RequestActor
+{
+    /// <summary>
+    /// Nothing. This is what an ordinary user holds on somebody else's request, and it is what every
+    /// refused cell admits, so the two are refused by the same comparison rather than by two rules.
+    /// <para>
+    /// It is the zero value on purpose, so that a set nobody filled in permits nothing. A default
+    /// that permitted something would make a forgotten cell the widest one in the table.
+    /// </para>
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// The person who asked for this thing. Held only against their own request, which is decided by
+    /// comparing the caller's user identifier with
+    /// <see cref="MediaRequest.RequestedByUserId"/> and never by comparing names.
+    /// <para>
+    /// No cell of the table admits this on its own today. Asking is not a move: approving one's own
+    /// request is the case this whole check exists for, a decline is an operator's answer, and there
+    /// is no state for a user withdrawing, refused with the <c>Cancelled</c> state on #113. The
+    /// value exists because the surfaces have to answer "is this yours" against the same comparison,
+    /// and because the per-user automatic approval left to M12 is a cell that admits it.
+    /// </para>
+    /// </summary>
+    Requester = 1,
+
+    /// <summary>
+    /// An administrator of the server. Every decision belongs here: an approval, a decline, and
+    /// taking either back.
+    /// <para>
+    /// Whether an administrator may decide on their own request is a configuration question that
+    /// belongs to M12, and it is asked of the caller rather than of the table: such a caller is
+    /// built with <see cref="RequestCaller.User"/> instead of
+    /// <see cref="RequestCaller.Administrator"/> and holds only <see cref="Requester"/> on that one
+    /// request. Nothing here decides it and nothing here has to change when it is decided.
+    /// </para>
+    /// </summary>
+    Administrator = 2,
+
+    /// <summary>
+    /// The plugin itself, acting on something it observed rather than on somebody's decision. Every
+    /// observation belongs here: that the library now holds what was asked for, and that something
+    /// sent onward did not arrive.
+    /// <para>
+    /// It is separate from an administrator because the two read differently in a history and in a
+    /// complaint. A request the library check fulfilled and one a person marked fulfilled are
+    /// different facts, and a person should not answer for a move nobody made.
+    /// </para>
+    /// </summary>
+    Plugin = 4
+}

--- a/Jellyfin.Plugin.Requests/Model/RequestCaller.cs
+++ b/Jellyfin.Plugin.Requests/Model/RequestCaller.cs
@@ -1,0 +1,94 @@
+using System;
+
+namespace Jellyfin.Plugin.Requests.Model;
+
+/// <summary>
+/// Who is asking for a move, and with what authority. Every call into
+/// <see cref="RequestLifecycle"/> carries one, so a new calling surface cannot make a move without
+/// having said on whose behalf it is making it.
+/// <para>
+/// It is a parameter rather than something the lifecycle looks up, because the lifecycle has no way
+/// to reach a session and should not grow one. The surface that has the session builds one of these
+/// and hands it in; what a caller of a given authority may do is then decided in one place, beside
+/// the table, and not in each surface.
+/// </para>
+/// <para>
+/// It is a class with three named doors rather than a struct with fields, so that there is no
+/// default value. A defaulted struct here would carry no user and no authority, and the shape that
+/// carries no user is the plugin itself, which is the most privileged caller there is. A caller
+/// that forgot to say who it was would have become the one caller that may make an observation.
+/// </para>
+/// <para>
+/// The authority is taken as given. Whether the session really belongs to an administrator is the
+/// server's answer and it is asked at the endpoint; handing in
+/// <see cref="Administrator(System.Guid)"/> for a session that is not one is a defect in that
+/// surface, and nothing here can detect it. The endpoint half of that is #51.
+/// </para>
+/// </summary>
+public sealed record RequestCaller
+{
+    private readonly RequestActor _authority;
+
+    private RequestCaller(Guid? userId, RequestActor authority)
+    {
+        UserId = userId;
+        _authority = authority;
+    }
+
+    /// <summary>
+    /// Gets the caller that is the plugin itself, moving a request on something it observed rather
+    /// than on a decision anybody took. It carries no user, which is what makes
+    /// <see cref="MediaRequest.StateChangedByUserId"/> and
+    /// <see cref="RequestHistoryEntry.ByUserId"/> read as absent for a move no person made.
+    /// </summary>
+    public static RequestCaller Plugin { get; } = new(userId: null, RequestActor.Plugin);
+
+    /// <summary>
+    /// Gets the Jellyfin user this call is made on behalf of, or <see langword="null"/> where the
+    /// plugin is making the call itself. It is the server's user identifier rather than a name,
+    /// because names are renamed and because two similar names must never end up deciding each
+    /// other's requests.
+    /// </summary>
+    public Guid? UserId { get; }
+
+    /// <summary>
+    /// A caller that is an administrator of this server.
+    /// </summary>
+    /// <param name="userId">The administrator's Jellyfin user identifier.</param>
+    /// <returns>A caller holding <see cref="RequestActor.Administrator"/> on every request, and
+    /// <see cref="RequestActor.Requester"/> as well on one they asked for themselves.</returns>
+    public static RequestCaller Administrator(Guid userId) => new(userId, RequestActor.Administrator);
+
+    /// <summary>
+    /// A caller that is an ordinary user of this server.
+    /// <para>
+    /// This is also the door for an administrator who is to be treated as an ordinary user for one
+    /// call, which is how a configuration that keeps administrators from deciding on their own
+    /// requests would be expressed without the table changing.
+    /// </para>
+    /// </summary>
+    /// <param name="userId">The user's Jellyfin user identifier.</param>
+    /// <returns>A caller holding <see cref="RequestActor.Requester"/> on a request they asked for
+    /// and nothing at all on anybody else's.</returns>
+    public static RequestCaller User(Guid userId) => new(userId, RequestActor.None);
+
+    /// <summary>
+    /// What this caller is, on one particular request.
+    /// </summary>
+    /// <param name="request">The request being moved.</param>
+    /// <returns>
+    /// The authority this caller was built with, together with
+    /// <see cref="RequestActor.Requester"/> where the request is one they asked for.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Where no request was given.</exception>
+    public RequestActor RolesOn(MediaRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // The plugin carries no user, so it can never match a requester, and the comparison below
+        // does not have to special-case it: no identifier equals a request's requester by accident.
+        return UserId is Guid caller && caller == request.RequestedByUserId
+            ? _authority | RequestActor.Requester
+            : _authority;
+    }
+}

--- a/Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs
+++ b/Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs
@@ -37,6 +37,32 @@ namespace Jellyfin.Plugin.Requests.Model;
 /// rather than a decision being undone, which is what <see cref="LibraryAvailability"/> and
 /// <see cref="MediaRequest.AvailabilityCheckedAt"/> are for.
 /// </para>
+/// <para>
+/// <b>Who may make a move is the second half of every cell.</b> A move is legal or illegal by the
+/// table and separately permitted or not permitted to the caller, and both are checked here rather
+/// than at whatever is calling, so that a surface added later cannot forget the second one. The
+/// caller says what it is, in <see cref="RequestCaller"/>; the cell says what it admits, in
+/// <see cref="RequestTransition.Permitted"/>; the move is permitted where the two sets share a
+/// value. A refused cell admits nobody, so the two checks never disagree about a move the table
+/// already refuses.
+/// </para>
+/// <para>
+/// One line decides every cell's permitted set: <b>a decision is an administrator's and an
+/// observation is the plugin's</b>. Approving, declining, taking either back and sending something
+/// onward again are answers a person gives, and they are the six cells an administrator may make.
+/// Arriving in the library and failing to arrive are things that happened whether or not anybody
+/// looked, and they are the four cells the plugin may make. A person marking a request fulfilled
+/// would be making the state say something about the library that the library does not say, and
+/// #42 is where that is detected instead.
+/// </para>
+/// <para>
+/// No cell admits the requester alone. Asking is not a move: approving one's own request is the
+/// case this check exists for, a decline is the operator's answer rather than the asker's, and a
+/// user withdrawing has no state to move to because <c>Cancelled</c> was refused on #113. An
+/// administrator who asked for something themselves holds both roles on it and may still decide it,
+/// and whether that should be so is a configuration question left to M12 that is answered at the
+/// caller rather than in this table.
+/// </para>
 /// </summary>
 public static class RequestLifecycle
 {
@@ -89,13 +115,16 @@ public static class RequestLifecycle
     /// <param name="at">
     /// When the move happened, from the injected clock rather than the machine's.
     /// </param>
-    /// <param name="movedByUserId">
-    /// The Jellyfin user who moved it, or <see langword="null"/> where the plugin moved it on its
-    /// own after looking at the library.
+    /// <param name="by">
+    /// Who is making the move, and with what authority. <see cref="RequestCaller.Plugin"/> is the
+    /// one that records no person, for a move made on something the plugin observed.
     /// </param>
     /// <returns>A new request in the new state.</returns>
-    /// <exception cref="ArgumentNullException">Where no request was given.</exception>
+    /// <exception cref="ArgumentNullException">Where no request or no caller was given.</exception>
     /// <exception cref="IllegalRequestTransitionException">Where the table refuses the move.</exception>
+    /// <exception cref="RequestMoveNotPermittedException">
+    /// Where the table allows the move and does not admit this caller for it.
+    /// </exception>
     /// <exception cref="ArgumentException">
     /// Where the state asked for is <see cref="RequestState.Declined"/>, which needs a reason and so
     /// has a door of its own.
@@ -104,7 +133,7 @@ public static class RequestLifecycle
         MediaRequest request,
         RequestState to,
         DateTimeOffset at,
-        Guid? movedByUserId)
+        RequestCaller by)
     {
         ArgumentNullException.ThrowIfNull(request);
 
@@ -119,7 +148,7 @@ public static class RequestLifecycle
         // declined it is a sentence that is no longer true, and the surfaces would show it beside a
         // state it contradicts. The entry that carried it stays in the history, so taking a decline
         // back loses the current reason and not the record of it.
-        return Moved(request, to, at, movedByUserId, reason: null, note: null);
+        return Moved(request, to, at, by, reason: null, note: null);
     }
 
     /// <summary>
@@ -139,10 +168,13 @@ public static class RequestLifecycle
     /// <param name="at">
     /// When the decline happened, from the injected clock rather than the machine's.
     /// </param>
-    /// <param name="declinedByUserId">The Jellyfin user who declined it.</param>
+    /// <param name="by">Who is declining it, and with what authority.</param>
     /// <returns>A new request, declined, carrying the reason.</returns>
-    /// <exception cref="ArgumentNullException">Where no request was given.</exception>
+    /// <exception cref="ArgumentNullException">Where no request or no caller was given.</exception>
     /// <exception cref="IllegalRequestTransitionException">Where the table refuses the move.</exception>
+    /// <exception cref="RequestMoveNotPermittedException">
+    /// Where the table allows the decline and does not admit this caller for it.
+    /// </exception>
     /// <exception cref="ArgumentException">
     /// Where the reason is <see cref="DeclineReason.Other"/> and no note says what happened.
     /// </exception>
@@ -152,7 +184,7 @@ public static class RequestLifecycle
         DeclineReason reason,
         string? note,
         DateTimeOffset at,
-        Guid? declinedByUserId)
+        RequestCaller by)
     {
         ArgumentNullException.ThrowIfNull(request);
 
@@ -163,18 +195,19 @@ public static class RequestLifecycle
                 nameof(note));
         }
 
-        return Moved(request, RequestState.Declined, at, declinedByUserId, reason, note);
+        return Moved(request, RequestState.Declined, at, by, reason, note);
     }
 
     /// <summary>
-    /// The one place a request changes state, and therefore the one place the history grows. Both
-    /// public methods above go through here, so "every transition appends exactly one entry" is a
-    /// property of the code's shape rather than a thing two call sites have to remember.
+    /// The one place a request changes state, and therefore the one place the history grows and the
+    /// one place a caller's authority is checked. Both public methods above go through here, so
+    /// "every transition appends exactly one entry" and "every transition asks who is making it" are
+    /// properties of the code's shape rather than things two call sites have to remember.
     /// </summary>
     /// <param name="request">The request to move.</param>
     /// <param name="to">The state to move it into.</param>
     /// <param name="at">When the move happened.</param>
-    /// <param name="movedByUserId">Who moved it, or nothing where the plugin did.</param>
+    /// <param name="by">Who is making the move, and with what authority.</param>
     /// <param name="reason">The decline reason, where this is a decline.</param>
     /// <param name="note">The text written beside the reason.</param>
     /// <returns>A new request in the new state, one entry longer.</returns>
@@ -182,15 +215,26 @@ public static class RequestLifecycle
         MediaRequest request,
         RequestState to,
         DateTimeOffset at,
-        Guid? movedByUserId,
+        RequestCaller by,
         DeclineReason? reason,
         string? note)
     {
+        ArgumentNullException.ThrowIfNull(by);
+
         var cell = Cell(request.State, to);
 
+        // Legality first, and the order is deliberate. A move the table refuses is refused to
+        // everybody, so answering it with "not you" would be wrong for every caller including the
+        // one who tried; and neither refusal names anything about the request, so nothing is
+        // disclosed by either order.
         if (!cell.IsLegal)
         {
             throw new IllegalRequestTransitionException(cell.From, cell.To, cell.Why);
+        }
+
+        if ((cell.Permitted & by.RolesOn(request)) == RequestActor.None)
+        {
+            throw new RequestMoveNotPermittedException(cell.From, cell.To, cell.Permitted);
         }
 
         var entry = new RequestHistoryEntry
@@ -198,7 +242,7 @@ public static class RequestLifecycle
             From = cell.From,
             To = cell.To,
             At = at,
-            ByUserId = movedByUserId,
+            ByUserId = by.UserId,
             Reason = reason,
             Note = note
         };
@@ -207,7 +251,7 @@ public static class RequestLifecycle
         {
             State = to,
             StateChangedAt = at,
-            StateChangedByUserId = movedByUserId,
+            StateChangedByUserId = by.UserId,
             DeclineReason = reason,
             DeclineNote = note,
 
@@ -229,14 +273,22 @@ public static class RequestLifecycle
         const string NothingWasSent =
             "Nothing was ever sent onward, so there is nothing that could have failed.";
 
+        // The two permitted sets the whole table is built out of, named rather than repeated, so
+        // that a cell reads as one of the two kinds of move rather than as its own arrangement. A
+        // cell needing a third set is a cell that has stopped being either a decision or an
+        // observation, and giving it a name here is the moment to say what it is instead.
+        const RequestActor Decision = RequestActor.Administrator;
+        const RequestActor Observation = RequestActor.Plugin;
+
         var table = new List<RequestTransition>
         {
             Refused(RequestState.Open, RequestState.Open, NotAMove),
-            Legal(RequestState.Open, RequestState.Approved, "An operator says yes."),
-            Legal(RequestState.Open, RequestState.Declined, "An operator says no."),
+            Legal(RequestState.Open, RequestState.Approved, Decision, "An operator says yes."),
+            Legal(RequestState.Open, RequestState.Declined, Decision, "An operator says no."),
             Legal(
                 RequestState.Open,
                 RequestState.Fulfilled,
+                Observation,
                 "The library already holds what was asked for, so there is nothing left for anybody to decide."),
             Refused(RequestState.Open, RequestState.Failed, NothingWasSent),
 
@@ -245,17 +297,24 @@ public static class RequestLifecycle
             Legal(
                 RequestState.Approved,
                 RequestState.Declined,
+                Decision,
                 "An operator takes an approval back, and the reason says why. This is the repair for an approval given by mistake."),
-            Legal(RequestState.Approved, RequestState.Fulfilled, "It arrived and the person who asked can watch it."),
+            Legal(
+                RequestState.Approved,
+                RequestState.Fulfilled,
+                Observation,
+                "It arrived and the person who asked can watch it."),
             Legal(
                 RequestState.Approved,
                 RequestState.Failed,
+                Observation,
                 "It was sent onward and did not arrive, so it stops looking like an operator forgot about it."),
 
             Refused(RequestState.Declined, RequestState.Open, NoUndeciding),
             Legal(
                 RequestState.Declined,
                 RequestState.Approved,
+                Decision,
                 "An operator changes their mind. One request carrying both moves beats asking the person who was refused to ask again."),
             Refused(RequestState.Declined, RequestState.Declined, NotAMove),
             Refused(
@@ -271,14 +330,16 @@ public static class RequestLifecycle
             Refused(RequestState.Fulfilled, RequestState.Failed, FulfilledIsTheEnd),
 
             Refused(RequestState.Failed, RequestState.Open, NoUndeciding),
-            Legal(RequestState.Failed, RequestState.Approved, "An operator sends it onward again."),
+            Legal(RequestState.Failed, RequestState.Approved, Decision, "An operator sends it onward again."),
             Legal(
                 RequestState.Failed,
                 RequestState.Declined,
+                Decision,
                 "An operator gives up on it, and the reason says why. Without this a failure has no ending."),
             Legal(
                 RequestState.Failed,
                 RequestState.Fulfilled,
+                Observation,
                 "It arrived after all, by this route or by somebody putting it in the library by hand."),
             Refused(RequestState.Failed, RequestState.Failed, NotAMove)
         };
@@ -286,9 +347,18 @@ public static class RequestLifecycle
         return new ReadOnlyCollection<RequestTransition>(table);
     }
 
-    private static RequestTransition Legal(RequestState from, RequestState to, string why)
-        => new() { From = from, To = to, IsLegal = true, Why = why };
+    private static RequestTransition Legal(RequestState from, RequestState to, RequestActor permitted, string why)
+        => new() { From = from, To = to, IsLegal = true, Permitted = permitted, Why = why };
 
+    /// <summary>
+    /// A cell nobody may make. The permitted set is <see cref="RequestActor.None"/> rather than a
+    /// parameter, because "this move is refused" and "some caller may still make it" cannot both be
+    /// true, and a helper that let them be written together is the disagreement waiting to happen.
+    /// </summary>
+    /// <param name="from">The state being moved out of.</param>
+    /// <param name="to">The state being moved into.</param>
+    /// <param name="why">The reason this pair is refused.</param>
+    /// <returns>The refused cell.</returns>
     private static RequestTransition Refused(RequestState from, RequestState to, string why)
-        => new() { From = from, To = to, IsLegal = false, Why = why };
+        => new() { From = from, To = to, IsLegal = false, Permitted = RequestActor.None, Why = why };
 }

--- a/Jellyfin.Plugin.Requests/Model/RequestMoveNotPermittedException.cs
+++ b/Jellyfin.Plugin.Requests/Model/RequestMoveNotPermittedException.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Globalization;
+
+namespace Jellyfin.Plugin.Requests.Model;
+
+/// <summary>
+/// Thrown when the move is one <see cref="RequestLifecycle.Table"/> allows, but not to this caller.
+/// <para>
+/// It is a different exception from <see cref="IllegalRequestTransitionException"/> because the two
+/// mean different things and are repaired differently. An illegal move is refused to everybody and
+/// stays refused; this one says the move is a real move that somebody else may make, and telling an
+/// operator that a request "cannot be approved" when what happened is that a user tried to approve
+/// their own is the sentence that sends them looking for a bug in the queue.
+/// </para>
+/// <para>
+/// <b>What it says and what it does not.</b> The message names the two states and the callers the
+/// table admits for that pair, all of which are printed in the documentation and true of every
+/// request in that state. It names nothing about the request it was thrown for: not the title, not
+/// the identifier, not who asked, not what they wrote. A refusal is the one message a caller can
+/// make the plugin produce about a request they were not allowed to touch, so it is written to be
+/// safe to hand back whole. What the caller turned out to be is deliberately absent too: on somebody
+/// else's request that value is a fact about the request rather than about the caller.
+/// </para>
+/// </summary>
+public sealed class RequestMoveNotPermittedException : InvalidOperationException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequestMoveNotPermittedException"/> class for a
+    /// named pair of states and the callers that pair admits.
+    /// </summary>
+    /// <param name="from">The state the move was out of.</param>
+    /// <param name="to">The state the move was into.</param>
+    /// <param name="permitted">The callers the table admits for that pair.</param>
+    public RequestMoveNotPermittedException(RequestState from, RequestState to, RequestActor permitted)
+        : base(Describe(from, to, permitted))
+    {
+        From = from;
+        To = to;
+        Permitted = permitted;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequestMoveNotPermittedException"/> class.
+    /// Present because the analyzers ask every exception for the three ordinary constructors; the
+    /// constructor above is the one this type exists for, and it is the only one that can say which
+    /// move was refused to whom.
+    /// </summary>
+    public RequestMoveNotPermittedException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequestMoveNotPermittedException"/> class with a
+    /// message of the caller's own. See the note on the parameterless constructor.
+    /// </summary>
+    /// <param name="message">The message.</param>
+    public RequestMoveNotPermittedException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequestMoveNotPermittedException"/> class with a
+    /// message and an inner exception. See the note on the parameterless constructor.
+    /// </summary>
+    /// <param name="message">The message.</param>
+    /// <param name="innerException">The inner exception.</param>
+    public RequestMoveNotPermittedException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    /// Gets the state the refused move was out of, or <see cref="RequestState.Open"/> where this was
+    /// built by one of the constructors that names no pair.
+    /// </summary>
+    public RequestState From { get; }
+
+    /// <summary>
+    /// Gets the state the refused move was into, or <see cref="RequestState.Open"/> where this was
+    /// built by one of the constructors that names no pair.
+    /// </summary>
+    public RequestState To { get; }
+
+    /// <summary>
+    /// Gets the callers the table admits for that pair, or <see cref="RequestActor.None"/> where
+    /// this was built by one of the constructors that names no pair. This is a cell of the table
+    /// rather than anything about the request, so a surface may show it.
+    /// </summary>
+    public RequestActor Permitted { get; }
+
+    private static string Describe(RequestState from, RequestState to, RequestActor permitted)
+        => string.Format(
+            CultureInfo.InvariantCulture,
+            "This caller may not move a request from {0} to {1}. That move is made by: {2}.",
+            from,
+            to,
+            permitted);
+}

--- a/Jellyfin.Plugin.Requests/Model/RequestTransition.cs
+++ b/Jellyfin.Plugin.Requests/Model/RequestTransition.cs
@@ -28,6 +28,22 @@ public sealed record RequestTransition
     public required bool IsLegal { get; init; }
 
     /// <summary>
+    /// Gets the callers who may make this move. A move is permitted where this set and the set the
+    /// caller holds on the request, from <see cref="RequestCaller.RolesOn"/>, share a value.
+    /// <para>
+    /// Whether a move is legal and who may make it are two questions, and both are answered here so
+    /// that a calling surface cannot answer the second on its own. A refused cell admits
+    /// <see cref="RequestActor.None"/>, so an illegal move and a move nobody may make are the same
+    /// row rather than two rules that can disagree.
+    /// </para>
+    /// <para>
+    /// It is required rather than defaulted, so a cell added to the table has to say who may make
+    /// it. A default would be a permission somebody chose by not writing anything.
+    /// </para>
+    /// </summary>
+    public required RequestActor Permitted { get; init; }
+
+    /// <summary>
     /// Gets the reason this cell reads the way it does, in one sentence. This is printed in
     /// <c>docs/lifecycle.md</c> and is the text a person reads when a move they expected to work
     /// was refused, so it says why rather than restating the verdict.


### PR DESCRIPTION
Closes #40.

A transition being legal and a caller being allowed to make it are two questions, and until now
only the first was asked. Every cell of `RequestLifecycle.Table` now carries `Permitted`, the set of
callers that cell admits, and the one private helper both public doors go through checks it beside
the legality check it already made. A user who asks for a film can no longer approve it by calling
the model.

## What the table now says

One line decides every cell. A decision is an administrator's and an observation is the plugin's.

Approving, declining, taking either back and sending something onward again are answers a person
gives, and they are the six cells an administrator may make. Arriving in the library and failing to
arrive are things that happened whether or not anybody looked, and they are the four cells the
plugin may make. A person marking a request fulfilled would make the state say something about the
library that the library does not say, and #42 is where that is detected instead.

No cell admits the requester on its own. Asking is not a move: approving one's own request is the
case the check exists for, a decline is the operator's answer rather than the asker's, and a user
withdrawing has no state to move to, because `Cancelled` was refused on #113. The role still exists,
because an administrator who asked for something themselves holds both roles on that one request and
may still decide it, and because the per-user automatic approval left to M12 is a cell that would
admit it.

A refused cell admits nobody, so an illegal move and a move nobody may make are one row rather than
two rules that can drift apart. `ARefusedCellAdmitsNobodyAndALegalCellAdmitsSomebody` refuses the
two disagreeing in either direction.

## The caller

`RequestCaller` is a parameter rather than something the lifecycle looks up, because the lifecycle
has no way to reach a session and should not grow one. The surface that has the session builds one
and hands it in, so what a caller of a given authority may do is decided in one place beside the
table instead of once per surface. That is the second condition on this issue: a check that lives at
a calling surface is one the next calling surface will not have.

It is a class with three named doors and no default value. The shape that carries no user is the
plugin itself, which is the most privileged caller there is, so a defaulted struct would have turned
a caller that forgot to say who it was into the one caller that may make an observation.

Whether an administrator may decide on their own request is left to M12, and it is answered at the
caller rather than in the table: such a call is built with `RequestCaller.User` and holds only
`Requester` on that request. Nothing in the table changes when that is decided.

## The refusal

`RequestMoveNotPermittedException` names the two states and the callers the cell admits. All three
are facts about the table, true of every request in that state, and printed in the documentation.

It names nothing about the request it was thrown for: not the title, not the identifier, not who
asked, not what they wrote. A refusal is the one message a caller can make the plugin produce about
a request they were not allowed to touch, so it is written to be safe to hand back whole. What the
caller turned out to be is left out for the same reason, because on somebody else's request that
value is a fact about the request rather than about the caller.
`TheRefusalNamesTheMoveAndNothingAboutTheRequest` asserts both halves.

Legality is checked before authority. A move the table refuses is refused to everybody, so answering
it with "not you" would be wrong for every caller including the one who tried, and neither refusal
names anything about the request, so nothing is disclosed by the order.

## Proof that the guard bites

Removing the two-line check from `Moved` and running the suite at this commit's tree, on `net9.0`:

    [FAIL] RequestAuthorityTests.EveryLegalCellIsMadeByTheCallersItAdmitsAndByNoOthers
    [FAIL] RequestAuthorityTests.AnAdministratorMayDecideOnTheirOwnRequest
    [FAIL] RequestAuthorityTests.TheRefusalNamesTheMoveAndNothingAboutTheRequest
    [FAIL] RequestAuthorityTests.AUserCannotApproveTheirOwnRequest
    [FAIL] RequestAuthorityTests.ARefusedCallerChangesNothing
    Fehler: 5, erfolgreich: 135, gesamt: 140

Five red and the rest of the suite unmoved, which is the second half worth reading: the guard is
what those five are about, and it did not make the other 135 depend on it. The check was put back
before this branch was pushed.

## What was run

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release \
      --collect "Code Coverage;Format=cobertura" --results-directory coverage
    Bestanden! Fehler: 0, erfolgreich: 140, gesamt: 140 (net9.0)
    Bestanden! Fehler: 0, erfolgreich: 140, gesamt: 140 (net10.0)

107 tests before this change and 140 after, both server lines. Line coverage of the plugin's own
package, computed with the gate's own reader over that report:

    rate 87.88% of 594 lines
      RequestCaller.cs                    (25, 27)
      RequestLifecycle.cs                 (227, 227)
      RequestMoveNotPermittedException.cs (28, 40)
      RequestTransition.cs                (15, 17)

The floor is 75. The twelve uncovered lines in the new exception are the three ordinary constructors
the analyzers ask every exception type for, which is where the same lines are uncovered in
`IllegalRequestTransitionException` beside it.

Every path this branch touches is inside the `Scope:` line on the issue, the model code and the test
project:

    git diff --name-only origin/master...HEAD
    Jellyfin.Plugin.Requests.Tests/Model/RequestAuthorityTests.cs
    Jellyfin.Plugin.Requests.Tests/Model/RequestHistoryTests.cs
    Jellyfin.Plugin.Requests.Tests/Model/RequestLifecycleTests.cs
    Jellyfin.Plugin.Requests.Tests/Model/RequestNotesTests.cs
    Jellyfin.Plugin.Requests/Model/RequestActor.cs
    Jellyfin.Plugin.Requests/Model/RequestCaller.cs
    Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs
    Jellyfin.Plugin.Requests/Model/RequestMoveNotPermittedException.cs
    Jellyfin.Plugin.Requests/Model/RequestTransition.cs

The means is C# in the projects that already exist, because the table this extends is already there,
the analyzers and the suite already judge that code, and a permitted set expressed anywhere else
would be a second place a rule lives.

## What this does not do

`docs/lifecycle.md` is not extended here. It sits outside the `Scope:` line this issue declares, and
the page's grid and reasons are compared against the table by two tests that both still pass, so
nothing on it has gone stale. A reader wanting the permitted sets reads them off `RequestActor` and
`RequestTransition.Permitted` until a documentation issue takes the page.

Three of the existing tests moved a request to `Fulfilled` with an operator as the mover, and now
pass `RequestCaller.Plugin`. That is the rule biting on this repository's own suite rather than a
test being adjusted to fit: fulfilment is an observation, and none of the three was about who made
it.

Nothing in the plugin calls `Move` or `Decline` yet, so this changes no behaviour a user of the
plugin can reach today. What it changes is what the first calling surface will find already decided,
which is #51 for the endpoints and #61 for the page.

There was no second reader for this change. What stands in its place is the evidence above: the
refusal proven by deletion, both server lines run, and the permitted set of every cell asserted
against a list written by hand rather than read back from the table it is checking.

The tree here is the same tree as the first attempt at this change, which carried no DCO
sign-off and was refused by the check that reads for one. The commit was cherry-picked onto a
fresh branch with the trailer, and `git diff --stat <old> HEAD` between the two heads is empty,
so nothing but the trailer differs.
