### PR TITLE
Decide what makes two requests the same request (#38)

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Model/MediaRequestTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Model/MediaRequestTests.cs
@@ -30,11 +30,13 @@ public class MediaRequestTests
         "DisplayYear",
         "History",
         "Id",
+        "JoinedByUserIds",
         "Kind",
         "ProviderIds",
         "RequestedAt",
         "RequestedByUserId",
         "RequesterNote",
+        "Seasons",
         "State",
         "StateChangedAt",
         "StateChangedByUserId"
@@ -189,12 +191,16 @@ public class MediaRequestTests
             return true;
         }
 
-        // The two collections on the record, and only in the shapes they are declared in. A
-        // read-only map of string to string carries no behaviour a caller could reach through, and
-        // a read-only list of history entries carries only entries whose own fields are checked by
-        // TheHistoryEntryIsAPlainValueToo below. Neither gives a reader anything to resolve a title
-        // through, which is the property this test is about.
+        // The four collections on the record, and only in the shapes they are declared in. A
+        // read-only map of string to string carries no behaviour a caller could reach through; the
+        // seasons and the people who joined are read-only lists of numbers and identifiers, which
+        // are plain values by the lines above; and a read-only list of history entries carries only
+        // entries whose own fields are checked by TheHistoryEntryIsAPlainValueToo below. None of
+        // them gives a reader anything to resolve a title through, which is the property this test
+        // is about.
         return underlying == typeof(IReadOnlyDictionary<string, string>)
+            || underlying == typeof(IReadOnlyList<int>)
+            || underlying == typeof(IReadOnlyList<Guid>)
             || underlying == typeof(IReadOnlyList<RequestHistoryEntry>);
     }
 

--- a/Jellyfin.Plugin.Requests.Tests/Model/RequestAuthorityTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Model/RequestAuthorityTests.cs
@@ -308,7 +308,8 @@ public class RequestAuthorityTests
             RequestedAt = asked,
             StateChangedAt = asked,
             Kind = RequestedItemKind.Movie,
-            DisplayTitle = "Wages of Fear"
+            DisplayTitle = "Wages of Fear",
+            ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tmdb"] = "269" }
         };
     }
 }

--- a/Jellyfin.Plugin.Requests.Tests/Model/RequestHistoryTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Model/RequestHistoryTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Jellyfin.Plugin.Requests.Model;
 using Xunit;
@@ -216,7 +217,8 @@ public class RequestHistoryTests
             RequestedAt = asked,
             StateChangedAt = asked,
             Kind = RequestedItemKind.Movie,
-            DisplayTitle = "Sorcerer"
+            DisplayTitle = "Sorcerer",
+            ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tmdb"] = "11631" }
         };
     }
 }

--- a/Jellyfin.Plugin.Requests.Tests/Model/RequestIdentityTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Model/RequestIdentityTests.cs
@@ -1,0 +1,316 @@
+using System;
+using System.Collections.Generic;
+using Jellyfin.Plugin.Requests.Model;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Model;
+
+/// <summary>
+/// What makes two requests the same request. The failure this stands against is a queue an operator
+/// decides three times, and the failure on the other side is two people waiting for one row that
+/// only covers what one of them asked for.
+/// </summary>
+public class RequestIdentityTests
+{
+    private static readonly Guid First = new("7a4e2f18-6b0c-4d39-95e7-1f8a3c6d2b40");
+
+    private static readonly Guid Second = new("5f0c8a26-3d17-4b94-8e05-9a1b7c2d6e38");
+
+    /// <summary>
+    /// A film is the same film when one provider names the same value on both, whatever the titles
+    /// say. The two here are the same work under two titles and two release years, which is what a
+    /// title comparison gets wrong and what this rule exists to get right.
+    /// </summary>
+    [Fact]
+    public void OneSharedIdentifierMakesTwoFilmsOneRequest()
+    {
+        var asked = AFilm("Le Salaire de la peur", ("Tmdb", "269"));
+        var again = AFilm("The Wages of Fear", ("Tmdb", "269")) with { DisplayYear = 1955 };
+
+        Assert.Equal(RequestMatch.Same, RequestIdentity.Compare(asked, again));
+    }
+
+    /// <summary>
+    /// One shared identifier is enough even where the rest disagree. A client that knows only one
+    /// provider would otherwise file a second request for something already in the queue, which is
+    /// the duplicate this rule is about.
+    /// </summary>
+    [Fact]
+    public void OneSharedIdentifierIsEnoughWhereTheOthersAreAbsent()
+    {
+        var rich = AFilm("Solaris", ("Tmdb", "593"), ("Imdb", "tt0069293"));
+        var thin = AFilm("Solaris", ("Imdb", "tt0069293"));
+
+        Assert.Equal(RequestMatch.Same, RequestIdentity.Compare(rich, thin));
+        Assert.Equal(RequestMatch.Same, RequestIdentity.Compare(thin, rich));
+    }
+
+    /// <summary>
+    /// The provider is named without regard to case and the value is not. Two callers spell the
+    /// provider differently and neither is wrong; two identifiers that differ are somebody else's
+    /// identifiers and this plugin does not get to decide they mean one thing.
+    /// </summary>
+    [Fact]
+    public void TheProviderIsMatchedWithoutCaseAndTheValueExactly()
+    {
+        var upper = AFilm("Stalker", ("Tmdb", "1398"));
+        var lower = AFilm("Stalker", ("tmdb", "1398"));
+        var other = AFilm("Stalker", ("Tmdb", "1398 "));
+
+        Assert.Equal(RequestMatch.Same, RequestIdentity.Compare(upper, lower));
+        Assert.Equal(RequestMatch.Different, RequestIdentity.Compare(upper, other));
+    }
+
+    /// <summary>
+    /// Two identical titles with no identifier between them are two requests. This is the answer the
+    /// issue asked for rather than a gap: matching them would mean matching on the text somebody
+    /// typed, which is the rule the whole class refuses, and it would join two people who may well
+    /// have meant two different films.
+    /// </summary>
+    [Fact]
+    public void ARequestWithNoIdentifierIsNobodysDuplicate()
+    {
+        var typed = AFilm("Nosferatu");
+        var typedAgain = AFilm("Nosferatu");
+
+        Assert.Equal(RequestMatch.Different, RequestIdentity.Compare(typed, typedAgain));
+        Assert.Equal(RequestMatch.Different, RequestIdentity.Compare(typed, typed));
+    }
+
+    /// <summary>
+    /// A film and a series carrying the same number under the same provider are two different works.
+    /// Provider numbering is per kind, so without this the first collision would join a programme to
+    /// a film.
+    /// </summary>
+    [Fact]
+    public void TheKindIsPartOfTheIdentity()
+    {
+        var film = AFilm("Fargo", ("Tmdb", "275"));
+        var series = ASeries("Fargo", [], ("Tmdb", "275"));
+
+        Assert.Equal(RequestMatch.Different, RequestIdentity.Compare(film, series));
+    }
+
+    /// <summary>
+    /// The season cases, which are the ones this rule was written for. An empty set means the whole
+    /// series, and the comparison is not symmetric: the show covers a season of it and a season does
+    /// not cover the show.
+    /// </summary>
+    /// <param name="existingSeasons">The seasons the open request covers.</param>
+    /// <param name="incomingSeasons">The seasons being asked for now.</param>
+    /// <param name="expected">What the two are.</param>
+    [Theory]
+
+    // The same seasons, in any order, are the same ask.
+    [InlineData(new[] { 1, 2 }, new[] { 1, 2 }, RequestMatch.Same)]
+    [InlineData(new[] { 1, 2 }, new[] { 2, 1 }, RequestMatch.Same)]
+
+    // Everything asked for is already covered, so there is nothing to create.
+    [InlineData(new[] { 1, 2, 3 }, new[] { 2 }, RequestMatch.Same)]
+    [InlineData(new int[0], new[] { 4 }, RequestMatch.Same)]
+    [InlineData(new int[0], new int[0], RequestMatch.Same)]
+
+    // Something is covered and something is not.
+    [InlineData(new[] { 1, 2 }, new[] { 2, 3 }, RequestMatch.Overlapping)]
+    [InlineData(new[] { 1 }, new int[0], RequestMatch.Overlapping)]
+
+    // The same programme, and nothing in common. Two people waiting for different things is two
+    // requests, and a queue showing the series twice there is telling the truth.
+    [InlineData(new[] { 1, 2 }, new[] { 3 }, RequestMatch.Different)]
+    public void TheSeasonsDecideWhetherASeriesRequestIsTheSameRequest(
+        int[] existingSeasons,
+        int[] incomingSeasons,
+        RequestMatch expected)
+    {
+        var existing = ASeries("Twin Peaks", existingSeasons, ("Tvdb", "70533"));
+        var incoming = ASeries("Twin Peaks", incomingSeasons, ("Tvdb", "70533"));
+
+        Assert.Equal(expected, RequestIdentity.Compare(existing, incoming));
+    }
+
+    /// <summary>
+    /// What is left to ask for when the seasons overlap. The seasons somebody is already waiting for
+    /// are not asked for twice and the ones nobody has asked for are not lost, which is the whole
+    /// reason the third answer exists.
+    /// </summary>
+    [Fact]
+    public void WhatIsLeftToAskForIsTheSeasonsTheOpenRequestDoesNotCover()
+    {
+        var existing = ASeries("Twin Peaks", [1, 2], ("Tvdb", "70533"));
+        var incoming = ASeries("Twin Peaks", [3, 2, 4], ("Tvdb", "70533"));
+
+        Assert.Equal(
+            [3, 4],
+            RequestIdentity.SeasonsNotAlreadyAskedFor(existing, incoming, []));
+    }
+
+    /// <summary>
+    /// Asking for the whole show against a request for part of it needs to know what the whole show
+    /// is. Where the caller knows, the answer is every other season; where it does not, the answer is
+    /// empty, which reads as the whole series and is the safe direction, because it asks for no more
+    /// than the person did.
+    /// </summary>
+    [Fact]
+    public void AskingForTheWholeShowLeavesTheSeasonsTheCallerKnowsAbout()
+    {
+        var existing = ASeries("Twin Peaks", [1, 2], ("Tvdb", "70533"));
+        var wholeShow = ASeries("Twin Peaks", [], ("Tvdb", "70533"));
+
+        Assert.Equal(
+            [3],
+            RequestIdentity.SeasonsNotAlreadyAskedFor(existing, wholeShow, [1, 2, 3]));
+
+        Assert.Empty(RequestIdentity.SeasonsNotAlreadyAskedFor(existing, wholeShow, []));
+    }
+
+    /// <summary>
+    /// Somebody asking for something already open joins it rather than filing a second one, and they
+    /// are recorded on the request they joined. Without the record the second person is either a row
+    /// an operator decides twice or a person nobody can tell when the answer arrives.
+    /// </summary>
+    [Fact]
+    public void JoiningRecordsTheSecondPersonOnTheRequestTheyJoined()
+    {
+        var open = AFilm("Solaris", ("Tmdb", "593"));
+
+        var joined = RequestLifecycle.Join(open, Second);
+
+        Assert.Equal([Second], joined.JoinedByUserIds);
+        Assert.True(joined.WasAskedForBy(Second));
+        Assert.True(joined.WasAskedForBy(First));
+        Assert.Empty(open.JoinedByUserIds);
+    }
+
+    /// <summary>
+    /// A join changes nothing else, and asking twice is not two facts. The state, the times and the
+    /// history are what somebody decided; a second person's interest is none of those, so nothing
+    /// is appended to the history and nothing moves.
+    /// </summary>
+    [Fact]
+    public void JoiningTwiceRecordsOnePersonAndMovesNothing()
+    {
+        var open = AFilm("Solaris", ("Tmdb", "593"));
+
+        var joined = RequestLifecycle.Join(RequestLifecycle.Join(open, Second), Second);
+
+        Assert.Single(joined.JoinedByUserIds);
+        Assert.Empty(joined.History);
+        Assert.Equal(open, joined with { JoinedByUserIds = open.JoinedByUserIds });
+
+        // The person who asked first joining their own request is the same non-event.
+        Assert.Empty(RequestLifecycle.Join(open, First).JoinedByUserIds);
+    }
+
+    /// <summary>
+    /// Only a request that is still waiting can be joined. A declined or fulfilled request has had
+    /// its answer, and handing somebody an answer that was given before they asked is worse than
+    /// giving them a request of their own.
+    /// </summary>
+    /// <param name="state">The state the request is in.</param>
+    [Theory]
+    [InlineData(RequestState.Declined)]
+    [InlineData(RequestState.Fulfilled)]
+    [InlineData(RequestState.Failed)]
+    public void ADecidedRequestCannotBeJoined(RequestState state)
+    {
+        var decided = AFilm("Solaris", ("Tmdb", "593")) with { State = state };
+
+        Assert.Throws<InvalidOperationException>(() => RequestLifecycle.Join(decided, Second));
+    }
+
+    /// <summary>
+    /// Somebody who joined is a requester on that request. Both surfaces answer "is this yours"
+    /// through the same comparison, so the second person sees on their own page the request they
+    /// joined rather than nothing at all.
+    /// </summary>
+    [Fact]
+    public void SomebodyWhoJoinedIsARequesterOnThatRequest()
+    {
+        var joined = RequestLifecycle.Join(AFilm("Solaris", ("Tmdb", "593")), Second);
+
+        Assert.Equal(RequestActor.Requester, RequestCaller.User(Second).RolesOn(joined));
+        Assert.Equal(RequestActor.Requester, RequestCaller.User(First).RolesOn(joined));
+        Assert.Equal(
+            RequestActor.None,
+            RequestCaller.User(new Guid("9c3b7e05-1d42-4a86-b0f9-5e2c8a7d6134")).RolesOn(joined));
+    }
+
+    /// <summary>
+    /// A request nobody can identify may be declined and may not be moved anywhere else. An
+    /// approval on such a request is an operator saying yes to something no part of the plugin can
+    /// act on afterwards, and a decline is the one answer that needs no identifier, so it is the one
+    /// that stays.
+    /// </summary>
+    [Fact]
+    public void ARequestWithNoIdentifierMayOnlyBeDeclined()
+    {
+        var typed = AFilm("something a person typed");
+        var at = new DateTimeOffset(2026, 8, 9, 15, 0, 0, TimeSpan.Zero);
+        var operatorCalling = RequestCaller.Administrator(new Guid("2d8f4b16-3a5c-4d97-8e21-7c6b5a4f3e29"));
+
+        var refusal = Assert.Throws<RequestNotIdentifiedException>(
+            () => RequestLifecycle.Move(typed, RequestState.Approved, at, operatorCalling));
+
+        Assert.Equal(RequestState.Approved, refusal.To);
+
+        Assert.Throws<RequestNotIdentifiedException>(
+            () => RequestLifecycle.Move(typed, RequestState.Fulfilled, at, RequestCaller.Plugin));
+
+        var declined = RequestLifecycle.Decline(typed, DeclineReason.Other, "Nobody could tell what this was.", at, operatorCalling);
+
+        Assert.Equal(RequestState.Declined, declined.State);
+    }
+
+    /// <summary>
+    /// The seasons asked for are a set of seasons. A repeat is a caller's mistake stored as a fact,
+    /// and a zero is not a season any client has; both are refused rather than tidied away, because
+    /// a list quietly cleaned up is one the caller never learns was wrong.
+    /// </summary>
+    [Fact]
+    public void TheSeasonsAskedForAreASetOfSeasons()
+    {
+        Assert.Throws<ArgumentException>(() => ASeries("Twin Peaks", [1, 1], ("Tvdb", "70533")));
+        Assert.Throws<ArgumentException>(() => ASeries("Twin Peaks", [0], ("Tvdb", "70533")));
+        Assert.Throws<ArgumentException>(() => ASeries("Twin Peaks", [-1], ("Tvdb", "70533")));
+
+        // The order the caller gave is the order it keeps, because two requests naming the same
+        // seasons in different orders are one ask and the comparison does not read the order anyway.
+        Assert.Equal([3, 1], ASeries("Twin Peaks", [3, 1], ("Tvdb", "70533")).Seasons);
+    }
+
+    private static MediaRequest AFilm(string title, params (string Provider, string Value)[] identifiers)
+        => ARequest(RequestedItemKind.Movie, title, [], identifiers);
+
+    private static MediaRequest ASeries(
+        string title,
+        int[] seasons,
+        params (string Provider, string Value)[] identifiers)
+        => ARequest(RequestedItemKind.Series, title, seasons, identifiers);
+
+    private static MediaRequest ARequest(
+        RequestedItemKind kind,
+        string title,
+        int[] seasons,
+        (string Provider, string Value)[] identifiers)
+    {
+        var asked = new DateTimeOffset(2026, 8, 9, 10, 0, 0, TimeSpan.Zero);
+        var providerIds = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        foreach (var (provider, value) in identifiers)
+        {
+            providerIds[provider] = value;
+        }
+
+        return new MediaRequest
+        {
+            Id = new Guid("41d7c0b2-9e3a-4f58-b6d1-8c2f5a0e7b93"),
+            RequestedByUserId = First,
+            RequestedAt = asked,
+            StateChangedAt = asked,
+            Kind = kind,
+            DisplayTitle = title,
+            Seasons = seasons,
+            ProviderIds = providerIds
+        };
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/Model/RequestLifecycleTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Model/RequestLifecycleTests.cs
@@ -363,7 +363,8 @@ public class RequestLifecycleTests
             RequestedAt = asked,
             StateChangedAt = asked,
             Kind = RequestedItemKind.Series,
-            DisplayTitle = "Tinker Tailor Soldier Spy"
+            DisplayTitle = "Tinker Tailor Soldier Spy",
+            ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tvdb"] = "76648" }
         };
     }
 }

--- a/Jellyfin.Plugin.Requests.Tests/Model/RequestNotesTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Model/RequestNotesTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Jellyfin.Plugin.Requests.Model;
 using Xunit;
 
@@ -296,7 +297,8 @@ public class RequestNotesTests
             RequestedAt = asked,
             StateChangedAt = asked,
             Kind = RequestedItemKind.Movie,
-            DisplayTitle = "The Conversation"
+            DisplayTitle = "The Conversation",
+            ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tmdb"] = "592" }
         };
     }
 }

--- a/Jellyfin.Plugin.Requests.Tests/Storage/FileRequestStoreDurabilityTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Storage/FileRequestStoreDurabilityTests.cs
@@ -75,6 +75,10 @@ public sealed class FileRequestStoreDurabilityTests : IDisposable
             new DateTimeOffset(2026, 8, 8, 9, 0, 0, TimeSpan.Zero),
             RequestCaller.Administrator(approvedBy));
 
+        // A second person waiting for the same thing, so the list that carries them has something
+        // in it to lose on the way to the file and back.
+        full = RequestLifecycle.Join(full, new Guid("5f0c8a26-3d17-4b94-8e05-9a1b7c2d6e38"));
+
         var bare = ARequest(2);
 
         var writing = NewStore(directory);
@@ -86,11 +90,18 @@ public sealed class FileRequestStoreDurabilityTests : IDisposable
         var readBare = await reading.GetAsync(bare.Id, CancellationToken.None).ConfigureAwait(true);
 
         Assert.NotNull(readFull);
+        // Every collection on the record is put back before the comparison, for the reason in the
+        // summary: they are declared as interfaces, so the generated equality compares each list or
+        // map itself and never what is in it. Each one is then compared for its contents below or,
+        // where it is empty on this request, by the field set test in MediaRequestTests refusing a
+        // collection that arrived without a line here.
         Assert.Equal(
             full with
             {
                 ProviderIds = readFull.Value.Request.ProviderIds,
-                History = readFull.Value.Request.History
+                History = readFull.Value.Request.History,
+                Seasons = readFull.Value.Request.Seasons,
+                JoinedByUserIds = readFull.Value.Request.JoinedByUserIds
             },
             readFull.Value.Request);
         Assert.Equal(
@@ -101,6 +112,9 @@ public sealed class FileRequestStoreDurabilityTests : IDisposable
         // said and not which list it is in. The approval above is the one entry there is to lose.
         Assert.Equal(full.History, readFull.Value.Request.History);
         Assert.Single(readFull.Value.Request.History);
+
+        Assert.Equal(full.JoinedByUserIds, readFull.Value.Request.JoinedByUserIds);
+        Assert.Single(readFull.Value.Request.JoinedByUserIds);
 
         Assert.NotNull(readBare);
         Assert.Null(readBare.Value.Request.DisplayYear);

--- a/Jellyfin.Plugin.Requests/Model/MediaRequest.cs
+++ b/Jellyfin.Plugin.Requests/Model/MediaRequest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace Jellyfin.Plugin.Requests.Model;
 
@@ -48,6 +49,7 @@ public sealed record MediaRequest
 
     private readonly string? _requesterNote;
     private readonly string? _declineNote;
+    private readonly IReadOnlyList<int> _seasons = [];
 
     /// <summary>
     /// Gets this request's own identifier, which is not the identifier of anything it refers to.
@@ -99,6 +101,46 @@ public sealed record MediaRequest
     /// </para>
     /// </summary>
     public IReadOnlyDictionary<string, string> ProviderIds { get; init; } = ReadOnlyDictionary<string, string>.Empty;
+
+    /// <summary>
+    /// Gets the seasons asked for, in order and without repeats. Empty means the whole series, and
+    /// on a film it means nothing at all and is the only value allowed there.
+    /// <para>
+    /// It is part of what was asked for rather than a detail of it, so it is part of what makes two
+    /// requests the same request in <see cref="RequestIdentity"/>. A request for one season and a
+    /// request for the programme are different asks, and a queue that treated them as one would
+    /// leave somebody waiting for seasons nobody ever approved.
+    /// </para>
+    /// <para>
+    /// Empty meaning the whole series is the one convention here worth remembering. The alternative,
+    /// listing every season a show has, means the request is wrong the day another one airs, and
+    /// this plugin has no metadata source to ask how many there are, decided in #92.
+    /// </para>
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Where a season is repeated, or is not a number a season can have.
+    /// </exception>
+    public IReadOnlyList<int> Seasons
+    {
+        get => _seasons;
+        init => _seasons = SeasonSet(value);
+    }
+
+    /// <summary>
+    /// Gets everyone who asked for this after it existed, oldest first. Empty on a request only one
+    /// person has asked for, which is most of them.
+    /// <para>
+    /// Two people asking for one film is one request, decided in #38, and this is where the second
+    /// person is recorded. Without it the second ask is either a duplicate row an operator decides
+    /// twice or a person who is silently not told when the answer arrives.
+    /// </para>
+    /// <para>
+    /// It never holds <see cref="RequestedByUserId"/>, and it never holds the same person twice.
+    /// Asking again for something you have already asked for is not a second fact about the request,
+    /// and a count of this list is a count of people rather than of clicks.
+    /// </para>
+    /// </summary>
+    public IReadOnlyList<Guid> JoinedByUserIds { get; init; } = [];
 
     /// <summary>
     /// Gets where the request stands. Defaults to <see cref="RequestState.Open"/>, because a
@@ -208,6 +250,56 @@ public sealed record MediaRequest
     /// operator asking why a request still says absent needs to know whether anything checked.
     /// </summary>
     public DateTimeOffset? AvailabilityCheckedAt { get; init; }
+
+    /// <summary>
+    /// Whether this person is one of the people waiting for this request, whether they asked first
+    /// or joined an existing one. Both surfaces have to answer "is this yours" the same way, and a
+    /// caller working it out for themselves is a caller that will check one of the two lists.
+    /// </summary>
+    /// <param name="userId">The Jellyfin user being asked about.</param>
+    /// <returns><see langword="true"/> where that person asked for this.</returns>
+    public bool WasAskedForBy(Guid userId)
+        => RequestedByUserId == userId || JoinedByUserIds.Contains(userId);
+
+    /// <summary>
+    /// Refuses a season list that is not a set of seasons. A repeat is a caller's mistake being
+    /// stored as a fact, and a zero or a negative number is not a season any client has, so both
+    /// are refused rather than tidied: a list quietly cleaned up is one the caller never learns was
+    /// wrong.
+    /// <para>
+    /// The order is the caller's own and is kept. Sorting here would make two requests that name the
+    /// same seasons in different orders read as different asks in a history, and the comparison in
+    /// <see cref="RequestIdentity"/> does not depend on the order anyway.
+    /// </para>
+    /// </summary>
+    /// <param name="seasons">The seasons as they arrived.</param>
+    /// <returns>The same seasons.</returns>
+    private static IReadOnlyList<int> SeasonSet(IReadOnlyList<int>? seasons)
+    {
+        if (seasons is null || seasons.Count == 0)
+        {
+            return [];
+        }
+
+        // Any rather than FirstOrDefault, because the value this refuses includes zero and a
+        // sentinel that is also a refused value says "nothing was wrong" for exactly one of them.
+        if (seasons.Any(season => season < 1))
+        {
+            throw new ArgumentException(
+                FormattableString.Invariant(
+                    $"A season number has to be 1 or more, and {seasons.First(season => season < 1)} is not."),
+                nameof(seasons));
+        }
+
+        if (seasons.Distinct().Count() != seasons.Count)
+        {
+            throw new ArgumentException(
+                "A season is named twice. The seasons asked for are a set, and a repeat is a caller's mistake rather than a request for it twice.",
+                nameof(seasons));
+        }
+
+        return [.. seasons];
+    }
 
     /// <summary>
     /// Refuses a note that is too long and flattens an empty one to nothing. Internal because

--- a/Jellyfin.Plugin.Requests/Model/RequestCaller.cs
+++ b/Jellyfin.Plugin.Requests/Model/RequestCaller.cs
@@ -87,7 +87,11 @@ public sealed record RequestCaller
 
         // The plugin carries no user, so it can never match a requester, and the comparison below
         // does not have to special-case it: no identifier equals a request's requester by accident.
-        return UserId is Guid caller && caller == request.RequestedByUserId
+        //
+        // Somebody who joined an existing request is a requester on it too, which is what makes
+        // "one request, several people waiting" a real answer rather than a queue trick: the second
+        // person can see it on their own page under the same rule as the first.
+        return UserId is Guid caller && request.WasAskedForBy(caller)
             ? _authority | RequestActor.Requester
             : _authority;
     }

--- a/Jellyfin.Plugin.Requests/Model/RequestIdentity.cs
+++ b/Jellyfin.Plugin.Requests/Model/RequestIdentity.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Jellyfin.Plugin.Requests.Model;
+
+/// <summary>
+/// What makes two requests the same request, in one function.
+/// <para>
+/// It is one function because the question gets asked in three places: when a request is created,
+/// when the sibling hands one over, and when an operator looks at a queue and wonders why the same
+/// film is in it twice. Three implementations of "the same" are three answers, and the one that
+/// disagrees is found by a person reading a queue rather than by anything here.
+/// </para>
+/// <para>
+/// <b>Identity is a provider identifier and a kind, never a title.</b> Titles collide, get
+/// re-released, differ by language and are typed by people. Two films called <c>Nosferatu</c> are
+/// two films, and one film is called two things on two clients. The identifiers are what the sibling
+/// hands over and what a fulfilment check matches on, so they are what identity is made of here as
+/// well; anything else would make three parts of this plugin disagree about one request.
+/// </para>
+/// <para>
+/// <b>A request carrying no identifier is nobody's duplicate.</b> It has no identity, so it is
+/// <see cref="RequestMatch.Different"/> from everything including another copy of itself, and two
+/// people typing the same title by hand get two requests. That is the honest answer rather than a
+/// convenient one: the alternative is matching on the text they typed, which is the rule this class
+/// exists to refuse. What such a request may do until somebody identifies it is
+/// <see cref="RequestLifecycle"/>'s answer, and it is narrow.
+/// </para>
+/// <para>
+/// <b>A series is identified by its seasons as well.</b> A request for one season is not a request
+/// for the show, and the set of seasons is part of what is being asked for rather than a detail of
+/// it. An empty set means the whole series, which is the one convention here that has to be
+/// remembered, and it is the shape a client sends when a person asks for a programme rather than for
+/// part of one.
+/// </para>
+/// </summary>
+public static class RequestIdentity
+{
+    /// <summary>
+    /// Holds a new ask up against a request that already exists.
+    /// <para>
+    /// The order of the arguments matters for a series and only for a series. Whether the seasons
+    /// being asked for are already covered is not a symmetric question: a whole-show request covers
+    /// a request for its second season, and the second season does not cover the show.
+    /// </para>
+    /// </summary>
+    /// <param name="existing">A request the store already holds.</param>
+    /// <param name="incoming">The ask being made now.</param>
+    /// <returns>Whether the two are one request, one request with seasons left over, or two.</returns>
+    /// <exception cref="ArgumentNullException">Where either request is missing.</exception>
+    public static RequestMatch Compare(MediaRequest existing, MediaRequest incoming)
+    {
+        ArgumentNullException.ThrowIfNull(existing);
+        ArgumentNullException.ThrowIfNull(incoming);
+
+        // A film and a series can carry the same number under the same provider and be two
+        // different works, so the kind is part of the identity rather than a property of it.
+        if (existing.Kind != incoming.Kind || !ShareAnIdentifier(existing, incoming))
+        {
+            return RequestMatch.Different;
+        }
+
+        if (existing.Kind != RequestedItemKind.Series)
+        {
+            return RequestMatch.Same;
+        }
+
+        // The whole show covers everything, so nothing can be left over against it.
+        if (existing.Seasons.Count == 0)
+        {
+            return RequestMatch.Same;
+        }
+
+        // Asked for the whole show against a request for some of it. Every season outside the
+        // existing request is still being asked for, and there is at least one.
+        if (incoming.Seasons.Count == 0)
+        {
+            return RequestMatch.Overlapping;
+        }
+
+        var covered = incoming.Seasons.Count(season => existing.Seasons.Contains(season));
+
+        if (covered == 0)
+        {
+            // The same series and no season in common. Two requests, and the queue showing the
+            // series twice is the truth rather than a duplicate: they are waiting for different
+            // things.
+            return RequestMatch.Different;
+        }
+
+        return covered == incoming.Seasons.Count ? RequestMatch.Same : RequestMatch.Overlapping;
+    }
+
+    /// <summary>
+    /// The seasons a new ask names that an existing request does not already cover. This is what a
+    /// caller creates a request for when <see cref="Compare"/> answered
+    /// <see cref="RequestMatch.Overlapping"/>, so that the seasons somebody is already waiting for
+    /// are not asked for twice and the ones nobody has asked for are not lost.
+    /// </summary>
+    /// <param name="existing">A request the store already holds.</param>
+    /// <param name="incoming">The ask being made now.</param>
+    /// <param name="everySeason">
+    /// Every season the series is known to have, for the case where the new ask means the whole show
+    /// and the existing request covers part of it. Empty where the caller does not know, and then
+    /// the answer is empty as well, which reads as "the whole show" and is the safe direction: it
+    /// asks for no more than the person did.
+    /// </param>
+    /// <returns>The seasons left to ask for, in order, without repeats.</returns>
+    /// <exception cref="ArgumentNullException">Where either request or the season list is missing.</exception>
+    public static IReadOnlyList<int> SeasonsNotAlreadyAskedFor(
+        MediaRequest existing,
+        MediaRequest incoming,
+        IReadOnlyCollection<int> everySeason)
+    {
+        ArgumentNullException.ThrowIfNull(existing);
+        ArgumentNullException.ThrowIfNull(incoming);
+        ArgumentNullException.ThrowIfNull(everySeason);
+
+        var asked = incoming.Seasons.Count == 0 ? everySeason : incoming.Seasons;
+
+        return [.. asked.Where(season => !existing.Seasons.Contains(season)).Distinct().Order()];
+    }
+
+    /// <summary>
+    /// Whether the two name the same thing under at least one provider. One is enough: a request
+    /// arriving from a client may carry only the identifier that client knows, and requiring every
+    /// identifier to match would make the same film two requests because one of them was asked for
+    /// from somewhere that had never heard of the other provider.
+    /// <para>
+    /// Provider names are compared without case, because the same provider is spelled <c>Tmdb</c>
+    /// and <c>tmdb</c> by different callers and neither is wrong. The values are compared exactly,
+    /// because they are somebody else's identifiers and this plugin does not get to decide that two
+    /// of them that differ are the same.
+    /// </para>
+    /// <para>
+    /// The comparison is written out rather than made by looking the name up in the other map. A
+    /// dictionary answers under whatever comparer it was built with, and the maps arriving here were
+    /// built by callers this class does not control, so a lookup would make the rule depend on how a
+    /// caller happened to construct theirs. A request carries a handful of identifiers, so walking
+    /// both is not a cost worth trading a rule for.
+    /// </para>
+    /// </summary>
+    /// <param name="existing">A request the store already holds.</param>
+    /// <param name="incoming">The ask being made now.</param>
+    /// <returns><see langword="true"/> where one provider names one value on both.</returns>
+    private static bool ShareAnIdentifier(MediaRequest existing, MediaRequest incoming)
+        => existing.ProviderIds.Any(mine =>
+            incoming.ProviderIds.Any(theirs =>
+                string.Equals(mine.Key, theirs.Key, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(mine.Value, theirs.Value, StringComparison.Ordinal)));
+}

--- a/Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs
+++ b/Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs
@@ -56,6 +56,14 @@ namespace Jellyfin.Plugin.Requests.Model;
 /// #42 is where that is detected instead.
 /// </para>
 /// <para>
+/// <b>A request with no provider identifier may only be declined.</b> It is a title somebody typed,
+/// it has no identity, and nothing downstream can act on it: no fulfilment check can match it and
+/// nothing can be submitted for it. Approving one would be an operator saying yes to something that
+/// then sits still forever. A decline needs no identifier and stays available, so such a request
+/// still has an ending, and putting identifiers on it opens every other move. This is #38's answer
+/// to what happens to a request that names nothing.
+/// </para>
+/// <para>
 /// No cell admits the requester alone. Asking is not a move: approving one's own request is the
 /// case this check exists for, a decline is the operator's answer rather than the asker's, and a
 /// user withdrawing has no state to move to because <c>Cancelled</c> was refused on #113. An
@@ -199,6 +207,48 @@ public static class RequestLifecycle
     }
 
     /// <summary>
+    /// Records that somebody else has asked for the same thing, on the request they are joining.
+    /// <para>
+    /// This is what happens instead of a second row when <see cref="RequestIdentity.Compare"/>
+    /// answers <see cref="RequestMatch.Same"/>. It is not a state change: nothing was decided, the
+    /// request is where it was, and the history is a record of decisions rather than of interest, so
+    /// nothing is appended to it.
+    /// </para>
+    /// <para>
+    /// Asking again for something you have already asked for changes nothing and is not an error.
+    /// A client that retries, a person who clicks twice and two tabs open on one page all arrive
+    /// here, and refusing them would make the surfaces carry a rule about it each.
+    /// </para>
+    /// </summary>
+    /// <param name="request">The request being joined.</param>
+    /// <param name="userId">The Jellyfin user who has now asked for the same thing.</param>
+    /// <returns>
+    /// The request with that person recorded on it, or the request unchanged where they were already
+    /// waiting for it.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Where no request was given.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Where the request has been decided. Joining a declined or fulfilled request would leave
+    /// somebody waiting for an answer that was given before they asked, and what they should get is
+    /// a request of their own.
+    /// </exception>
+    public static MediaRequest Join(MediaRequest request, Guid userId)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (request.State is not (RequestState.Open or RequestState.Approved))
+        {
+            throw new InvalidOperationException(
+                FormattableString.Invariant(
+                    $"A request that is {request.State} cannot be joined. Only an open or an approved request is still waiting for something, and joining one that is not would hand somebody an answer that was given before they asked."));
+        }
+
+        return request.WasAskedForBy(userId)
+            ? request
+            : request with { JoinedByUserIds = [.. request.JoinedByUserIds, userId] };
+    }
+
+    /// <summary>
     /// The one place a request changes state, and therefore the one place the history grows and the
     /// one place a caller's authority is checked. Both public methods above go through here, so
     /// "every transition appends exactly one entry" and "every transition asks who is making it" are
@@ -235,6 +285,14 @@ public static class RequestLifecycle
         if ((cell.Permitted & by.RolesOn(request)) == RequestActor.None)
         {
             throw new RequestMoveNotPermittedException(cell.From, cell.To, cell.Permitted);
+        }
+
+        // Authority before this one, and that order is deliberate too. Whether a request carries an
+        // identifier is a fact about the request, and a caller who may not touch it should not learn
+        // that fact by attempting a move.
+        if (request.ProviderIds.Count == 0 && to != RequestState.Declined)
+        {
+            throw new RequestNotIdentifiedException(to);
         }
 
         var entry = new RequestHistoryEntry

--- a/Jellyfin.Plugin.Requests/Model/RequestMatch.cs
+++ b/Jellyfin.Plugin.Requests/Model/RequestMatch.cs
@@ -1,0 +1,35 @@
+namespace Jellyfin.Plugin.Requests.Model;
+
+/// <summary>
+/// What <see cref="RequestIdentity.Compare"/> found when it held a new ask up against a request that
+/// already exists.
+/// <para>
+/// Three answers rather than two, because a series makes "the same request" a question of degree. A
+/// request for the whole show and a request for its second season are neither the same thing nor
+/// unrelated, and collapsing that into a yes or a no gets one of the two cases wrong: joining loses
+/// the seasons the existing request does not cover, and creating loses the fact that somebody is
+/// already waiting for most of what was asked for.
+/// </para>
+/// </summary>
+public enum RequestMatch
+{
+    /// <summary>
+    /// Two different things. Nothing is shared, or what is shared is a title rather than an
+    /// identifier, or the seasons asked for do not meet.
+    /// </summary>
+    Different = 0,
+
+    /// <summary>
+    /// One thing. Everything the new ask names is already inside the existing request, so the
+    /// existing request is what the person is waiting for and there is nothing to create.
+    /// </summary>
+    Same = 1,
+
+    /// <summary>
+    /// The same series, and the new ask names at least one season the existing request does not
+    /// cover. The existing request is not widened, because widening an approved request would
+    /// approve seasons nobody approved; what is created is a request for the seasons that are left,
+    /// which <see cref="RequestIdentity.SeasonsNotAlreadyAskedFor"/> works out.
+    /// </summary>
+    Overlapping = 2
+}

--- a/Jellyfin.Plugin.Requests/Model/RequestNotIdentifiedException.cs
+++ b/Jellyfin.Plugin.Requests/Model/RequestNotIdentifiedException.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Globalization;
+
+namespace Jellyfin.Plugin.Requests.Model;
+
+/// <summary>
+/// Thrown when a request that carries no provider identifier is asked to move somewhere that needs
+/// one.
+/// <para>
+/// A request with no identifier is a title somebody typed. It has no identity, so
+/// <see cref="RequestIdentity"/> never joins it to anything, a fulfilment check has nothing to match
+/// it against, and a bridge has nothing to submit. Approving one is an operator saying yes to
+/// something no part of the plugin can act on afterwards, and it would sit in the queue looking
+/// decided while nothing at all was happening.
+/// </para>
+/// <para>
+/// A decline is the one move that needs no identifier, and it stays open on purpose. An operator who
+/// cannot tell what was asked for can still say so, with the reason, and the person who asked is
+/// told. Refusing that as well would leave such a request with no ending at all.
+/// </para>
+/// <para>
+/// The way out is the other direction: somebody puts the identifiers on the request, and then every
+/// move is available. Which surface offers that is #52's and #61's, and nothing here decides it.
+/// </para>
+/// </summary>
+public sealed class RequestNotIdentifiedException : InvalidOperationException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequestNotIdentifiedException"/> class for the
+    /// move that was refused.
+    /// </summary>
+    /// <param name="to">The state the move was into.</param>
+    public RequestNotIdentifiedException(RequestState to)
+        : base(Describe(to))
+    {
+        To = to;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequestNotIdentifiedException"/> class. Present
+    /// because the analyzers ask every exception for the three ordinary constructors; the
+    /// constructor above is the one this type exists for.
+    /// </summary>
+    public RequestNotIdentifiedException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequestNotIdentifiedException"/> class with a
+    /// message of the caller's own. See the note on the parameterless constructor.
+    /// </summary>
+    /// <param name="message">The message.</param>
+    public RequestNotIdentifiedException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequestNotIdentifiedException"/> class with a
+    /// message and an inner exception. See the note on the parameterless constructor.
+    /// </summary>
+    /// <param name="message">The message.</param>
+    /// <param name="innerException">The inner exception.</param>
+    public RequestNotIdentifiedException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    /// Gets the state the refused move was into, or <see cref="RequestState.Open"/> where this was
+    /// built by one of the constructors that names no move.
+    /// </summary>
+    public RequestState To { get; }
+
+    private static string Describe(RequestState to)
+        => string.Format(
+            CultureInfo.InvariantCulture,
+            "A request that carries no provider identifier cannot be moved to {0}. Nothing can match it in the library and nothing can be submitted for it, so the moves that need an identifier are refused until one is on the request. A decline needs none and stays available.",
+            to);
+}


### PR DESCRIPTION
Closes #38.

Two users will ask for the same film and the same user will ask twice. `RequestIdentity.Compare` is
the one function that says whether two asks are one request, and `RequestLifecycle.Join` is what
happens instead of a second row.

## What identity is made of

A provider identifier and a kind. Not a title: titles collide, get re-released, differ by language
and are typed by people, and the sibling hands over identifiers anyway. One shared identifier under
one provider is enough, so a client that knows only `Imdb` does not file a second request for
something the queue already holds under `Tmdb` and `Imdb` both.

The provider name is matched without regard to case and the value exactly. The name is spelled
`Tmdb` by one caller and `tmdb` by another and neither is wrong; the values are somebody else's
identifiers and this plugin does not get to decide that two of them that differ mean one thing. The
comparison walks both maps rather than looking a name up in one of them, because a dictionary answers
under whatever comparer it was built with and those maps are built by callers this code does not
control.

The kind is part of the identity. Provider numbering runs per kind, so without it the first collision
joins a programme to a film.

## The seasons, which are why there are three answers

A request for one season is not a request for the show, so the seasons asked for are part of what is
being asked for. That makes the comparison give `Same`, `Different` or `Overlapping`.

`Overlapping` is the case that has no two-valued answer. Joining would lose the seasons the open
request does not cover, and widening the open request would approve seasons nobody approved. What
happens instead is a request for the seasons that are left, which
`RequestIdentity.SeasonsNotAlreadyAskedFor` works out.

An empty set means the whole series. It is the one convention here to remember, and it is what a
client sends when somebody asks for a programme rather than for part of one. Listing every season a
show has would make the request wrong the day another one airs, and this plugin has no metadata
source to ask, decided in #92. The comparison is therefore not symmetric, which is deliberate: the
whole show covers a season of it and a season does not cover the show. Where the new ask means the
whole show and the caller does not know how many seasons there are, the answer for what is left is
empty, which reads as the whole series and is the safe direction, because it asks for no more than
the person did.

The seasons are refused rather than tidied. A repeat is a caller's mistake stored as a fact and a
zero is not a season any client has, so both throw. The order the caller gave is kept, because two
requests naming the same seasons in a different order are one ask and the comparison never reads the
order.

## Joining

`JoinedByUserIds` holds everyone who asked after the request existed, oldest first. It never holds
the person who asked first and never holds anybody twice, so a count of it is a count of people
rather than of clicks. Asking again changes nothing and is not an error: a client that retries, a
person who clicks twice and two tabs on one page all arrive there.

A join is not a state change. Nothing was decided, so nothing is appended to the history, which is a
record of decisions rather than of interest.

Only a request that is still waiting can be joined. A declined, fulfilled or failed request has had
its answer, and handing somebody an answer given before they asked is worse than giving them a
request of their own.

Somebody who joined is a requester on that request. `RequestCaller.RolesOn` now asks
`MediaRequest.WasAskedForBy`, so both surfaces answer "is this yours" through one comparison and the
second person sees on their own page the request they joined rather than nothing at all.

## A request that names nothing

The issue offered two answers and this takes the second one. Such a request can exist, and what it
may do is narrow rather than accidental: it may be declined, and nothing else.

It has no identity, so it is `Different` from everything including another copy of itself. Two people
typing the same title get two requests, which is the honest answer: the alternative is matching on the
text they typed, and they may well have meant two different films.

Approving it would be an operator saying yes to something no fulfilment check can match and no bridge
can submit, and it would sit in the queue looking decided while nothing at all happened. A decline
needs no identifier, so the request still has an ending and the person who asked is told with a
reason. Putting identifiers on it opens every other move, and which surface offers that is #52's and
#61's.

The check runs after the caller's authority is checked, so a caller who may not touch a request does
not learn from a refusal whether it carries an identifier.

## Proof that the guards bite

Removing both new guards from `RequestLifecycle` and running the suite:

    [FAIL] RequestIdentityTests.ARequestWithNoIdentifierMayOnlyBeDeclined
    [FAIL] RequestIdentityTests.ADecidedRequestCannotBeJoined(state: Declined)
    [FAIL] RequestIdentityTests.ADecidedRequestCannotBeJoined(state: Fulfilled)
    [FAIL] RequestIdentityTests.ADecidedRequestCannotBeJoined(state: Failed)
    Fehler: 4, erfolgreich: 185, gesamt: 189

Removing the two that refuse a season list that is not a set of seasons:

    [FAIL] RequestIdentityTests.TheSeasonsAskedForAreASetOfSeasons
    Fehler: 1, erfolgreich: 188, gesamt: 189

Neither near-miss is committed, and the rest of the suite is unmoved in both, which is the half worth
reading: each guard is what its own tests are about and none of them made the other 185 depend on it.

The season cases are asserted against a list written by hand rather than derived from the comparison,
for the same reason the transition table is: a derived expectation agrees with whatever the code says,
including on the day a case is widened by accident.

## What was run

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release \
      --collect "Code Coverage;Format=cobertura" --results-directory coverage
    Bestanden! Fehler: 0, erfolgreich: 189, gesamt: 189 (net9.0)
    Bestanden! Fehler: 0, erfolgreich: 189, gesamt: 189 (net10.0)

166 tests before this change and 189 after, both server lines. Line coverage of the plugin's own
package, computed with the gate's own reader over that report:

    rate 90.52% of 1002 lines
      MediaRequest.cs   (102, 102)

The floor is 75.

Every path is inside the `Scope:` line on the issue, the model code and the test project. One file in
the test project is not a model test: `FileRequestStoreDurabilityTests` compares whole records across
a round trip, and the record now holds two more collections. They are put back before that comparison
for the reason already measured there, that the generated equality compares a collection held behind
an interface by reference and never by its contents. The request in that proof now also carries
somebody who joined it, so the new list has something to lose on the way to the file and back.

## What this does not do

Nothing creates a request yet, so nothing calls `Compare` outside the suite. The caller that will is
#52, and the response field that says whether an ask created or joined is its condition rather than
this one.

`JoinedByUserIds` is kept by `Join` and by nothing else. A caller could still write the property
directly, exactly as one could write `State`, and the lint rule that refuses such an assignment for
the history covers only the history. Adding one for this list is a change to `tools/opengrep/rules.yaml`,
which is outside this issue's scope, and #28 is where that rule set lives.

The on-disk shape gained two fields and carries no version, which is #47 and unchanged by this. There
is no released version and nothing to strand.

This change is 774 lines added against a board that warns at 400 and says at the warning that it is
not a limit. It is one topic: what makes two requests one request, and every consequence of answering
it. The seasons are here because the answer for a series is wrong without them, the joining is here
because the second condition on the issue asks what happens to the second person, and the rule for a
request with no identifier is the third condition. Splitting it would have produced two halves that
only mean anything together.

There was no second reader for this change. What stands in its place is the evidence above: three
guards proven by deletion, both server lines run, and the season cases asserted against a list written
by hand rather than read back from the code that decides them.
