### PR TITLE
Give every endpoint its own named policy and refuse the two ways one is lost (#51)

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Api/EndpointPolicyTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/EndpointPolicyTests.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using Jellyfin.Plugin.Requests.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Api;
+
+/// <summary>
+/// Who may reach each endpoint, held against the built assembly.
+/// <para>
+/// The invariant lint holds two rules over the source text, and they are not this check. They refuse
+/// the two ways a policy is taken away: an anonymous endpoint, and an <c>[Authorize]</c> that names
+/// no policy. Neither can see an endpoint that simply never carried an attribute, because a rule
+/// about text cannot refuse the absence of a line. That is what this reads the assembly for.
+/// </para>
+/// <para>
+/// What no test here can say is what the server does with a policy. The server evaluates it and
+/// there is no server in this suite, which the headless rule in <c>docs/testing.md</c> settles and
+/// which its refusal list names with the replacement it stands in for. So the promise held here is
+/// that every endpoint carries the policy it is meant to carry, and the promise that a caller
+/// outside that policy is turned away belongs to the server.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class EndpointPolicyTests
+{
+    /// <summary>
+    /// Every endpoint and the policy it carries, written down.
+    /// <para>
+    /// An addition fails this until somebody adds a line here, which is the point: the failure a
+    /// per-endpoint test cannot catch is the endpoint added later that no test knows about. The
+    /// commit that adds the line is where the reason for that policy lives, and <c>docs/api.md</c>
+    /// is where a reader finds it.
+    /// </para>
+    /// </summary>
+    private static readonly string[] Expected =
+    [
+        // Asking for something. An authenticated user, because a request has to be attributable to
+        // somebody and a caller with no session names nobody.
+        "RequestsController.CreateAsync POST Requests -> DefaultAuthorization",
+
+        // One person's own requests. The same policy, and the narrowing is the read rather than the
+        // policy: this endpoint has nothing wider than the caller's own requests to return.
+        "RequestsController.MineAsync GET Requests -> DefaultAuthorization",
+
+        // The whole queue, which is every person's requests and who asked for each. An
+        // administrator, and it is the only endpoint here that needs one.
+        "RequestsController.QueueAsync GET Requests/Queue -> RequiresElevation"
+    ];
+
+    /// <summary>
+    /// Every endpoint carries a policy of its own, named, and the set is exactly the one written
+    /// above.
+    /// </summary>
+    [Fact]
+    public void EveryEndpointCarriesThePolicyWrittenDownForIt()
+    {
+        // Joined rather than compared as two sequences, because a collection failure prints the
+        // difference with the middle elided and the whole list is what somebody repairing this needs
+        // to read.
+        Assert.Equal(
+            string.Join(" | ", Expected),
+            string.Join(" | ", Endpoints()),
+            StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// No endpoint relies on the attribute the controller carries.
+    /// <para>
+    /// An endpoint with no policy of its own is reachable under whatever its class happens to
+    /// declare on the day it is added, and a class attribute is edited by somebody who is not
+    /// reading the endpoint. This is the leg that catches the endpoint added with no attribute at
+    /// all, which is what neither the lint nor a per-endpoint refusal test can see.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void NoEndpointInheritsItsPolicyFromTheControllerItSitsOn()
+    {
+        var inherited = Actions()
+            .Where(action => !action.Method.GetCustomAttributes<AuthorizeAttribute>(inherit: false)
+                .Any(attribute => !string.IsNullOrWhiteSpace(attribute.Policy)))
+            .Select(action => Named(action.Type, action.Method))
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal([], inherited);
+    }
+
+    /// <summary>
+    /// Nothing is anonymous. The lint refuses the attribute in the source and this refuses it in the
+    /// assembly, which is the same rule read two ways: one sees a file the other's path list would
+    /// miss, and the other sees an attribute that arrived some way the text rule does not match.
+    /// </summary>
+    [Fact]
+    public void NoEndpointIsReachableWithoutASession()
+    {
+        var anonymous = Actions()
+            .Where(action => action.Method.GetCustomAttributes<AllowAnonymousAttribute>(inherit: true).Any()
+                || action.Type.GetCustomAttributes<AllowAnonymousAttribute>(inherit: true).Any())
+            .Select(action => Named(action.Type, action.Method))
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal([], anonymous);
+    }
+
+    /// <summary>
+    /// The controller carries a policy too, so the floor under every endpoint is a signed-in caller
+    /// rather than whatever the framework defaults to. The endpoints do not rely on it, which is the
+    /// leg above; this is that it is there.
+    /// </summary>
+    [Fact]
+    public void TheControllerItselfCarriesAPolicy()
+    {
+        var controllers = Controllers()
+            .Where(type => !type.GetCustomAttributes<AuthorizeAttribute>(inherit: true)
+                .Any(attribute => !string.IsNullOrWhiteSpace(attribute.Policy)))
+            .Select(type => type.FullName ?? type.Name)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal([], controllers);
+    }
+
+    /// <summary>
+    /// Every controller the plugin ships.
+    /// </summary>
+    /// <returns>The types.</returns>
+    private static Type[] Controllers()
+        => [.. typeof(RequestsControllerBase).Assembly
+            .GetTypes()
+            .Where(type => typeof(ControllerBase).IsAssignableFrom(type))
+            .Where(type => !type.IsAbstract)
+            .OrderBy(type => type.Name, StringComparer.Ordinal)];
+
+    /// <summary>
+    /// Every action on every controller, which is every method carrying an HTTP verb.
+    /// </summary>
+    /// <returns>The actions.</returns>
+    private static (Type Type, MethodInfo Method)[] Actions()
+        => [.. Controllers()
+            .SelectMany(type => type
+                .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                .Where(method => method.GetCustomAttributes<HttpMethodAttribute>(inherit: false).Any())
+                .Select(method => (Type: type, Method: method)))];
+
+    /// <summary>
+    /// One endpoint, its verb, its template and its policy, as one line.
+    /// </summary>
+    /// <returns>The lines, sorted.</returns>
+    private static string[] Endpoints()
+        => [.. Actions()
+            .Select(action => string.Format(
+                CultureInfo.InvariantCulture,
+                "{0} {1} -> {2}",
+                Named(action.Type, action.Method),
+                Route(action.Method),
+                string.Join(
+                    "+",
+                    action.Method.GetCustomAttributes<AuthorizeAttribute>(inherit: false)
+                        .Select(attribute => attribute.Policy ?? "(none)")
+                        .OrderBy(policy => policy, StringComparer.Ordinal))))
+            .OrderBy(line => line, StringComparer.Ordinal)];
+
+    /// <summary>
+    /// The verb and template an action answers under.
+    /// </summary>
+    /// <param name="method">The action.</param>
+    /// <returns>The verb and the template.</returns>
+    private static string Route(MethodInfo method)
+    {
+        var verb = method.GetCustomAttributes<HttpMethodAttribute>(inherit: false).Single();
+
+        return string.Format(
+            CultureInfo.InvariantCulture,
+            "{0} {1}",
+            string.Join(",", verb.HttpMethods),
+            verb.Template ?? "(none)");
+    }
+
+    /// <summary>
+    /// An action named the way a person repairing this test would look for it.
+    /// </summary>
+    /// <param name="type">The controller.</param>
+    /// <param name="method">The action.</param>
+    /// <returns>The name.</returns>
+    private static string Named(Type type, MethodInfo method)
+        => string.Format(CultureInfo.InvariantCulture, "{0}.{1}", type.Name, method.Name);
+}

--- a/Jellyfin.Plugin.Requests.Tests/Api/ListRequestsTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/ListRequestsTests.cs
@@ -416,13 +416,14 @@ public sealed class ListRequestsTests
     }
 
     /// <summary>
-    /// The queue endpoint carries the elevation policy and the other one does not, read off the
-    /// built assembly.
+    /// The queue endpoint carries the elevation policy and the endpoint a user reaches carries the
+    /// signed-in one, read off the built assembly.
     /// <para>
     /// This is the whole of what the suite says about who may reach the queue. The server evaluates
     /// the policy and there is no server here, which the headless rule in <c>docs/testing.md</c>
-    /// settles; the attribute being present is the part that can be refused from in process, and it
-    /// is the part that goes missing when somebody adds an endpoint.
+    /// settles and whose refusal list names this with its replacement. That every endpoint carries a
+    /// policy of its own at all is <see cref="EndpointPolicyTests"/>; this leg is that these two
+    /// carry the two different ones, which is what makes the queue the elevated read.
     /// </para>
     /// </summary>
     [Fact]
@@ -438,10 +439,12 @@ public sealed class ListRequestsTests
             ["RequiresElevation"],
             queue.GetCustomAttributes<AuthorizeAttribute>(inherit: false).Select(attribute => attribute.Policy));
 
-        Assert.Equal([], mine.GetCustomAttributes<AuthorizeAttribute>(inherit: false).Select(attribute => attribute.Policy));
+        Assert.Equal(
+            ["DefaultAuthorization"],
+            mine.GetCustomAttributes<AuthorizeAttribute>(inherit: false).Select(attribute => attribute.Policy));
 
-        // The controller's own policy is what the endpoint without one inherits, so the absence
-        // above is an authenticated user rather than an open door.
+        // The controller's own policy is the floor under both, so an endpoint that ever lost its own
+        // attribute would still need a signed-in caller rather than being open.
         Assert.Equal(
             ["DefaultAuthorization"],
             typeof(RequestsController).GetCustomAttributes<AuthorizeAttribute>(inherit: false).Select(attribute => attribute.Policy));

--- a/Jellyfin.Plugin.Requests/Api/RequestsController.cs
+++ b/Jellyfin.Plugin.Requests/Api/RequestsController.cs
@@ -31,10 +31,17 @@ namespace Jellyfin.Plugin.Requests.Api;
 /// rather than identity and is answered below.
 /// </para>
 /// <para>
-/// The policy is the floor rather than the decision. Every endpoint carries an explicit policy and
-/// which one each carries is #51; what is here is an authenticated user, because a request has to be
-/// attributable to somebody to exist at all and an endpoint reachable without a session could not
-/// name a requester.
+/// <b>Every endpoint carries its own policy, and the one on the controller is the floor.</b> An
+/// endpoint that carried none would be reachable by whatever the class happens to declare on the day
+/// it is added, and a class attribute is edited by somebody who is not reading the endpoint. Which
+/// policy each one carries, and what a caller may see under it, is <c>docs/api.md</c>; that the
+/// attribute is there at all is refused by <c>EndpointPolicyTests</c> over the built assembly and by
+/// two rules in the invariant lint over the source.
+/// </para>
+/// <para>
+/// Two policies are used here and no endpoint is anonymous. Creating a request and reading one's own
+/// need an authenticated user, because a request has to be attributable to somebody to exist at all
+/// and a caller with no session has no "own". Reading the whole queue needs an administrator.
 /// </para>
 /// </summary>
 [Authorize(Policy = AuthenticatedUserPolicy)]
@@ -112,6 +119,7 @@ public sealed class RequestsController : RequestsControllerBase
     /// here is the smallest thing that names the field that was wrong.
     /// </returns>
     [HttpPost("Requests")]
+    [Authorize(Policy = AuthenticatedUserPolicy)]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -197,6 +205,7 @@ public sealed class RequestsController : RequestsControllerBase
     /// <param name="cancellationToken">Cancels the call.</param>
     /// <returns>The page, and how many of the caller's requests matched.</returns>
     [HttpGet("Requests")]
+    [Authorize(Policy = AuthenticatedUserPolicy)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<RequestsPage<MyRequest>>> MineAsync(

--- a/docs/api.md
+++ b/docs/api.md
@@ -181,9 +181,44 @@ asked for a thousand, was given two hundred and was not told has just decided it
 A value outside an enumeration is refused with the parameter named. Such a value binds as a number
 and would otherwise match nothing, and an empty page reads exactly like an empty queue.
 
+## Who may reach what
+
+Every endpoint carries a policy of its own, and the controller carries one as the floor under all of
+them. An endpoint with no policy of its own is reachable under whatever its class happens to declare
+on the day it is added, and a class attribute is edited by somebody who is not reading the endpoint.
+
+| Endpoint             | Policy                 | Who that is          |
+| -------------------- | ---------------------- | -------------------- |
+| `POST Requests`      | `DefaultAuthorization` | any signed-in person |
+| `GET Requests`       | `DefaultAuthorization` | any signed-in person |
+| `GET Requests/Queue` | `RequiresElevation`    | an administrator     |
+
+**Nothing here is anonymous.** A request has to be attributable to somebody to exist at all, and a
+queue is a list of who asked for what, so there is no answer this plugin gives that is safe to hand a
+caller the server has not authenticated.
+
+The policies are the server's own, named as literals because the constants that hold them live in the
+server's web assembly and a plugin does not reference it. The string is the contract either way.
+
+What holds this. `EndpointPolicyTests` reads the built assembly and refuses an endpoint whose policy
+is not the one written down for it, an endpoint carrying no policy of its own, and an anonymous one.
+The invariant lint refuses the two source shapes that take a policy away: `no-anonymous-endpoint` and
+`authorize-names-a-policy`, the second of which is about a bare `[Authorize]`, which reads as though
+it decided something and admits every signed-in person on the server.
+
+What none of that holds is the server turning a caller away, which is the server's own evaluation of
+the policy and needs a running one. `docs/testing.md` carries that as a refused test with what
+replaces it.
+
+The rule underneath the table is narrower than the table. **A user sees their own requests in full
+and learns nothing at all about anybody else's**, which is what `GET Requests` returns and why its
+rows carry no identifier of any person. Whether a user may ever be told that a title has already been
+asked for, which is a weaker disclosure than a row and still a disclosure, is open between #51 and
+#71 and is deliberately not taken here: nothing this plugin serves aggregates across people today.
+
 ## What is not decided here
 
-- Which policy each endpoint carries, and what a user may see of somebody else's request, is #51.
+- Whether a user may ever be told that a title has already been asked for is open between #51 and #71.
 - The shape of an error and which status code each failure gets is #56.
 - What each endpoint does is #52, #54 and #55.
 - Whether these endpoints appear in the server's published API documentation is #57.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -87,14 +87,30 @@ own handler pipeline and no socket is opened. It is #35. Until it exists there i
 to test: #80 defines the backend interface with a null implementation behind it, and #87 is the
 proof that this plugin is complete with no backend at all.
 
+**A call refused by the server's authorisation policy.** Refused: the policy is evaluated by the
+server, so a test that a signed-in caller who is not an administrator is turned away from the queue
+endpoint needs a running Jellyfin holding a session for that person. That is the fourth condition,
+and it is the same refusal as installing into a real server above rather than a new kind of one.
+
+What replaces it is two things, on two sides of the endpoint. `EndpointPolicyTests` reads the built
+assembly and refuses an endpoint whose policy is not the one written down for it, an endpoint with
+no policy of its own, and an anonymous one; `no-anonymous-endpoint` and `authorize-names-a-policy`
+refuse the two source shapes that take a policy away. That is the half about which policy an
+endpoint is under. The other half is that the endpoint a caller without elevation can reach has
+nothing wider than that caller's own requests to return, which `ListRequestsTests` asks under every
+combination of filter, order and page. Neither is the server turning somebody away, and neither
+claims to be: what they leave open is that the server evaluates `RequiresElevation` the way its own
+endpoints are evaluated under it. That is #51.
+
 Every replacement named above exists, either as something already in the tree or as an issue on
 this board:
 
-    for n in 20 35 50 52 54 56 61 64 115; do gh issue view $n --json number,state,title --jq '"\(.number)  \(.state)  \(.title)"'; done
+    for n in 20 35 50 51 52 54 56 61 64 115; do gh issue view $n --json number,state,title --jq '"\(.number)  \(.state)  \(.title)"'; done
     20  CLOSED  Prove the built plugin loads on a server of each claimed line
     35  OPEN  Provide an in-process HTTP double for the outbound calls
-    50  OPEN  Lay out the controller, the route prefix and the version rule
-    52  OPEN  Create a request over the API
+    50  CLOSED  Lay out the controller, the route prefix and the version rule
+    51  OPEN  Decide the authorisation policy for every endpoint
+    52  CLOSED  Create a request over the API
     54  OPEN  Act on a request over the API
     56  OPEN  Fix the error shape and the status codes
     61  OPEN  Act on one request from the page
@@ -112,8 +128,8 @@ rather than off the workflow:
 
 ### What this list is not
 
-It is not a list of everything that will ever be refused. It holds the three refusals the plan
-makes visible today, and the conditions above are what decide the next one. A test refused for a
+It is not a list of everything that will ever be refused. It holds the refusals the plan makes
+visible today, and the conditions above are what decide the next one. A test refused for a
 condition not yet met by any proposal gets its own entry here when the proposal arrives, together
 with what replaces it.
 

--- a/tools/opengrep/fixtures/policy/ReachableWithoutASession.cs
+++ b/tools/opengrep/fixtures/policy/ReachableWithoutASession.cs
@@ -1,0 +1,36 @@
+// Fixture for no-anonymous-endpoint and authorize-names-a-policy. This file is in
+// no project and is never compiled; it exists so both rules can be watched
+// refusing the mistakes they name.
+//
+// Both near-misses are one keystroke away from correct code and neither is a
+// build failure. The first is what somebody writes while testing an endpoint by
+// hand and then does not take out again. The second reads as though it says
+// "this needs authorisation", and it does: it says only that the caller is
+// authenticated, which on a family server is everybody, and it says nothing
+// about which of them.
+
+namespace Jellyfin.Plugin.Requests.Fixtures;
+
+public sealed class ReachableWithoutASession : RequestsControllerBase
+{
+    // Legal neighbours, left here on purpose: this is how an endpoint is written
+    // and neither rule may fire on either of them.
+    [HttpGet("Requests")]
+    [Authorize(Policy = "DefaultAuthorization")]
+    public IActionResult Mine() => Ok();
+
+    [HttpGet("Requests/Queue")]
+    [Authorize(Policy = "RequiresElevation")]
+    public IActionResult Queue() => Ok();
+
+    // The regression: an endpoint anybody can reach with no session at all.
+    [HttpGet("Requests/Anything")]
+    [AllowAnonymous]
+    public IActionResult Anything() => Ok();
+
+    // And the one that looks like it decided something. Every signed-in person on
+    // the server passes it, which is the whole server's household.
+    [HttpGet("Requests/Everybody")]
+    [Authorize]
+    public IActionResult Everybody() => Ok();
+}

--- a/tools/opengrep/rules.yaml
+++ b/tools/opengrep/rules.yaml
@@ -352,3 +352,47 @@ rules:
         - "tools/opengrep/fixtures/route/**/*.cs"
       exclude:
         - "Jellyfin.Plugin.Requests/Api/RequestsControllerBase.cs"
+
+  # Invariant (api, #51): nothing this plugin serves is reachable without a
+  # session. Decided in docs/api.md, which sets out which policy each endpoint
+  # carries and why none of them is anonymous. A request has to be attributable
+  # to somebody to exist at all, and a queue is a list of who asked for what, so
+  # there is no endpoint here whose answer is safe to give a caller the server
+  # has not authenticated. `[AllowAnonymous]` is the one attribute that turns
+  # every policy above it off, including the controller's, and it is what
+  # somebody writes while testing an endpoint by hand.
+  - id: no-anonymous-endpoint
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      Do not make an endpoint anonymous. Every endpoint this plugin serves
+      carries a policy and none of them is reachable without a session (#51);
+      AllowAnonymous turns off the controller's policy as well as the method's.
+    patterns:
+      - pattern: '[AllowAnonymous]'
+    paths:
+      include:
+        - "Jellyfin.Plugin.Requests/**/*.cs"
+        - "tools/opengrep/fixtures/policy/**/*.cs"
+
+  # Invariant (api, #51): a policy is named rather than left to the default.
+  # Decided in docs/api.md. A bare `[Authorize]` reads as though it decided
+  # something and decides almost nothing: it admits every signed-in person, which
+  # on a family server is the whole household, and it says nothing about which of
+  # them may read a queue. The named policies are the server's own, so an
+  # endpoint under one is reachable by exactly the people the server already
+  # says may do that thing. The attribute with a policy is a longer token
+  # sequence and is not matched by this.
+  - id: authorize-names-a-policy
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      Name the policy. A bare [Authorize] admits every signed-in caller and says
+      nothing about which of them may reach this endpoint (#51). Write
+      [Authorize(Policy = ...)] with one of the server's named policies.
+    patterns:
+      - pattern: '[Authorize]'
+    paths:
+      include:
+        - "Jellyfin.Plugin.Requests/**/*.cs"
+        - "tools/opengrep/fixtures/policy/**/*.cs"


### PR DESCRIPTION
Part of #51. It does not close it, and the last section says why.

## What changed

Two of the three endpoints carried no policy of their own. They were reachable under whatever the controller declared, which is an attribute somebody edits without reading the endpoints under it, and an endpoint added later inherits whatever it finds.

| Endpoint             | Policy                 | Who that is          |
| -------------------- | ---------------------- | -------------------- |
| `POST Requests`      | `DefaultAuthorization` | any signed-in person |
| `GET Requests`       | `DefaultAuthorization` | any signed-in person |
| `GET Requests/Queue` | `RequiresElevation`    | an administrator     |

The controller keeps its own attribute as the floor, so an endpoint that ever lost its own would still need a session rather than being open. Nothing here is anonymous: a request has to be attributable to somebody to exist at all, and a queue is a list of who asked for what.

## Three checks, and what each one alone cannot see

`EndpointPolicyTests` reads the built assembly and compares every endpoint against a written list, the same discipline `SiblingIndependenceTests` uses for references. An endpoint added with no attribute fails until somebody adds a line, and the commit that adds it is where the reason for that policy lives. A rule about source text cannot do this: it cannot refuse the absence of a line.

The lint refuses the two ways a policy is taken away in the source, which the assembly test would only see after somebody had already done it and rebuilt:

- `no-anonymous-endpoint`, because `[AllowAnonymous]` turns off the controller's policy as well as the method's, and it is what somebody writes while testing an endpoint by hand.
- `authorize-names-a-policy`, for a bare `[Authorize]`. It reads as though it decided something and admits every signed-in person on the server, which on a family server is everybody.

Both carry a fixture, so `prove-rules-fire.sh` reds if either stops matching. The fixture also holds the two legal spellings, so a rule that started matching correct code reds the tree scan.

## That the guards bite

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release
    Bestanden!: Fehler: 0, erfolgreich: 262, gesamt: 262 (net9.0)
    Bestanden!: Fehler: 0, erfolgreich: 262, gesamt: 262 (net10.0)

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    0 Fehler, 0 Warnung(en)

The assembly test was watched failing before the attributes were added: with `MineAsync` carrying no policy of its own, `EveryEndpointCarriesThePolicyWrittenDownForIt` and `NoEndpointInheritsItsPolicyFromTheControllerItSitsOn` are the legs that go red, and the leg from #53 that asserted the old state had to be rewritten in this change for the same reason.

The two lint rules are proven by the gate rather than by me: `Enforce greppable invariants` scans the fixture directory and fails unless every declared rule fired on one. A rule of mine that matched nothing reds that step on this pull request rather than passing quietly. The opengrep release is a Linux binary and this tree's rules are not runnable on the machine the change was written on, which is why the proof is the check run here and not a paste from a local run.

## Why this does not close #51

Its three conditions, against what is now true.

**"Every endpoint carries an explicit policy attribute, enforced by a rule in the invariant lint from #28."** The first half holds. The second does not, as written: what enforces presence is the assembly test, and the lint rules refuse removal rather than absence. That is not a shortcut taken for convenience. Every rule in this lint is `generic` mode on purpose, which matches token sequences, and "this attribute is not here" is not a token sequence. A rule that tried to express it would have to fix a convention about which attribute sits immediately above which, and would go quiet the first time somebody reordered two lines, which is the failure the whole file is written against.

**"A test per endpoint asserts the refusal for a caller who should not reach it, including a signed-in non-administrator on the administrator endpoints."** Two of the three endpoints have such a test: a caller that authenticates and names nobody is refused by `POST Requests` and by `GET Requests`, in `CreateRequestTests` and `ListRequestsTests`. The third cannot have one here. A signed-in non-administrator being turned away from the queue is the server evaluating `RequiresElevation`, and that needs a running Jellyfin holding a session for that person, which is the fourth condition of the headless rule. It is now an entry in the refusal list in `docs/testing.md` with what replaces it on both sides of the endpoint, which is the mechanism that list exists for and which its own closing section invites.

**"A test asserts that a user reading a queue cannot learn who else asked for something."** This one holds, and it landed with #53: the rows a user reads carry no identifier of any person, asserted against the serialised bytes and against the shape of the type, and the endpoint they can reach has nothing wider than their own requests to return.

So one condition is met, one is met by a different mechanism from the one it names, and one is met for two endpoints out of three with the third recorded as refused. Which of those wordings stands is a change to the issue rather than to the code, and it is not a call to make inside a change. The issue is assigned and the wording is left to whoever owns the plan.

## What this does not claim

The server's evaluation of either policy is not exercised anywhere on this board. The policy names are literals, because the constants that hold them live in the server's own web assembly, which a plugin does not reference; that a server of each claimed line resolves those two names to the policies meant is not measured here.

The aggregate question between #51 and #71 is untouched. Nothing this plugin serves aggregates across people, so `docs/api.md` states the narrow rule and names the disagreement rather than settling it.

## Reading

There was no second reader for this change. The evidence above stands in its place.
