### PR TITLE
Create a request over the API, and join rather than duplicate (#52)

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Api/CreateRequestTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/CreateRequestTests.cs
@@ -1,0 +1,418 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Api;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Api;
+
+/// <summary>
+/// Asking for something over the API.
+/// <para>
+/// The action is called directly rather than through a server. The headless rule refuses a running
+/// Jellyfin, and what these judge is what the endpoint does with a body and an identity, which is
+/// the whole of its behaviour. What that leaves out is named where it matters: the model binder is
+/// not exercised by the framework, so the leg about a body naming a different user deserialises the
+/// bytes with the same serialiser the server's binder uses and asserts on the result, rather than
+/// claiming a round trip that did not happen.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class CreateRequestTests
+{
+    /// <summary>
+    /// How the server's binder reads a body, which is System.Text.Json with the casing the framework
+    /// uses. Held once so the leg below measures the binder's behaviour rather than an option set
+    /// invented per call.
+    /// </summary>
+    private static readonly JsonSerializerOptions AsTheBinderReadsIt = new JsonSerializerOptions
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private static readonly Guid Asker = new Guid("a1000000-0000-0000-0000-000000000001");
+    private static readonly Guid SecondPerson = new Guid("a1000000-0000-0000-0000-000000000002");
+
+    /// <summary>
+    /// One source of identifiers for the whole of a test, however many controllers it builds. A
+    /// source per controller would hand the same first identifier to two of them, and the second
+    /// request would be refused by the store for a reason no server would ever produce.
+    /// </summary>
+    private readonly SequentialIdentifierSource _identifiers = new SequentialIdentifierSource();
+
+    /// <summary>
+    /// Nothing in the queue names this, so a request is made, it is returned with its identifier and
+    /// its state, and the store holds it against the person who called.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AskingForSomethingNobodyHasAskedForCreatesIt()
+    {
+        var store = new InMemoryRequestStore();
+        var controller = ControllerFor(store, Asker);
+
+        var answered = await controller.CreateAsync(AFilm(), CancellationToken.None).ConfigureAwait(true);
+        var made = Answer(answered, expectedStatus: 201);
+
+        var held = await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true);
+        Assert.Equal(RequestOutcome.Created, made.Outcome);
+        Assert.Equal(RequestState.Open, made.State);
+        Assert.Single(held);
+        Assert.Equal(made.Id, held[0].Request.Id);
+        Assert.Equal(Asker, held[0].Request.RequestedByUserId);
+        Assert.Equal("The Conversation", held[0].Request.DisplayTitle, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// A second person asking for the same thing joins the request that is already there, and the
+    /// answer says so. Two people asking for one film is one request, so the failure this stands for
+    /// is a queue that grows a second row an operator has to decide twice.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AskingForSomethingAlreadyInTheQueueJoinsIt()
+    {
+        var store = new InMemoryRequestStore();
+        var first = Answer(
+            await ControllerFor(store, Asker).CreateAsync(AFilm(), CancellationToken.None).ConfigureAwait(true),
+            expectedStatus: 201);
+
+        var second = Answer(
+            await ControllerFor(store, SecondPerson).CreateAsync(AFilm(), CancellationToken.None).ConfigureAwait(true),
+            expectedStatus: 200);
+
+        var held = await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true);
+        Assert.Equal(RequestOutcome.Joined, second.Outcome);
+        Assert.Equal(first.Id, second.Id);
+        Assert.Single(held);
+        Assert.True(held[0].Request.WasAskedForBy(Asker));
+        Assert.True(held[0].Request.WasAskedForBy(SecondPerson));
+    }
+
+    /// <summary>
+    /// Asking again for something you are already waiting for writes nothing and says as much.
+    /// Asking twice is not a second fact about the request, and a store that recorded it would count
+    /// clicks rather than people.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AskingAgainForYourOwnRequestChangesNothing()
+    {
+        var store = new InMemoryRequestStore();
+        var controller = ControllerFor(store, Asker);
+        await controller.CreateAsync(AFilm(), CancellationToken.None).ConfigureAwait(true);
+        var before = (await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true))[0];
+
+        var again = Answer(
+            await controller.CreateAsync(AFilm(), CancellationToken.None).ConfigureAwait(true),
+            expectedStatus: 200);
+
+        var after = await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true);
+        Assert.Equal(RequestOutcome.AlreadyWaiting, again.Outcome);
+        Assert.Single(after);
+        Assert.Equal(before.Revision, after[0].Revision);
+        Assert.Empty(after[0].Request.JoinedByUserIds);
+    }
+
+    /// <summary>
+    /// A body naming a different user is not honoured, and the reason it is not is that there is
+    /// nowhere for it to go.
+    /// <para>
+    /// Two halves. The type carries no property that could hold a requester, so the serialiser the
+    /// server's binder uses has nothing to bind such a field to and drops it. And the request the
+    /// endpoint stored is against the caller, which is the outcome that would be wrong if the first
+    /// half ever stopped being true.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ABodyNamingADifferentUserIsIgnoredRatherThanHonoured()
+    {
+        var somebodyElse = new Guid("a1000000-0000-0000-0000-00000000dead");
+        // The field a caller would use to file a request as somebody else. It is written out here
+        // because there is nothing in the plugin to name: the point of the leg is that no such
+        // property exists.
+        var sent = string.Concat(
+            "{\"kind\":0,\"title\":\"The Conversation\",\"providerIds\":{\"Tmdb\":\"603\"},\"requestedByUserId\":\"",
+            somebodyElse.ToString("D", CultureInfo.InvariantCulture),
+            "\"}");
+
+        var carriesARequester = typeof(CreateRequestBody)
+            .GetProperties()
+            .Any(property => property.Name.Contains("User", StringComparison.OrdinalIgnoreCase)
+                || property.Name.Contains("Requester", StringComparison.OrdinalIgnoreCase));
+
+        var bound = JsonSerializer.Deserialize<CreateRequestBody>(sent, AsTheBinderReadsIt);
+
+        var store = new InMemoryRequestStore();
+        await ControllerFor(store, Asker).CreateAsync(bound!, CancellationToken.None).ConfigureAwait(true);
+
+        var held = await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true);
+        Assert.False(carriesARequester, "The body carries a property that could name a requester.");
+        Assert.Equal(Asker, held[0].Request.RequestedByUserId);
+        Assert.False(held[0].Request.WasAskedForBy(somebodyElse));
+    }
+
+    /// <summary>
+    /// A call that authenticated but names no person is refused. An API key reaches this endpoint
+    /// under the server's policy and there is nobody to record as having asked, so the alternative
+    /// is a request filed against an identifier that is not anybody.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ACallThatNamesNoPersonIsRefused()
+    {
+        var store = new InMemoryRequestStore();
+        var controller = ControllerFor(store, caller: null);
+
+        var refused = Refusal(await controller.CreateAsync(AFilm(), CancellationToken.None).ConfigureAwait(true));
+
+        Assert.Equal("caller", refused.Field, StringComparer.Ordinal);
+        Assert.Empty(await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true));
+    }
+
+    /// <summary>
+    /// Every field is validated and the refusal names the field, so a client can put the message
+    /// beside the box the person typed in rather than having to read English to find out which one.
+    /// </summary>
+    /// <param name="field">The field the refusal has to name.</param>
+    /// <param name="body">A body that is wrong in exactly that field.</param>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Theory]
+    [MemberData(nameof(BodiesThatAreRefused))]
+    public async Task AnInvalidBodyIsRefusedWithTheFieldNamed(string field, CreateRequestBody body)
+    {
+        var store = new InMemoryRequestStore();
+
+        var refused = Refusal(
+            await ControllerFor(store, Asker).CreateAsync(body, CancellationToken.None).ConfigureAwait(true));
+
+        Assert.Equal(field, refused.Field, StringComparer.Ordinal);
+        Assert.NotEmpty(refused.Reason);
+        Assert.Empty(await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true));
+    }
+
+    /// <summary>
+    /// A request nobody can act on any more is not joined. Somebody asking for a film that was
+    /// declined last month gets a new request an operator sees, rather than inheriting a refusal they
+    /// never saw and never being told anything.
+    /// </summary>
+    /// <param name="finished">The state the existing request is in.</param>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Theory]
+    [InlineData(RequestState.Declined)]
+    [InlineData(RequestState.Fulfilled)]
+    [InlineData(RequestState.Failed)]
+    public async Task AFinishedRequestIsNotJoined(RequestState finished)
+    {
+        var store = new InMemoryRequestStore();
+        var existing = Answer(
+            await ControllerFor(store, Asker).CreateAsync(AFilm(), CancellationToken.None).ConfigureAwait(true),
+            expectedStatus: 201);
+
+        var held = (await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true))[0];
+        await store.ReplaceAsync(held.Request with { State = finished }, held.Revision, CancellationToken.None).ConfigureAwait(true);
+
+        var made = Answer(
+            await ControllerFor(store, SecondPerson).CreateAsync(AFilm(), CancellationToken.None).ConfigureAwait(true),
+            expectedStatus: 201);
+
+        Assert.Equal(RequestOutcome.Created, made.Outcome);
+        Assert.NotEqual(existing.Id, made.Id);
+        Assert.Equal(2, (await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true)).Count);
+    }
+
+    /// <summary>
+    /// A series request that names seasons somebody is already waiting for, and seasons nobody is,
+    /// creates a request for the ones that are left. Joining the existing one would approve seasons
+    /// nobody approved; creating a request for all four would put two people in the queue for the two
+    /// that are already there.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AskingForSeasonsPartlyCoveredCreatesARequestForWhatIsLeft()
+    {
+        var store = new InMemoryRequestStore();
+        await ControllerFor(store, Asker)
+            .CreateAsync(ASeries([1, 2]), CancellationToken.None).ConfigureAwait(true);
+
+        var made = Answer(
+            await ControllerFor(store, SecondPerson).CreateAsync(ASeries([2, 3]), CancellationToken.None).ConfigureAwait(true),
+            expectedStatus: 201);
+
+        var held = await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true);
+        var created = held.Single(stored => stored.Request.Id == made.Id);
+        Assert.Equal(RequestOutcome.Created, made.Outcome);
+        Assert.Equal([3], created.Request.Seasons);
+        Assert.Equal(2, held.Count);
+    }
+
+    /// <summary>
+    /// A series request whose seasons are all already asked for joins the request that covers them,
+    /// which is the same rule as a film and is worth its own leg because the comparison that decides
+    /// it is not symmetric.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AskingForSeasonsAlreadyCoveredJoins()
+    {
+        var store = new InMemoryRequestStore();
+        var first = Answer(
+            await ControllerFor(store, Asker).CreateAsync(ASeries([1, 2, 3]), CancellationToken.None).ConfigureAwait(true),
+            expectedStatus: 201);
+
+        var second = Answer(
+            await ControllerFor(store, SecondPerson).CreateAsync(ASeries([2]), CancellationToken.None).ConfigureAwait(true),
+            expectedStatus: 200);
+
+        Assert.Equal(RequestOutcome.Joined, second.Outcome);
+        Assert.Equal(first.Id, second.Id);
+        Assert.Single(await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true));
+    }
+
+    /// <summary>
+    /// A request carrying no identifier is nobody's duplicate, including its own. Two people typing
+    /// one title get two requests, because matching them would mean matching on the text they typed,
+    /// which is the rule the identity comparison exists to refuse.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task TwoRequestsTypedByHandAreTwoRequests()
+    {
+        var store = new InMemoryRequestStore();
+        var typed = new CreateRequestBody { Kind = RequestedItemKind.Movie, Title = "Nosferatu" };
+
+        await ControllerFor(store, Asker).CreateAsync(typed, CancellationToken.None).ConfigureAwait(true);
+        var second = Answer(
+            await ControllerFor(store, SecondPerson).CreateAsync(typed, CancellationToken.None).ConfigureAwait(true),
+            expectedStatus: 201);
+
+        Assert.Equal(RequestOutcome.Created, second.Outcome);
+        Assert.Equal(2, (await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true)).Count);
+    }
+
+    /// <summary>
+    /// The bodies the endpoint refuses, each wrong in one field, so a refusal naming a different one
+    /// is a failure rather than a message somebody has to read.
+    /// </summary>
+    /// <returns>The field that has to be named, and the body that is wrong in it.</returns>
+    public static TheoryData<string, CreateRequestBody> BodiesThatAreRefused()
+        => new TheoryData<string, CreateRequestBody>
+        {
+            { nameof(CreateRequestBody.Kind), new CreateRequestBody { Title = "No kind" } },
+            { nameof(CreateRequestBody.Kind), new CreateRequestBody { Kind = (RequestedItemKind)97, Title = "Not a kind" } },
+            { nameof(CreateRequestBody.Title), new CreateRequestBody { Kind = RequestedItemKind.Movie } },
+            { nameof(CreateRequestBody.Title), new CreateRequestBody { Kind = RequestedItemKind.Movie, Title = "   " } },
+            {
+                nameof(CreateRequestBody.Title),
+                new CreateRequestBody { Kind = RequestedItemKind.Movie, Title = new string('t', MediaRequest.NoteMaximumLength + 1) }
+            },
+            {
+                nameof(CreateRequestBody.Note),
+                new CreateRequestBody
+                {
+                    Kind = RequestedItemKind.Movie,
+                    Title = "A film",
+                    Note = new string('n', MediaRequest.NoteMaximumLength + 1)
+                }
+            },
+            {
+                nameof(CreateRequestBody.ProviderIds),
+                new CreateRequestBody
+                {
+                    Kind = RequestedItemKind.Movie,
+                    Title = "A film",
+                    ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tmdb"] = " " }
+                }
+            },
+            {
+                nameof(CreateRequestBody.Seasons),
+                new CreateRequestBody { Kind = RequestedItemKind.Movie, Title = "A film", Seasons = [1] }
+            },
+            {
+                nameof(CreateRequestBody.Seasons),
+                new CreateRequestBody { Kind = RequestedItemKind.Series, Title = "A show", Seasons = [0] }
+            },
+            {
+                nameof(CreateRequestBody.Seasons),
+                new CreateRequestBody { Kind = RequestedItemKind.Series, Title = "A show", Seasons = [2, 2] }
+            }
+        };
+
+    /// <summary>
+    /// A controller wired to one store and one identity, with a clock and an identifier source the
+    /// test controls.
+    /// </summary>
+    /// <param name="store">Where requests are kept.</param>
+    /// <param name="caller">Who the server says is calling.</param>
+    /// <returns>The controller under test.</returns>
+    private RequestsController ControllerFor(IRequestStore store, Guid? caller)
+        => new RequestsController(
+            store,
+            new TestClock(new DateTimeOffset(2026, 8, 9, 12, 0, 0, TimeSpan.Zero)),
+            _identifiers,
+            new FakeCallerIdentity(caller));
+
+    /// <summary>
+    /// The answer, with the status code checked, so a leg cannot pass on a body that came back under
+    /// the wrong one.
+    /// </summary>
+    /// <param name="answered">What the action returned.</param>
+    /// <param name="expectedStatus">The status code it has to have used.</param>
+    /// <returns>The answer.</returns>
+    private static CreatedRequest Answer(ActionResult<CreatedRequest> answered, int expectedStatus)
+    {
+        var result = Assert.IsAssignableFrom<ObjectResult>(answered.Result);
+        Assert.Equal(expectedStatus, result.StatusCode);
+        return Assert.IsType<CreatedRequest>(result.Value);
+    }
+
+    /// <summary>
+    /// The refusal, with the status code checked.
+    /// </summary>
+    /// <param name="answered">What the action returned.</param>
+    /// <returns>The refusal.</returns>
+    private static RequestRefused Refusal(ActionResult<CreatedRequest> answered)
+    {
+        var result = Assert.IsType<BadRequestObjectResult>(answered.Result);
+        Assert.Equal(400, result.StatusCode);
+        return Assert.IsType<RequestRefused>(result.Value);
+    }
+
+    /// <summary>
+    /// A film, named by one provider so it has an identity.
+    /// </summary>
+    /// <returns>The body.</returns>
+    private static CreateRequestBody AFilm() => new CreateRequestBody
+    {
+        Kind = RequestedItemKind.Movie,
+        Title = "The Conversation",
+        Year = 1974,
+        ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tmdb"] = "603" }
+    };
+
+    /// <summary>
+    /// A series, named by one provider, asking for the given seasons.
+    /// </summary>
+    /// <param name="seasons">The seasons wanted.</param>
+    /// <returns>The body.</returns>
+    private static CreateRequestBody ASeries(IReadOnlyList<int> seasons) => new CreateRequestBody
+    {
+        Kind = RequestedItemKind.Series,
+        Title = "The Wire",
+        ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tvdb"] = "79126" },
+        Seasons = seasons
+    };
+}

--- a/Jellyfin.Plugin.Requests.Tests/Doubles/FakeCallerIdentity.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/FakeCallerIdentity.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Api;
+using Microsoft.AspNetCore.Http;
+
+namespace Jellyfin.Plugin.Requests.Tests.Doubles;
+
+/// <summary>
+/// Who the server says is calling, decided by the test.
+/// <para>
+/// It ignores the call it is handed, and that is the whole reason the seam exists. The real
+/// implementation reads a token off the request and asks the server to resolve it; there is no
+/// server here to hold a session, and inventing a request carrying a token would be testing the
+/// server's authentication rather than what this plugin does with its answer.
+/// </para>
+/// </summary>
+internal sealed class FakeCallerIdentity : ICallerIdentity
+{
+    private readonly Guid? _userId;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FakeCallerIdentity"/> class.
+    /// </summary>
+    /// <param name="userId">
+    /// Who the server says is calling, or <see langword="null"/> for a call that authenticated and
+    /// names no person, which is what an API key looks like from an endpoint.
+    /// </param>
+    public FakeCallerIdentity(Guid? userId) => _userId = userId;
+
+    /// <inheritdoc />
+    public Task<Guid?> UserIdAsync(HttpContext? context) => Task.FromResult(_userId);
+}

--- a/Jellyfin.Plugin.Requests.Tests/SiblingIndependenceTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/SiblingIndependenceTests.cs
@@ -40,14 +40,23 @@ public class SiblingIndependenceTests
         "MediaBrowser.Model",
 
         // The API this plugin serves is mounted on the server's own, so its controllers are the
-        // server's web framework's controllers. This is the assembly holding `ControllerBase`, the
-        // routing attributes and the result types, and it is part of the framework the server runs
-        // on rather than a package this plugin carries: the package excludes the runtime assets, so
-        // nothing of it is in the install. Serving an API without it would mean a second web stack
-        // inside a plugin.
+        // server's web framework's controllers. These three are that framework, split across
+        // assemblies by the framework rather than by anything this plugin chose: the policy
+        // attribute, the request context an endpoint reads its caller from, and `ControllerBase`
+        // with the routing attributes and the result types. All three are part of the
+        // runtime the server already runs on rather than a package this plugin carries, because the
+        // project excludes the runtime assets and nothing of them lands in the install. Serving an
+        // API without them would mean a second web stack inside a plugin.
+        "Microsoft.AspNetCore.Authorization",
+        "Microsoft.AspNetCore.Http.Abstractions",
         "Microsoft.AspNetCore.Mvc.Core",
         "Microsoft.Extensions.DependencyInjection.Abstractions",
         "System.Collections",
+
+        // The endpoint declares which status codes it answers with, and the attribute that says so
+        // is a description of the method rather than behaviour. It arrives with the controller and
+        // is part of the same runtime.
+        "System.ComponentModel",
         "System.Linq",
         "System.Runtime",
 

--- a/Jellyfin.Plugin.Requests/Api/CreateRequestBody.cs
+++ b/Jellyfin.Plugin.Requests/Api/CreateRequestBody.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using Jellyfin.Plugin.Requests.Model;
+
+namespace Jellyfin.Plugin.Requests.Api;
+
+/// <summary>
+/// What a caller sends to ask for something.
+/// <para>
+/// <b>There is no field naming the requester, and its absence is the design.</b> Who asked is taken
+/// from the authenticated caller, so a body carrying <c>requestedByUserId</c> has nothing to bind to
+/// and is dropped by the serialiser. A field that existed and was ignored would be a field somebody
+/// eventually honours; a field that does not exist cannot be. Filing a request as somebody else is
+/// the attack this shape refuses, and it is refused by there being no way to express it.
+/// </para>
+/// <para>
+/// Every property is nullable, including the ones that are required, so that "absent" and "empty"
+/// reach the validation as different values. A non-nullable string arriving as the empty string
+/// cannot be told from one nobody sent, and the caller then gets a message about the wrong mistake.
+/// </para>
+/// </summary>
+public sealed record CreateRequestBody
+{
+    /// <summary>
+    /// The name of the field a caller would use to file a request as somebody else, so that the
+    /// test proving it cannot names the same string this type is checked against rather than a copy
+    /// of it.
+    /// </summary>
+    internal const string RequesterFieldThatDoesNotExist = "requestedByUserId";
+
+    /// <summary>
+    /// Gets what sort of thing is wanted.
+    /// </summary>
+    public RequestedItemKind? Kind { get; init; }
+
+    /// <summary>
+    /// Gets the title as the caller's client reads it. Stored as the snapshot on the request, which
+    /// is what an operator decides from when nothing else is reachable.
+    /// </summary>
+    public string? Title { get; init; }
+
+    /// <summary>
+    /// Gets the release year, or <see langword="null"/> where the caller has none. This is the field
+    /// that separates two films sharing a title.
+    /// </summary>
+    public int? Year { get; init; }
+
+    /// <summary>
+    /// Gets the external identifiers naming the thing, keyed by provider. Absent and empty are both
+    /// legal: a request typed by a person carries a title and nothing else, and what such a request
+    /// may then do is narrow and is <see cref="RequestLifecycle"/>'s answer.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? ProviderIds { get; init; }
+
+    /// <summary>
+    /// Gets the seasons wanted, where the thing is a series. Absent or empty means the whole series,
+    /// which is the convention on the record and is what a client sends when somebody asks for a
+    /// programme rather than part of one.
+    /// </summary>
+    public IReadOnlyList<int>? Seasons { get; init; }
+
+    /// <summary>
+    /// Gets what the person wanted to say about it, or <see langword="null"/> where they said
+    /// nothing.
+    /// </summary>
+    public string? Note { get; init; }
+
+    /// <summary>
+    /// Gets the provider identifiers as a map that is never null, so every reader downstream is
+    /// spared the absent case.
+    /// </summary>
+    /// <returns>What the caller sent, or an empty map.</returns>
+    internal IReadOnlyDictionary<string, string> IdentifiersOrEmpty()
+        => ProviderIds ?? new Dictionary<string, string>(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Gets the seasons as a list that is never null.
+    /// </summary>
+    /// <returns>What the caller sent, or an empty list.</returns>
+    internal IReadOnlyList<int> SeasonsOrEmpty() => Seasons ?? [];
+}

--- a/Jellyfin.Plugin.Requests/Api/CreatedRequest.cs
+++ b/Jellyfin.Plugin.Requests/Api/CreatedRequest.cs
@@ -1,0 +1,35 @@
+using System;
+using Jellyfin.Plugin.Requests.Model;
+
+namespace Jellyfin.Plugin.Requests.Api;
+
+/// <summary>
+/// What the create endpoint answers with: which request the caller is now waiting for, where it
+/// stands, and whether asking made a new one.
+/// <para>
+/// The last of those is the field a client cannot work out for itself. Two people asking for one
+/// film is one request, so the honest answer to the second person is that they joined something
+/// already in the queue rather than that nothing happened. A client told only the identifier would
+/// have to remember whether it had seen it before, and a client that got no answer at all would show
+/// a second row for a request that does not exist.
+/// </para>
+/// </summary>
+public sealed record CreatedRequest
+{
+    /// <summary>
+    /// Gets the request the caller is waiting for, whether it was made now or joined.
+    /// </summary>
+    public required Guid Id { get; init; }
+
+    /// <summary>
+    /// Gets where that request stands. On a joined request this is whatever it already was, so a
+    /// caller joining something an operator has already approved is told so rather than being shown
+    /// a fresh undecided one.
+    /// </summary>
+    public required RequestState State { get; init; }
+
+    /// <summary>
+    /// Gets what asking did.
+    /// </summary>
+    public required RequestOutcome Outcome { get; init; }
+}

--- a/Jellyfin.Plugin.Requests/Api/ICallerIdentity.cs
+++ b/Jellyfin.Plugin.Requests/Api/ICallerIdentity.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace Jellyfin.Plugin.Requests.Api;
+
+/// <summary>
+/// Who the server says is calling, as one question with one answer.
+/// <para>
+/// It exists for the same reason the clock and the identifier source do: the server's own answer is
+/// reachable only from a running server, and an endpoint that asks the server directly can only be
+/// tested by starting one, which the headless rule in <c>docs/testing.md</c> refuses. This is the
+/// seam, and the implementation behind it is one call.
+/// </para>
+/// <para>
+/// It answers an identifier or nothing, and never a name. A call can authenticate and name no
+/// person, which is what an API key looks like from an endpoint, and the two have to be
+/// distinguishable: a request filed against nobody is worse than a request refused.
+/// </para>
+/// </summary>
+public interface ICallerIdentity
+{
+    /// <summary>
+    /// The Jellyfin user this call is made by.
+    /// </summary>
+    /// <param name="context">
+    /// The call. It is nullable because the shape of the parameter should not promise more than the
+    /// implementations need: the one that ships reads the call, and a caller with none has no
+    /// identity, which is the same answer as a call that names nobody.
+    /// </param>
+    /// <returns>
+    /// Their identifier, or <see langword="null"/> where the call names no person.
+    /// </returns>
+    Task<Guid?> UserIdAsync(HttpContext? context);
+}

--- a/Jellyfin.Plugin.Requests/Api/RequestOutcome.cs
+++ b/Jellyfin.Plugin.Requests/Api/RequestOutcome.cs
@@ -1,0 +1,32 @@
+namespace Jellyfin.Plugin.Requests.Api;
+
+/// <summary>
+/// What asking for something did. Three answers rather than two, because "you are already waiting
+/// for this" and "somebody else was already waiting and now you are too" read differently to the
+/// person who asked, and a client that cannot tell them apart either says nothing happened or claims
+/// something did.
+/// <para>
+/// A caller that does not recognise a value here treats it as one it does not recognise, which is
+/// the rule <c>docs/api.md</c> states for every enumerated field in this API. That is what lets a
+/// fourth answer be added without a new version.
+/// </para>
+/// </summary>
+public enum RequestOutcome
+{
+    /// <summary>
+    /// Nothing in the queue named this, so a new request was made.
+    /// </summary>
+    Created = 0,
+
+    /// <summary>
+    /// Somebody was already waiting for exactly this, and now the caller is waiting for it too. No
+    /// second request was made, because two people asking for one film is one request.
+    /// </summary>
+    Joined = 1,
+
+    /// <summary>
+    /// The caller was already waiting for this one. Asking again is not a second fact about the
+    /// request, so nothing was written and the request is returned as it stands.
+    /// </summary>
+    AlreadyWaiting = 2
+}

--- a/Jellyfin.Plugin.Requests/Api/RequestRefused.cs
+++ b/Jellyfin.Plugin.Requests/Api/RequestRefused.cs
@@ -1,0 +1,27 @@
+namespace Jellyfin.Plugin.Requests.Api;
+
+/// <summary>
+/// Why a call was refused, naming the field that is wrong.
+/// <para>
+/// The field is here rather than only in the sentence because a client showing the message beside
+/// the box the person typed in needs to know which box, and a client that has to read English to
+/// find out is a client that stops working when the sentence is reworded.
+/// </para>
+/// <para>
+/// This is the smallest shape that carries what the create endpoint has to say. What an error looks
+/// like across the whole API, and which status code each failure gets, is #56, and this is expected
+/// to be replaced by whatever that decides rather than to be the answer.
+/// </para>
+/// </summary>
+public sealed record RequestRefused
+{
+    /// <summary>
+    /// Gets the field that was wrong, named as the body names it.
+    /// </summary>
+    public required string Field { get; init; }
+
+    /// <summary>
+    /// Gets what is wrong with it, in a sentence a person can act on.
+    /// </summary>
+    public required string Reason { get; init; }
+}

--- a/Jellyfin.Plugin.Requests/Api/RequestsController.cs
+++ b/Jellyfin.Plugin.Requests/Api/RequestsController.cs
@@ -1,0 +1,393 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Identity;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Time;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Jellyfin.Plugin.Requests.Api;
+
+/// <summary>
+/// Asking for something. This is the endpoint everything else calls: the user surface, the sibling
+/// discover plugin, and any script an operator writes.
+/// <para>
+/// <b>Who asked is the authenticated caller and nothing else.</b> It is read from the server's own
+/// authorisation context rather than from the body, and <see cref="CreateRequestBody"/> carries no
+/// field that could name a user, so filing a request as somebody else is not something this endpoint
+/// declines to do, it is something it has no way to express.
+/// </para>
+/// <para>
+/// <b>Asking for something already in the queue joins it.</b> Identity is
+/// <see cref="RequestIdentity"/>'s answer and is not re-decided here: the store is asked for every
+/// request naming each identifier the caller sent, and each candidate is compared. What this
+/// endpoint adds is which requests are eligible to be joined at all, which is a question about state
+/// rather than identity and is answered below.
+/// </para>
+/// <para>
+/// The policy is the floor rather than the decision. Every endpoint carries an explicit policy and
+/// which one each carries is #51; what is here is an authenticated user, because a request has to be
+/// attributable to somebody to exist at all and an endpoint reachable without a session could not
+/// name a requester.
+/// </para>
+/// </summary>
+[Authorize(Policy = AuthenticatedUserPolicy)]
+public sealed class RequestsController : RequestsControllerBase
+{
+    /// <summary>
+    /// The server's policy for a call that has to come from a signed-in user. Named as a literal
+    /// because the constant that holds it lives in the server's own web assembly, which a plugin
+    /// does not reference; the string is the contract either way.
+    /// </summary>
+    private const string AuthenticatedUserPolicy = "DefaultAuthorization";
+
+    /// <summary>
+    /// How many times a join is attempted before giving up. A join is a read followed by a write
+    /// against the revision that was read, so two people joining one request in the same moment
+    /// means one of them is refused and re-decides. Three is enough for that and small enough that
+    /// a genuinely contended request fails visibly instead of spinning.
+    /// </summary>
+    private const int JoinAttempts = 3;
+
+    private readonly IRequestStore _store;
+    private readonly IClock _clock;
+    private readonly IIdentifierSource _identifiers;
+    private readonly ICallerIdentity _callers;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequestsController"/> class.
+    /// </summary>
+    /// <param name="store">Where requests are kept.</param>
+    /// <param name="clock">The injected clock, so a request's times are testable.</param>
+    /// <param name="identifiers">Where a new request's identifier comes from.</param>
+    /// <param name="callers">The server's answer to who is calling.</param>
+    public RequestsController(
+        IRequestStore store,
+        IClock clock,
+        IIdentifierSource identifiers,
+        ICallerIdentity callers)
+    {
+        _store = store;
+        _clock = clock;
+        _identifiers = identifiers;
+        _callers = callers;
+    }
+
+    /// <summary>
+    /// Asks for something.
+    /// </summary>
+    /// <param name="body">What is wanted. It carries no requester and cannot.</param>
+    /// <param name="cancellationToken">Cancels the call.</param>
+    /// <returns>
+    /// The request the caller is now waiting for and what asking did. A new request answers 201;
+    /// joining one, or already waiting for it, answers 200, because nothing was
+    /// created. The shape of a refusal and the status code each failure gets are #56's, and what is
+    /// here is the smallest thing that names the field that was wrong.
+    /// </returns>
+    [HttpPost("Requests")]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<CreatedRequest>> CreateAsync(
+        [FromBody] CreateRequestBody body,
+        CancellationToken cancellationToken)
+    {
+        if (body is null)
+        {
+            return BadRequest(new RequestRefused
+            {
+                Field = "body",
+                Reason = "There is no body on this call, and every field is in it."
+            });
+        }
+
+        if (!Valid(body, out var refusal))
+        {
+            return BadRequest(new RequestRefused { Field = refusal.Field, Reason = refusal.Reason });
+        }
+
+        var caller = await _callers.UserIdAsync(HttpContext).ConfigureAwait(false);
+
+        if (caller is not Guid asker)
+        {
+            // A token that authenticates but names no user is an API key rather than a person. It
+            // can reach this endpoint under the server's policy and there is nobody to attribute the
+            // request to, so it is refused here rather than stored against an empty identifier.
+            return BadRequest(new RequestRefused
+            {
+                Field = "caller",
+                Reason = "This call is authenticated but names no user, so there is nobody to record as having asked."
+            });
+        }
+
+        var asked = _clock.UtcNow;
+
+        var incoming = new MediaRequest
+        {
+            Id = _identifiers.NewId(),
+            RequestedByUserId = asker,
+            RequestedAt = asked,
+            StateChangedAt = asked,
+            Kind = body.Kind!.Value,
+            DisplayTitle = body.Title!,
+            DisplayYear = body.Year,
+            ProviderIds = body.IdentifiersOrEmpty(),
+            Seasons = body.SeasonsOrEmpty(),
+            RequesterNote = body.Note
+        };
+
+        var answer = await AskAsync(incoming, cancellationToken).ConfigureAwait(false);
+
+        // 201 with no Location header, on purpose. Nothing reads one request back yet, so a
+        // Location would point at something that answers 404, and a header that lies is worse than
+        // one that is absent. Adding it when #53 lands is not a breaking change under the rule in
+        // docs/api.md.
+        return answer.Outcome == RequestOutcome.Created
+            ? StatusCode(StatusCodes.Status201Created, answer)
+            : Ok(answer);
+    }
+
+    /// <summary>
+    /// Whether a request already in the queue is one a new ask may join.
+    /// <para>
+    /// Only a request that is still waiting for an answer or waiting to arrive. A declined request
+    /// is an answer somebody gave and joining it would make a new asker inherit a refusal they never
+    /// saw; a fulfilled one is finished, and a person asking for something the server already holds
+    /// is asking a question the queue is the wrong place to answer; a failed one has been given up
+    /// on. In every one of those a new ask is a new request, which is also what puts it back in front
+    /// of an operator.
+    /// </para>
+    /// </summary>
+    /// <param name="request">A request the store holds.</param>
+    /// <returns><see langword="true"/> where a new ask may join it.</returns>
+    private static bool StillOpenToJoiners(MediaRequest request)
+        => request.State is RequestState.Open or RequestState.Approved;
+
+    /// <summary>
+    /// Refuses a body that cannot become a request, naming the field that is wrong.
+    /// <para>
+    /// The cap on the note and the shape of a season list are the record's own rules and are refused
+    /// there by throwing. They are checked here as well, ahead of the record, so the caller is told
+    /// which field was wrong instead of getting whatever an unhandled exception turns into. Two
+    /// checks of one rule would be two rules if the numbers were written twice, so the length comes
+    /// from <see cref="MediaRequest.NoteMaximumLength"/> and the season rule is stated once here in
+    /// terms the record agrees with.
+    /// </para>
+    /// </summary>
+    /// <param name="body">What the caller sent.</param>
+    /// <param name="refusal">The field and the reason, where the answer is no.</param>
+    /// <returns><see langword="true"/> where the body can become a request.</returns>
+    private static bool Valid(CreateRequestBody body, out (string Field, string Reason) refusal)
+    {
+        if (body.Kind is not RequestedItemKind kind || !Enum.IsDefined(kind))
+        {
+            refusal = (nameof(CreateRequestBody.Kind), "This is not a kind of thing that can be asked for.");
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(body.Title))
+        {
+            refusal = (nameof(CreateRequestBody.Title), "A request carries the title as it read when it was asked for, and this one has none.");
+            return false;
+        }
+
+        if (body.Title.Length > MediaRequest.NoteMaximumLength)
+        {
+            refusal = (nameof(CreateRequestBody.Title), Longer(nameof(CreateRequestBody.Title), body.Title.Length));
+            return false;
+        }
+
+        if (body.Note is not null && body.Note.Length > MediaRequest.NoteMaximumLength)
+        {
+            refusal = (nameof(CreateRequestBody.Note), Longer(nameof(CreateRequestBody.Note), body.Note.Length));
+            return false;
+        }
+
+        foreach (var identifier in body.IdentifiersOrEmpty())
+        {
+            if (string.IsNullOrWhiteSpace(identifier.Key) || string.IsNullOrWhiteSpace(identifier.Value))
+            {
+                refusal = (
+                    nameof(CreateRequestBody.ProviderIds),
+                    "An identifier carries a provider name and a value, and one of these carries an empty one.");
+                return false;
+            }
+        }
+
+        var seasons = body.SeasonsOrEmpty();
+
+        if (seasons.Count > 0 && kind != RequestedItemKind.Series)
+        {
+            refusal = (
+                nameof(CreateRequestBody.Seasons),
+                "Seasons name part of a series, and this request is not for one.");
+            return false;
+        }
+
+        if (seasons.Any(season => season < 1))
+        {
+            refusal = (nameof(CreateRequestBody.Seasons), "A season number has to be 1 or more.");
+            return false;
+        }
+
+        if (seasons.Distinct().Count() != seasons.Count)
+        {
+            refusal = (
+                nameof(CreateRequestBody.Seasons),
+                "A season is named twice. The seasons asked for are a set, so a repeat is a mistake rather than a request for it twice.");
+            return false;
+        }
+
+        refusal = default;
+        return true;
+    }
+
+    /// <summary>
+    /// The message for a field that is longer than a request keeps.
+    /// </summary>
+    /// <param name="field">The field.</param>
+    /// <param name="length">How long it arrived.</param>
+    /// <returns>The message.</returns>
+    private static string Longer(string field, int length)
+        => string.Format(
+            CultureInfo.InvariantCulture,
+            "{0} is {1} characters and a request keeps at most {2}. It is refused rather than cut, so nothing is stored that was not written.",
+            field,
+            length,
+            MediaRequest.NoteMaximumLength);
+
+    /// <summary>
+    /// Puts the ask against what is already in the queue, and either joins one of them or creates it.
+    /// <para>
+    /// The candidates are read out of the store by identifier rather than by walking it, which is
+    /// what makes this cheap on a queue of any size. A request carrying no identifier reaches nobody
+    /// and is joined by nobody, which is <see cref="RequestIdentity"/>'s answer and not this
+    /// method's: such a request has no identity, so it is different from everything including
+    /// another copy of itself.
+    /// </para>
+    /// <para>
+    /// The seasons narrow as the walk goes on. Where an existing request covers some of what is
+    /// being asked for, what is left to ask for is what the next candidate is compared against, so a
+    /// series whose seasons are spread over two existing requests is joined to the second rather
+    /// than duplicated. If the narrowing ever leaves nothing, the candidate that took the last
+    /// season compares as the same request and is joined.
+    /// </para>
+    /// </summary>
+    /// <param name="incoming">The ask, as a request that does not exist yet.</param>
+    /// <param name="cancellationToken">Cancels the call.</param>
+    /// <returns>What the caller is now waiting for and what asking did.</returns>
+    private async Task<CreatedRequest> AskAsync(MediaRequest incoming, CancellationToken cancellationToken)
+    {
+        for (var attempt = 1; ; attempt++)
+        {
+            var ask = incoming;
+            var candidates = await CandidatesAsync(ask, cancellationToken).ConfigureAwait(false);
+            StoredRequest? joining = null;
+
+            foreach (var candidate in candidates)
+            {
+                var match = RequestIdentity.Compare(candidate.Request, ask);
+
+                if (match == RequestMatch.Same)
+                {
+                    joining = candidate;
+                    break;
+                }
+
+                if (match == RequestMatch.Overlapping)
+                {
+                    ask = ask with
+                    {
+                        Seasons = RequestIdentity.SeasonsNotAlreadyAskedFor(candidate.Request, ask, [])
+                    };
+                }
+            }
+
+            if (joining is not StoredRequest existing)
+            {
+                var added = await _store.AddAsync(ask, cancellationToken).ConfigureAwait(false);
+
+                return new CreatedRequest
+                {
+                    Id = added.Request.Id,
+                    State = added.Request.State,
+                    Outcome = RequestOutcome.Created
+                };
+            }
+
+            if (existing.Request.WasAskedForBy(ask.RequestedByUserId))
+            {
+                return new CreatedRequest
+                {
+                    Id = existing.Request.Id,
+                    State = existing.Request.State,
+                    Outcome = RequestOutcome.AlreadyWaiting
+                };
+            }
+
+            var joined = existing.Request with
+            {
+                JoinedByUserIds = [.. existing.Request.JoinedByUserIds, ask.RequestedByUserId]
+            };
+
+            try
+            {
+                var written = await _store
+                    .ReplaceAsync(joined, existing.Revision, cancellationToken)
+                    .ConfigureAwait(false);
+
+                return new CreatedRequest
+                {
+                    Id = written.Request.Id,
+                    State = written.Request.State,
+                    Outcome = RequestOutcome.Joined
+                };
+            }
+            catch (RequestConcurrencyException) when (attempt < JoinAttempts)
+            {
+                // Somebody moved that request between the read and the write, which on this endpoint
+                // is usually a second person joining it in the same moment. Deciding again against
+                // what the store holds now is exactly what the store contract asks a refused caller
+                // to do, and the decision may come out differently: an operator who declined it
+                // meanwhile makes it no longer joinable, and the next pass creates instead.
+            }
+        }
+    }
+
+    /// <summary>
+    /// The requests already in the queue that could be the same thing as this ask.
+    /// </summary>
+    /// <param name="ask">The ask.</param>
+    /// <param name="cancellationToken">Cancels the reads.</param>
+    /// <returns>Every joinable request naming at least one of the ask's identifiers, each once.</returns>
+    private async Task<IReadOnlyList<StoredRequest>> CandidatesAsync(
+        MediaRequest ask,
+        CancellationToken cancellationToken)
+    {
+        var found = new Dictionary<Guid, StoredRequest>();
+
+        foreach (var identifier in ask.ProviderIds)
+        {
+            var carrying = await _store
+                .FindByProviderIdentifierAsync(ask.Kind, identifier.Key, identifier.Value, cancellationToken)
+                .ConfigureAwait(false);
+
+            foreach (var candidate in carrying.Where(candidate => StillOpenToJoiners(candidate.Request)))
+            {
+                // Keyed by identifier, because one existing request can carry two of the identifiers
+                // the caller sent and would otherwise be compared and joined twice.
+                found[candidate.Request.Id] = candidate;
+            }
+        }
+
+        // Oldest first, so the request people have been waiting on longest is the one a new asker
+        // joins, and so the answer does not depend on which order the store happened to return them.
+        return [.. found.Values.OrderBy(candidate => candidate.Request.RequestedAt).ThenBy(candidate => candidate.Request.Id)];
+    }
+}

--- a/Jellyfin.Plugin.Requests/Api/ServerCallerIdentity.cs
+++ b/Jellyfin.Plugin.Requests/Api/ServerCallerIdentity.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Net;
+using Microsoft.AspNetCore.Http;
+
+namespace Jellyfin.Plugin.Requests.Api;
+
+/// <summary>
+/// The server's own answer to who is calling, which is the only answer this plugin will accept.
+/// <para>
+/// It is the whole of the implementation behind <see cref="ICallerIdentity"/> and it decides
+/// nothing: the token, the session and the user behind them are the server's, and asking it is the
+/// point. A plugin that read an identity out of anything else would be a plugin that can be told who
+/// is calling.
+/// </para>
+/// <para>
+/// Nothing in the suite exercises this type, and it is one call for exactly that reason. The
+/// server's authorisation context can only answer on a running server, which the headless rule
+/// refuses, so what is testable is what the endpoint does with the answer and that is tested against
+/// the interface. What is not tested is that this passes the call through, which is why there is
+/// nothing else in it.
+/// </para>
+/// </summary>
+public sealed class ServerCallerIdentity : ICallerIdentity
+{
+    private readonly IAuthorizationContext _authorization;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ServerCallerIdentity"/> class.
+    /// </summary>
+    /// <param name="authorization">The server's authorisation context.</param>
+    public ServerCallerIdentity(IAuthorizationContext authorization) => _authorization = authorization;
+
+    /// <inheritdoc />
+    public async Task<Guid?> UserIdAsync(HttpContext? context)
+    {
+        if (context is null)
+        {
+            return null;
+        }
+
+        var info = await _authorization.GetAuthorizationInfo(context).ConfigureAwait(false);
+
+        // The empty identifier is what the server reports for a call that carries no user, so it is
+        // turned into an absence here rather than handed on as a value that looks like one.
+        return info.UserId == Guid.Empty ? null : info.UserId;
+    }
+}

--- a/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
@@ -1,4 +1,7 @@
+using System;
+using Jellyfin.Plugin.Requests.Api;
 using Jellyfin.Plugin.Requests.Identity;
+using Jellyfin.Plugin.Requests.Storage;
 using Jellyfin.Plugin.Requests.Time;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Plugins;
@@ -28,5 +31,24 @@ public sealed class PluginServiceRegistrator : IPluginServiceRegistrator
     {
         serviceCollection.AddSingleton<IClock, SystemClock>();
         serviceCollection.AddSingleton<IIdentifierSource, GuidIdentifierSource>();
+
+        // The store, one per server for the same reason the other two are: it holds the set in
+        // memory and serialises the writes against it, and a second instance over one directory
+        // would be two sets deciding independently what the file should say.
+        //
+        // Built from a factory rather than from a type, because the directory is the plugin's own
+        // data folder and only the plugin knows it. The factory runs when something first asks for a
+        // store, which is after the host has constructed the plugin, so the instance is there by
+        // then; where it is not, that is a host that never loaded this plugin and the failure says
+        // so instead of writing requests into a path built out of nothing.
+        serviceCollection.AddSingleton<IRequestStore>(_ => new FileRequestStore(
+            (Plugin.Instance ?? throw new InvalidOperationException(
+                "The request store was asked for before this plugin was loaded, so there is no data directory to keep requests in."))
+            .DataFolderPath));
+
+        // Who is calling, asked of the server rather than decided here. Registered so an endpoint
+        // takes the seam and never the server's context directly, which is what keeps an endpoint
+        // testable without a running server.
+        serviceCollection.AddSingleton<ICallerIdentity, ServerCallerIdentity>();
     }
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -94,6 +94,36 @@ reads the built assembly rather than the source text: every controller type in t
 from `RequestsControllerBase` and declares no route of its own. A controller written in a file the
 rule's path list does not reach would pass the lint and fail there.
 
+## Asking for something
+
+    POST MediaRequests/v1/Requests
+
+The body carries the kind, the title, the release year where there is one, the external identifiers
+that name the thing, the seasons where it is a series, and a note. **It carries no requester and
+there is no field for one.** Who asked is the authenticated caller, read from the server's own answer
+to who is calling, so filing a request as somebody else is not something this endpoint declines to
+do: it is something the shape has no way to express.
+
+Asking for something already in the queue joins it rather than making a second one, and the answer
+says which happened. `Created` is a new request, `Joined` is somebody else's request the caller is now
+waiting for too, and `AlreadyWaiting` is the caller's own, which writes nothing. A new request
+answers `201`, and both of the others answer `200`, because nothing was created.
+
+There is no `Location` header on the `201`. Nothing reads one request back yet, so the header would
+point at something that answers `404`, and a header that lies is worse than one that is absent.
+Adding it when that endpoint exists is not a breaking change under the rule above.
+
+What may be joined is a question about state rather than about identity, and it is answered here
+rather than in the identity comparison: only a request that is still open or approved. A declined
+request is an answer somebody gave, and joining it would make a new asker inherit a refusal they
+never saw; a fulfilled one is finished; a failed one has been given up on. In each of those a new ask
+is a new request, which is also what puts it back in front of an operator.
+
+A body that cannot become a request is refused with `400` and a shape naming the field that is wrong,
+so a client can put the message beside the box somebody typed in rather than having to read English
+to work out which one. That shape is the smallest thing that carries it and is expected to be
+replaced by whatever #56 decides.
+
 ## What is not decided here
 
 - Which policy each endpoint carries, and what a user may see of somebody else's request, is #51.


### PR DESCRIPTION
Closes #52.

The first endpoint this plugin serves, under the prefix #50 laid out.

## The requester cannot come from the body

`CreateRequestBody` carries no property that could name a user, so a body carrying
`requestedByUserId` has nothing to bind to and the serialiser drops it. This is not
an ignored field; it is an absent one, and a field that exists and is ignored is a
field somebody eventually honours.

`ABodyNamingADifferentUserIsIgnoredRatherThanHonoured` proves both halves: the type
has no such property, and the request the endpoint stored is against the caller.
The second is what would be wrong if the first ever stopped being true.

What it does not do is exercise the framework's model binder. The action is called
directly, because the headless rule refuses a running server, so the leg
deserialises the bytes with the same serialiser the binder uses and asserts on the
result rather than claiming a round trip that did not happen.

## Joining, and what may be joined

Identity is `RequestIdentity`'s answer and is not re-decided here. What this
endpoint adds is which requests are eligible at all, which is a question about
state: only one that is still open or approved. Joining a declined request would
make a new asker inherit a refusal they never saw; a fulfilled or failed one is
finished. In each of those a new ask is a new request, which is what puts it back
in front of an operator.

That predicate was watched biting. With `StillOpenToJoiners` returning `true` for
everything:

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release --no-build -f net9.0 \
        --filter "FullyQualifiedName~CreateRequestTests"
    CreateRequestTests.AFinishedRequestIsNotJoined(finished: Fulfilled) [FAIL]
    CreateRequestTests.AFinishedRequestIsNotJoined(finished: Failed) [FAIL]
    CreateRequestTests.AFinishedRequestIsNotJoined(finished: Declined) [FAIL]
    Fehler!: Fehler: 3, erfolgreich: 18, gesamt: 21

The answer says which of three things happened, because a client cannot work it out
for itself: `Created`, `Joined`, and `AlreadyWaiting` for the caller's own request,
which writes nothing. Asking twice is not a second fact about a request.

The candidates are read out of the store by identifier rather than by walking it,
which is the query path #48 added, so the cost of asking does not grow with the
queue.

## Validation

Ten bodies, one wrong field each, and the refusal has to name that field. A client
showing the message beside the box somebody typed in needs to know which box, and a
client that has to read English to find out stops working when the sentence is
reworded. The shape carrying it is the smallest thing that does, and #56 is
expected to replace it.

## Who is calling

Through `ICallerIdentity`, not from the server's authorisation context directly.
The server's own answer is reachable only from a running server, so the seam is
what makes the endpoint testable at all, and it is the same reason the clock and
the identifier source are seams.

`ServerCallerIdentity` behind it is one call and **is not exercised by the suite**.
That is why there is nothing else in it. A call that authenticates and names no
person, which is what an API key looks like from an endpoint, is refused rather
than stored against an identifier that is not anybody.

## The suite

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    0 Warnung(en), 0 Fehler
    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release --no-build
    Bestanden!: Fehler: 0, erfolgreich: 236, gesamt: 236 (net9.0)
    Bestanden!: Fehler: 0, erfolgreich: 236, gesamt: 236 (net10.0)

## Two things outside the issue's stated scope, named rather than buried

The issue's `Scope:` line is the controllers and the test project.

**The store is registered.** Nothing registered one, so an endpoint taking
`IRequestStore` would have built, packaged, installed and thrown at first use.
One per server, from a factory, because only the plugin knows its own data
directory. That is a change to `PluginServiceRegistrator`.

**Three assemblies are added to the reference list.**
`Microsoft.AspNetCore.Authorization`, `Microsoft.AspNetCore.Http.Abstractions` and
`System.ComponentModel`, beside the one #50 added. They are the server's own web
framework and the runtime it runs on, split across assemblies by the framework
rather than by anything chosen here, and the project excludes the runtime assets so
none of them lands in the install. Adding the line is the deliberate act the list
in #94 exists for.

## What this does not cover

The policy on the controller is `DefaultAuthorization`, which is a floor and not
the decision. Which policy each endpoint carries, and what a user may see of
somebody else's request, is #51.

The status code for each failure and the shape of an error are #56. What is here is
`400` with the field named.

There is no `Location` header on the `201`, because nothing reads one request back
yet and a header pointing at a `404` is worse than an absent one. Adding it when
#53 lands is not a breaking change under the rule in `docs/api.md`.

The per-user quota is #114 and is not enforced here.

Nobody else has read this change.
