### PR TITLE
Pick the API prefix and the version rule, and refuse an endpoint outside it (#50)

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Api/RequestsApiLayoutTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/RequestsApiLayoutTests.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using Jellyfin.Plugin.Requests.Api;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Api;
+
+/// <summary>
+/// Where this plugin's API sits, held by the suite rather than by the document that argues it.
+/// <para>
+/// The invariant lint holds the same rule over the source text, and the two halves are not the same
+/// check. The lint reads files under a path list and cannot see a controller written somewhere that
+/// list does not reach; this reads the built assembly and cannot see a route that is correct in a
+/// file nobody compiled. Together they cover the case each one misses alone.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class RequestsApiLayoutTests
+{
+    /// <summary>
+    /// The prefix carries the version segment, and the two are not two strings that happen to agree
+    /// today. A path and a version that can be edited apart is how an endpoint ends up answering
+    /// under a number that no longer describes what it returns.
+    /// </summary>
+    [Fact]
+    public void ThePrefixCarriesTheVersionSegment()
+    {
+        Assert.Equal("v1", RequestsControllerBase.VersionSegment, StringComparer.Ordinal);
+        Assert.Equal("MediaRequests/v1", RequestsControllerBase.RoutePrefix, StringComparer.Ordinal);
+        Assert.EndsWith(
+            "/" + RequestsControllerBase.VersionSegment,
+            RequestsControllerBase.RoutePrefix,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The prefix is relative. A template beginning with a slash is an absolute route, and one on the
+    /// base class would put every endpoint at the root of the server's API rather than under a prefix
+    /// of this plugin's own, which is the failure the whole layout exists to prevent and the one a
+    /// reader of the string would not notice.
+    /// </summary>
+    [Fact]
+    public void ThePrefixIsRelativeRatherThanRootedAtTheServersApi()
+    {
+        Assert.False(
+            RequestsControllerBase.RoutePrefix.StartsWith('/'),
+            "The route prefix begins with a slash, which makes it an absolute route at the root of the server's API.");
+    }
+
+    /// <summary>
+    /// The base class declares the prefix, once, as the route every endpoint inherits.
+    /// </summary>
+    [Fact]
+    public void TheBaseClassDeclaresThePrefixAsItsRoute()
+    {
+        var routes = typeof(RequestsControllerBase)
+            .GetCustomAttributes<RouteAttribute>(inherit: false)
+            .Select(route => route.Template)
+            .ToArray();
+
+        Assert.Equal([RequestsControllerBase.RoutePrefix], routes);
+    }
+
+    /// <summary>
+    /// Every controller in the plugin derives from the base and declares no route of its own, so
+    /// every endpoint sits under the versioned prefix.
+    /// <para>
+    /// This is the leg that bites when an endpoint is added. It passes over an assembly with no
+    /// controller in it yet, which is the state the tree is in the moment the layout lands and
+    /// before anything is served, so the assertion below that at least the base class is present is
+    /// what stops the whole test from being vacuously green if the API ever disappears.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void EveryControllerInheritsTheVersionedPrefix()
+    {
+        var controllers = typeof(RequestsControllerBase).Assembly
+            .GetTypes()
+            .Where(type => typeof(ControllerBase).IsAssignableFrom(type))
+            .Where(type => !type.IsAbstract)
+            .ToArray();
+
+        var outside = controllers
+            .Where(type => !typeof(RequestsControllerBase).IsAssignableFrom(type)
+                || type.GetCustomAttributes<RouteAttribute>(inherit: false).Any())
+            .Select(type => type.FullName ?? type.Name)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal([], outside);
+        Assert.Contains(typeof(RequestsControllerBase), typeof(RequestsControllerBase).Assembly.GetTypes());
+    }
+
+    /// <summary>
+    /// No endpoint anywhere in the plugin carries a template that begins with a slash. ASP.NET reads
+    /// one as an absolute route and discards the controller's prefix, so such an endpoint answers
+    /// outside the version every promise in <c>docs/api.md</c> is written about, while reading in the
+    /// source like a relative path with a stray character.
+    /// </summary>
+    [Fact]
+    public void NoEndpointTemplateIsRootedAtTheServersApi()
+    {
+        var rooted = typeof(RequestsControllerBase).Assembly
+            .GetTypes()
+            .Where(type => typeof(ControllerBase).IsAssignableFrom(type))
+            .SelectMany(type => type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                .SelectMany(method => method.GetCustomAttributes<HttpMethodAttribute>()
+                    .Where(verb => verb.Template is not null && verb.Template.StartsWith('/'))
+                    .Select(verb => string.Format(
+                        CultureInfo.InvariantCulture,
+                        "{0}.{1} -> {2}",
+                        type.Name,
+                        method.Name,
+                        verb.Template))))
+            .OrderBy(named => named, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal([], rooted);
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/SiblingIndependenceTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/SiblingIndependenceTests.cs
@@ -38,6 +38,14 @@ public class SiblingIndependenceTests
         "MediaBrowser.Common",
         "MediaBrowser.Controller",
         "MediaBrowser.Model",
+
+        // The API this plugin serves is mounted on the server's own, so its controllers are the
+        // server's web framework's controllers. This is the assembly holding `ControllerBase`, the
+        // routing attributes and the result types, and it is part of the framework the server runs
+        // on rather than a package this plugin carries: the package excludes the runtime assets, so
+        // nothing of it is in the install. Serving an API without it would mean a second web stack
+        // inside a plugin.
+        "Microsoft.AspNetCore.Mvc.Core",
         "Microsoft.Extensions.DependencyInjection.Abstractions",
         "System.Collections",
         "System.Linq",

--- a/Jellyfin.Plugin.Requests/Api/RequestsControllerBase.cs
+++ b/Jellyfin.Plugin.Requests/Api/RequestsControllerBase.cs
@@ -1,0 +1,52 @@
+using System.Net.Mime;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Jellyfin.Plugin.Requests.Api;
+
+/// <summary>
+/// Where this plugin's API lives, declared once so every endpoint inherits it.
+/// <para>
+/// A plugin controller is mounted on the server's own API, beside the server's routes and beside
+/// every other plugin's. The prefix is permanent in the only sense that matters: a script an
+/// operator wrote, the sibling discover plugin and anything anybody built against it all break the
+/// day it changes. The rule for changing it, what counts as a breaking change and what does not,
+/// is <c>docs/api.md</c>, and it is written down rather than left to whoever ships the second
+/// version.
+/// </para>
+/// <para>
+/// Every endpoint sits under <see cref="RoutePrefix"/> because it is declared here and inherited,
+/// and the two ways out of that are refused by <c>every-endpoint-sits-under-the-versioned-prefix</c>
+/// in the invariant lint: a second route attribute anywhere else, and a method template beginning
+/// with a slash, which silently replaces the controller's route rather than extending it.
+/// </para>
+/// </summary>
+[ApiController]
+[Route(RoutePrefix)]
+[Produces(MediaTypeNames.Application.Json)]
+public abstract class RequestsControllerBase : ControllerBase
+{
+    /// <summary>
+    /// The version segment every endpoint under <see cref="RoutePrefix"/> answers as.
+    /// <para>
+    /// It is in the path rather than in a header. A caller that has to set a header to get the shape
+    /// it expects is a caller that gets some other shape the first time somebody forgets, and a
+    /// version in the path is visible in a log, in a browser and in the script an operator wrote.
+    /// </para>
+    /// </summary>
+    public const string VersionSegment = "v1";
+
+    /// <summary>
+    /// The prefix every endpoint sits under, version segment included. Built from
+    /// <see cref="VersionSegment"/> rather than written out again, so the two cannot say different
+    /// numbers.
+    /// <para>
+    /// <c>MediaRequests</c> rather than <c>Requests</c>. The word on its own is a generic noun in an
+    /// API whose neighbouring segments are <c>Items</c>, <c>Users</c> and <c>Sessions</c>, and a
+    /// plugin taking it is a plugin betting that neither the server nor any other plugin ever wants
+    /// it. The server's route table was not enumerated to check, so this lowers the chance of a
+    /// collision rather than proving there is none. The compound noun costs nothing today, and a
+    /// rename later is exactly the breaking change the version segment exists to make survivable.
+    /// </para>
+    /// </summary>
+    public const string RoutePrefix = "MediaRequests/" + VersionSegment;
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,102 @@
+# The API
+
+## The prefix
+
+Every endpoint this plugin serves sits under one prefix, version segment included:
+
+    MediaRequests/v1
+
+It is mounted on the server's own API, so a caller reaches it at the server's address and nothing
+about it is on a port or a host of this plugin's own.
+
+`MediaRequests` rather than `Requests`. A plugin controller sits beside the server's routes and
+beside every other plugin's, and `Requests` on its own is a generic noun in an API whose neighbouring
+segments are `Items`, `Users` and `Sessions`. Taking it is a bet that neither the server nor any
+other plugin ever wants it. The server's route table was not enumerated to check, so the compound
+noun lowers the chance of a collision rather than proving there is none. It costs nothing today, and
+a rename later is exactly the breaking change the version segment exists to make survivable.
+
+The prefix is declared once, as `RequestsControllerBase.RoutePrefix`, and every controller inherits
+it. `RoutePrefix` is built from `VersionSegment` rather than written out again, so the path and the
+version cannot come to say different numbers.
+
+## The version rule
+
+The version is a whole number in the path. It is not a header and not a query parameter: a caller
+that has to set a header to get the shape it expects is a caller that gets some other shape the first
+time somebody forgets, and a version in a path is visible in a log, in a browser and in the script an
+operator wrote.
+
+**A breaking change ships as a new version segment beside the old one, never as an edit to the
+existing one.** `v2` appears, `v1` keeps answering as it did, and callers move when they move. What
+`v1` may never do is change under a caller who did not ask for it.
+
+Nothing here says how long an old version is kept. That is a decision for the release the first one
+is retired in, and it needs an install base to be decided against.
+
+### What counts as breaking
+
+A change is breaking when a caller written against the current version, and behaving correctly, can
+start getting an answer it cannot use.
+
+- Removing an endpoint, or moving one to a different path.
+- Removing a field from a response, or renaming one.
+- Changing the type of a field, or narrowing what a field accepts.
+- Adding a required field to a request body, or making an optional one required.
+- Changing which status code an outcome is reported with, where a caller branches on it.
+- Changing what a value means while keeping its name.
+
+Two examples of the same size, one on each side of the line.
+
+**Breaking.** `state` on a request is renamed to `status`. Every caller reading the field gets
+nothing, and nothing tells them why: the response still parses, the field they want is simply absent.
+This ships as `v2`.
+
+**Not breaking.** A `note` field is added to the response for a request. A caller that does not know
+about it ignores it, and a caller that wants it asks for the same endpoint and finds it there. This
+ships inside `v1`.
+
+### What is not breaking, and is written down here because it looks like it is
+
+**A new value in an enumerated field.** `state` grew a fifth value when a failed state was decided,
+and a sixth is possible. This is not breaking, and the reason it is not is a promise made here rather
+than a fact about the change: **a caller must treat a value it does not recognise as one it does not
+recognise**, and must not fail, and must not map it onto a value it does know. A caller that switches
+exhaustively over the values that existed the day it was written is a caller this contract does not
+promise anything to.
+
+That rule is stated now, in the first version, because stating it later would itself be the breaking
+change. A contract that starts by promising a closed set cannot open it afterwards without a new
+version, and every enumerated field in this API would be frozen for as long as `v1` answers.
+
+**A new optional field in a request body**, and **a new endpoint under the same prefix**. Neither
+changes anything a caller already sends or already reads.
+
+## What holds the prefix
+
+`every-endpoint-sits-under-the-versioned-prefix`, in `tools/opengrep/rules.yaml`, refuses the two
+ways out of it:
+
+- a second route attribute anywhere in the plugin, which replaces the inherited prefix for that
+  controller;
+- a method template beginning with a slash, which is the quieter of the two. It reads as a relative
+  path with a stray character and ASP.NET treats it as an absolute route, discarding the controller's
+  prefix entirely.
+
+The one file excluded from the rule is the one that declares the prefix. The rule is watched refusing
+both spellings on a fixture, in `tools/opengrep/fixtures/route/`, so a pattern that stopped matching
+reds the gate rather than passing quietly:
+
+    ./tools/opengrep/prove-rules-fire.sh
+
+`EveryControllerInheritsTheVersionedPrefix` in the suite is the other half, and it is the half that
+reads the built assembly rather than the source text: every controller type in the plugin derives
+from `RequestsControllerBase` and declares no route of its own. A controller written in a file the
+rule's path list does not reach would pass the lint and fail there.
+
+## What is not decided here
+
+- Which policy each endpoint carries, and what a user may see of somebody else's request, is #51.
+- The shape of an error and which status code each failure gets is #56.
+- What each endpoint does is #52, #53, #54 and #55.
+- Whether these endpoints appear in the server's published API documentation is #57.

--- a/tools/opengrep/fixtures/route/EscapesTheVersionedPrefix.cs
+++ b/tools/opengrep/fixtures/route/EscapesTheVersionedPrefix.cs
@@ -1,0 +1,46 @@
+// Fixture for every-endpoint-sits-under-the-versioned-prefix. This file is in no
+// project and is never compiled; it exists so the rule can be watched refusing
+// the mistake it names.
+//
+// The near-miss is the second one below. Somebody adds an endpoint, writes the
+// template the way every other framework writes a path, and the leading slash
+// turns it from a segment under the controller's prefix into a route of its own
+// at the root of the server's API. It compiles, it answers, and it is outside
+// the version every compatibility promise in docs/api.md is written about.
+
+namespace Jellyfin.Plugin.Requests.Fixtures;
+
+public sealed class EscapesTheVersionedPrefix : RequestsControllerBase
+{
+    // Legal neighbours, left here on purpose: this is how an endpoint is written
+    // and the rule has to stay quiet on both. The template is relative, so it
+    // extends the prefix the base class declares instead of replacing it.
+    [HttpGet("Requests")]
+    public IActionResult List() => Ok();
+
+    [HttpPost("Requests")]
+    public IActionResult Create() => Ok();
+
+    // The regression, in both spellings. A route attribute of its own replaces
+    // the inherited prefix for the whole controller.
+    [Route("Requests")]
+    public IActionResult ListSomewhereElse() => Ok();
+
+    // And the leading slash, once per verb the plugin will use, because a rule
+    // that covers the verb somebody used and not the one they will use next is a
+    // rule that passes on the day it matters.
+    [HttpGet("/Requests")]
+    public IActionResult ReadAtTheRoot() => Ok();
+
+    [HttpPost("/Requests")]
+    public IActionResult CreateAtTheRoot() => Ok();
+
+    [HttpPut("/Requests/1")]
+    public IActionResult ReplaceAtTheRoot() => Ok();
+
+    [HttpPatch("/Requests/1")]
+    public IActionResult AmendAtTheRoot() => Ok();
+
+    [HttpDelete("/Requests/1")]
+    public IActionResult RemoveAtTheRoot() => Ok();
+}

--- a/tools/opengrep/rules.yaml
+++ b/tools/opengrep/rules.yaml
@@ -314,3 +314,41 @@ rules:
         - "tools/opengrep/fixtures/history/**/*.cs"
       exclude:
         - "Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs"
+
+  # Invariant (api, #50): every endpoint this plugin serves sits under the
+  # versioned prefix, and the prefix is declared in exactly one place. Decided in
+  # docs/api.md, whose version rule is worth nothing if an endpoint can sit
+  # outside the segment the rule is about: a caller pinned to v1 would reach a
+  # route that has no version at all and would break on a change the rule said
+  # was safe.
+  #
+  # Two spellings get out of the prefix and both are refused. A second `[Route]`
+  # attribute anywhere replaces the inherited one for that controller.
+  # `[HttpGet("/...")]`, with a leading slash, is the quieter of the two: the
+  # template looks like a relative path with a typo, and ASP.NET treats it as an
+  # absolute route that discards the controller's prefix entirely.
+  #
+  # RequestsControllerBase is the one place excluded, because it is the file that
+  # declares the prefix this rule exists to hold everything else to.
+  - id: every-endpoint-sits-under-the-versioned-prefix
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      Do not declare a route here. Every endpoint inherits the versioned prefix
+      from RequestsControllerBase, and a route attribute of its own, or a method
+      template beginning with a slash, puts an endpoint outside the version the
+      compatibility rule in docs/api.md is written about (#50).
+    patterns:
+      - pattern-either:
+          - pattern: '[Route(...)]'
+          - pattern: '[HttpGet("/...")]'
+          - pattern: '[HttpPost("/...")]'
+          - pattern: '[HttpPut("/...")]'
+          - pattern: '[HttpPatch("/...")]'
+          - pattern: '[HttpDelete("/...")]'
+    paths:
+      include:
+        - "Jellyfin.Plugin.Requests/**/*.cs"
+        - "tools/opengrep/fixtures/route/**/*.cs"
+      exclude:
+        - "Jellyfin.Plugin.Requests/Api/RequestsControllerBase.cs"


### PR DESCRIPTION
Closes #50.

## The prefix

`MediaRequests/v1`, declared once on `RequestsControllerBase` and inherited by
every controller.

The bare word `Requests` was not taken. A plugin controller sits beside the
server's routes and beside every other plugin's, and `Requests` is a generic noun
in an API whose neighbouring segments are `Items`, `Users` and `Sessions`. The
server's route table was not enumerated to check for a collision, so the compound
noun lowers the chance of one rather than proving there is none, and `docs/api.md`
says that rather than implying a check that was not made.

`RoutePrefix` is built from `VersionSegment`, so the path and the version cannot
come to say different numbers.

## The version rule

In `docs/api.md`, with an example on each side of the line. Renaming `state` to
`status` is breaking and ships as `v2` beside a `v1` that keeps answering; adding
a `note` field to a response is not and ships inside `v1`.

The part worth reading is the case that looks breaking and is not. A new value in
an enumerated field is not breaking **because the contract says now that a caller
must treat a value it does not recognise as one it does not recognise**. That has
to be stated in the first version: a contract that starts by promising a closed
set cannot open it while the same version answers, so stating it later would be
the breaking change. `state` already grew a fifth value once.

## Both guards were watched refusing

The lint rule and the suite test are not the same check. The lint reads source
text under a path list and cannot see a controller written outside it; the suite
reads the built assembly and cannot see a file nobody compiled.

A controller with a route of its own and a rooted template, added temporarily and
removed before this was pushed:

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release --no-build -f net9.0 \
        --filter "FullyQualifiedName~RequestsApiLayoutTests"
    RequestsApiLayoutTests.NoEndpointTemplateIsRootedAtTheServersApi [FAIL]
       Assert.Equal() Failure: Collections differ
       Actual: ["TemporaryProofController.ReadAtTheRoot -> /Request"...]
    RequestsApiLayoutTests.EveryControllerInheritsTheVersionedPrefix [FAIL]
       Assert.Equal() Failure: Collections differ
       Actual: ["Jellyfin.Plugin.Requests.Api.TemporaryProofControl"...]
    Fehler!: Fehler: 2, erfolgreich: 3, gesamt: 5

The lint rule's fixture carries both spellings beside two legal neighbours, and
`prove-rules-fire.sh` is what makes that a standing proof rather than a state
somebody checked once. Opengrep publishes a Linux binary only, so the fixture leg
was not run on this machine: `Enforce greppable invariants` on this pull request is
the run that judges it.

The leading slash is the spelling worth having a rule for. It reads as a relative
path with a stray character, and ASP.NET treats it as an absolute route that
discards the controller's prefix entirely, so the endpoint answers outside the
version every promise in the document is written about.

## The suite

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    0 Warnung(en), 0 Fehler
    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release --no-build
    Bestanden!: Fehler: 0, erfolgreich: 215, gesamt: 215 (net9.0)
    Bestanden!: Fehler: 0, erfolgreich: 215, gesamt: 215 (net10.0)

## One reference is added

`Microsoft.AspNetCore.Mvc.Core`, which is the deliberate act the list in #94 was
built for. It is the server's own web framework, the package excludes the runtime
assets so nothing of it lands in the install, and an API mounted on the host
without it would mean a second web stack inside a plugin. It is the only name the
build added:

    Actual: ... | MediaBrowser.Model | Microsoft.AspNetCore.Mvc.Core | Microsoft.Extensions.DependencyInjection.Abstractions | ...

## What this does not cover

No endpoint is served yet. `EveryControllerInheritsTheVersionedPrefix` passes over
an assembly holding only the abstract base, which is the tree's state until #52,
so what it proves today is that the base is there and that nothing has escaped;
what it proves from the first endpoint onward is the condition the issue asks for.

The issue's `Scope:` line names the controllers and `docs/api.md`. Its second
done-condition asks for a rule in the invariant lint, which lives in `tools/`, and
the reference list it moves lives in the test project. Both are named here rather
than left for a reader to find in the diff.

Nobody else has read this change.
