### PR TITLE
Keep CodeQL out of the generated build output (#194)

### DIFF
--- a/.github/workflows/scan-codeql.yaml
+++ b/.github/workflows/scan-codeql.yaml
@@ -83,6 +83,15 @@ jobs:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-extended
+          # Path filtering for the ANALYSIS. The paths-ignore under `on:` above
+          # decides when this workflow runs, not what CodeQL reads, so without
+          # this block the generated sources under obj/ are analysed too. They
+          # are not in the tree, nobody can change them, and the source
+          # generator that writes them does not follow these rules.
+          config: |
+            paths-ignore:
+              - "**/obj/**"
+              - "**/bin/**"
 
       - name: Build for the analysis
         # Manual rather than autobuild, so the analysis is over what this


### PR DESCRIPTION
Closes #194.

`paths-ignore` under `on:` governs when the workflow runs, not what the analysis reads. The `Initialize CodeQL` step carried no `config`, so generated sources under `obj/` were analysed as well.

The exclusion is deliberately narrow: `**/obj/**` and `**/bin/**` only. Nothing a person wrote is silenced.

Landed first in `Flowfin/jellyfin-plugin-discover`, where the open findings went from 18 to 13 and nothing else changed.