### PR TITLE
Name the three query paths the surfaces need and bound what each costs (#48)

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Doubles/InMemoryRequestStore.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/InMemoryRequestStore.cs
@@ -52,6 +52,66 @@ internal sealed class InMemoryRequestStore : IRequestStore
     }
 
     /// <inheritdoc />
+    public Task<IReadOnlyList<StoredRequest>> FindForUserAsync(Guid userId, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_gate)
+        {
+            return Task.FromResult<IReadOnlyList<StoredRequest>>(
+                [.. _held.Values.Where(stored => stored.Request.WasAskedForBy(userId))]);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<StoredRequest>> FindByProviderIdentifierAsync(
+        RequestedItemKind kind,
+        string provider,
+        string value,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(provider);
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_gate)
+        {
+            return Task.FromResult<IReadOnlyList<StoredRequest>>(
+                [.. _held.Values.Where(stored => Carries(stored.Request, kind, provider, value))]);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<RequestPage> PageAsync(RequestQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_gate)
+        {
+            var matched = _held.Values.Where(stored => query.Matches(stored.Request)).ToArray();
+
+            var ordered = query.Order switch
+            {
+                RequestQueryOrder.RequestedAt => matched.OrderBy(stored => stored.Request.RequestedAt).ThenBy(stored => stored.Request.Id),
+                RequestQueryOrder.StateChangedAt => matched.OrderBy(stored => stored.Request.StateChangedAt).ThenBy(stored => stored.Request.Id),
+                RequestQueryOrder.DisplayTitle => matched.OrderBy(stored => stored.Request.DisplayTitle, StringComparer.InvariantCulture).ThenBy(stored => stored.Request.Id),
+                _ => throw new ArgumentOutOfRangeException(nameof(query), query.Order, "This store has no comparison for that order.")
+            };
+
+            // The descending case is the ascending one reversed rather than a second set of arms.
+            // Two spellings of one order are two places a tiebreak can be dropped from, and the
+            // tiebreak is what makes paging see every match exactly once.
+            var page = (query.Descending ? ordered.Reverse() : ordered)
+                .Skip(query.Skip)
+                .Take(query.Take)
+                .ToArray();
+
+            return Task.FromResult(new RequestPage(page, matched.Length));
+        }
+    }
+
+    /// <inheritdoc />
     public Task<StoredRequest> AddAsync(MediaRequest request, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(request);
@@ -112,4 +172,22 @@ internal sealed class InMemoryRequestStore : IRequestStore
             return Task.FromResult(true);
         }
     }
+
+    /// <summary>
+    /// Whether one request names one external identifier, written out here rather than taken from
+    /// the shipped store. A double that borrowed the implementation it stands beside would agree
+    /// with it by construction, and the contract is meant to be two answers that have to match.
+    /// The comparison is the one <see cref="RequestIdentity"/> makes: the provider name without
+    /// case, the value exactly, and the kind as part of the identity.
+    /// </summary>
+    /// <param name="request">The request being judged.</param>
+    /// <param name="kind">What sort of thing the identifier names.</param>
+    /// <param name="provider">The provider's name.</param>
+    /// <param name="value">The identifier under that provider.</param>
+    /// <returns><see langword="true"/> where the request names it.</returns>
+    private static bool Carries(MediaRequest request, RequestedItemKind kind, string provider, string value)
+        => request.Kind == kind
+            && request.ProviderIds.Any(entry =>
+                string.Equals(entry.Key, provider, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(entry.Value, value, StringComparison.Ordinal));
 }

--- a/Jellyfin.Plugin.Requests.Tests/Storage/FileRequestStoreQueryCostTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Storage/FileRequestStoreQueryCostTests.cs
@@ -1,0 +1,338 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Storage;
+
+/// <summary>
+/// What the three query paths cost at a size worth caring about, as a bound the suite holds rather
+/// than as a sentence in a document. A store that is fine at fifty records and unusable at ten
+/// thousand is a decision nobody made, and this is where the decision is kept honest.
+/// <para>
+/// Each leg measures the workload the path actually carries rather than one call of it. A single
+/// call answered by walking ten thousand records takes under a millisecond, so a bound over one call
+/// would pass whatever shape the store had underneath and would prove nothing. One call per user and
+/// one call per library item is what the surfaces and the fulfilment sweep do, and at that workload
+/// the difference between a lookup and a walk is the difference between milliseconds and minutes.
+/// </para>
+/// <para>
+/// <b>What these bounds catch and what they do not.</b> They catch a query path that grows with how
+/// much the store holds where it should not: an index dropped, a lookup replaced by a walk, a read
+/// that goes back to the file on every call. They do not catch a path that is merely slower than it
+/// could be, and they are not a benchmark. The headroom is deliberately wide, because a shared
+/// machine under load is the ordinary case for a suite and a bound that fails there teaches people
+/// to delete it. The numbers below say what was measured and what the bound is, so the distance
+/// between the two is visible rather than implied.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class FileRequestStoreQueryCostTests : IDisposable
+{
+    /// <summary>
+    /// The size the bounds are stated at. Ten thousand is well past what a household request queue
+    /// reaches and is the number the plan asks these paths to be answerable at.
+    /// </summary>
+    private const int Records = 10_000;
+
+    /// <summary>
+    /// How many people the requests are spread over, so each of them is waiting for ten and a
+    /// lookup has something to return.
+    /// </summary>
+    private const int Users = 1_000;
+
+    /// <summary>
+    /// How many rows one page of the queue holds.
+    /// </summary>
+    private const int PageSize = 50;
+
+    /// <summary>
+    /// How many pages the queue leg turns. An operator working through a queue turns a handful, and
+    /// a hundred is enough that the walk behind each one is measured rather than lost in the noise
+    /// of a single call.
+    /// </summary>
+    private const int PagesTurned = 100;
+
+    /// <summary>
+    /// One state in five, so the filtered leg matches a fifth of the store and every page it asks
+    /// for is a full one.
+    /// </summary>
+    private const int StatesUsed = 5;
+
+    /// <summary>
+    /// How many times the user leg asks. A thousand people opening their page ten times each, which
+    /// is the workload rather than one call of it.
+    /// </summary>
+    private const int UserLookups = 10_000;
+
+    /// <summary>
+    /// The bound on answering one person's own requests, ten thousand times, over ten thousand
+    /// records.
+    /// <para>
+    /// The window this sits in was measured in both directions. The store as it ships took 5 ms; the
+    /// same leg with the lookup replaced by a walk of the set took 2,610 ms. The bound is far above
+    /// the first and far below the second, so a machine many times slower than this one still passes
+    /// and a store that lost the lookup still fails.
+    /// </para>
+    /// </summary>
+    private const int UserLookupsBoundMilliseconds = 400;
+
+    /// <summary>
+    /// The bound on answering one external identifier per record, over ten thousand records. This
+    /// is the shape of the fulfilment sweep in #42: one question per library item, and the leg where
+    /// a walk becomes ten thousand walks.
+    /// <para>
+    /// Measured the same way, on the same run. As it ships, 10 ms; with the lookup replaced by a
+    /// walk, 3,070 ms.
+    /// </para>
+    /// </summary>
+    private const int IdentifierLookupsBoundMilliseconds = 600;
+
+    /// <summary>
+    /// The bound on turning a hundred filtered, ordered pages of the queue.
+    /// <para>
+    /// Measured at 153 ms. This leg is a walk by construction and the bound is not about avoiding
+    /// one: a filter and an order chosen at the call cannot be served by a lookup built before it.
+    /// The run that turned the other two lookups into walks measured 98 ms here, which is the same
+    /// leg unmoved, so this bound does not separate a walk from a lookup and is not claimed to. What
+    /// it catches is a page that stops being one walk, which is what a read going back to the file,
+    /// or a count taken by a second pass over the set, would make it.
+    /// </para>
+    /// </summary>
+    private const int QueuePagesBoundMilliseconds = 8_000;
+
+    private readonly List<FileRequestStore> _stores = [];
+    private readonly List<string> _directories = [];
+
+    /// <summary>
+    /// One person's own requests, answered ten thousand times against a store of ten thousand,
+    /// inside the stated bound.
+    /// <para>
+    /// The answers are counted as well as timed. A store that returned nothing would be the fastest
+    /// one there is, and a bound on its own cannot tell a lookup from a broken lookup.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task EveryUsersOwnRequestsAreAnsweredWithinTheBound()
+    {
+        var store = await LoadedStore().ConfigureAwait(true);
+
+        var found = 0;
+        var clock = Stopwatch.StartNew();
+
+        for (var lookup = 0; lookup < UserLookups; lookup++)
+        {
+            var theirs = await store.FindForUserAsync(UserId(lookup % Users), CancellationToken.None).ConfigureAwait(true);
+            found += theirs.Count;
+        }
+
+        clock.Stop();
+
+        Assert.Equal(UserLookups * (Records / Users), found);
+        AssertWithin(UserLookupsBoundMilliseconds, clock, "ten thousand user lookups");
+    }
+
+    /// <summary>
+    /// One external identifier per record, which is the shape of a fulfilment sweep walking the
+    /// library, inside the stated bound.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task EveryIdentifierIsAnsweredWithinTheBound()
+    {
+        var store = await LoadedStore().ConfigureAwait(true);
+
+        var found = 0;
+        var clock = Stopwatch.StartNew();
+
+        for (var record = 0; record < Records; record++)
+        {
+            var carrying = await store.FindByProviderIdentifierAsync(
+                KindOf(record),
+                "Tmdb",
+                IdentifierOf(record),
+                CancellationToken.None).ConfigureAwait(true);
+
+            found += carrying.Count;
+        }
+
+        clock.Stop();
+
+        Assert.Equal(Records, found);
+        AssertWithin(IdentifierLookupsBoundMilliseconds, clock, "one identifier lookup for each of ten thousand records");
+    }
+
+    /// <summary>
+    /// A hundred filtered, ordered pages of the queue over ten thousand records, inside the stated
+    /// bound. The count that comes back with each page is asserted too, because a page that stopped
+    /// counting the matches would be the cheapest way to make this leg faster and the queue wrong.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task TurningTheQueuePagesStaysWithinTheBound()
+    {
+        var store = await LoadedStore().ConfigureAwait(true);
+        var matches = Records / StatesUsed;
+        var pagesInTheQueue = matches / PageSize;
+
+        var rows = 0;
+        var clock = Stopwatch.StartNew();
+
+        for (var turn = 0; turn < PagesTurned; turn++)
+        {
+            var page = await store.PageAsync(
+                new RequestQuery
+                {
+                    States = [RequestState.Open],
+                    Order = RequestQueryOrder.DisplayTitle,
+                    Skip = (turn % pagesInTheQueue) * PageSize,
+                    Take = PageSize
+                },
+                CancellationToken.None).ConfigureAwait(true);
+
+            Assert.Equal(matches, page.MatchCount);
+            rows += page.Requests.Count;
+        }
+
+        clock.Stop();
+
+        Assert.Equal(PagesTurned * PageSize, rows);
+        AssertWithin(QueuePagesBoundMilliseconds, clock, "a hundred filtered and ordered pages");
+    }
+
+    /// <summary>
+    /// Removes every store this test made and the directory each one wrote in.
+    /// </summary>
+    public void Dispose()
+    {
+        foreach (var store in _stores)
+        {
+            store.Dispose();
+        }
+
+        foreach (var directory in _directories)
+        {
+            TestRunDirectory.Remove(directory);
+        }
+    }
+
+    /// <summary>
+    /// Fails with the measurement in the message rather than with a bare assertion, so a run that
+    /// went over says by how much and the next reader has the number without re-running anything.
+    /// </summary>
+    /// <param name="boundMilliseconds">The bound this leg is held to.</param>
+    /// <param name="clock">The stopped clock.</param>
+    /// <param name="workload">What was measured, for the message.</param>
+    private static void AssertWithin(int boundMilliseconds, Stopwatch clock, string workload)
+        => Assert.True(
+            clock.ElapsedMilliseconds <= boundMilliseconds,
+            string.Format(
+                CultureInfo.InvariantCulture,
+                "{0} over {1} records took {2} ms, past the bound of {3} ms.",
+                workload,
+                Records,
+                clock.ElapsedMilliseconds,
+                boundMilliseconds));
+
+    /// <summary>
+    /// The user a record belongs to. Spread evenly, so every one of them is waiting for the same
+    /// number and no lookup is answered by a bucket that happens to be empty.
+    /// </summary>
+    /// <param name="user">Which user.</param>
+    /// <returns>Their identifier.</returns>
+    private static Guid UserId(int user)
+        => new Guid(user, 0, 0, [0, 0, 0, 0, 0, 0, 0, 1]);
+
+    /// <summary>
+    /// What sort of thing a record names. Alternating, so the kind is part of every identifier
+    /// question rather than a constant the store could ignore.
+    /// </summary>
+    /// <param name="record">Which record.</param>
+    /// <returns>The kind.</returns>
+    private static RequestedItemKind KindOf(int record)
+        => record % 2 == 0 ? RequestedItemKind.Movie : RequestedItemKind.Series;
+
+    /// <summary>
+    /// The external identifier a record carries. One per record, so a lookup that returned a bucket
+    /// instead of a match would be caught by the count.
+    /// </summary>
+    /// <param name="record">Which record.</param>
+    /// <returns>The identifier under the provider.</returns>
+    private static string IdentifierOf(int record)
+        => record.ToString(CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Ten thousand requests, spread over a thousand people, five states and two kinds, each
+    /// carrying one external identifier of its own.
+    /// </summary>
+    /// <returns>The requests.</returns>
+    private static IReadOnlyList<MediaRequest> Requests()
+    {
+        var asked = new DateTimeOffset(2026, 8, 8, 8, 0, 0, TimeSpan.Zero);
+
+        return [.. Enumerable.Range(0, Records).Select(record => new MediaRequest
+        {
+            Id = new Guid(record, 0, 0, [0, 0, 0, 0, 0, 0, 0, 2]),
+            RequestedByUserId = UserId(record % Users),
+            RequestedAt = asked.AddSeconds(record),
+            StateChangedAt = asked.AddSeconds(record),
+            Kind = KindOf(record),
+
+            // Titles that do not arrive in order, so the ordered leg has a sort to do rather than a
+            // list that is already in the order it asked for.
+            DisplayTitle = string.Create(CultureInfo.InvariantCulture, $"Request {(record * 7919) % Records:D5}"),
+            State = (RequestState)(record % StatesUsed),
+            ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["Tmdb"] = IdentifierOf(record)
+            }
+        })];
+    }
+
+    /// <summary>
+    /// A store holding ten thousand records, and the load already done.
+    /// <para>
+    /// The file is written directly rather than through ten thousand calls of the store's own add,
+    /// because each of those rewrites the whole set and the arrangement would cost more than
+    /// everything being measured. That is also the honest shape of the case: a server restarting
+    /// reads a file somebody else's process wrote. What it costs is a coupling to the on-disk shape,
+    /// and the count asserted here is what turns a change to that shape into a failure with a
+    /// reason rather than a leg that quietly measures an empty store.
+    /// </para>
+    /// </summary>
+    /// <returns>The store, with its file already read.</returns>
+    private async Task<FileRequestStore> LoadedStore()
+    {
+        var directory = TestRunDirectory.CreateSubdirectory();
+        _directories.Add(directory);
+
+        var persisted = Requests().Select(request => new { Revision = 1L, Request = request }).ToArray();
+        await File.WriteAllTextAsync(
+            Path.Combine(directory, FileRequestStore.FileName),
+            JsonSerializer.Serialize(persisted)).ConfigureAwait(true);
+
+        var store = new FileRequestStore(directory);
+        _stores.Add(store);
+
+        // The first read is what parses the file, so it is made here and not inside a measured
+        // region. It is also the assertion that the store read what was written.
+        var all = await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true);
+        Assert.Equal(Records, all.Count);
+
+        return store;
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/Storage/RequestStoreContract.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Storage/RequestStoreContract.cs
@@ -235,6 +235,271 @@ public abstract class RequestStoreContract
     }
 
     /// <summary>
+    /// One person's requests are the ones they asked for and the ones they joined, and a store that
+    /// answered only the first would show somebody nothing for the request they are most likely to
+    /// be looking for. Somebody else's request is not theirs, which is the other half and the one a
+    /// store returning everything would still pass without.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task OneUsersRequestsAreTheOnesTheyAskedForAndTheOnesTheyJoined()
+    {
+        var store = NewStore();
+        var asker = Guid.NewGuid();
+        var joiner = Guid.NewGuid();
+        var stranger = Guid.NewGuid();
+
+        var theirs = await store.AddAsync(
+            ARequest() with { RequestedByUserId = asker },
+            CancellationToken.None).ConfigureAwait(true);
+        var joined = await store.AddAsync(
+            ARequest() with { RequestedByUserId = stranger, JoinedByUserIds = [joiner, asker] },
+            CancellationToken.None).ConfigureAwait(true);
+        await store.AddAsync(
+            ARequest() with { RequestedByUserId = stranger },
+            CancellationToken.None).ConfigureAwait(true);
+
+        var forAsker = await store.FindForUserAsync(asker, CancellationToken.None).ConfigureAwait(true);
+        var forJoiner = await store.FindForUserAsync(joiner, CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Equal(2, forAsker.Count);
+        Assert.Contains(theirs, forAsker);
+        Assert.Contains(joined, forAsker);
+        Assert.Equal(new[] { joined }, forJoiner);
+    }
+
+    /// <summary>
+    /// Somebody who has asked for nothing gets an empty answer rather than a failure. Every user on
+    /// the server reaches this call the first time they open the page, so the ordinary case must not
+    /// be an exception a surface has to catch.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task SomebodyWhoHasAskedForNothingGetsAnEmptyAnswer()
+    {
+        var store = NewStore();
+        await store.AddAsync(ARequest(), CancellationToken.None).ConfigureAwait(true);
+
+        var theirs = await store.FindForUserAsync(Guid.NewGuid(), CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Empty(theirs);
+    }
+
+    /// <summary>
+    /// The identifier lookup answers the comparison <see cref="RequestIdentity"/> makes: the
+    /// provider name without case, because two callers spell one provider two ways and neither is
+    /// wrong.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AnIdentifierIsFoundHoweverTheProviderNameIsSpelled()
+    {
+        var store = NewStore();
+        var carrying = await store.AddAsync(
+            ARequest() with { ProviderIds = new Dictionary<string, string> { ["Tmdb"] = "603" } },
+            CancellationToken.None).ConfigureAwait(true);
+        await store.AddAsync(
+            ARequest() with { ProviderIds = new Dictionary<string, string> { ["Tmdb"] = "604" } },
+            CancellationToken.None).ConfigureAwait(true);
+
+        var found = await store.FindByProviderIdentifierAsync(
+            RequestedItemKind.Movie,
+            "tmdb",
+            "603",
+            CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Equal(new[] { carrying }, found);
+    }
+
+    /// <summary>
+    /// The other half of the same comparison, and the half a store written with one case-insensitive
+    /// dictionary would fail. The value is somebody else's identifier, so two that differ are two
+    /// things, and the kind is part of the identity because a film and a series can carry the same
+    /// number under one provider.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AnIdentifierOfAnotherKindOrAnotherValueIsAnotherThing()
+    {
+        var store = NewStore();
+        await store.AddAsync(
+            ARequest() with
+            {
+                Kind = RequestedItemKind.Series,
+                ProviderIds = new Dictionary<string, string> { ["Tvdb"] = "tt42" }
+            },
+            CancellationToken.None).ConfigureAwait(true);
+
+        var wrongKind = await store.FindByProviderIdentifierAsync(
+            RequestedItemKind.Movie,
+            "Tvdb",
+            "tt42",
+            CancellationToken.None).ConfigureAwait(true);
+        var wrongCase = await store.FindByProviderIdentifierAsync(
+            RequestedItemKind.Series,
+            "Tvdb",
+            "TT42",
+            CancellationToken.None).ConfigureAwait(true);
+        var rightBoth = await store.FindByProviderIdentifierAsync(
+            RequestedItemKind.Series,
+            "Tvdb",
+            "tt42",
+            CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Empty(wrongKind);
+        Assert.Empty(wrongCase);
+        Assert.Single(rightBoth);
+    }
+
+    /// <summary>
+    /// A query naming no state and no kind is a queue nobody has narrowed, and it matches
+    /// everything. The opposite reading, that an empty list matches nothing, is the mistake a filter
+    /// written as a membership test without an emptiness test makes, and it turns an unfiltered
+    /// queue into an empty page.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AQueryNamingNoFilterMatchesEverything()
+    {
+        var store = NewStore();
+        await store.AddAsync(ARequest(), CancellationToken.None).ConfigureAwait(true);
+        await store.AddAsync(
+            ARequest() with { Kind = RequestedItemKind.Series, State = RequestState.Approved },
+            CancellationToken.None).ConfigureAwait(true);
+
+        var page = await store.PageAsync(new RequestQuery { Take = 10 }, CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Equal(2, page.MatchCount);
+        Assert.Equal(2, page.Requests.Count);
+    }
+
+    /// <summary>
+    /// Both filters have to hold, and the count is over the filter rather than over the store. A
+    /// store applying either filter alone would return the wrong rows; one counting the whole store
+    /// would return the right rows under a pager that says there are more.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task EveryNamedFilterHasToHoldAndTheCountIsOverThem()
+    {
+        var store = NewStore();
+        var wanted = await store.AddAsync(
+            ARequest() with { Kind = RequestedItemKind.Series, State = RequestState.Approved },
+            CancellationToken.None).ConfigureAwait(true);
+        await store.AddAsync(
+            ARequest() with { Kind = RequestedItemKind.Movie, State = RequestState.Approved },
+            CancellationToken.None).ConfigureAwait(true);
+        await store.AddAsync(
+            ARequest() with { Kind = RequestedItemKind.Series, State = RequestState.Open },
+            CancellationToken.None).ConfigureAwait(true);
+
+        var page = await store.PageAsync(
+            new RequestQuery
+            {
+                States = [RequestState.Approved],
+                Kinds = [RequestedItemKind.Series],
+                Take = 10
+            },
+            CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Equal(1, page.MatchCount);
+        Assert.Equal(new[] { wanted }, page.Requests);
+    }
+
+    /// <summary>
+    /// The count is how many matched and not how many the page carries. It is what a pager is drawn
+    /// from, and a store answering the page length would tell an operator on the first page of six
+    /// that there is one page.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ThePageSaysHowManyMatchedRatherThanHowManyItCarries()
+    {
+        var store = NewStore();
+
+        for (var made = 0; made < 6; made++)
+        {
+            await store.AddAsync(ARequest(), CancellationToken.None).ConfigureAwait(true);
+        }
+
+        var page = await store.PageAsync(new RequestQuery { Take = 2 }, CancellationToken.None).ConfigureAwait(true);
+        var counted = await store.PageAsync(new RequestQuery { Take = 0 }, CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Equal(6, page.MatchCount);
+        Assert.Equal(2, page.Requests.Count);
+        Assert.Equal(6, counted.MatchCount);
+        Assert.Empty(counted.Requests);
+    }
+
+    /// <summary>
+    /// Walking the pages sees every match exactly once, over requests that were all made in the same
+    /// moment so nothing but the tiebreak separates them.
+    /// <para>
+    /// What this stands for is the page arithmetic: a boundary off by one shows a request twice or
+    /// skips it, and neither throws. It is not the proof that the order is total. Removing the
+    /// tiebreak from the store leaves this leg green, because the sort behind it is stable and the
+    /// set it reads is enumerated the same way each time; what goes red then is
+    /// <see cref="DescendingIsTheAscendingOrderReadBackwards"/>, which is where that proof is.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task WalkingThePagesSeesEveryMatchExactlyOnce()
+    {
+        var store = NewStore();
+        var added = new List<Guid>();
+
+        for (var made = 0; made < 7; made++)
+        {
+            var stored = await store.AddAsync(ARequest(), CancellationToken.None).ConfigureAwait(true);
+            added.Add(stored.Request.Id);
+        }
+
+        var walked = new List<Guid>();
+
+        for (var skip = 0; skip < 7; skip += 2)
+        {
+            var page = await store.PageAsync(
+                new RequestQuery { Skip = skip, Take = 2 },
+                CancellationToken.None).ConfigureAwait(true);
+
+            walked.AddRange(page.Requests.Select(stored => stored.Request.Id));
+        }
+
+        Assert.Equal(added.Order(), walked.Order());
+        Assert.Equal(7, walked.Distinct().Count());
+    }
+
+    /// <summary>
+    /// Descending is the ascending order read backwards, tiebreak included. A store that reversed
+    /// the chosen key and left the tiebreak alone would answer a third order, and two requests made
+    /// in the same tick would sit one way going down the queue and the other going up it.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task DescendingIsTheAscendingOrderReadBackwards()
+    {
+        var store = NewStore();
+        var asked = new DateTimeOffset(2026, 8, 8, 8, 0, 0, TimeSpan.Zero);
+
+        for (var made = 0; made < 5; made++)
+        {
+            // Two of the five share a moment, so the tiebreak is what decides their order and the
+            // reversal has something to get wrong.
+            await store.AddAsync(
+                ARequest() with { RequestedAt = asked.AddMinutes(made / 2) },
+                CancellationToken.None).ConfigureAwait(true);
+        }
+
+        var up = await store.PageAsync(new RequestQuery { Take = 5 }, CancellationToken.None).ConfigureAwait(true);
+        var down = await store.PageAsync(
+            new RequestQuery { Take = 5, Descending = true },
+            CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Equal(up.Requests.Reverse(), down.Requests);
+    }
+
+    /// <summary>
     /// Many callers write against one revision at the same moment. Exactly one is accepted, every
     /// other is refused, and the store ends one revision on rather than <see cref="Writers"/> of
     /// them.

--- a/Jellyfin.Plugin.Requests/Storage/FileRequestStore.cs
+++ b/Jellyfin.Plugin.Requests/Storage/FileRequestStore.cs
@@ -49,6 +49,13 @@ namespace Jellyfin.Plugin.Requests.Storage;
 /// replaced only after the disk has taken the same set, so what the plugin reports and what survives
 /// a restart cannot disagree.
 /// </para>
+/// <para>
+/// <b>The three reads the surfaces make are not walks of the set.</b> One person's requests and one
+/// external identifier are answered out of two lookups built beside the set each time it is
+/// replaced, so neither grows with how much the store holds. The queue page is a walk, because a
+/// filter and an order chosen at the call cannot be served by a lookup built before it. What each
+/// costs, at what size, and the run behind those numbers are in <c>docs/storage.md</c>.
+/// </para>
 /// </summary>
 public sealed class FileRequestStore : IRequestStore, IDisposable
 {
@@ -79,10 +86,11 @@ public sealed class FileRequestStore : IRequestStore, IDisposable
     private readonly SemaphoreSlim _writes = new SemaphoreSlim(1, 1);
 
     /// <summary>
-    /// What the store holds, or null before the first call has read the file. Replaced whole and
-    /// never edited, which is what lets a reader take it without waiting for anything.
+    /// What the store holds and the two lookups over it, or null before the first call has read the
+    /// file. Replaced whole and never edited, which is what lets a reader take it without waiting
+    /// for anything.
     /// </summary>
-    private Dictionary<Guid, StoredRequest>? _held;
+    private Snapshot? _held;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FileRequestStore"/> class.
@@ -116,7 +124,7 @@ public sealed class FileRequestStore : IRequestStore, IDisposable
         cancellationToken.ThrowIfCancellationRequested();
 
         var held = await HeldAsync(cancellationToken).ConfigureAwait(false);
-        return held.TryGetValue(id, out var stored) ? stored : null;
+        return held.Held.TryGetValue(id, out var stored) ? stored : null;
     }
 
     /// <inheritdoc />
@@ -125,7 +133,57 @@ public sealed class FileRequestStore : IRequestStore, IDisposable
         cancellationToken.ThrowIfCancellationRequested();
 
         var held = await HeldAsync(cancellationToken).ConfigureAwait(false);
-        return held.Values.ToArray();
+        return held.Held.Values.ToArray();
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<StoredRequest>> FindForUserAsync(Guid userId, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var held = await HeldAsync(cancellationToken).ConfigureAwait(false);
+
+        // The stored array is handed back rather than copied. It was built when the snapshot was
+        // built and nothing ever writes into it, so a caller holding it holds a value the same way
+        // a caller holding a request does.
+        return held.ByUser.TryGetValue(userId, out var theirs) ? theirs : [];
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<StoredRequest>> FindByProviderIdentifierAsync(
+        RequestedItemKind kind,
+        string provider,
+        string value,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(provider);
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var held = await HeldAsync(cancellationToken).ConfigureAwait(false);
+        var key = new ProviderKey(kind, provider, value);
+
+        return held.ByProviderIdentifier.TryGetValue(key, out var carrying) ? carrying : [];
+    }
+
+    /// <inheritdoc />
+    public async Task<RequestPage> PageAsync(RequestQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var held = await HeldAsync(cancellationToken).ConfigureAwait(false);
+
+        // One walk of the set, and everything below is over what survived it. The count and the
+        // page are taken from this one list, which is how the two cannot disagree.
+        var matched = held.Held.Values.Where(stored => query.Matches(stored.Request)).ToArray();
+
+        var page = Ordered(matched, query)
+            .Skip(query.Skip)
+            .Take(query.Take)
+            .ToArray();
+
+        return new RequestPage(page, matched.Length);
     }
 
     /// <inheritdoc />
@@ -140,16 +198,16 @@ public sealed class FileRequestStore : IRequestStore, IDisposable
         {
             var held = LoadedWhileHoldingTheWriteLock();
 
-            if (held.ContainsKey(request.Id))
+            if (held.Held.ContainsKey(request.Id))
             {
                 throw new DuplicateRequestException(request.Id);
             }
 
             var stored = new StoredRequest(request, 1);
-            var next = new Dictionary<Guid, StoredRequest>(held) { [request.Id] = stored };
+            var next = new Dictionary<Guid, StoredRequest>(held.Held) { [request.Id] = stored };
 
             await PersistAsync(next, cancellationToken).ConfigureAwait(false);
-            Volatile.Write(ref _held, next);
+            Volatile.Write(ref _held, new Snapshot(next));
             return stored;
         }
         finally
@@ -169,7 +227,7 @@ public sealed class FileRequestStore : IRequestStore, IDisposable
         try
         {
             var held = LoadedWhileHoldingTheWriteLock();
-            var current = held.TryGetValue(request.Id, out var stored) ? stored : (StoredRequest?)null;
+            var current = held.Held.TryGetValue(request.Id, out var stored) ? stored : (StoredRequest?)null;
 
             if (current is null || current.Value.Revision != expectedRevision)
             {
@@ -177,10 +235,10 @@ public sealed class FileRequestStore : IRequestStore, IDisposable
             }
 
             var written = new StoredRequest(request, expectedRevision + 1);
-            var next = new Dictionary<Guid, StoredRequest>(held) { [request.Id] = written };
+            var next = new Dictionary<Guid, StoredRequest>(held.Held) { [request.Id] = written };
 
             await PersistAsync(next, cancellationToken).ConfigureAwait(false);
-            Volatile.Write(ref _held, next);
+            Volatile.Write(ref _held, new Snapshot(next));
             return written;
         }
         finally
@@ -200,7 +258,7 @@ public sealed class FileRequestStore : IRequestStore, IDisposable
         {
             var held = LoadedWhileHoldingTheWriteLock();
 
-            if (!held.TryGetValue(id, out var stored))
+            if (!held.Held.TryGetValue(id, out var stored))
             {
                 return false;
             }
@@ -210,11 +268,11 @@ public sealed class FileRequestStore : IRequestStore, IDisposable
                 throw new RequestConcurrencyException(id, expectedRevision, stored);
             }
 
-            var next = new Dictionary<Guid, StoredRequest>(held);
+            var next = new Dictionary<Guid, StoredRequest>(held.Held);
             next.Remove(id);
 
             await PersistAsync(next, cancellationToken).ConfigureAwait(false);
-            Volatile.Write(ref _held, next);
+            Volatile.Write(ref _held, new Snapshot(next));
             return true;
         }
         finally
@@ -285,13 +343,58 @@ public sealed class FileRequestStore : IRequestStore, IDisposable
     }
 
     /// <summary>
+    /// Puts the matches in the order the query asked for.
+    /// <para>
+    /// The identifier is the last key of every order, so requests that compare equal under the
+    /// chosen one still have exactly one position. Without it their order is whatever order the set
+    /// is enumerated in, and the set is a dictionary that is rebuilt on every write: a request
+    /// created between two page turns can reorder rows that have nothing to do with it, so an
+    /// operator turning to the next page sees one of them again and never sees another.
+    /// </para>
+    /// <para>
+    /// Descending reverses the identifier as well as the chosen key, so the descending order is
+    /// exactly the ascending one read backwards. A tiebreak left ascending under a reversed primary
+    /// key is a third order, and two requests made in the same tick would sit in one order going
+    /// down the queue and the other going up it.
+    /// </para>
+    /// <para>
+    /// The title is compared as text somebody reads rather than as bytes, so an accented title
+    /// sorts beside its unaccented neighbour instead of after every unaccented title there is. That
+    /// is the one order here where the byte comparison and the reading one differ, and the reading
+    /// one is what a person scanning a column expects.
+    /// </para>
+    /// </summary>
+    /// <param name="matched">What survived the filter.</param>
+    /// <param name="query">The order asked for.</param>
+    /// <returns>The matches, ordered.</returns>
+    private static IOrderedEnumerable<StoredRequest> Ordered(IEnumerable<StoredRequest> matched, RequestQuery query)
+        => query.Order switch
+        {
+            RequestQueryOrder.RequestedAt => query.Descending
+                ? matched.OrderByDescending(stored => stored.Request.RequestedAt).ThenByDescending(stored => stored.Request.Id)
+                : matched.OrderBy(stored => stored.Request.RequestedAt).ThenBy(stored => stored.Request.Id),
+            RequestQueryOrder.StateChangedAt => query.Descending
+                ? matched.OrderByDescending(stored => stored.Request.StateChangedAt).ThenByDescending(stored => stored.Request.Id)
+                : matched.OrderBy(stored => stored.Request.StateChangedAt).ThenBy(stored => stored.Request.Id),
+            RequestQueryOrder.DisplayTitle => query.Descending
+                ? matched.OrderByDescending(stored => stored.Request.DisplayTitle, StringComparer.InvariantCulture).ThenByDescending(stored => stored.Request.Id)
+                : matched.OrderBy(stored => stored.Request.DisplayTitle, StringComparer.InvariantCulture).ThenBy(stored => stored.Request.Id),
+
+            // An order this store has no comparison for is refused rather than served by whichever
+            // arm happened to be written last. A value added to the enumeration is a value that
+            // reaches here, and being told so is cheaper than a queue quietly ordered by something
+            // else.
+            _ => throw new ArgumentOutOfRangeException(nameof(query), query.Order, "This store has no comparison for that order.")
+        };
+
+    /// <summary>
     /// The set, reading the file on the first call that needs it. A caller that finds it already
     /// read takes it without waiting for anything, which is what
     /// <see cref="IRequestStore.GetAsync"/> promises.
     /// </summary>
     /// <param name="cancellationToken">Cancels the wait for the first read.</param>
     /// <returns>What the store holds.</returns>
-    private async Task<Dictionary<Guid, StoredRequest>> HeldAsync(CancellationToken cancellationToken)
+    private async Task<Snapshot> HeldAsync(CancellationToken cancellationToken)
     {
         var held = Volatile.Read(ref _held);
 
@@ -318,7 +421,7 @@ public sealed class FileRequestStore : IRequestStore, IDisposable
     /// stops a write deciding against a set that was read before another write replaced it.
     /// </summary>
     /// <returns>What the store holds.</returns>
-    private Dictionary<Guid, StoredRequest> LoadedWhileHoldingTheWriteLock()
+    private Snapshot LoadedWhileHoldingTheWriteLock()
     {
         var held = _held;
 
@@ -327,7 +430,7 @@ public sealed class FileRequestStore : IRequestStore, IDisposable
             return held;
         }
 
-        held = Read(_filePath);
+        held = new Snapshot(Read(_filePath));
         Volatile.Write(ref _held, held);
         return held;
     }
@@ -372,5 +475,142 @@ public sealed class FileRequestStore : IRequestStore, IDisposable
         }
 
         File.Move(_pendingFilePath, _filePath, overwrite: true);
+    }
+
+    /// <summary>
+    /// One external identifier under one kind, as the identifier lookup is keyed by it. The kind is
+    /// part of the key because a film and a series can carry the same number under the same
+    /// provider and be two different works, which is the rule
+    /// <see cref="RequestIdentity"/> is written to.
+    /// </summary>
+    /// <param name="Kind">What sort of thing the identifier names.</param>
+    /// <param name="Provider">The provider's name.</param>
+    /// <param name="Value">The identifier under that provider.</param>
+    private readonly record struct ProviderKey(RequestedItemKind Kind, string Provider, string Value);
+
+    /// <summary>
+    /// What the store holds, and the two lookups the surfaces read it through.
+    /// <para>
+    /// Both lookups are built once, here, out of the set that is about to be published, and neither
+    /// is edited afterwards. That is what makes them safe to hand out: a reader that took this
+    /// snapshot holds a value nothing will change under it, which is the same promise the set
+    /// itself carries.
+    /// </para>
+    /// <para>
+    /// Building them costs one pass over the set on every write. That is the same order as
+    /// serialising the set, which the write has just done, so a write does not change shape for
+    /// having two lookups to rebuild. Keeping them up to date incrementally instead would mean an
+    /// edit in place, and an edit in place is what the snapshot exists to avoid.
+    /// </para>
+    /// </summary>
+    private sealed class Snapshot
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Snapshot"/> class over a set that is about
+        /// to be published.
+        /// </summary>
+        /// <param name="held">The set. It may not be written to after this call.</param>
+        public Snapshot(Dictionary<Guid, StoredRequest> held)
+        {
+            Held = held;
+
+            var byUser = new Dictionary<Guid, List<StoredRequest>>();
+            var byProviderIdentifier = new Dictionary<ProviderKey, List<StoredRequest>>(ProviderKeyComparer.Instance);
+
+            foreach (var stored in held.Values)
+            {
+                // Distinct, and the person who asked appended to the people who joined rather than
+                // assumed to be absent from them. The record says the two lists never overlap and
+                // nothing in the type refuses one that does, so a request that carried a person
+                // twice would otherwise put it in their list twice.
+                foreach (var user in stored.Request.JoinedByUserIds.Append(stored.Request.RequestedByUserId).Distinct())
+                {
+                    Under(byUser, user).Add(stored);
+                }
+
+                // Distinct under the same comparison the lookup uses, because a request may carry
+                // `Tmdb` and `tmdb` as two entries of its own map and they are one identifier here.
+                foreach (var identifier in stored.Request.ProviderIds
+                    .Select(entry => new ProviderKey(stored.Request.Kind, entry.Key, entry.Value))
+                    .Distinct(ProviderKeyComparer.Instance))
+                {
+                    Under(byProviderIdentifier, identifier).Add(stored);
+                }
+            }
+
+            ByUser = byUser.ToDictionary(entry => entry.Key, entry => entry.Value.ToArray());
+            ByProviderIdentifier = byProviderIdentifier.ToDictionary(
+                entry => entry.Key,
+                entry => entry.Value.ToArray(),
+                ProviderKeyComparer.Instance);
+        }
+
+        /// <summary>
+        /// Gets every request, by its own identifier.
+        /// </summary>
+        public Dictionary<Guid, StoredRequest> Held { get; }
+
+        /// <summary>
+        /// Gets the requests each person is waiting for, whether they asked first or joined.
+        /// </summary>
+        public Dictionary<Guid, StoredRequest[]> ByUser { get; }
+
+        /// <summary>
+        /// Gets the requests carrying each external identifier.
+        /// </summary>
+        public Dictionary<ProviderKey, StoredRequest[]> ByProviderIdentifier { get; }
+
+        /// <summary>
+        /// The list under a key, made if it is the first one.
+        /// </summary>
+        /// <typeparam name="TKey">What the lookup is keyed by.</typeparam>
+        /// <param name="lookup">The lookup being built.</param>
+        /// <param name="key">The key.</param>
+        /// <returns>The list to add to.</returns>
+        private static List<StoredRequest> Under<TKey>(Dictionary<TKey, List<StoredRequest>> lookup, TKey key)
+            where TKey : notnull
+        {
+            if (!lookup.TryGetValue(key, out var under))
+            {
+                under = [];
+                lookup[key] = under;
+            }
+
+            return under;
+        }
+    }
+
+    /// <summary>
+    /// How two external identifiers are compared, which is the comparison
+    /// <see cref="RequestIdentity"/> makes and not the one a dictionary makes by default.
+    /// <para>
+    /// The provider name matches without case, because the same provider is spelled <c>Tmdb</c> and
+    /// <c>tmdb</c> by different callers and neither is wrong. The value matches exactly, because it
+    /// is somebody else's identifier and this plugin does not get to decide that two of them that
+    /// differ are the same. A store comparing either differently from
+    /// <see cref="RequestIdentity"/> would let a fulfilment sweep and a duplicate check disagree
+    /// about whether two things are one thing.
+    /// </para>
+    /// </summary>
+    private sealed class ProviderKeyComparer : IEqualityComparer<ProviderKey>
+    {
+        /// <summary>
+        /// Gets the one instance. It holds nothing, so a second would be a second object with the
+        /// same answers.
+        /// </summary>
+        public static ProviderKeyComparer Instance { get; } = new ProviderKeyComparer();
+
+        /// <inheritdoc />
+        public bool Equals(ProviderKey x, ProviderKey y)
+            => x.Kind == y.Kind
+                && string.Equals(x.Provider, y.Provider, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(x.Value, y.Value, StringComparison.Ordinal);
+
+        /// <inheritdoc />
+        public int GetHashCode(ProviderKey obj)
+            => HashCode.Combine(
+                obj.Kind,
+                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Provider),
+                StringComparer.Ordinal.GetHashCode(obj.Value));
     }
 }

--- a/Jellyfin.Plugin.Requests/Storage/IRequestStore.cs
+++ b/Jellyfin.Plugin.Requests/Storage/IRequestStore.cs
@@ -28,7 +28,9 @@ namespace Jellyfin.Plugin.Requests.Storage;
 /// that reads the whole store while writes are running may see request A as of one moment and
 /// request B as of another. Reading never blocks a writer and never blocks another reader. A
 /// snapshot is stale the moment it is taken, which is exactly why a write carries the revision it
-/// was read at.
+/// was read at. <see cref="PageAsync"/> is the one read that promises more: its page and its count
+/// come from one snapshot, because the two are read side by side on a screen and a disagreement
+/// between them is visible to the person reading it.
 /// </para>
 /// <para>
 /// <b>Two callers moving the same request.</b> Not last writer wins. Every write names the revision
@@ -72,14 +74,79 @@ public interface IRequestStore
     /// <summary>
     /// Reads every request the store holds.
     /// <para>
-    /// This is the whole-store read the contract above is stated over, and it is not the query
-    /// surface the administrator and user pages need. Filtering, sorting and paging are their own
-    /// work and are not on this interface yet.
+    /// This is the whole-store read the contract above is stated over, and it is not what a surface
+    /// should call. The three reads the surfaces actually make are below, and each is named because
+    /// a store built for three questions is a different store from one that answers all three by
+    /// walking everything. What each costs is in <c>docs/storage.md</c>.
     /// </para>
     /// </summary>
     /// <param name="cancellationToken">Cancels the read.</param>
     /// <returns>Every request, each with the revision the store holds it at, in no defined order.</returns>
     Task<IReadOnlyList<StoredRequest>> GetAllAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Every request one person is waiting for, whether they asked first or joined an existing one.
+    /// <para>
+    /// The two lists are one question. A store answering only <see cref="MediaRequest.RequestedByUserId"/>
+    /// would show a person nothing for the request they joined, which is the request they are most
+    /// likely to be looking for.
+    /// </para>
+    /// </summary>
+    /// <param name="userId">The Jellyfin user being asked about.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>
+    /// Their requests, each at the revision the store holds it at, in no defined order. Empty where
+    /// they have asked for nothing, which is an answer rather than an error.
+    /// </returns>
+    Task<IReadOnlyList<StoredRequest>> FindForUserAsync(Guid userId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Every request naming one external identifier, which is the question a fulfilment sweep asks
+    /// once per library item.
+    /// <para>
+    /// It answers identity and never policy. Which states a match may move, and whether a series
+    /// with some of its seasons counts, are the model's answers in <see cref="RequestIdentity"/> and
+    /// <see cref="LibraryAvailability"/>; a store deciding either would put half of the fulfilment
+    /// rule somewhere nobody looks for it. What comes back is at most a handful of requests, so the
+    /// caller filtering them costs nothing.
+    /// </para>
+    /// <para>
+    /// The kind is part of the question because a film and a series can carry the same number under
+    /// the same provider and be two different works, which is the rule <see cref="RequestIdentity"/>
+    /// is written to. Provider names match without case and values match exactly, for the reasons
+    /// stated there.
+    /// </para>
+    /// </summary>
+    /// <param name="kind">What sort of thing the identifier names.</param>
+    /// <param name="provider">The provider's name, matched without case.</param>
+    /// <param name="value">The identifier under that provider, matched exactly.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>
+    /// The requests carrying that identifier, each at the revision the store holds it at, in no
+    /// defined order. Empty where nothing has been asked for under it.
+    /// </returns>
+    /// <exception cref="ArgumentException">Where the provider name or the value is empty.</exception>
+    Task<IReadOnlyList<StoredRequest>> FindByProviderIdentifierAsync(
+        RequestedItemKind kind,
+        string provider,
+        string value,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// One page of the queue an operator reads, filtered, ordered and counted from a single
+    /// snapshot.
+    /// <para>
+    /// The count comes back with the page because a pager rendered from a second read can disagree
+    /// with the rows above it. What is filterable and what the order is are
+    /// <see cref="RequestQuery"/>'s, and the order is total: requests equal under the chosen key are
+    /// ordered by their own identifier, so walking the pages sees every match exactly once.
+    /// </para>
+    /// </summary>
+    /// <param name="query">Which requests, in what order, and which slice of them.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>The page and how many requests the filter matched.</returns>
+    /// <exception cref="ArgumentNullException">Where the query is missing.</exception>
+    Task<RequestPage> PageAsync(RequestQuery query, CancellationToken cancellationToken);
 
     /// <summary>
     /// Puts a request the store does not already hold into it.

--- a/Jellyfin.Plugin.Requests/Storage/RequestPage.cs
+++ b/Jellyfin.Plugin.Requests/Storage/RequestPage.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.Requests.Storage;
+
+/// <summary>
+/// One page of the queue, and how many requests the filter matched before the page was taken.
+/// <para>
+/// The count is here rather than on a second call because the two have to be answered from one
+/// snapshot. A page and a count taken from two reads can disagree, and a queue that says "showing 1
+/// to 50 of 49" is a queue an operator stops trusting for the rest of the numbers on the screen.
+/// </para>
+/// </summary>
+/// <param name="Requests">
+/// The requests on this page, in the order <see cref="RequestQuery.Order"/> asked for. Empty where
+/// the page starts past the end of the matches, which is an ordinary answer rather than an error:
+/// a request removed between two page turns shortens the queue under the reader.
+/// </param>
+/// <param name="MatchCount">
+/// How many requests matched the filter, whatever the page holds. This is what a pager is rendered
+/// from, and it is never the length of <see cref="Requests"/> unless the page happens to hold every
+/// match.
+/// </param>
+public readonly record struct RequestPage(IReadOnlyList<StoredRequest> Requests, int MatchCount);

--- a/Jellyfin.Plugin.Requests/Storage/RequestQuery.cs
+++ b/Jellyfin.Plugin.Requests/Storage/RequestQuery.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Jellyfin.Plugin.Requests.Model;
+
+namespace Jellyfin.Plugin.Requests.Storage;
+
+/// <summary>
+/// What the administrator queue asks the store for: which requests, in what order, and which slice
+/// of them.
+/// <para>
+/// Two filters rather than one per field. The state and the kind are what an operator narrows a
+/// queue by, and each one the store offers is a condition it has to be able to answer at the size
+/// the queue reaches. Adding a third is one line in the store's filter and one property here, and
+/// it is a decision rather than a convenience: <c>docs/storage.md</c> states what this path costs
+/// and a filter added without reading that is a filter added without paying for it.
+/// </para>
+/// <para>
+/// Whose requests these are is deliberately not a filter here. One person's requests are their own
+/// query path, <see cref="IRequestStore.FindForUserAsync"/>, because it is asked once per page view
+/// by every user on the server rather than by one operator, and it is served by a lookup instead of
+/// by a walk of the queue.
+/// </para>
+/// </summary>
+public sealed record RequestQuery
+{
+    private readonly IReadOnlyList<RequestState> _states = [];
+    private readonly IReadOnlyList<RequestedItemKind> _kinds = [];
+    private readonly int _skip;
+    private readonly int _take;
+
+    /// <summary>
+    /// Gets the states a request may be in to match, or empty for all of them. Empty means all
+    /// rather than none, because a query naming no state is a queue that has not been narrowed and
+    /// not a queue with nothing in it.
+    /// </summary>
+    public IReadOnlyList<RequestState> States
+    {
+        get => _states;
+        init => _states = [.. value ?? []];
+    }
+
+    /// <summary>
+    /// Gets the kinds of thing a request may name to match, or empty for all of them. Empty means
+    /// all, under the same rule as <see cref="States"/>.
+    /// </summary>
+    public IReadOnlyList<RequestedItemKind> Kinds
+    {
+        get => _kinds;
+        init => _kinds = [.. value ?? []];
+    }
+
+    /// <summary>
+    /// Gets what the matches are ordered by before the page is taken.
+    /// </summary>
+    public RequestQueryOrder Order { get; init; } = RequestQueryOrder.RequestedAt;
+
+    /// <summary>
+    /// Gets a value indicating whether the order runs the other way. A queue is usually read oldest
+    /// first, which is why this defaults to <see langword="false"/>, and the recently moved one is
+    /// read newest first.
+    /// </summary>
+    public bool Descending { get; init; }
+
+    /// <summary>
+    /// Gets how many matches to step over before the page starts.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">Where it is below zero.</exception>
+    public int Skip
+    {
+        get => _skip;
+        init
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            _skip = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets how many matches the page holds at most. Required, because a page size nobody stated is
+    /// one somebody inherited: the caller that wants the whole queue in one answer should have to
+    /// write that down.
+    /// <para>
+    /// Zero is legal and is the shape of "how many are there". It returns no requests and the count
+    /// of matches, which is what a surface asks when it is drawing a pager before it draws rows.
+    /// </para>
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">Where it is below zero.</exception>
+    public required int Take
+    {
+        get => _take;
+        init
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            _take = value;
+        }
+    }
+
+    /// <summary>
+    /// Whether one request is inside this query's filter. Here rather than in the store, so the
+    /// rule a page is taken under and the rule a count is made under cannot drift apart, and so a
+    /// filter added to this type is a filter every store keeps.
+    /// </summary>
+    /// <param name="request">The request being judged.</param>
+    /// <returns><see langword="true"/> where every named filter admits it.</returns>
+    /// <exception cref="ArgumentNullException">Where the request is missing.</exception>
+    public bool Matches(MediaRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // The emptiness is tested before the membership, in both filters, because an empty list
+        // contains nothing and asking it directly would turn "not narrowed" into "matches nothing".
+        if (_states.Count > 0 && !_states.Contains(request.State))
+        {
+            return false;
+        }
+
+        return _kinds.Count == 0 || _kinds.Contains(request.Kind);
+    }
+}

--- a/Jellyfin.Plugin.Requests/Storage/RequestQueryOrder.cs
+++ b/Jellyfin.Plugin.Requests/Storage/RequestQueryOrder.cs
@@ -1,0 +1,35 @@
+namespace Jellyfin.Plugin.Requests.Storage;
+
+/// <summary>
+/// What a page of the queue is ordered by. Three values rather than every field on the record,
+/// because an order the store offers is an order it has to keep stable across pages, and a column
+/// nobody sorts by is a promise nobody needed.
+/// <para>
+/// Whatever is chosen here, requests that compare equal under it are ordered by their own
+/// identifier, so two requests made in the same tick hold one position however the store happens to
+/// be enumerated that moment. That is what makes the order total, and a total order is what lets a
+/// reader turn a page without a row moving underneath them for a reason that has nothing to do with
+/// the column they sorted by.
+/// </para>
+/// </summary>
+public enum RequestQueryOrder
+{
+    /// <summary>
+    /// When it was asked for. The order a queue is read in by default: an operator works through
+    /// what has been waiting longest.
+    /// </summary>
+    RequestedAt = 0,
+
+    /// <summary>
+    /// When the state last moved. What an operator reads to see what has happened recently, which is
+    /// a different question from what has been waiting longest.
+    /// </summary>
+    StateChangedAt = 1,
+
+    /// <summary>
+    /// The title as it read when the request was made. Compared as text a person reads rather than
+    /// as bytes, so an accented title sorts beside its unaccented neighbour instead of after every
+    /// unaccented title there is.
+    /// </summary>
+    DisplayTitle = 2
+}

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -55,8 +55,77 @@ What is not decided here, and where it is:
 
 - What happens to a write interrupted halfway is #46.
 - The on-disk shape, its version, and the rules for changing it are #47.
-- Filtering, sorting and paging for the surfaces are #48.
 - How long a finished request is kept is #49, and the number itself is decision 5 on #113.
+
+## The three questions the store is asked
+
+There are three, and naming them is the point: a store built for three questions is a different store
+from one that answers all of them by walking everything it holds.
+
+**One person's own requests.** The user surface asks it, once per page view, for every person on the
+server. Answered by a lookup keyed on the user, holding the requests they asked for and the ones they
+joined, because a surface that showed only the first would show somebody nothing for the request they
+are most likely to be looking for.
+
+**One external identifier.** Fulfilment detection asks it once per library item, which is where a
+walk becomes ten thousand walks. Answered by a lookup keyed on the kind, the provider name and the
+value, compared the way `RequestIdentity` compares them: the name without case, the value exactly.
+The lookup answers identity and never policy. Which states a match may move, and whether a series
+with some of its seasons counts, stay in the model, and what comes back is at most a handful of
+requests so a caller filtering them costs nothing.
+
+**A page of the queue.** The administrator surface asks it, filtered by state and kind, ordered by
+one of three columns, and paged. This one is a walk of the whole set and is meant to be: a filter and
+an order chosen at the call cannot be served by a lookup built before the call. The count of matches
+comes back with the page, from the same walk, so a pager cannot disagree with the rows above it.
+
+Both lookups are built beside the set each time the set is replaced, which costs one pass over it per
+write. That is the same order as serialising the set, which the write has just done, so a write does
+not change shape for having them. Keeping them up to date incrementally instead would mean editing
+the held set in place, which is the thing the whole store is built not to do.
+
+The order every page is taken in ends with the request's own identifier, so requests that compare
+equal under the chosen column still hold one position. Without that, their order is the order the set
+happens to be enumerated in, and the set is rebuilt on every write: one request created between two
+page turns can reorder rows that have nothing to do with it.
+
+## What those three cost at ten thousand records
+
+The bounds are in the suite rather than here, in `FileRequestStoreQueryCostTests`, so a change that
+breaks one fails rather than being noticed by somebody with a large queue. Each leg measures the
+workload the path carries rather than one call of it, because one call answered by walking ten
+thousand records takes under a millisecond and a bound over one call would pass whatever shape sat
+underneath it.
+
+The numbers below were read by setting each bound to zero, so the assertion fails and prints what it
+measured, and running the leg on an ordinary desktop:
+
+    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release --no-build -f net9.0 \
+        --filter "FullyQualifiedName~FileRequestStoreQueryCostTests"
+    a hundred filtered and ordered pages over 10000 records took 153 ms, past the bound of 0 ms.
+    one identifier lookup for each of ten thousand records over 10000 records took 10 ms, past the bound of 0 ms.
+    ten thousand user lookups over 10000 records took 5 ms, past the bound of 0 ms.
+
+The third column is the same command over a tree with the two lookups replaced by a walk of the set,
+which is the change each bound exists to refuse:
+
+| Path                    | Workload measured           | As it ships | With the lookup replaced by a walk | Bound in the suite |
+| ----------------------- | --------------------------- | ----------: | ---------------------------------: | -----------------: |
+| One person's requests   | 10,000 lookups              |        5 ms |                           2,610 ms |             400 ms |
+| One external identifier | 10,000 lookups              |       10 ms |                           3,070 ms |             600 ms |
+| A page of the queue     | 100 filtered, ordered pages |      153 ms |                              98 ms |           8,000 ms |
+
+The second column of numbers is how the first two bounds were placed. Each sits far above the run it
+passes and far below the failure it exists for, so a machine several times slower than this one still
+passes and a store that lost a lookup still fails.
+
+The third row is the one to read carefully. Turning the two lookups into walks left it where it was,
+so that bound does not separate a walk from a lookup and nothing here claims it does. What it catches
+is a page that stops being one walk: a read that goes back to the file per call, or a count taken by
+a second pass over the set.
+
+None of the three bounds is a benchmark, and none of them catches a path that is merely slower than
+it could be.
 
 ## It adds no package reference
 


### PR DESCRIPTION
Closes #48.

The store held one read of the whole set and nothing else. The user page and the
fulfilment sweep would each have had to find their answer inside it, once per page
view and once per library item, and the administrator queue had no filter, no
order and no page at all.

## What the three paths are

`IRequestStore` now names the three reads the surfaces make, and `docs/storage.md`
carries the shape that serves each.

One person's own requests, and one external identifier, are answered by lookups
built beside the set each time the set is replaced. The first is keyed on the
user and holds both the requests they asked for and the ones they joined. The
second is keyed on the kind, the provider name and the value, compared the way
`RequestIdentity` compares them: the name without case, the value exactly. It
answers identity and never policy, so which states a match may move stays in the
model where the rest of that rule is.

A page of the queue stays a walk of the set and is meant to be. A filter and an
order chosen at the call cannot be served by a lookup built before the call. The
count of matches comes back from that same walk, so a pager cannot disagree with
the rows above it.

Building the two lookups costs one pass over the set per write, which is the same
order as serialising the set that the write has just done.

## The order is total, and the tiebreak was proven by deleting it

Every order ends with the request's own identifier. Without it, requests equal
under the chosen column are ordered by whatever order the set is enumerated in,
and the set is a dictionary rebuilt on every write, so one request created between
two page turns reorders rows that have nothing to do with it.

Removing `.ThenBy(Id)` and `.ThenByDescending(Id)` from `Ordered`:

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release --no-build -f net9.0 \
        --filter "FullyQualifiedName~FileRequestStoreTests"
    Jellyfin.Plugin.Requests.Tests.Storage.FileRequestStoreTests.DescendingIsTheAscendingOrderReadBackwards [FAIL]
       Assert.Equal() Failure: Collections differ
    Fehler!: Fehler: 1, erfolgreich: 22, gesamt: 23

`WalkingThePagesSeesEveryMatchExactlyOnce` stays green under that deletion,
because the sort behind it is stable and the set is enumerated the same way twice
in one test. Its own documentation says so rather than claiming the proof it does
not carry.

## The bounds, and what they catch

`FileRequestStoreQueryCostTests` loads ten thousand records and holds each path to
a bound stated as a constant in the test. Each leg measures the workload the path
carries rather than one call of it, because one call answered by walking ten
thousand records takes under a millisecond and a bound over one call would pass
whatever shape sat underneath.

The numbers were read by setting each bound to zero so the assertion prints what
it measured:

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release --no-build -f net9.0 \
        --filter "FullyQualifiedName~FileRequestStoreQueryCostTests"
    a hundred filtered and ordered pages over 10000 records took 153 ms, past the bound of 0 ms.
    one identifier lookup for each of ten thousand records over 10000 records took 10 ms, past the bound of 0 ms.
    ten thousand user lookups over 10000 records took 5 ms, past the bound of 0 ms.

and again over a tree with the two lookups replaced by a walk of the set, which is
the change the bounds exist to refuse:

    a hundred filtered and ordered pages over 10000 records took 98 ms, past the bound of 0 ms.
    one identifier lookup for each of ten thousand records over 10000 records took 3070 ms, past the bound of 0 ms.
    ten thousand user lookups over 10000 records took 2610 ms, past the bound of 0 ms.

Bounds are 400 ms, 600 ms and 8,000 ms. Each of the first two sits far above the
run it passes and far below the failure it is for.

The queue bound is the one to read carefully, and `docs/storage.md` says this in
the document as well: turning the lookups into walks left that leg where it was,
so it does not separate a walk from a lookup and nothing here claims it does. What
it catches is a page that stops being one walk. None of the three is a benchmark,
and none catches a path that is merely slower than it could be.

## The suite

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    0 Warnung(en), 0 Fehler
    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release --no-build
    Bestanden!: Fehler: 0, erfolgreich: 210, gesamt: 210 (net9.0)
    Bestanden!: Fehler: 0, erfolgreich: 210, gesamt: 210 (net10.0)

Nine of the new tests are on `RequestStoreContract`, so both the shipped store and
the in-memory double are judged by them. The double answers the three paths by
walking its own dictionary and writes its own comparison out rather than borrowing
the shipped one, because a double that shared the implementation would agree with
it by construction.

## The means

Unchanged, and that is the answer rather than an omission. Nothing here adds a
package reference, a language or a runtime: both lookups are dictionaries the
runtime already supplies, and the bounds are assertions in the suite that already
exists. A means that could not carry a refusable property or an executed proof
would have failed the same check.

## What this does not cover

The file the cost test loads is written directly rather than through ten thousand
calls of the store's own add, each of which rewrites the whole set. That couples
the test to the on-disk shape #47 owns; the count asserted after the load is what
turns a change to that shape into a failure with a reason rather than a leg
quietly measuring an empty store.

Nobody else has read this change.

