### PR TITLE
Measure whether a pull request aimed at a non-default branch is scanned (#24)

### DIFF
--- a/Jellyfin.Plugin.Requests/Api/ScanProofController.cs
+++ b/Jellyfin.Plugin.Requests/Api/ScanProofController.cs
@@ -39,3 +39,5 @@ public sealed class ScanProofController : RequestsControllerBase
         return Ok();
     }
 }
+
+// A second line, so this branch differs from its base and a pull request can exist.


### PR DESCRIPTION
Not for merge, and it will be closed as soon as the checks report.

#24's second condition asks that a pull request from a branch aimed at any branch
gets its own scan. Every pull request on this board so far has been aimed at
`master`, so that half was configured in `scan-codeql.yaml` and never observed.
This one is aimed at `proof/24-csharp-intake`, which is not the default branch,
and what it measures is whether the three `Analyze` checks report on it.

Both branches carry a deliberate defect and neither is for merge.