### PR TITLE
List and filter requests, and narrow by the read rather than after it (#53)

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Api/ListRequestsTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/ListRequestsTests.cs
@@ -1,0 +1,601 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Api;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Api;
+
+/// <summary>
+/// Reading requests back: one person's own, and the whole queue.
+/// <para>
+/// The actions are called directly rather than through a server, for the reason
+/// <see cref="CreateRequestTests"/> gives. What that leaves out is the server enforcing the policy
+/// attribute on the queue endpoint, and it is named here rather than implied: the elevation is
+/// asserted as an attribute on the action, and what the server does with it is not exercised by any
+/// test on this board.
+/// </para>
+/// <para>
+/// The leg that matters most is the one that fills the store with two people's requests and then
+/// asks, as one of them, under every combination of filter, order and page this endpoint offers. A
+/// test that asks once and gets its own rows back would pass a controller that filtered after the
+/// read, which is the shape that leaks the day somebody adds a sort.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class ListRequestsTests
+{
+    private static readonly Guid Reader = new Guid("c1000000-0000-0000-0000-000000000001");
+    private static readonly Guid SomebodyElse = new Guid("c1000000-0000-0000-0000-000000000002");
+    private static readonly Guid AThirdPerson = new Guid("c1000000-0000-0000-0000-000000000003");
+
+    private readonly SequentialIdentifierSource _identifiers = new SequentialIdentifierSource();
+
+    /// <summary>
+    /// The one that has to hold whatever is asked for. The store holds requests from three people,
+    /// including one the reader joined and one they did not, and every combination of state filter,
+    /// kind filter, order, direction and page is asked for as the reader.
+    /// <para>
+    /// Every row that comes back is one the reader is waiting for, and the count beside it never
+    /// exceeds how many of theirs there are. The count is asserted as well as the rows, because a
+    /// count taken over the whole queue is the same disclosure as a row: it says how many other
+    /// people have asked for things.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task NothingButTheCallersOwnRequestsComesBackWhateverIsAskedFor()
+    {
+        var store = new InMemoryRequestStore();
+        var theirs = await ASpreadOfRequestsAsync(store).ConfigureAwait(true);
+        var controller = ControllerFor(store, Reader);
+
+        var everyState = new RequestState[]?[]
+        {
+            null,
+            [],
+            [RequestState.Open],
+            [RequestState.Approved],
+            [RequestState.Declined],
+            [RequestState.Open, RequestState.Approved, RequestState.Declined, RequestState.Fulfilled, RequestState.Failed]
+        };
+
+        var everyKind = new RequestedItemKind[]?[]
+        {
+            null,
+            [],
+            [RequestedItemKind.Movie],
+            [RequestedItemKind.Series],
+            [RequestedItemKind.Movie, RequestedItemKind.Series]
+        };
+
+        var combinations = 0;
+
+        foreach (var states in everyState)
+        {
+            foreach (var kinds in everyKind)
+            {
+                foreach (var order in Enum.GetValues<RequestQueryOrder>())
+                {
+                    foreach (var descending in new[] { false, true })
+                    {
+                        // Paged one row at a time as well as whole, because a page taken after the
+                        // narrowing and a page taken before it differ only once there is more than
+                        // one page.
+                        foreach (var take in new[] { 0, 1, 2, RequestsController.MaximumPageSize })
+                        {
+                            for (var skip = 0; skip <= 3; skip++)
+                            {
+                                var page = Page(await controller.MineAsync(
+                                    states,
+                                    kinds,
+                                    order,
+                                    descending,
+                                    skip,
+                                    take,
+                                    CancellationToken.None).ConfigureAwait(true));
+
+                                Assert.All(
+                                    page.Requests,
+                                    row => Assert.Contains(row.Id, theirs));
+                                Assert.True(
+                                    page.MatchCount <= theirs.Count,
+                                    string.Format(
+                                        CultureInfo.InvariantCulture,
+                                        "The count was {0} and this person is waiting for {1} requests.",
+                                        page.MatchCount,
+                                        theirs.Count));
+
+                                combinations++;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // The loop is asserted to have run, so a change that makes one of the sequences empty turns
+        // into a failure rather than into a test that passes over nothing.
+        Assert.Equal(everyState.Length * everyKind.Length * 3 * 2 * 4 * 4, combinations);
+    }
+
+    /// <summary>
+    /// The rows carry no identifier of any person, checked against the bytes rather than against the
+    /// properties. The request the reader joined was asked for by somebody else and a third person
+    /// joined it too, so a shape that leaked any of the three would print one of their identifiers
+    /// here.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task NoRowNamesAnybodyIncludingTheCaller()
+    {
+        var store = new InMemoryRequestStore();
+        await ASpreadOfRequestsAsync(store).ConfigureAwait(true);
+        var controller = ControllerFor(store, Reader);
+
+        var page = Page(await controller.MineAsync(
+            take: RequestsController.MaximumPageSize,
+            cancellationToken: CancellationToken.None).ConfigureAwait(true));
+
+        Assert.NotEmpty(page.Requests);
+
+        var written = JsonSerializer.Serialize(page);
+
+        foreach (var person in new[] { Reader, SomebodyElse, AThirdPerson })
+        {
+            Assert.DoesNotContain(person.ToString(), written, StringComparison.OrdinalIgnoreCase);
+        }
+
+        // The same statement about the shape rather than about one document: no property of a row is
+        // an identifier of a person, whatever a particular request happens to hold.
+        var identifiers = typeof(MyRequest)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(property => property.PropertyType == typeof(Guid) || property.PropertyType == typeof(Guid?)
+                || property.PropertyType == typeof(IReadOnlyList<Guid>))
+            .Select(property => property.Name)
+            .Where(name => !string.Equals(name, nameof(MyRequest.Id), StringComparison.Ordinal))
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal([], identifiers);
+    }
+
+    /// <summary>
+    /// A note is the requester's writing, so a joined request carries none. The reader joined a
+    /// request whose first asker wrote one, and that text is not in the answer.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ANoteOnARequestSomebodyElseAskedForIsNotHandedToWhoeverJoinedIt()
+    {
+        var store = new InMemoryRequestStore();
+        await ASpreadOfRequestsAsync(store).ConfigureAwait(true);
+        var controller = ControllerFor(store, Reader);
+
+        var page = Page(await controller.MineAsync(
+            take: RequestsController.MaximumPageSize,
+            cancellationToken: CancellationToken.None).ConfigureAwait(true));
+
+        var joined = Assert.Single(page.Requests, row => !row.AskedByYou);
+        Assert.Null(joined.YourNote);
+
+        var own = Assert.Single(page.Requests, row => row.AskedByYou && row.YourNote is not null);
+        Assert.Equal("The reader wrote this.", own.YourNote, StringComparer.Ordinal);
+
+        Assert.DoesNotContain(
+            "somebody else wrote this",
+            JsonSerializer.Serialize(page),
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Paging over one person's own requests: every match is seen exactly once across the pages, the
+    /// count is the same on every page, and it is the count of matches rather than of rows returned.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task PagingWalksEveryMatchExactlyOnceAndTheCountIsTheSameOnEveryPage()
+    {
+        var store = new InMemoryRequestStore();
+        var theirs = await ASpreadOfRequestsAsync(store).ConfigureAwait(true);
+        var controller = ControllerFor(store, Reader);
+
+        var seen = new List<Guid>();
+        var counts = new List<int>();
+
+        for (var skip = 0; skip < theirs.Count + 2; skip++)
+        {
+            var page = Page(await controller.MineAsync(
+                skip: skip,
+                take: 1,
+                cancellationToken: CancellationToken.None).ConfigureAwait(true));
+
+            counts.Add(page.MatchCount);
+            seen.AddRange(page.Requests.Select(row => row.Id));
+        }
+
+        Assert.Equal(theirs.OrderBy(id => id), seen.OrderBy(id => id));
+        Assert.Equal(theirs.Count, seen.Distinct().Count());
+        Assert.All(counts, count => Assert.Equal(theirs.Count, count));
+    }
+
+    /// <summary>
+    /// The filters narrow, and each one is asserted against a request that is inside it and one that
+    /// is not, so a filter that admitted everything would fail as loudly as one that admitted
+    /// nothing.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task EachFilterNarrowsToWhatItNames()
+    {
+        var store = new InMemoryRequestStore();
+        await ASpreadOfRequestsAsync(store).ConfigureAwait(true);
+        var controller = ControllerFor(store, Reader);
+
+        var open = Page(await controller.MineAsync(
+            [RequestState.Open],
+            take: RequestsController.MaximumPageSize,
+            cancellationToken: CancellationToken.None).ConfigureAwait(true));
+        Assert.NotEmpty(open.Requests);
+        Assert.All(open.Requests, row => Assert.Equal(RequestState.Open, row.State));
+
+        var approved = Page(await controller.MineAsync(
+            [RequestState.Approved],
+            take: RequestsController.MaximumPageSize,
+            cancellationToken: CancellationToken.None).ConfigureAwait(true));
+        Assert.NotEmpty(approved.Requests);
+        Assert.All(approved.Requests, row => Assert.Equal(RequestState.Approved, row.State));
+
+        var films = Page(await controller.MineAsync(
+            kind: [RequestedItemKind.Movie],
+            take: RequestsController.MaximumPageSize,
+            cancellationToken: CancellationToken.None).ConfigureAwait(true));
+        Assert.NotEmpty(films.Requests);
+        Assert.All(films.Requests, row => Assert.Equal(RequestedItemKind.Movie, row.Kind));
+
+        var series = Page(await controller.MineAsync(
+            kind: [RequestedItemKind.Series],
+            take: RequestsController.MaximumPageSize,
+            cancellationToken: CancellationToken.None).ConfigureAwait(true));
+        Assert.NotEmpty(series.Requests);
+        Assert.All(series.Requests, row => Assert.Equal(RequestedItemKind.Series, row.Kind));
+
+        // Both filters at once narrow by both, rather than by whichever was applied last.
+        var openFilms = Page(await controller.MineAsync(
+            [RequestState.Open],
+            [RequestedItemKind.Movie],
+            take: RequestsController.MaximumPageSize,
+            cancellationToken: CancellationToken.None).ConfigureAwait(true));
+        Assert.All(openFilms.Requests, row =>
+        {
+            Assert.Equal(RequestState.Open, row.State);
+            Assert.Equal(RequestedItemKind.Movie, row.Kind);
+        });
+        Assert.True(openFilms.MatchCount <= Math.Min(open.MatchCount, films.MatchCount));
+    }
+
+    /// <summary>
+    /// Each order is asked for in both directions and the rows come back in it, with the descending
+    /// answer being the ascending one read backwards. The tiebreak is what makes that true of
+    /// requests that compare equal under the chosen column.
+    /// </summary>
+    /// <param name="order">The order asked for.</param>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Theory]
+    [InlineData(RequestQueryOrder.RequestedAt)]
+    [InlineData(RequestQueryOrder.StateChangedAt)]
+    [InlineData(RequestQueryOrder.DisplayTitle)]
+    public async Task EachOrderIsAnsweredAndItsReverseIsTheSameOrderBackwards(RequestQueryOrder order)
+    {
+        var store = new InMemoryRequestStore();
+        await ASpreadOfRequestsAsync(store).ConfigureAwait(true);
+        var controller = ControllerFor(store, Reader);
+
+        var up = Page(await controller.MineAsync(
+            order: order,
+            take: RequestsController.MaximumPageSize,
+            cancellationToken: CancellationToken.None).ConfigureAwait(true));
+
+        var down = Page(await controller.MineAsync(
+            order: order,
+            descending: true,
+            take: RequestsController.MaximumPageSize,
+            cancellationToken: CancellationToken.None).ConfigureAwait(true));
+
+        Assert.NotEmpty(up.Requests);
+        Assert.Equal(
+            up.Requests.Select(row => row.Id).Reverse(),
+            down.Requests.Select(row => row.Id));
+
+        var ascending = order switch
+        {
+            RequestQueryOrder.RequestedAt => up.Requests.OrderBy(row => row.RequestedAt).ThenBy(row => row.Id),
+            RequestQueryOrder.StateChangedAt => up.Requests.OrderBy(row => row.StateChangedAt).ThenBy(row => row.Id),
+            _ => up.Requests.OrderBy(row => row.DisplayTitle, StringComparer.InvariantCulture).ThenBy(row => row.Id)
+        };
+
+        Assert.Equal(ascending.Select(row => row.Id), up.Requests.Select(row => row.Id));
+    }
+
+    /// <summary>
+    /// A parameter that cannot be answered is refused with the field named, rather than answered
+    /// with whatever it happens to match. A state outside the enumeration is the one worth having:
+    /// it binds as a number, it matches nothing, and an empty page reads exactly like an empty
+    /// queue.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AParameterThatCannotBeAnsweredIsRefusedWithTheFieldNamed()
+    {
+        var store = new InMemoryRequestStore();
+        await ASpreadOfRequestsAsync(store).ConfigureAwait(true);
+        var controller = ControllerFor(store, Reader);
+
+        var refusedState = Refusal(await controller.MineAsync([(RequestState)99], cancellationToken: CancellationToken.None).ConfigureAwait(true));
+        Assert.Equal("state", refusedState.Field, StringComparer.Ordinal);
+
+        var refusedKind = Refusal(await controller.MineAsync(kind: [(RequestedItemKind)99], cancellationToken: CancellationToken.None).ConfigureAwait(true));
+        Assert.Equal("kind", refusedKind.Field, StringComparer.Ordinal);
+
+        var refusedOrder = Refusal(await controller.MineAsync(order: (RequestQueryOrder)99, cancellationToken: CancellationToken.None).ConfigureAwait(true));
+        Assert.Equal("order", refusedOrder.Field, StringComparer.Ordinal);
+
+        var refusedSkip = Refusal(await controller.MineAsync(skip: -1, cancellationToken: CancellationToken.None).ConfigureAwait(true));
+        Assert.Equal("skip", refusedSkip.Field, StringComparer.Ordinal);
+
+        var refusedTake = Refusal(await controller.MineAsync(take: -1, cancellationToken: CancellationToken.None).ConfigureAwait(true));
+        Assert.Equal("take", refusedTake.Field, StringComparer.Ordinal);
+
+        // Asked for more than a page holds, and refused rather than quietly given fewer.
+        var refusedTooMany = Refusal(await controller.MineAsync(take: RequestsController.MaximumPageSize + 1, cancellationToken: CancellationToken.None).ConfigureAwait(true));
+        Assert.Equal("take", refusedTooMany.Field, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// The same refusals on the queue endpoint. Two endpoints reading one set of parameters is two
+    /// places a check can be dropped from, so both are asked.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task TheQueueRefusesTheSameParameters()
+    {
+        var store = new InMemoryRequestStore();
+        await ASpreadOfRequestsAsync(store).ConfigureAwait(true);
+        var controller = ControllerFor(store, Reader);
+
+        var result = await controller.QueueAsync(
+            [(RequestState)99],
+            cancellationToken: CancellationToken.None).ConfigureAwait(true);
+        var refused = Assert.IsType<BadRequestObjectResult>(result.Result);
+        Assert.Equal("state", Assert.IsType<RequestRefused>(refused.Value).Field, StringComparer.Ordinal);
+
+        result = await controller.QueueAsync(
+            take: RequestsController.MaximumPageSize + 1,
+            cancellationToken: CancellationToken.None).ConfigureAwait(true);
+        refused = Assert.IsType<BadRequestObjectResult>(result.Result);
+        Assert.Equal("take", Assert.IsType<RequestRefused>(refused.Value).Field, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// The queue answers with everything, which is what the elevation on it is for, and every row
+    /// carries the revision the store has it at.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task TheQueueHoldsEverybodysRequestsAndEachRowCarriesItsRevision()
+    {
+        var store = new InMemoryRequestStore();
+        var theirs = await ASpreadOfRequestsAsync(store).ConfigureAwait(true);
+        var controller = ControllerFor(store, Reader);
+
+        var result = await controller.QueueAsync(
+            take: RequestsController.MaximumPageSize,
+            cancellationToken: CancellationToken.None).ConfigureAwait(true);
+        var page = Assert.IsType<RequestsPage<QueuedRequest>>(Assert.IsType<OkObjectResult>(result.Result).Value);
+
+        var held = await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Equal(held.Count, page.MatchCount);
+        Assert.True(page.MatchCount > theirs.Count, "The queue holds no request the reader is not waiting for, so this proves nothing.");
+        Assert.All(page.Requests, row => Assert.True(row.Revision >= 1));
+        Assert.Contains(page.Requests, row => row.RequestedByUserId == SomebodyElse);
+    }
+
+    /// <summary>
+    /// The queue endpoint carries the elevation policy and the other one does not, read off the
+    /// built assembly.
+    /// <para>
+    /// This is the whole of what the suite says about who may reach the queue. The server evaluates
+    /// the policy and there is no server here, which the headless rule in <c>docs/testing.md</c>
+    /// settles; the attribute being present is the part that can be refused from in process, and it
+    /// is the part that goes missing when somebody adds an endpoint.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void TheQueueEndpointCarriesTheElevationPolicyAndTheOwnRequestsEndpointDoesNot()
+    {
+        var queue = typeof(RequestsController).GetMethod(nameof(RequestsController.QueueAsync));
+        var mine = typeof(RequestsController).GetMethod(nameof(RequestsController.MineAsync));
+
+        Assert.NotNull(queue);
+        Assert.NotNull(mine);
+
+        Assert.Equal(
+            ["RequiresElevation"],
+            queue.GetCustomAttributes<AuthorizeAttribute>(inherit: false).Select(attribute => attribute.Policy));
+
+        Assert.Equal([], mine.GetCustomAttributes<AuthorizeAttribute>(inherit: false).Select(attribute => attribute.Policy));
+
+        // The controller's own policy is what the endpoint without one inherits, so the absence
+        // above is an authenticated user rather than an open door.
+        Assert.Equal(
+            ["DefaultAuthorization"],
+            typeof(RequestsController).GetCustomAttributes<AuthorizeAttribute>(inherit: false).Select(attribute => attribute.Policy));
+    }
+
+    /// <summary>
+    /// A call that authenticates and names nobody is refused rather than answered with an empty
+    /// page. There is no "own" for an API key, and an empty page would say there are none.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ACallNamingNobodyIsRefusedRatherThanAnsweredWithAnEmptyPage()
+    {
+        var store = new InMemoryRequestStore();
+        await ASpreadOfRequestsAsync(store).ConfigureAwait(true);
+        var controller = ControllerFor(store, caller: null);
+
+        var refused = Refusal(await controller.MineAsync(cancellationToken: CancellationToken.None).ConfigureAwait(true));
+        Assert.Equal("caller", refused.Field, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Requests from three people, in several states and both kinds, with the reader asking for some
+    /// and joining one somebody else asked for.
+    /// </summary>
+    /// <param name="store">Where they go.</param>
+    /// <returns>The identifiers of the requests the reader is waiting for.</returns>
+    private async Task<IReadOnlyList<Guid>> ASpreadOfRequestsAsync(InMemoryRequestStore store)
+    {
+        var asked = new DateTimeOffset(2026, 8, 1, 12, 0, 0, TimeSpan.Zero);
+        var theirs = new List<Guid>();
+
+        // The reader's own, one per state that a request can be moved into from open, so a state
+        // filter has something on both sides of it.
+        var open = await Add(store, Reader, asked, RequestedItemKind.Movie, "Zulu", note: "The reader wrote this.").ConfigureAwait(true);
+        theirs.Add(open.Id);
+
+        var approved = await Add(store, Reader, asked.AddHours(2), RequestedItemKind.Series, "Alpha").ConfigureAwait(true);
+        theirs.Add(approved.Id);
+        await Move(store, approved, RequestState.Approved, asked.AddHours(9)).ConfigureAwait(true);
+
+        var declined = await Add(store, Reader, asked.AddHours(3), RequestedItemKind.Movie, "Mike").ConfigureAwait(true);
+        theirs.Add(declined.Id);
+        await Move(store, declined, RequestState.Declined, asked.AddHours(4)).ConfigureAwait(true);
+
+        // Somebody else's, joined by the reader and then by a third person, so the row the reader
+        // sees is one whose requester and whose other joiner are both other people.
+        var joined = await Add(store, SomebodyElse, asked.AddHours(1), RequestedItemKind.Series, "Bravo", note: "Somebody else wrote this.").ConfigureAwait(true);
+        theirs.Add(joined.Id);
+        var withReader = RequestLifecycle.Join(joined, Reader);
+        var withBoth = RequestLifecycle.Join(withReader, AThirdPerson);
+        await store.ReplaceAsync(withBoth, 1, CancellationToken.None).ConfigureAwait(true);
+
+        // Two the reader has nothing to do with, so the queue is wider than their own list and a
+        // filter that stopped narrowing would show them.
+        await Add(store, SomebodyElse, asked.AddHours(5), RequestedItemKind.Movie, "Yankee").ConfigureAwait(true);
+        await Add(store, AThirdPerson, asked.AddHours(6), RequestedItemKind.Series, "Charlie").ConfigureAwait(true);
+
+        return theirs;
+    }
+
+    /// <summary>
+    /// A request in the store, made by the given person.
+    /// </summary>
+    /// <param name="store">Where it goes.</param>
+    /// <param name="asker">Who asked.</param>
+    /// <param name="asked">When.</param>
+    /// <param name="kind">What sort of thing.</param>
+    /// <param name="title">The title, which is also what the title order is read from.</param>
+    /// <param name="note">What they wrote, where they wrote anything.</param>
+    /// <returns>The request as it was stored.</returns>
+    private async Task<MediaRequest> Add(
+        InMemoryRequestStore store,
+        Guid asker,
+        DateTimeOffset asked,
+        RequestedItemKind kind,
+        string title,
+        string? note = null)
+    {
+        var request = new MediaRequest
+        {
+            Id = _identifiers.NewId(),
+            RequestedByUserId = asker,
+            RequestedAt = asked,
+            StateChangedAt = asked,
+            Kind = kind,
+            DisplayTitle = title,
+
+            // Named by a provider, because a request carrying no identifier cannot be approved: the
+            // model refuses the moves that need one, and a fixture that could not be moved would
+            // leave the state filter with nothing on one side of it.
+            ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tmdb"] = title },
+            RequesterNote = note
+        };
+
+        var stored = await store.AddAsync(request, CancellationToken.None).ConfigureAwait(true);
+        return stored.Request;
+    }
+
+    /// <summary>
+    /// Moves a request, so the state filter and the moved-at order have something to work on.
+    /// </summary>
+    /// <param name="store">Where it is.</param>
+    /// <param name="request">The request.</param>
+    /// <param name="state">Where it goes.</param>
+    /// <param name="at">When it moved.</param>
+    /// <returns>A task that completes when the store holds the move.</returns>
+    private static async Task Move(InMemoryRequestStore store, MediaRequest request, RequestState state, DateTimeOffset at)
+    {
+        var operator_ = RequestCaller.Administrator(new Guid("c1000000-0000-0000-0000-0000000000ad"));
+
+        // A decline carries a reason and is made through its own verb, because a decline with no
+        // reason reads as arbitrary to the person who asked.
+        var moved = state == RequestState.Declined
+            ? RequestLifecycle.Decline(request, DeclineReason.NotWanted, "The operator wrote this.", at, operator_)
+            : RequestLifecycle.Move(request, state, at, operator_);
+
+        await store.ReplaceAsync(moved, 1, CancellationToken.None).ConfigureAwait(true);
+    }
+
+    /// <summary>
+    /// The page, with the status code checked.
+    /// </summary>
+    /// <param name="answered">What the action returned.</param>
+    /// <returns>The page.</returns>
+    private static RequestsPage<MyRequest> Page(ActionResult<RequestsPage<MyRequest>> answered)
+    {
+        var result = Assert.IsType<OkObjectResult>(answered.Result);
+        Assert.Equal(200, result.StatusCode);
+        return Assert.IsType<RequestsPage<MyRequest>>(result.Value);
+    }
+
+    /// <summary>
+    /// The refusal, with the status code checked.
+    /// </summary>
+    /// <param name="answered">What the action returned.</param>
+    /// <returns>The refusal.</returns>
+    private static RequestRefused Refusal(ActionResult<RequestsPage<MyRequest>> answered)
+    {
+        var result = Assert.IsType<BadRequestObjectResult>(answered.Result);
+        Assert.Equal(400, result.StatusCode);
+        return Assert.IsType<RequestRefused>(result.Value);
+    }
+
+    /// <summary>
+    /// A controller wired to one store and one identity.
+    /// </summary>
+    /// <param name="store">Where requests are kept.</param>
+    /// <param name="caller">Who the server says is calling.</param>
+    /// <returns>The controller under test.</returns>
+    private RequestsController ControllerFor(IRequestStore store, Guid? caller)
+        => new RequestsController(
+            store,
+            new TestClock(new DateTimeOffset(2026, 8, 9, 12, 0, 0, TimeSpan.Zero)),
+            _identifiers,
+            new FakeCallerIdentity(caller));
+}

--- a/Jellyfin.Plugin.Requests.Tests/Doubles/InMemoryRequestStore.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/InMemoryRequestStore.cs
@@ -89,25 +89,11 @@ internal sealed class InMemoryRequestStore : IRequestStore
 
         lock (_gate)
         {
-            var matched = _held.Values.Where(stored => query.Matches(stored.Request)).ToArray();
-
-            var ordered = query.Order switch
-            {
-                RequestQueryOrder.RequestedAt => matched.OrderBy(stored => stored.Request.RequestedAt).ThenBy(stored => stored.Request.Id),
-                RequestQueryOrder.StateChangedAt => matched.OrderBy(stored => stored.Request.StateChangedAt).ThenBy(stored => stored.Request.Id),
-                RequestQueryOrder.DisplayTitle => matched.OrderBy(stored => stored.Request.DisplayTitle, StringComparer.InvariantCulture).ThenBy(stored => stored.Request.Id),
-                _ => throw new ArgumentOutOfRangeException(nameof(query), query.Order, "This store has no comparison for that order.")
-            };
-
-            // The descending case is the ascending one reversed rather than a second set of arms.
-            // Two spellings of one order are two places a tiebreak can be dropped from, and the
-            // tiebreak is what makes paging see every match exactly once.
-            var page = (query.Descending ? ordered.Reverse() : ordered)
-                .Skip(query.Skip)
-                .Take(query.Take)
-                .ToArray();
-
-            return Task.FromResult(new RequestPage(page, matched.Length));
+            // The filter, the order and the page are the query's own, which is what makes this
+            // double answer the same question as the store that ships rather than a second reading
+            // of it. A double with an ordering of its own is a double that can agree with the
+            // contract suite and disagree with the store it stands in for.
+            return Task.FromResult(query.PageOf(_held.Values));
         }
     }
 

--- a/Jellyfin.Plugin.Requests/Api/MyRequest.cs
+++ b/Jellyfin.Plugin.Requests/Api/MyRequest.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using Jellyfin.Plugin.Requests.Model;
+
+namespace Jellyfin.Plugin.Requests.Api;
+
+/// <summary>
+/// One request as the person waiting for it sees it.
+/// <para>
+/// <b>It carries no identifier of any person, including the caller's own.</b> That is the whole
+/// reason this type exists rather than the stored request being returned. A user's own list holds
+/// requests they asked for and requests they joined, and a joined one was asked for by somebody
+/// else: handing back the stored record would tell the caller who that was, and who else is waiting
+/// alongside them. Nothing here says how many people are waiting either, because a count is the
+/// same disclosure made smaller.
+/// </para>
+/// <para>
+/// The history is left out for the same reason one step further. Every entry names the
+/// administrator who made the move, and a queue a user can read is not an audit trail.
+/// </para>
+/// <para>
+/// What a user may learn about other people's requests at all is #51, and #71 asks the question from
+/// the surface side. Nothing here aggregates across people, so this endpoint takes no position on
+/// either beyond refusing to be the place it leaks.
+/// </para>
+/// </summary>
+public sealed record MyRequest
+{
+    /// <summary>
+    /// Gets the request's identifier, which is the only identifier in this shape and names a
+    /// request rather than a person.
+    /// </summary>
+    public required Guid Id { get; init; }
+
+    /// <summary>
+    /// Gets what sort of thing was asked for.
+    /// </summary>
+    public required RequestedItemKind Kind { get; init; }
+
+    /// <summary>
+    /// Gets the title as it read when it was asked for.
+    /// </summary>
+    public required string DisplayTitle { get; init; }
+
+    /// <summary>
+    /// Gets the release year, where the ask carried one.
+    /// </summary>
+    public int? DisplayYear { get; init; }
+
+    /// <summary>
+    /// Gets the seasons asked for. Empty means the whole series, and on a film it is always empty.
+    /// </summary>
+    public IReadOnlyList<int> Seasons { get; init; } = [];
+
+    /// <summary>
+    /// Gets where the request stands.
+    /// </summary>
+    public required RequestState State { get; init; }
+
+    /// <summary>
+    /// Gets when it was asked for. On a request the caller joined this is when the first person
+    /// asked, which is what the caller is waiting behind.
+    /// </summary>
+    public required DateTimeOffset RequestedAt { get; init; }
+
+    /// <summary>
+    /// Gets when it last moved.
+    /// </summary>
+    public required DateTimeOffset StateChangedAt { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the caller is the person who asked first, as opposed to
+    /// somebody who joined a request that already existed. It is a fact about the caller and
+    /// discloses nobody else.
+    /// </summary>
+    public required bool AskedByYou { get; init; }
+
+    /// <summary>
+    /// Gets the note the caller wrote when they asked, and nothing where they joined instead. A
+    /// note on a joined request is another person's writing, and this shape does not carry it.
+    /// </summary>
+    public string? YourNote { get; init; }
+
+    /// <summary>
+    /// Gets why it was declined, where it was. A decline reason is required, decided by the
+    /// maintainer on #113, and a requester who is not told why asks the same thing again.
+    /// </summary>
+    public DeclineReason? DeclineReason { get; init; }
+
+    /// <summary>
+    /// Gets what the operator wrote alongside that reason, where they wrote anything. It is written
+    /// for the requester to read, which is why it is here and the history is not.
+    /// </summary>
+    public string? DeclineNote { get; init; }
+
+    /// <summary>
+    /// Gets how much of what was asked for the library already holds.
+    /// </summary>
+    public required LibraryAvailability Availability { get; init; }
+}

--- a/Jellyfin.Plugin.Requests/Api/QueuedRequest.cs
+++ b/Jellyfin.Plugin.Requests/Api/QueuedRequest.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using Jellyfin.Plugin.Requests.Model;
+
+namespace Jellyfin.Plugin.Requests.Api;
+
+/// <summary>
+/// One request as an administrator reading the queue sees it: everything a decision is made from,
+/// and the revision the store has it at.
+/// <para>
+/// The revision is here because the next thing an operator does is move the request, and the store
+/// refuses a write made against a revision that has moved underneath it. A row without one would
+/// force a second read before every decision, and the answer to that read is what the queue already
+/// held.
+/// </para>
+/// <para>
+/// Who asked and who joined are here, and this is the only shape that carries them. Reading the
+/// whole queue is what the elevation on the endpoint is for. What a queue must show for a decision
+/// to be possible at all is #59, so this is what the queue can show rather than a settled answer to
+/// what it should.
+/// </para>
+/// <para>
+/// The history is left out. It is the record of every move a request made, it grows without bound,
+/// and a page of the queue is not where it is read. Whichever surface needs it should read one
+/// request rather than have every row carry one.
+/// </para>
+/// </summary>
+public sealed record QueuedRequest
+{
+    /// <summary>
+    /// Gets the request's identifier.
+    /// </summary>
+    public required Guid Id { get; init; }
+
+    /// <summary>
+    /// Gets what the store has this request at. It is handed back with a write, which is how two
+    /// operators deciding one request at the same moment end with one decision rather than a silent
+    /// overwrite.
+    /// </summary>
+    public required long Revision { get; init; }
+
+    /// <summary>
+    /// Gets the person who asked first.
+    /// </summary>
+    public required Guid RequestedByUserId { get; init; }
+
+    /// <summary>
+    /// Gets everyone who asked for this after it existed, oldest first.
+    /// </summary>
+    public IReadOnlyList<Guid> JoinedByUserIds { get; init; } = [];
+
+    /// <summary>
+    /// Gets what sort of thing was asked for.
+    /// </summary>
+    public required RequestedItemKind Kind { get; init; }
+
+    /// <summary>
+    /// Gets the title as it read when it was asked for.
+    /// </summary>
+    public required string DisplayTitle { get; init; }
+
+    /// <summary>
+    /// Gets the release year, where the ask carried one.
+    /// </summary>
+    public int? DisplayYear { get; init; }
+
+    /// <summary>
+    /// Gets the external identifiers that name the thing.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> ProviderIds { get; init; } = new Dictionary<string, string>(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Gets the seasons asked for. Empty means the whole series.
+    /// </summary>
+    public IReadOnlyList<int> Seasons { get; init; } = [];
+
+    /// <summary>
+    /// Gets where the request stands.
+    /// </summary>
+    public required RequestState State { get; init; }
+
+    /// <summary>
+    /// Gets when it was asked for.
+    /// </summary>
+    public required DateTimeOffset RequestedAt { get; init; }
+
+    /// <summary>
+    /// Gets when it last moved.
+    /// </summary>
+    public required DateTimeOffset StateChangedAt { get; init; }
+
+    /// <summary>
+    /// Gets who moved it last, where anybody has.
+    /// </summary>
+    public Guid? StateChangedByUserId { get; init; }
+
+    /// <summary>
+    /// Gets the note the person who asked wrote.
+    /// </summary>
+    public string? RequesterNote { get; init; }
+
+    /// <summary>
+    /// Gets why it was declined, where it was.
+    /// </summary>
+    public DeclineReason? DeclineReason { get; init; }
+
+    /// <summary>
+    /// Gets what was written alongside that reason.
+    /// </summary>
+    public string? DeclineNote { get; init; }
+
+    /// <summary>
+    /// Gets how much of what was asked for the library already holds.
+    /// </summary>
+    public required LibraryAvailability Availability { get; init; }
+
+    /// <summary>
+    /// Gets when that was last worked out, where it has been.
+    /// </summary>
+    public DateTimeOffset? AvailabilityCheckedAt { get; init; }
+}

--- a/Jellyfin.Plugin.Requests/Api/RequestsController.cs
+++ b/Jellyfin.Plugin.Requests/Api/RequestsController.cs
@@ -48,6 +48,27 @@ public sealed class RequestsController : RequestsControllerBase
     private const string AuthenticatedUserPolicy = "DefaultAuthorization";
 
     /// <summary>
+    /// The server's policy for a call that has to come from an administrator, named as a literal for
+    /// the same reason as the one above. It is what the server's own dashboard endpoints carry, so an
+    /// endpoint under it is reachable by exactly the people who can already administer the server.
+    /// </summary>
+    private const string AdministratorPolicy = "RequiresElevation";
+
+    /// <summary>
+    /// How many rows a page holds when the caller does not say. Fifty is a screen of a queue and a
+    /// small answer for a client that only wanted to know whether there is anything at all.
+    /// </summary>
+    public const int DefaultPageSize = 50;
+
+    /// <summary>
+    /// The largest page any caller may ask for. A page size is what stands between a queue with
+    /// three years of history and an answer nobody can render, and a caller asking for more is
+    /// refused rather than quietly given fewer: a client that asked for a thousand, got two hundred
+    /// and was not told has just decided it has seen everything.
+    /// </summary>
+    public const int MaximumPageSize = 200;
+
+    /// <summary>
     /// How many times a join is attempted before giving up. A join is a read followed by a write
     /// against the revision that was read, so two people joining one request in the same moment
     /// means one of them is refused and re-decides. Three is enough for that and small enough that
@@ -152,6 +173,275 @@ public sealed class RequestsController : RequestsControllerBase
             ? StatusCode(StatusCodes.Status201Created, answer)
             : Ok(answer);
     }
+
+    /// <summary>
+    /// The caller's own requests: the ones they asked for and the ones they joined.
+    /// <para>
+    /// <b>Nobody else's request can come back from here, whatever is asked for.</b> The narrowing is
+    /// the read rather than a filter over a wider one: the store is asked for this person's requests
+    /// through its own lookup, and the filter, the order and the page are applied to what that
+    /// returns. There is no parameter that widens it, because there is nothing wider to widen to.
+    /// </para>
+    /// <para>
+    /// The rows carry no identifier of any person. A request the caller joined was asked for by
+    /// somebody else, so the stored record would name them and everybody else waiting alongside;
+    /// <see cref="MyRequest"/> is what this returns instead.
+    /// </para>
+    /// </summary>
+    /// <param name="state">The states to show, or none of them for every state.</param>
+    /// <param name="kind">The kinds to show, or none of them for every kind.</param>
+    /// <param name="order">What the rows are ordered by.</param>
+    /// <param name="descending">Whether that order runs the other way.</param>
+    /// <param name="skip">How many matches to step over before the page starts.</param>
+    /// <param name="take">How many rows the page holds at most.</param>
+    /// <param name="cancellationToken">Cancels the call.</param>
+    /// <returns>The page, and how many of the caller's requests matched.</returns>
+    [HttpGet("Requests")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<RequestsPage<MyRequest>>> MineAsync(
+        [FromQuery] RequestState[]? state = null,
+        [FromQuery] RequestedItemKind[]? kind = null,
+        [FromQuery] RequestQueryOrder order = RequestQueryOrder.RequestedAt,
+        [FromQuery] bool descending = false,
+        [FromQuery] int skip = 0,
+        [FromQuery] int take = DefaultPageSize,
+        CancellationToken cancellationToken = default)
+    {
+        if (!Asked(state, kind, order, skip, take, descending, out var query, out var refusal))
+        {
+            return BadRequest(refusal);
+        }
+
+        var caller = await _callers.UserIdAsync(HttpContext).ConfigureAwait(false);
+
+        if (caller is not Guid reader)
+        {
+            // Authenticated and naming nobody, which is what an API key looks like from here. There
+            // is no "own" for such a caller, and answering with an empty page would say there are
+            // none rather than that the question does not apply.
+            return BadRequest(new RequestRefused
+            {
+                Field = "caller",
+                Reason = "This call is authenticated but names no user, so there is nobody whose requests these would be."
+            });
+        }
+
+        var theirs = await _store.FindForUserAsync(reader, cancellationToken).ConfigureAwait(false);
+        var page = query.PageOf(theirs);
+
+        return Ok(new RequestsPage<MyRequest>
+        {
+            Requests = [.. page.Requests.Select(stored => Mine(stored.Request, reader))],
+            MatchCount = page.MatchCount,
+            Skip = query.Skip,
+            Take = query.Take
+        });
+    }
+
+    /// <summary>
+    /// The whole queue, for an administrator deciding on it.
+    /// <para>
+    /// The elevation is the endpoint's own and is on top of the controller's policy. It is what makes
+    /// this the one place the whole queue is readable, and it is why the endpoint below it can be
+    /// written without a filter that decides who may see what: a caller who is not an administrator
+    /// never reaches this action at all, and the other one has nothing wider than one person's own
+    /// requests to return.
+    /// </para>
+    /// <para>
+    /// What the server does with that policy is the server's, and no test on this board exercises it:
+    /// the headless rule in <c>docs/testing.md</c> refuses a running Jellyfin, so what the suite holds
+    /// is that the attribute is on the action and that the other endpoint cannot be widened.
+    /// </para>
+    /// </summary>
+    /// <param name="state">The states to show, or none of them for every state.</param>
+    /// <param name="kind">The kinds to show, or none of them for every kind.</param>
+    /// <param name="order">What the rows are ordered by.</param>
+    /// <param name="descending">Whether that order runs the other way.</param>
+    /// <param name="skip">How many matches to step over before the page starts.</param>
+    /// <param name="take">How many rows the page holds at most.</param>
+    /// <param name="cancellationToken">Cancels the call.</param>
+    /// <returns>The page, and how many requests matched.</returns>
+    [HttpGet("Requests/Queue")]
+    [Authorize(Policy = AdministratorPolicy)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<RequestsPage<QueuedRequest>>> QueueAsync(
+        [FromQuery] RequestState[]? state = null,
+        [FromQuery] RequestedItemKind[]? kind = null,
+        [FromQuery] RequestQueryOrder order = RequestQueryOrder.RequestedAt,
+        [FromQuery] bool descending = false,
+        [FromQuery] int skip = 0,
+        [FromQuery] int take = DefaultPageSize,
+        CancellationToken cancellationToken = default)
+    {
+        if (!Asked(state, kind, order, skip, take, descending, out var query, out var refusal))
+        {
+            return BadRequest(refusal);
+        }
+
+        var page = await _store.PageAsync(query, cancellationToken).ConfigureAwait(false);
+
+        return Ok(new RequestsPage<QueuedRequest>
+        {
+            Requests = [.. page.Requests.Select(Queued)],
+            MatchCount = page.MatchCount,
+            Skip = query.Skip,
+            Take = query.Take
+        });
+    }
+
+    /// <summary>
+    /// The query a call asked for, or the field that made it refusable.
+    /// <para>
+    /// Every enumeration is checked against what it declares. A value outside it arrives as a number
+    /// the binder is happy to cast, so a state of 99 would otherwise reach the filter and match
+    /// nothing, and the caller would read an empty queue as an empty queue.
+    /// </para>
+    /// </summary>
+    /// <param name="states">The states asked for.</param>
+    /// <param name="kinds">The kinds asked for.</param>
+    /// <param name="order">The order asked for.</param>
+    /// <param name="skip">The offset asked for.</param>
+    /// <param name="take">The page size asked for.</param>
+    /// <param name="descending">Whether the order runs the other way.</param>
+    /// <param name="query">The query, where the call is answerable.</param>
+    /// <param name="refusal">The field and the reason, where it is not.</param>
+    /// <returns><see langword="true"/> where the call is answerable.</returns>
+    private static bool Asked(
+        RequestState[]? states,
+        RequestedItemKind[]? kinds,
+        RequestQueryOrder order,
+        int skip,
+        int take,
+        bool descending,
+        out RequestQuery query,
+        out RequestRefused refusal)
+    {
+        query = null!;
+
+        if (states is not null && Array.Exists(states, asked => !Enum.IsDefined(asked)))
+        {
+            refusal = Refused("state", "That is not a state a request can be in.");
+            return false;
+        }
+
+        if (kinds is not null && Array.Exists(kinds, asked => !Enum.IsDefined(asked)))
+        {
+            refusal = Refused("kind", "That is not a kind of thing that can be asked for.");
+            return false;
+        }
+
+        if (!Enum.IsDefined(order))
+        {
+            refusal = Refused("order", "That is not something these requests can be ordered by.");
+            return false;
+        }
+
+        if (skip < 0)
+        {
+            refusal = Refused("skip", "A page cannot start before the beginning.");
+            return false;
+        }
+
+        if (take < 0)
+        {
+            refusal = Refused("take", "A page cannot hold fewer than no rows.");
+            return false;
+        }
+
+        if (take > MaximumPageSize)
+        {
+            refusal = Refused(
+                "take",
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    "A page holds at most {0} rows. This is refused rather than answered with fewer, because a caller given fewer than it asked for and not told has no way to know there is more.",
+                    MaximumPageSize));
+            return false;
+        }
+
+        query = new RequestQuery
+        {
+            States = states ?? [],
+            Kinds = kinds ?? [],
+            Order = order,
+            Descending = descending,
+            Skip = skip,
+            Take = take
+        };
+
+        refusal = null!;
+        return true;
+    }
+
+    /// <summary>
+    /// A refusal naming the query parameter that is wrong.
+    /// </summary>
+    /// <param name="field">The parameter, spelled as the caller wrote it.</param>
+    /// <param name="reason">What is wrong with it.</param>
+    /// <returns>The refusal.</returns>
+    private static RequestRefused Refused(string field, string reason)
+        => new RequestRefused { Field = field, Reason = reason };
+
+    /// <summary>
+    /// One request as the person waiting for it sees it.
+    /// </summary>
+    /// <param name="request">The stored request.</param>
+    /// <param name="reader">Who is reading it.</param>
+    /// <returns>The row.</returns>
+    private static MyRequest Mine(MediaRequest request, Guid reader)
+    {
+        var asked = request.RequestedByUserId == reader;
+
+        return new MyRequest
+        {
+            Id = request.Id,
+            Kind = request.Kind,
+            DisplayTitle = request.DisplayTitle,
+            DisplayYear = request.DisplayYear,
+            Seasons = request.Seasons,
+            State = request.State,
+            RequestedAt = request.RequestedAt,
+            StateChangedAt = request.StateChangedAt,
+            AskedByYou = asked,
+
+            // Only where the caller wrote it. On a request they joined, the note is the first
+            // person's writing and this shape does not carry another person's words.
+            YourNote = asked ? request.RequesterNote : null,
+            DeclineReason = request.DeclineReason,
+            DeclineNote = request.DeclineNote,
+            Availability = request.Availability
+        };
+    }
+
+    /// <summary>
+    /// One request as an administrator reading the queue sees it.
+    /// </summary>
+    /// <param name="stored">The request and the revision the store has it at.</param>
+    /// <returns>The row.</returns>
+    private static QueuedRequest Queued(StoredRequest stored)
+        => new QueuedRequest
+        {
+            Id = stored.Request.Id,
+            Revision = stored.Revision,
+            RequestedByUserId = stored.Request.RequestedByUserId,
+            JoinedByUserIds = stored.Request.JoinedByUserIds,
+            Kind = stored.Request.Kind,
+            DisplayTitle = stored.Request.DisplayTitle,
+            DisplayYear = stored.Request.DisplayYear,
+            ProviderIds = stored.Request.ProviderIds,
+            Seasons = stored.Request.Seasons,
+            State = stored.Request.State,
+            RequestedAt = stored.Request.RequestedAt,
+            StateChangedAt = stored.Request.StateChangedAt,
+            StateChangedByUserId = stored.Request.StateChangedByUserId,
+            RequesterNote = stored.Request.RequesterNote,
+            DeclineReason = stored.Request.DeclineReason,
+            DeclineNote = stored.Request.DeclineNote,
+            Availability = stored.Request.Availability,
+            AvailabilityCheckedAt = stored.Request.AvailabilityCheckedAt
+        };
 
     /// <summary>
     /// Whether a request already in the queue is one a new ask may join.

--- a/Jellyfin.Plugin.Requests/Api/RequestsPage.cs
+++ b/Jellyfin.Plugin.Requests/Api/RequestsPage.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.Requests.Api;
+
+/// <summary>
+/// One page of requests, and how many the filter matched before the page was taken.
+/// <para>
+/// The count comes back with the page rather than from a second call, because the two have to be
+/// answered from one read. A page and a count taken separately can disagree, and a surface saying
+/// "1 to 50 of 49" is one an operator stops trusting for the rest of the numbers on the screen.
+/// </para>
+/// <para>
+/// The slice the caller asked for is echoed back. A client that has to remember what it sent in
+/// order to know what it got is a client that draws the wrong pager the first time two calls are in
+/// flight at once, and the endpoint may return a smaller page than was asked for.
+/// </para>
+/// </summary>
+/// <typeparam name="TRequest">
+/// What one row looks like, which is not the same shape for a person reading their own requests and
+/// for an administrator reading the queue.
+/// </typeparam>
+public sealed record RequestsPage<TRequest>
+{
+    /// <summary>
+    /// Gets the rows on this page, in the order that was asked for. Empty where the page starts past
+    /// the end of the matches, which is an ordinary answer rather than an error.
+    /// </summary>
+    public required IReadOnlyList<TRequest> Requests { get; init; }
+
+    /// <summary>
+    /// Gets how many requests matched, whatever this page holds. This is what a pager is drawn from,
+    /// and it is the count of matches rather than the length of the page.
+    /// </summary>
+    public required int MatchCount { get; init; }
+
+    /// <summary>
+    /// Gets how many matches were stepped over before this page.
+    /// </summary>
+    public required int Skip { get; init; }
+
+    /// <summary>
+    /// Gets how many rows were asked for at most.
+    /// </summary>
+    public required int Take { get; init; }
+}

--- a/Jellyfin.Plugin.Requests/Storage/FileRequestStore.cs
+++ b/Jellyfin.Plugin.Requests/Storage/FileRequestStore.cs
@@ -206,16 +206,10 @@ public sealed class FileRequestStore : IRequestStore, IDisposable
 
         var held = await HeldAsync(cancellationToken).ConfigureAwait(false);
 
-        // One walk of the set, and everything below is over what survived it. The count and the
-        // page are taken from this one list, which is how the two cannot disagree.
-        var matched = held.Held.Values.Where(stored => query.Matches(stored.Request)).ToArray();
-
-        var page = Ordered(matched, query)
-            .Skip(query.Skip)
-            .Take(query.Take)
-            .ToArray();
-
-        return new RequestPage(page, matched.Length);
+        // One walk of the set, and the count and the page come out of it together. The filter and
+        // the order are the query's own, so this store and the surface that pages one person's own
+        // requests answer under one rule rather than under two that agree today.
+        return query.PageOf(held.Held.Values);
     }
 
     /// <inheritdoc />
@@ -496,51 +490,6 @@ public sealed class FileRequestStore : IRequestStore, IDisposable
             ? new RequestStoreLoadException(filePath, detail)
             : new RequestStoreLoadException(filePath, detail, reason);
     }
-
-    /// <summary>
-    /// Puts the matches in the order the query asked for.
-    /// <para>
-    /// The identifier is the last key of every order, so requests that compare equal under the
-    /// chosen one still have exactly one position. Without it their order is whatever order the set
-    /// is enumerated in, and the set is a dictionary that is rebuilt on every write: a request
-    /// created between two page turns can reorder rows that have nothing to do with it, so an
-    /// operator turning to the next page sees one of them again and never sees another.
-    /// </para>
-    /// <para>
-    /// Descending reverses the identifier as well as the chosen key, so the descending order is
-    /// exactly the ascending one read backwards. A tiebreak left ascending under a reversed primary
-    /// key is a third order, and two requests made in the same tick would sit in one order going
-    /// down the queue and the other going up it.
-    /// </para>
-    /// <para>
-    /// The title is compared as text somebody reads rather than as bytes, so an accented title
-    /// sorts beside its unaccented neighbour instead of after every unaccented title there is. That
-    /// is the one order here where the byte comparison and the reading one differ, and the reading
-    /// one is what a person scanning a column expects.
-    /// </para>
-    /// </summary>
-    /// <param name="matched">What survived the filter.</param>
-    /// <param name="query">The order asked for.</param>
-    /// <returns>The matches, ordered.</returns>
-    private static IOrderedEnumerable<StoredRequest> Ordered(IEnumerable<StoredRequest> matched, RequestQuery query)
-        => query.Order switch
-        {
-            RequestQueryOrder.RequestedAt => query.Descending
-                ? matched.OrderByDescending(stored => stored.Request.RequestedAt).ThenByDescending(stored => stored.Request.Id)
-                : matched.OrderBy(stored => stored.Request.RequestedAt).ThenBy(stored => stored.Request.Id),
-            RequestQueryOrder.StateChangedAt => query.Descending
-                ? matched.OrderByDescending(stored => stored.Request.StateChangedAt).ThenByDescending(stored => stored.Request.Id)
-                : matched.OrderBy(stored => stored.Request.StateChangedAt).ThenBy(stored => stored.Request.Id),
-            RequestQueryOrder.DisplayTitle => query.Descending
-                ? matched.OrderByDescending(stored => stored.Request.DisplayTitle, StringComparer.InvariantCulture).ThenByDescending(stored => stored.Request.Id)
-                : matched.OrderBy(stored => stored.Request.DisplayTitle, StringComparer.InvariantCulture).ThenBy(stored => stored.Request.Id),
-
-            // An order this store has no comparison for is refused rather than served by whichever
-            // arm happened to be written last. A value added to the enumeration is a value that
-            // reaches here, and being told so is cheaper than a queue quietly ordered by something
-            // else.
-            _ => throw new ArgumentOutOfRangeException(nameof(query), query.Order, "This store has no comparison for that order.")
-        };
 
     /// <summary>
     /// The set, reading the file on the first call that needs it. A caller that finds it already

--- a/Jellyfin.Plugin.Requests/Storage/RequestQuery.cs
+++ b/Jellyfin.Plugin.Requests/Storage/RequestQuery.cs
@@ -117,4 +117,82 @@ public sealed record RequestQuery
 
         return _kinds.Count == 0 || _kinds.Contains(request.Kind);
     }
+
+    /// <summary>
+    /// This query answered against a set of requests: the filter, the order and the page, and the
+    /// count of everything that matched before the page was taken.
+    /// <para>
+    /// It is here for the reason <see cref="Matches"/> is. A store answers this over everything it
+    /// holds; the user surface answers it over one person's own requests, which the store hands back
+    /// through its own lookup rather than by walking the queue. Both are the same question over a
+    /// different set, and a second implementation of the ordering is a second place the tiebreak can
+    /// be dropped from.
+    /// </para>
+    /// <para>
+    /// One walk of the candidates, and the count and the page come out of the same walk, so a pager
+    /// cannot disagree with the rows above it.
+    /// </para>
+    /// </summary>
+    /// <param name="candidates">The requests this query is answered over.</param>
+    /// <returns>The page, and how many matched.</returns>
+    /// <exception cref="ArgumentNullException">Where the candidates are missing.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Where <see cref="Order"/> is a value nothing here has a comparison for. It is refused rather
+    /// than served by whichever arm happened to be written last, because a queue quietly ordered by
+    /// something else is worse than one that says it cannot answer.
+    /// </exception>
+    public RequestPage PageOf(IEnumerable<StoredRequest> candidates)
+    {
+        ArgumentNullException.ThrowIfNull(candidates);
+
+        var matched = candidates.Where(stored => Matches(stored.Request)).ToArray();
+
+        var page = Ordered(matched)
+            .Skip(Skip)
+            .Take(Take)
+            .ToArray();
+
+        return new RequestPage(page, matched.Length);
+    }
+
+    /// <summary>
+    /// The matches in the order this query asked for.
+    /// <para>
+    /// The identifier is the last key of every order, so requests that compare equal under the
+    /// chosen one still have exactly one position. Without it their order is whatever order the set
+    /// is enumerated in, and a set held by a store is rebuilt on every write: a request created
+    /// between two page turns can reorder rows that have nothing to do with it, so a reader turning
+    /// to the next page sees one of them again and never sees another.
+    /// </para>
+    /// <para>
+    /// Descending reverses the identifier as well as the chosen key, so the descending order is
+    /// exactly the ascending one read backwards. A tiebreak left ascending under a reversed primary
+    /// key is a third order, and two requests made in the same tick would sit in one order going
+    /// down the queue and the other going up it.
+    /// </para>
+    /// <para>
+    /// The title is compared as text somebody reads rather than as bytes, so an accented title
+    /// sorts beside its unaccented neighbour instead of after every unaccented title there is. That
+    /// is the one order here where the byte comparison and the reading one differ, and the reading
+    /// one is what a person scanning a column expects.
+    /// </para>
+    /// </summary>
+    /// <param name="matched">What survived the filter.</param>
+    /// <returns>The matches, ordered.</returns>
+    private IOrderedEnumerable<StoredRequest> Ordered(IEnumerable<StoredRequest> matched)
+        => Order switch
+        {
+            RequestQueryOrder.RequestedAt => Descending
+                ? matched.OrderByDescending(stored => stored.Request.RequestedAt).ThenByDescending(stored => stored.Request.Id)
+                : matched.OrderBy(stored => stored.Request.RequestedAt).ThenBy(stored => stored.Request.Id),
+            RequestQueryOrder.StateChangedAt => Descending
+                ? matched.OrderByDescending(stored => stored.Request.StateChangedAt).ThenByDescending(stored => stored.Request.Id)
+                : matched.OrderBy(stored => stored.Request.StateChangedAt).ThenBy(stored => stored.Request.Id),
+            RequestQueryOrder.DisplayTitle => Descending
+                ? matched.OrderByDescending(stored => stored.Request.DisplayTitle, StringComparer.InvariantCulture).ThenByDescending(stored => stored.Request.Id)
+                : matched.OrderBy(stored => stored.Request.DisplayTitle, StringComparer.InvariantCulture).ThenBy(stored => stored.Request.Id),
+
+            _ => throw new InvalidOperationException(FormattableString.Invariant(
+                $"There is no comparison for the order {Order}, so this query cannot say what its page holds."))
+        };
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -124,9 +124,66 @@ so a client can put the message beside the box somebody typed in rather than hav
 to work out which one. That shape is the smallest thing that carries it and is expected to be
 replaced by whatever #56 decides.
 
+## Reading your own requests
+
+    GET MediaRequests/v1/Requests
+
+Everything the caller is waiting for: the requests they asked for and the ones they joined.
+
+**Nothing else can come back from it, whatever is asked for.** The narrowing is the read rather than
+a filter over a wider one. The store is asked for this person's requests through its own lookup, and
+the filter, the order and the page are applied to what that returns, so there is no parameter that
+widens it and nothing wider for one to widen to.
+
+The rows carry no identifier of any person, the caller included. A request somebody else asked for
+and the caller joined would otherwise name the first asker and everybody else waiting alongside them,
+and a count of how many people are waiting is the same disclosure made smaller, so there is none of
+that either. `AskedByYou` says whether the caller asked first, which is a fact about the caller. A
+note is the writing of whoever asked, so it comes back only on a request the caller asked for
+themselves.
+
+The history is not in the answer. Every entry names the administrator who made the move, and a list a
+user reads is not an audit trail.
+
+## Reading the queue
+
+    GET MediaRequests/v1/Requests/Queue
+
+Every request on the server, for an administrator deciding on them. It carries the server's elevation
+policy on top of the controller's, so it is reachable by the people who can already administer the
+server and by nobody else.
+
+Each row carries the revision the store has the request at, because the next thing an operator does
+is move it and the store refuses a write made against a revision that has moved underneath it.
+
+What a queue must show for a decision to be possible is #59, so this is what the queue can show
+rather than a settled answer to what it should.
+
+## The parameters both reads take
+
+| Parameter    | Meaning                                            | Default       |
+| ------------ | -------------------------------------------------- | ------------- |
+| `state`      | Which states to show. Repeatable. None means all.  | all           |
+| `kind`       | Which kinds to show. Repeatable. None means all.   | all           |
+| `order`      | `RequestedAt`, `StateChangedAt` or `DisplayTitle`. | `RequestedAt` |
+| `descending` | Whether that order runs the other way.             | `false`       |
+| `skip`       | How many matches to step over.                     | `0`           |
+| `take`       | How many rows the page holds at most.              | `50`          |
+
+The answer carries the rows, how many matched the filter before the page was taken, and the slice
+that was asked for. The count is what a pager is drawn from: a page and a count taken from two reads
+can disagree, and a surface saying "1 to 50 of 49" is one an operator stops trusting for the rest of
+the numbers on the screen.
+
+`take` is capped at 200 and a larger one is **refused** rather than answered with fewer. A caller that
+asked for a thousand, was given two hundred and was not told has just decided it has seen everything.
+
+A value outside an enumeration is refused with the parameter named. Such a value binds as a number
+and would otherwise match nothing, and an empty page reads exactly like an empty queue.
+
 ## What is not decided here
 
 - Which policy each endpoint carries, and what a user may see of somebody else's request, is #51.
 - The shape of an error and which status code each failure gets is #56.
-- What each endpoint does is #52, #53, #54 and #55.
+- What each endpoint does is #52, #54 and #55.
 - Whether these endpoints appear in the server's published API documentation is #57.


### PR DESCRIPTION
Closes #53.

## The two endpoints

    GET MediaRequests/v1/Requests        the caller's own
    GET MediaRequests/v1/Requests/Queue  everything, elevated

Who may read what is the difference between them rather than a parameter on one of them. The queue carries `RequiresElevation` on top of the controller's `DefaultAuthorization`; the other carries what the controller already had.

Both take the same parameters: `state` and `kind` repeatable and meaning all when absent, `order` of `RequestedAt`, `StateChangedAt` or `DisplayTitle`, `descending`, `skip` and `take`. Both answer with the rows, the count of everything that matched before the page was taken, and the slice that was asked for. `docs/api.md` carries the table.

## The narrowing is the read

The endpoint a user reaches asks the store for that person's requests through `FindForUserAsync`, which is the lookup #48 built, and applies the filter, the order and the page to what comes back. There is no parameter that widens it and nothing wider to widen to.

That matters because a filter applied after a whole-queue read passes a test that asks once and gets its own rows back. The leg that bites here seeds three people's requests, including one the caller joined and two they have nothing to do with, and then asks as the caller under every combination of state filter, kind filter, order, direction and page size, 1440 calls. Every row is one they are waiting for, and the count beside it never exceeds how many of theirs there are, because a count over the whole queue is the same disclosure as a row.

## The rows a user reads name nobody

`MyRequest` carries the request and not the people. A request somebody else asked for and the caller joined would otherwise name the first asker and everybody else waiting alongside them. There is no count of joiners either, which would be the same disclosure made smaller.

- `AskedByYou` is a fact about the caller.
- `YourNote` is the caller's own writing, and is absent on a request they joined, because the note there belongs to whoever asked.
- The history is out entirely: every entry names the administrator who made the move.

Two assertions hold that. One serialises a page containing the joined request and asserts none of the three people's identifiers appears in the bytes. The other reads the type and asserts no property of it is a `Guid`, a `Guid?` or a list of them apart from the request's own identifier, so a field added later is refused rather than only a field present today.

The aggregate question #51 and #71 disagree about is untouched here: nothing in either endpoint aggregates across people, so this takes no position beyond refusing to be the place it leaks.

## One rule for filtering, ordering and paging

`RequestQuery.PageOf` is the filter, the order and the page in the type that already held the filter, for the reason written there: a page and a count taken under two readings can disagree. `FileRequestStore`, the in-memory double and the endpoint that pages one person's own requests now call it instead of each carrying an ordering. The double had its own arms and had lost the descending tiebreak's second half; that is gone with the duplication rather than fixed twice.

## What is refused rather than absorbed

`take` above 200 is refused. A caller that asked for a thousand, was given two hundred and was not told has decided it has seen everything.

A state, kind or order outside its enumeration is refused with the parameter named. Such a value binds as a number the model binder is happy to cast, matches nothing, and an empty page reads exactly like an empty queue.

A call that authenticates and names nobody, which is what an API key looks like from an endpoint, is refused rather than answered with an empty page.

## That the guards bite

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release --framework net9.0

The own-requests read widened to the whole store, `FindForUserAsync` to `GetAllAsync`:

    ListRequestsTests.NothingButTheCallersOwnRequestsComesBackWhateverIsAskedFor [FAIL]
    ListRequestsTests.PagingWalksEveryMatchExactlyOnceAndTheCountIsTheSameOnEveryPage [FAIL]
    ListRequestsTests.ANoteOnARequestSomebodyElseAskedForIsNotHandedToWhoeverJoinedIt [FAIL]
    Fehler: 3, erfolgreich: 255, gesamt: 258

The note handed back whoever wrote it, `asked ? request.RequesterNote : null` to `request.RequesterNote`:

    ListRequestsTests.ANoteOnARequestSomebodyElseAskedForIsNotHandedToWhoeverJoinedIt [FAIL]
    Fehler: 1, erfolgreich: 257, gesamt: 258

A requester identifier added to the user-facing row:

    ListRequestsTests.NoRowNamesAnybodyIncludingTheCaller [FAIL]
    Fehler: 1, erfolgreich: 257, gesamt: 258

Restored, on the pushed tree:

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release
    Bestanden!: Fehler: 0, erfolgreich: 258, gesamt: 258 (net9.0)
    Bestanden!: Fehler: 0, erfolgreich: 258, gesamt: 258 (net10.0)

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    0 Fehler, 0 Warnung(en)

## The means

C# in the controller the API already has, over the query paths the store already offers, and no package is added. The one thing that could have been done another way is the administrator split: an endpoint that asked the server whether the caller is an administrator and returned a wider or narrower answer from one route. That would have meant reading the server's permission model from inside the plugin, and a mistake in it is a leak rather than a refusal. The policy attribute puts the same question to the server's own authorisation, in the place the server already answers it.

## What this does not claim

The server enforcing `RequiresElevation` is not exercised. There is no running Jellyfin in this suite, which `docs/testing.md` settles, so what the suite holds is that the attribute is on the action, that the controller's own policy is what an action without one inherits, and that the endpoint a non-administrator can reach has nothing wider than one person's requests to return. Whether a non-administrator reaching `Requests/Queue` is refused is the server's answer and is untested here.

`docs/api.md`'s table of parameters is a document rather than a check. Nothing refuses a parameter added to the endpoint and not written there.

The cost of the queue read is the store's, measured in `FileRequestStoreQueryCostTests` and unchanged by this: it is one walk with the count and the page from that walk. The user path is a lookup and then a walk of one person's own requests, which is bounded by how many requests one person has made rather than by the size of the queue, and that is not separately measured.

## Reading

There was no second reader for this change. The three near-miss runs above are the part worth re-running rather than trusting.
