### PR TITLE
Act on a request over the API, through the model rather than around it (#54)

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Api/ActOnARequestTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/ActOnARequestTests.cs
@@ -1,0 +1,558 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Api;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Api;
+
+/// <summary>
+/// Deciding on a request over the API.
+/// <para>
+/// The actions are called directly rather than through a server, for the reason the create tests
+/// give: the headless rule refuses a running Jellyfin, and what these judge is what an endpoint does
+/// with a body, an identity and a store. What that leaves out is the server evaluating the policy
+/// on the action, which no test on this board makes and which <c>docs/testing.md</c> carries as a
+/// refused test with what stands in for it.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class ActOnARequestTests
+{
+    private static readonly Guid Asker = new Guid("b2000000-0000-0000-0000-000000000001");
+    private static readonly Guid Operator = new Guid("b2000000-0000-0000-0000-000000000002");
+    private static readonly Guid SecondOperator = new Guid("b2000000-0000-0000-0000-000000000003");
+    private static readonly DateTimeOffset Started = new DateTimeOffset(2026, 8, 10, 9, 0, 0, TimeSpan.Zero);
+
+    private readonly SequentialIdentifierSource _identifiers = new SequentialIdentifierSource();
+
+    /// <summary>
+    /// An approval moves the request, hands back the row at its new revision, and leaves exactly one
+    /// entry in the history naming the person who made it.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ApprovingAnOpenRequestMovesItAndAppendsOneEntry()
+    {
+        var store = new InMemoryRequestStore();
+        var open = await AnOpenRequestAsync(store).ConfigureAwait(true);
+
+        var answered = await ControllerFor(store, Operator)
+            .ApproveAsync(open.Request.Id, new ApproveRequestBody { Revision = open.Revision }, CancellationToken.None)
+            .ConfigureAwait(true);
+
+        var row = Moved(answered);
+        var held = await Held(store, open.Request.Id).ConfigureAwait(true);
+
+        Assert.Equal(RequestState.Approved, row.State);
+        Assert.Equal(open.Revision + 1, row.Revision);
+        Assert.Equal(RequestState.Approved, held.Request.State);
+        Assert.Equal(Operator, held.Request.StateChangedByUserId);
+
+        var entry = Assert.Single(held.Request.History);
+        Assert.Equal(RequestState.Open, entry.From);
+        Assert.Equal(RequestState.Approved, entry.To);
+        Assert.Equal(Operator, entry.ByUserId);
+        Assert.Equal(Started, entry.At);
+    }
+
+    /// <summary>
+    /// A decline carries the reason and the note, and leaves one entry holding both. The entry is
+    /// worth more than the fields on the request: taking the decline back overwrites those and
+    /// leaves this.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task DecliningCarriesTheReasonAndAppendsOneEntry()
+    {
+        var store = new InMemoryRequestStore();
+        var open = await AnOpenRequestAsync(store).ConfigureAwait(true);
+
+        var answered = await ControllerFor(store, Operator)
+            .DeclineAsync(
+                open.Request.Id,
+                new DeclineRequestBody
+                {
+                    Revision = open.Revision,
+                    Reason = DeclineReason.NoRoomForIt,
+                    Note = "The disk this would go on is full until the new one arrives."
+                },
+                CancellationToken.None)
+            .ConfigureAwait(true);
+
+        var row = Moved(answered);
+        var held = await Held(store, open.Request.Id).ConfigureAwait(true);
+
+        Assert.Equal(RequestState.Declined, row.State);
+        Assert.Equal(DeclineReason.NoRoomForIt, row.DeclineReason);
+
+        var entry = Assert.Single(held.Request.History);
+        Assert.Equal(RequestState.Declined, entry.To);
+        Assert.Equal(DeclineReason.NoRoomForIt, entry.Reason);
+        Assert.Equal("The disk this would go on is full until the new one arrives.", entry.Note, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Two decisions on one request leave two entries and no more. One entry per move is the
+    /// property the whole history is worth reading for, and it is checked over a sequence rather
+    /// than over a single call because a second entry appended by the wrong layer would not show on
+    /// the first.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task EachDecisionAppendsOneEntryAndNoMore()
+    {
+        var store = new InMemoryRequestStore();
+        var open = await AnOpenRequestAsync(store).ConfigureAwait(true);
+        var controller = ControllerFor(store, Operator);
+
+        var approved = Moved(await controller
+            .ApproveAsync(open.Request.Id, new ApproveRequestBody { Revision = open.Revision }, CancellationToken.None)
+            .ConfigureAwait(true));
+
+        await controller
+            .DeclineAsync(
+                open.Request.Id,
+                new DeclineRequestBody { Revision = approved.Revision, Reason = DeclineReason.NotWanted },
+                CancellationToken.None)
+            .ConfigureAwait(true);
+
+        var held = await Held(store, open.Request.Id).ConfigureAwait(true);
+
+        Assert.Equal(2, held.Request.History.Count);
+        Assert.Equal([RequestState.Approved, RequestState.Declined], held.Request.History.Select(entry => entry.To));
+    }
+
+    /// <summary>
+    /// A decision made against a revision that has moved is refused, the store keeps what the other
+    /// operator decided, and the answer carries the row as it now reads so the caller can decide
+    /// again against it rather than re-reading the queue.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ADecisionOnARequestThatMovedIsRefusedWithWhatTheQueueHoldsNow()
+    {
+        var store = new InMemoryRequestStore();
+        var open = await AnOpenRequestAsync(store).ConfigureAwait(true);
+
+        await ControllerFor(store, Operator)
+            .ApproveAsync(open.Request.Id, new ApproveRequestBody { Revision = open.Revision }, CancellationToken.None)
+            .ConfigureAwait(true);
+
+        var late = await ControllerFor(store, SecondOperator)
+            .DeclineAsync(
+                open.Request.Id,
+                new DeclineRequestBody { Revision = open.Revision, Reason = DeclineReason.NotWanted },
+                CancellationToken.None)
+            .ConfigureAwait(true);
+
+        var refused = Refusal(late, expectedStatus: 409);
+        var held = await Held(store, open.Request.Id).ConfigureAwait(true);
+
+        Assert.Equal(RequestMoveRefusal.MovedSinceItWasRead, refused.Refusal);
+        Assert.NotNull(refused.Current);
+        Assert.Equal(RequestState.Approved, refused.Current!.State);
+        Assert.Equal(open.Revision + 1, refused.Current.Revision);
+        Assert.Equal(RequestState.Approved, held.Request.State);
+        Assert.Single(held.Request.History);
+    }
+
+    /// <summary>
+    /// The window between the read and the write is refused too. The revision check above answers
+    /// the ordinary case, where the caller has been holding a stale row; this is the case where the
+    /// row was current when the call started and stopped being current while it ran, and only the
+    /// store can catch it.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ADecisionOvertakenWhileItIsBeingWrittenIsRefused()
+    {
+        var inner = new InMemoryRequestStore();
+        var open = await AnOpenRequestAsync(inner).ConfigureAwait(true);
+        var store = new StoreThatMovesARequestUnderTheWrite(
+            inner,
+            request => RequestLifecycle.Move(request, RequestState.Approved, Started, RequestCaller.Administrator(SecondOperator)));
+
+        var answered = await ControllerFor(store, Operator)
+            .DeclineAsync(
+                open.Request.Id,
+                new DeclineRequestBody { Revision = open.Revision, Reason = DeclineReason.NotWanted },
+                CancellationToken.None)
+            .ConfigureAwait(true);
+
+        var refused = Refusal(answered, expectedStatus: 409);
+        var held = await Held(inner, open.Request.Id).ConfigureAwait(true);
+
+        Assert.Equal(RequestMoveRefusal.MovedSinceItWasRead, refused.Refusal);
+        Assert.NotNull(refused.Current);
+        Assert.Equal(RequestState.Approved, refused.Current!.State);
+        Assert.Equal(RequestState.Approved, held.Request.State);
+        Assert.Equal(SecondOperator, held.Request.StateChangedByUserId);
+    }
+
+    /// <summary>
+    /// A request that moved into a state this move is illegal from is refused as having moved, not
+    /// as illegal. Both answers are a refusal and they tell the operator different things: one says
+    /// somebody else got there first and here is what they did, the other says this request can
+    /// never be approved. The second is false, and it is what an endpoint that asked the table
+    /// before it looked at the revision would say.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ARequestThatMovedIntoAStateTheTableRefusesIsRefusedAsMoved()
+    {
+        var store = new InMemoryRequestStore();
+        var open = await AnOpenRequestAsync(store).ConfigureAwait(true);
+        var arrived = RequestLifecycle.Move(open.Request, RequestState.Fulfilled, Started, RequestCaller.Plugin);
+        await store.ReplaceAsync(arrived, open.Revision, CancellationToken.None).ConfigureAwait(true);
+
+        var answered = await ControllerFor(store, Operator)
+            .ApproveAsync(open.Request.Id, new ApproveRequestBody { Revision = open.Revision }, CancellationToken.None)
+            .ConfigureAwait(true);
+
+        var refused = Refusal(answered, expectedStatus: 409);
+
+        Assert.Equal(RequestMoveRefusal.MovedSinceItWasRead, refused.Refusal);
+        Assert.NotNull(refused.Current);
+        Assert.Equal(RequestState.Fulfilled, refused.Current!.State);
+    }
+
+    /// <summary>
+    /// A move the table refuses comes back with the table's own sentence for that cell, so an
+    /// operator is told why the move is not available rather than that it is not.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AMoveTheTableRefusesIsRefusedWithTheTablesOwnReason()
+    {
+        var store = new InMemoryRequestStore();
+        var open = await AnOpenRequestAsync(store).ConfigureAwait(true);
+        var fulfilled = RequestLifecycle.Move(open.Request, RequestState.Fulfilled, Started, RequestCaller.Plugin);
+        var held = await store.ReplaceAsync(fulfilled, open.Revision, CancellationToken.None).ConfigureAwait(true);
+
+        var answered = await ControllerFor(store, Operator)
+            .ApproveAsync(held.Request.Id, new ApproveRequestBody { Revision = held.Revision }, CancellationToken.None)
+            .ConfigureAwait(true);
+
+        var refused = Refusal(answered, expectedStatus: 409);
+
+        Assert.Equal(RequestMoveRefusal.TheTableRefusesTheMove, refused.Refusal);
+        Assert.Contains(
+            RequestLifecycle.Cell(RequestState.Fulfilled, RequestState.Approved).Why,
+            refused.Reason,
+            StringComparison.Ordinal);
+        Assert.Equal(RequestState.Fulfilled, (await Held(store, held.Request.Id).ConfigureAwait(true)).Request.State);
+    }
+
+    /// <summary>
+    /// A request nobody can act on because it names nothing may only be declined. Approving one is
+    /// refused with a value of its own rather than with the table's refusal, because the request is
+    /// in a state the move is legal from and the thing standing in the way is the request itself.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ARequestThatNamesNothingCanOnlyBeDeclined()
+    {
+        var store = new InMemoryRequestStore();
+        var typed = await store
+            .AddAsync(
+                new MediaRequest
+                {
+                    Id = _identifiers.NewId(),
+                    RequestedByUserId = Asker,
+                    RequestedAt = Started,
+                    StateChangedAt = Started,
+                    Kind = RequestedItemKind.Movie,
+                    DisplayTitle = "A title somebody typed"
+                },
+                CancellationToken.None)
+            .ConfigureAwait(true);
+
+        var approving = await ControllerFor(store, Operator)
+            .ApproveAsync(typed.Request.Id, new ApproveRequestBody { Revision = typed.Revision }, CancellationToken.None)
+            .ConfigureAwait(true);
+
+        var refused = Refusal(approving, expectedStatus: 409);
+        Assert.Equal(RequestMoveRefusal.TheRequestNamesNothing, refused.Refusal);
+
+        var declining = await ControllerFor(store, Operator)
+            .DeclineAsync(
+                typed.Request.Id,
+                new DeclineRequestBody { Revision = typed.Revision, Reason = DeclineReason.CannotBeObtained },
+                CancellationToken.None)
+            .ConfigureAwait(true);
+
+        Assert.Equal(RequestState.Declined, Moved(declining).State);
+    }
+
+    /// <summary>
+    /// A decision on a request the store does not hold is not found, and nothing is written.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ADecisionOnARequestThatIsNotThereIsNotFound()
+    {
+        var store = new InMemoryRequestStore();
+
+        var answered = await ControllerFor(store, Operator)
+            .ApproveAsync(_identifiers.NewId(), new ApproveRequestBody { Revision = 1 }, CancellationToken.None)
+            .ConfigureAwait(true);
+
+        Assert.IsType<NotFoundResult>(answered.Result);
+        Assert.Empty(await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true));
+    }
+
+    /// <summary>
+    /// A decision carrying no revision is refused rather than read as a revision nobody sent. This
+    /// is the shape a script written against the endpoint arrives in, and obeying it would be the
+    /// silent overwrite the revision exists to refuse.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ADecisionCarryingNoRevisionIsRefused()
+    {
+        var store = new InMemoryRequestStore();
+        var open = await AnOpenRequestAsync(store).ConfigureAwait(true);
+        var controller = ControllerFor(store, Operator);
+
+        var approving = await controller
+            .ApproveAsync(open.Request.Id, new ApproveRequestBody(), CancellationToken.None)
+            .ConfigureAwait(true);
+
+        var declining = await controller
+            .DeclineAsync(
+                open.Request.Id,
+                new DeclineRequestBody { Reason = DeclineReason.NotWanted },
+                CancellationToken.None)
+            .ConfigureAwait(true);
+
+        Assert.Equal(nameof(ApproveRequestBody.Revision), Field(approving), StringComparer.Ordinal);
+        Assert.Equal(nameof(DeclineRequestBody.Revision), Field(declining), StringComparer.Ordinal);
+        Assert.Equal(RequestState.Open, (await Held(store, open.Request.Id).ConfigureAwait(true)).Request.State);
+    }
+
+    /// <summary>
+    /// A call with no body at all names the body rather than the field that would have been in it.
+    /// A caller told its revision is missing, when what it actually sent was nothing, is a caller
+    /// looking for a bug in the wrong place.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ADecisionWithNoBodyNamesTheBody()
+    {
+        var store = new InMemoryRequestStore();
+        var open = await AnOpenRequestAsync(store).ConfigureAwait(true);
+        var controller = ControllerFor(store, Operator);
+
+        var approving = await controller
+            .ApproveAsync(open.Request.Id, null!, CancellationToken.None)
+            .ConfigureAwait(true);
+
+        var declining = await controller
+            .DeclineAsync(open.Request.Id, null!, CancellationToken.None)
+            .ConfigureAwait(true);
+
+        Assert.Equal("body", Field(approving), StringComparer.Ordinal);
+        Assert.Equal("body", Field(declining), StringComparer.Ordinal);
+        Assert.Equal(RequestState.Open, (await Held(store, open.Request.Id).ConfigureAwait(true)).Request.State);
+    }
+
+    /// <summary>
+    /// The decline bodies that are refused, each wrong in one field, so a refusal naming a different
+    /// one is a failure rather than a message somebody has to read.
+    /// </summary>
+    /// <param name="field">The field that has to be named.</param>
+    /// <param name="reason">The reason the body carries.</param>
+    /// <param name="note">The note the body carries.</param>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Theory]
+    [InlineData(nameof(DeclineRequestBody.Reason), null, "A note without a reason")]
+    [InlineData(nameof(DeclineRequestBody.Reason), (DeclineReason)97, null)]
+    [InlineData(nameof(DeclineRequestBody.Note), DeclineReason.Other, null)]
+    [InlineData(nameof(DeclineRequestBody.Note), DeclineReason.Other, "   ")]
+    public async Task ADeclineThatSaysNothingIsRefused(string field, DeclineReason? reason, string? note)
+    {
+        var store = new InMemoryRequestStore();
+        var open = await AnOpenRequestAsync(store).ConfigureAwait(true);
+
+        var answered = await ControllerFor(store, Operator)
+            .DeclineAsync(
+                open.Request.Id,
+                new DeclineRequestBody { Revision = open.Revision, Reason = reason, Note = note },
+                CancellationToken.None)
+            .ConfigureAwait(true);
+
+        Assert.Equal(field, Field(answered), StringComparer.Ordinal);
+        Assert.Equal(RequestState.Open, (await Held(store, open.Request.Id).ConfigureAwait(true)).Request.State);
+    }
+
+    /// <summary>
+    /// A note longer than a request keeps is refused rather than cut, by the same rule and the same
+    /// number as the note the person who asked wrote. Nothing is stored that was not written.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ADeclineNoteTooLongToKeepIsRefused()
+    {
+        var store = new InMemoryRequestStore();
+        var open = await AnOpenRequestAsync(store).ConfigureAwait(true);
+
+        var answered = await ControllerFor(store, Operator)
+            .DeclineAsync(
+                open.Request.Id,
+                new DeclineRequestBody
+                {
+                    Revision = open.Revision,
+                    Reason = DeclineReason.NotWanted,
+                    Note = new string('n', MediaRequest.NoteMaximumLength + 1)
+                },
+                CancellationToken.None)
+            .ConfigureAwait(true);
+
+        Assert.Equal(nameof(DeclineRequestBody.Note), Field(answered), StringComparer.Ordinal);
+        Assert.Equal(RequestState.Open, (await Held(store, open.Request.Id).ConfigureAwait(true)).Request.State);
+    }
+
+    /// <summary>
+    /// A call that authenticated and names nobody is refused. A decision is somebody's, and the
+    /// history entry has a field for who made it that would otherwise read as the plugin having
+    /// observed something.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ADecisionByACallerNamingNoUserIsRefused()
+    {
+        var store = new InMemoryRequestStore();
+        var open = await AnOpenRequestAsync(store).ConfigureAwait(true);
+
+        var answered = await ControllerFor(store, caller: null)
+            .ApproveAsync(open.Request.Id, new ApproveRequestBody { Revision = open.Revision }, CancellationToken.None)
+            .ConfigureAwait(true);
+
+        Assert.Equal("caller", Field(answered), StringComparer.Ordinal);
+        Assert.Equal(RequestState.Open, (await Held(store, open.Request.Id).ConfigureAwait(true)).Request.State);
+    }
+
+    /// <summary>
+    /// Both endpoints build one caller, an administrator, so the only authority these two moves are
+    /// ever attempted under is that one. Every legal cell they can reach admits it.
+    /// <para>
+    /// This is why the arm answering <see cref="RequestMoveRefusal.TheCallerMayNotMakeThisMove"/> is
+    /// not reached by any leg above: no call can produce it while this holds. It is the day it stops
+    /// holding that the arm is for, and this reds on that day rather than the endpoint returning a
+    /// failure nobody shaped.
+    /// </para>
+    /// </summary>
+    /// <param name="to">The state one of the two endpoints moves into.</param>
+    [Theory]
+    [InlineData(RequestState.Approved)]
+    [InlineData(RequestState.Declined)]
+    public void TheOnlyCallerTheseEndpointsBuildIsAdmittedByEveryMoveTheyCanMake(RequestState to)
+    {
+        var reachable = RequestLifecycle.Table
+            .Where(cell => cell.To == to && cell.IsLegal)
+            .ToArray();
+
+        Assert.NotEmpty(reachable);
+        Assert.Equal(
+            [],
+            reachable
+                .Where(cell => (cell.Permitted & RequestActor.Administrator) == RequestActor.None)
+                .Select(cell => string.Concat(cell.From.ToString(), " to ", cell.To.ToString()))
+                .ToArray());
+    }
+
+    /// <summary>
+    /// An open request in the store, asked for by somebody and named by one provider so every move
+    /// is available on it.
+    /// </summary>
+    /// <param name="store">Where it goes.</param>
+    /// <returns>The request and the revision the store holds it at.</returns>
+    private async Task<StoredRequest> AnOpenRequestAsync(InMemoryRequestStore store)
+        => await store.AddAsync(
+            new MediaRequest
+            {
+                Id = _identifiers.NewId(),
+                RequestedByUserId = Asker,
+                RequestedAt = Started,
+                StateChangedAt = Started,
+                Kind = RequestedItemKind.Movie,
+                DisplayTitle = "The Conversation",
+                DisplayYear = 1974,
+                ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tmdb"] = "603" }
+            },
+            CancellationToken.None).ConfigureAwait(true);
+
+    /// <summary>
+    /// What the store holds for one request, which is what a leg asserts against rather than the
+    /// answer the endpoint returned.
+    /// </summary>
+    /// <param name="store">The store.</param>
+    /// <param name="id">The request.</param>
+    /// <returns>The request and its revision.</returns>
+    private static async Task<StoredRequest> Held(InMemoryRequestStore store, Guid id)
+    {
+        var stored = await store.GetAsync(id, CancellationToken.None).ConfigureAwait(true);
+
+        return Assert.NotNull(stored);
+    }
+
+    /// <summary>
+    /// A controller wired to one store and one identity, with a clock and an identifier source the
+    /// test controls.
+    /// </summary>
+    /// <param name="store">Where requests are kept.</param>
+    /// <param name="caller">Who the server says is calling.</param>
+    /// <returns>The controller under test.</returns>
+    private RequestsController ControllerFor(IRequestStore store, Guid? caller)
+        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller));
+
+    /// <summary>
+    /// The row a successful decision handed back, with the status code checked.
+    /// </summary>
+    /// <param name="answered">What the action returned.</param>
+    /// <returns>The row.</returns>
+    private static QueuedRequest Moved(ActionResult<QueuedRequest> answered)
+    {
+        var result = Assert.IsAssignableFrom<ObjectResult>(answered.Result);
+        Assert.Equal(200, result.StatusCode);
+        return Assert.IsType<QueuedRequest>(result.Value);
+    }
+
+    /// <summary>
+    /// The refusal a decision came back with, and the status code it came back under.
+    /// </summary>
+    /// <param name="answered">What the action returned.</param>
+    /// <param name="expectedStatus">The status code it has to have used.</param>
+    /// <returns>The refusal.</returns>
+    private static RequestMoveRefused Refusal(ActionResult<QueuedRequest> answered, int expectedStatus)
+    {
+        var result = Assert.IsAssignableFrom<ObjectResult>(answered.Result);
+        Assert.Equal(expectedStatus, result.StatusCode);
+        return Assert.IsType<RequestMoveRefused>(result.Value);
+    }
+
+    /// <summary>
+    /// The field a refused body named, with the status code checked.
+    /// </summary>
+    /// <param name="answered">What the action returned.</param>
+    /// <returns>The field.</returns>
+    private static string Field(ActionResult<QueuedRequest> answered)
+    {
+        var result = Assert.IsType<BadRequestObjectResult>(answered.Result);
+        Assert.Equal(400, result.StatusCode);
+        var refused = Assert.IsType<RequestRefused>(result.Value);
+        Assert.NotEmpty(refused.Reason);
+        return refused.Field;
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/Api/EndpointPolicyTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/EndpointPolicyTests.cs
@@ -41,19 +41,35 @@ public sealed class EndpointPolicyTests
     /// commit that adds the line is where the reason for that policy lives, and <c>docs/api.md</c>
     /// is where a reader finds it.
     /// </para>
+    /// <para>
+    /// The lines are in the order the comparison sorts them, which is by the whole line and so by
+    /// the action's name. A line added in the place a reader would put it fails until it is moved,
+    /// which is noise rather than a finding, and the alternative is a comparison that cannot say
+    /// which endpoint is missing.
+    /// </para>
     /// </summary>
     private static readonly string[] Expected =
     [
+        // Saying yes. A decision is an administrator's, in the transition table and here, and the
+        // two answers have to agree: an endpoint reachable by a signed-in user would refuse every
+        // such call in the model, which is a permission decided in two places.
+        "RequestsController.ApproveAsync POST Requests/{id}/Approve -> RequiresElevation",
+
         // Asking for something. An authenticated user, because a request has to be attributable to
         // somebody and a caller with no session names nobody.
         "RequestsController.CreateAsync POST Requests -> DefaultAuthorization",
 
-        // One person's own requests. The same policy, and the narrowing is the read rather than the
-        // policy: this endpoint has nothing wider than the caller's own requests to return.
+        // Saying no. The same policy as an approval, and the decline reason is something a user
+        // reads rather than writes.
+        "RequestsController.DeclineAsync POST Requests/{id}/Decline -> RequiresElevation",
+
+        // One person's own requests. The same policy as asking, and the narrowing is the read
+        // rather than the policy: this endpoint has nothing wider than the caller's own requests to
+        // return.
         "RequestsController.MineAsync GET Requests -> DefaultAuthorization",
 
         // The whole queue, which is every person's requests and who asked for each. An
-        // administrator, and it is the only endpoint here that needs one.
+        // administrator, and it is the only read here that needs one.
         "RequestsController.QueueAsync GET Requests/Queue -> RequiresElevation"
     ];
 

--- a/Jellyfin.Plugin.Requests.Tests/Doubles/StoreThatMovesARequestUnderTheWrite.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/StoreThatMovesARequestUnderTheWrite.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+
+namespace Jellyfin.Plugin.Requests.Tests.Doubles;
+
+/// <summary>
+/// A store that lets somebody else move a request in the window between a caller reading it and the
+/// same caller writing it back.
+/// <para>
+/// That window is what the revision on a write exists for, and it cannot be reached from outside:
+/// a test can move a request before the call or after it, and either one is checked before the
+/// write is attempted. This moves it during, once, on the first write it is asked to make, which is
+/// the only way to watch the store refuse a write the caller had every reason to believe was safe.
+/// </para>
+/// <para>
+/// It moves the request by writing it at the revision it currently holds, through the same
+/// interface every other caller uses, so what the caller under test then meets is the store's own
+/// refusal and not one this double invented.
+/// </para>
+/// </summary>
+internal sealed class StoreThatMovesARequestUnderTheWrite : IRequestStore
+{
+    private readonly IRequestStore _inner;
+    private readonly Func<MediaRequest, MediaRequest> _move;
+    private bool _moved;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StoreThatMovesARequestUnderTheWrite"/> class.
+    /// </summary>
+    /// <param name="inner">The store that actually holds the requests.</param>
+    /// <param name="move">
+    /// What the other caller does to the request, applied once, immediately before the first write
+    /// this store is asked to make.
+    /// </param>
+    public StoreThatMovesARequestUnderTheWrite(IRequestStore inner, Func<MediaRequest, MediaRequest> move)
+    {
+        _inner = inner;
+        _move = move;
+    }
+
+    /// <inheritdoc />
+    public Task<StoredRequest?> GetAsync(Guid id, CancellationToken cancellationToken)
+        => _inner.GetAsync(id, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<StoredRequest>> GetAllAsync(CancellationToken cancellationToken)
+        => _inner.GetAllAsync(cancellationToken);
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<StoredRequest>> FindForUserAsync(Guid userId, CancellationToken cancellationToken)
+        => _inner.FindForUserAsync(userId, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<StoredRequest>> FindByProviderIdentifierAsync(
+        RequestedItemKind kind,
+        string provider,
+        string value,
+        CancellationToken cancellationToken)
+        => _inner.FindByProviderIdentifierAsync(kind, provider, value, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<RequestPage> PageAsync(RequestQuery query, CancellationToken cancellationToken)
+        => _inner.PageAsync(query, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<StoredRequest> AddAsync(MediaRequest request, CancellationToken cancellationToken)
+        => _inner.AddAsync(request, cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<StoredRequest> ReplaceAsync(
+        MediaRequest request,
+        long expectedRevision,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (!_moved)
+        {
+            _moved = true;
+
+            var held = await _inner.GetAsync(request.Id, cancellationToken).ConfigureAwait(false);
+
+            if (held is StoredRequest current)
+            {
+                await _inner
+                    .ReplaceAsync(_move(current.Request), current.Revision, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
+
+        return await _inner.ReplaceAsync(request, expectedRevision, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public Task<bool> RemoveAsync(Guid id, long expectedRevision, CancellationToken cancellationToken)
+        => _inner.RemoveAsync(id, expectedRevision, cancellationToken);
+}

--- a/Jellyfin.Plugin.Requests/Api/ApproveRequestBody.cs
+++ b/Jellyfin.Plugin.Requests/Api/ApproveRequestBody.cs
@@ -1,0 +1,28 @@
+namespace Jellyfin.Plugin.Requests.Api;
+
+/// <summary>
+/// What an approval carries, which is only the revision the operator was looking at.
+/// <para>
+/// There is no field for the state being moved to. Which move this endpoint makes is the endpoint,
+/// so a caller cannot ask for one move and get another, and a log line naming the path says what
+/// was done without anybody reading a body.
+/// </para>
+/// <para>
+/// The revision is what the operator's screen was drawn from. Two administrators with the queue
+/// open will decide the same request in the same minute, and a write carrying no revision is a
+/// write against whatever the store happens to hold by the time it arrives, which is the silent
+/// overwrite this shape exists to make impossible.
+/// </para>
+/// </summary>
+public sealed record ApproveRequestBody
+{
+    /// <summary>
+    /// Gets the revision the caller read the request at, from <see cref="QueuedRequest.Revision"/>.
+    /// <para>
+    /// It is nullable so that a body which left it out is refused rather than read as zero. A
+    /// missing number and a number that happens to be the first revision are different statements,
+    /// and defaulting would turn the first into the second on the one request where it is wrong.
+    /// </para>
+    /// </summary>
+    public long? Revision { get; init; }
+}

--- a/Jellyfin.Plugin.Requests/Api/DeclineRequestBody.cs
+++ b/Jellyfin.Plugin.Requests/Api/DeclineRequestBody.cs
@@ -1,0 +1,37 @@
+using Jellyfin.Plugin.Requests.Model;
+
+namespace Jellyfin.Plugin.Requests.Api;
+
+/// <summary>
+/// What a decline carries: the revision the operator was looking at, why the answer is no, and
+/// whatever they want to say about it.
+/// <para>
+/// The reason is a field on this body and not on the approval, which is the reason there are two
+/// endpoints rather than one taking a target state. A single endpoint would carry a reason that is
+/// required for one value of another field, which is a rule a caller reads in prose; two shapes is
+/// a rule the caller meets at the door.
+/// </para>
+/// </summary>
+public sealed record DeclineRequestBody
+{
+    /// <summary>
+    /// Gets the revision the caller read the request at, from <see cref="QueuedRequest.Revision"/>.
+    /// Nullable for the same reason as on an approval: a body that left it out is refused rather
+    /// than read as a revision nobody sent.
+    /// </summary>
+    public long? Revision { get; init; }
+
+    /// <summary>
+    /// Gets why the request is being declined. Required, decided on #113: a decline with no reason
+    /// reads as arbitrary to the person who asked, and what they do next is ask for the same title
+    /// again, because nothing told them what was wrong with the first attempt.
+    /// </summary>
+    public DeclineReason? Reason { get; init; }
+
+    /// <summary>
+    /// Gets what the operator wants to say about it. Required beside
+    /// <see cref="DeclineReason.Other"/>, which says nothing on its own, and optional beside every
+    /// other reason.
+    /// </summary>
+    public string? Note { get; init; }
+}

--- a/Jellyfin.Plugin.Requests/Api/RequestMoveRefusal.cs
+++ b/Jellyfin.Plugin.Requests/Api/RequestMoveRefusal.cs
@@ -1,0 +1,44 @@
+namespace Jellyfin.Plugin.Requests.Api;
+
+/// <summary>
+/// Why a move was refused, as a value a caller can branch on rather than a sentence it has to read.
+/// <para>
+/// A page that can only show the message has one behaviour for every refusal. These four want three
+/// different ones: redraw the row and let the operator decide again, tell them this move is not
+/// available on this request at all, or say the request has to be declined because nothing can be
+/// done with it. The sentence beside the value is for the person, and this is for the client.
+/// </para>
+/// <para>
+/// A caller must treat a value it does not recognise as one it does not recognise, per the rule in
+/// <c>docs/api.md</c>. Adding a value here is not a breaking change; a caller switching exhaustively
+/// over the values that existed the day it was written is a caller this API promises nothing to.
+/// </para>
+/// </summary>
+public enum RequestMoveRefusal
+{
+    /// <summary>
+    /// Somebody moved the request between the caller reading it and the caller acting on it. The
+    /// current row comes back with this, so the client can draw what is there now and let the
+    /// operator decide against it.
+    /// </summary>
+    MovedSinceItWasRead = 0,
+
+    /// <summary>
+    /// The transition table refuses this move from the state the request is in. Approving something
+    /// already fulfilled is the ordinary case, and the reason beside it is the table's own sentence
+    /// for that cell.
+    /// </summary>
+    TheTableRefusesTheMove = 1,
+
+    /// <summary>
+    /// The request carries no external identifier, so nothing downstream can act on it and the only
+    /// move it has is a decline. This is a title somebody typed, and approving it would be an
+    /// operator saying yes to something that then sits still forever.
+    /// </summary>
+    TheRequestNamesNothing = 2,
+
+    /// <summary>
+    /// The table allows this move and does not admit this caller for it.
+    /// </summary>
+    TheCallerMayNotMakeThisMove = 3
+}

--- a/Jellyfin.Plugin.Requests/Api/RequestMoveRefused.cs
+++ b/Jellyfin.Plugin.Requests/Api/RequestMoveRefused.cs
@@ -1,0 +1,39 @@
+namespace Jellyfin.Plugin.Requests.Api;
+
+/// <summary>
+/// A move that was refused, with enough beside it for the caller to do something other than give up.
+/// <para>
+/// This is what separates a refusal an operator can act on from a failed call. Two administrators
+/// working one queue is the ordinary case rather than the exceptional one, and the second of them
+/// should be told what the request looks like now, not obeyed and not left guessing.
+/// </para>
+/// <para>
+/// The shape of an error across the whole API, and which status code each class of failure gets, is
+/// #56. This carries what refusing a move needs and is expected to be folded into whatever that
+/// decides.
+/// </para>
+/// </summary>
+public sealed record RequestMoveRefused
+{
+    /// <summary>
+    /// Gets why the move was refused, as a value a client branches on.
+    /// </summary>
+    public required RequestMoveRefusal Refusal { get; init; }
+
+    /// <summary>
+    /// Gets the same answer as a sentence for the person reading the screen. Where the transition
+    /// table refused the move, this is that cell's own reason rather than a restatement of the
+    /// verdict, so an operator is told why the move is not available instead of that it is not.
+    /// </summary>
+    public required string Reason { get; init; }
+
+    /// <summary>
+    /// Gets the request as the store holds it now, where that is known.
+    /// <para>
+    /// It is here so a refusal is one round trip rather than two: the client redraws the row from
+    /// this and the operator decides against what is actually there. It is absent where the store no
+    /// longer holds the request at all, which is a real answer and not a missing field.
+    /// </para>
+    /// </summary>
+    public QueuedRequest? Current { get; init; }
+}

--- a/Jellyfin.Plugin.Requests/Api/RequestsController.cs
+++ b/Jellyfin.Plugin.Requests/Api/RequestsController.cs
@@ -15,8 +15,16 @@ using Microsoft.AspNetCore.Mvc;
 namespace Jellyfin.Plugin.Requests.Api;
 
 /// <summary>
-/// Asking for something. This is the endpoint everything else calls: the user surface, the sibling
-/// discover plugin, and any script an operator writes.
+/// Asking for something, reading what has been asked for, and deciding on it. These are the
+/// endpoints everything else calls: the user surface, the administrator page, the sibling discover
+/// plugin, and any script an operator writes.
+/// <para>
+/// <b>A decision is a call into the model and never a state written here.</b> Approving and
+/// declining go through <see cref="RequestLifecycle"/>, which is where the transition table, the
+/// caller's authority and the one history entry per move are. Four surfaces ask the same question,
+/// and four copies of the rule are four chances for one of them to be a version behind. The lint
+/// rule <c>state-written-only-by-the-lifecycle</c> refuses the shortcut in the source.
+/// </para>
 /// <para>
 /// <b>Who asked is the authenticated caller and nothing else.</b> It is read from the server's own
 /// authorisation context rather than from the body, and <see cref="CreateRequestBody"/> carries no
@@ -298,6 +306,244 @@ public sealed class RequestsController : RequestsControllerBase
             Skip = query.Skip,
             Take = query.Take
         });
+    }
+
+    /// <summary>
+    /// Approves a request.
+    /// <para>
+    /// The move is <see cref="RequestLifecycle.Move"/>'s and nothing here decides it. Which states
+    /// can be approved from, and by whom, is the table, so this endpoint cannot be the surface that
+    /// knows one rule fewer than the page or the bridge does.
+    /// </para>
+    /// </summary>
+    /// <param name="id">The request being approved.</param>
+    /// <param name="body">The revision the operator was looking at.</param>
+    /// <param name="cancellationToken">Cancels the call.</param>
+    /// <returns>
+    /// The request as the queue now holds it, at its new revision. A request that moved since it
+    /// was read, or one the table refuses this move on, is refused with
+    /// <see cref="RequestMoveRefused"/> rather than obeyed.
+    /// </returns>
+    [HttpPost("Requests/{id}/Approve")]
+    [Authorize(Policy = AdministratorPolicy)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public async Task<ActionResult<QueuedRequest>> ApproveAsync(
+        Guid id,
+        [FromBody] ApproveRequestBody body,
+        CancellationToken cancellationToken)
+    {
+        if (body is null)
+        {
+            return BadRequest(Refused(
+                "body",
+                "There is no body on this call, and the revision the decision was made against is in it."));
+        }
+
+        if (body.Revision is not long revision)
+        {
+            return BadRequest(Refused(
+                nameof(ApproveRequestBody.Revision),
+                "A decision carries the revision it was made against. Without one this would be a write against whatever the store holds by the time it arrives, which is how two operators deciding one request end with one decision silently lost."));
+        }
+
+        return await MoveAsync(
+            id,
+            revision,
+            static (request, at, by) => RequestLifecycle.Move(request, RequestState.Approved, at, by),
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Declines a request, with the reason a decline is required to carry.
+    /// <para>
+    /// The reason is checked here as well as in the model, so the caller is told which field was
+    /// wrong instead of getting whatever an unhandled exception turns into. The rule is stated once,
+    /// in <see cref="RequestLifecycle.Decline"/>, and this agrees with it rather than restating it.
+    /// </para>
+    /// </summary>
+    /// <param name="id">The request being declined.</param>
+    /// <param name="body">The revision, the reason, and what the operator wants to say.</param>
+    /// <param name="cancellationToken">Cancels the call.</param>
+    /// <returns>
+    /// The request as the queue now holds it, at its new revision, or the refusal.
+    /// </returns>
+    [HttpPost("Requests/{id}/Decline")]
+    [Authorize(Policy = AdministratorPolicy)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public async Task<ActionResult<QueuedRequest>> DeclineAsync(
+        Guid id,
+        [FromBody] DeclineRequestBody body,
+        CancellationToken cancellationToken)
+    {
+        if (body is null)
+        {
+            return BadRequest(Refused(
+                "body",
+                "There is no body on this call, and the revision the decision was made against is in it."));
+        }
+
+        if (body.Revision is not long revision)
+        {
+            return BadRequest(Refused(
+                nameof(DeclineRequestBody.Revision),
+                "A decision carries the revision it was made against. Without one this would be a write against whatever the store holds by the time it arrives, which is how two operators deciding one request end with one decision silently lost."));
+        }
+
+        if (body.Reason is not DeclineReason reason || !Enum.IsDefined(reason))
+        {
+            return BadRequest(Refused(
+                nameof(DeclineRequestBody.Reason),
+                "A decline carries a reason. Without one the person who asked is told no and nothing else, and what they do next is ask for the same title again."));
+        }
+
+        if (reason == DeclineReason.Other && string.IsNullOrWhiteSpace(body.Note))
+        {
+            return BadRequest(Refused(
+                nameof(DeclineRequestBody.Note),
+                "A decline for a reason that is not on the list has to say what the reason was. Other with nothing beside it is a decline with no reason, which is the thing a required reason exists to prevent."));
+        }
+
+        if (body.Note is not null && body.Note.Length > MediaRequest.NoteMaximumLength)
+        {
+            return BadRequest(Refused(nameof(DeclineRequestBody.Note), Longer(nameof(DeclineRequestBody.Note), body.Note.Length)));
+        }
+
+        return await MoveAsync(
+            id,
+            revision,
+            (request, at, by) => RequestLifecycle.Decline(request, reason, body.Note, at, by),
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Reads the request, makes the move the caller asked for, and writes it back against the
+    /// revision they read it at.
+    /// <para>
+    /// Both endpoints above are this method and a move. What each one does that is its own is the
+    /// body it takes and the cell of the table it aims at; everything else - who is calling, whether
+    /// the request is still where the caller thinks it is, what the table says, and what a refused
+    /// write means - is one piece of code, so a third operation added later cannot come with one of
+    /// these steps missing.
+    /// </para>
+    /// <para>
+    /// <b>The revision is checked before the model is asked and again by the store.</b> The second
+    /// is what makes the write safe; the first is what makes the answer true. Without it, a request
+    /// that was fulfilled between the read and the call would be refused by the table, and the
+    /// caller would be told this move is never available on that request when what actually happened
+    /// is that somebody else moved it a moment ago.
+    /// </para>
+    /// </summary>
+    /// <param name="id">The request being moved.</param>
+    /// <param name="revision">The revision the caller read it at.</param>
+    /// <param name="move">The move, as the model makes it.</param>
+    /// <param name="cancellationToken">Cancels the call.</param>
+    /// <returns>The request at its new revision, or the refusal.</returns>
+    private async Task<ActionResult<QueuedRequest>> MoveAsync(
+        Guid id,
+        long revision,
+        Func<MediaRequest, DateTimeOffset, RequestCaller, MediaRequest> move,
+        CancellationToken cancellationToken)
+    {
+        var caller = await _callers.UserIdAsync(HttpContext).ConfigureAwait(false);
+
+        if (caller is not Guid administrator)
+        {
+            // Authenticated and naming nobody, which is what an API key looks like from here. A
+            // decision is somebody's, and the history entry this move appends has a field for who
+            // made it that would otherwise read as the plugin having observed something.
+            return BadRequest(Refused(
+                "caller",
+                "This call is authenticated but names no user, so there is nobody to record as having decided."));
+        }
+
+        var stored = await _store.GetAsync(id, cancellationToken).ConfigureAwait(false);
+
+        if (stored is not StoredRequest held)
+        {
+            return NotFound();
+        }
+
+        if (held.Revision != revision)
+        {
+            return Conflict(new RequestMoveRefused
+            {
+                Refusal = RequestMoveRefusal.MovedSinceItWasRead,
+                Reason = "This request has moved since it was read, so the decision was made against something that is no longer there. What the queue holds now is beside this.",
+                Current = Queued(held)
+            });
+        }
+
+        MediaRequest moved;
+
+        try
+        {
+            // The whole of the decision is this line. The transition table, who may make the move
+            // and the one history entry it appends are the model's, and an endpoint that reached
+            // around them would be a fourth copy of a rule that already has three readers.
+            moved = move(held.Request, _clock.UtcNow, RequestCaller.Administrator(administrator));
+        }
+        catch (IllegalRequestTransitionException refused)
+        {
+            return Conflict(new RequestMoveRefused
+            {
+                Refusal = RequestMoveRefusal.TheTableRefusesTheMove,
+                Reason = refused.Message,
+                Current = Queued(held)
+            });
+        }
+        catch (RequestNotIdentifiedException refused)
+        {
+            return Conflict(new RequestMoveRefused
+            {
+                Refusal = RequestMoveRefusal.TheRequestNamesNothing,
+                Reason = refused.Message,
+                Current = Queued(held)
+            });
+        }
+        catch (RequestMoveNotPermittedException refused)
+        {
+            // No call that reaches here can produce this today, and the reason is measured rather
+            // than assumed: both endpoints require elevation, so the caller is built as an
+            // administrator, and every legal cell into Approved or Declined is a decision cell that
+            // admits one. TheOnlyCallerTheseEndpointsBuildIsAdmittedByEveryMoveTheyCanMake holds
+            // that, and it reds the day a cell in the table stops admitting an administrator. This
+            // arm is what that day answers with instead of a stack trace.
+            return StatusCode(
+                StatusCodes.Status403Forbidden,
+                new RequestMoveRefused
+                {
+                    Refusal = RequestMoveRefusal.TheCallerMayNotMakeThisMove,
+                    Reason = refused.Message,
+                    Current = Queued(held)
+                });
+        }
+
+        try
+        {
+            var written = await _store.ReplaceAsync(moved, revision, cancellationToken).ConfigureAwait(false);
+
+            return Ok(Queued(written));
+        }
+        catch (RequestConcurrencyException lost)
+        {
+            // The window between the read above and this write. It is small and it is real: two
+            // administrators clicking within it both pass the revision check and exactly one of
+            // them is accepted here.
+            return Conflict(new RequestMoveRefused
+            {
+                Refusal = RequestMoveRefusal.MovedSinceItWasRead,
+                Reason = "This request moved while the decision was being written, so it was refused rather than applied over somebody else's.",
+                Current = lost.Current is StoredRequest now ? Queued(now) : null
+            });
+        }
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs
+++ b/Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs
@@ -113,9 +113,10 @@ public static class RequestLifecycle
     /// Moves a request into any state except <see cref="RequestState.Declined"/>, or refuses to.
     /// <para>
     /// This and <see cref="Decline"/> are the only places in the plugin that change a request's
-    /// state. The record is immutable and a caller could still write <c>with { State = ... }</c>, so
-    /// that being true is held by review and by the callers that exist rather than by anything that
-    /// refuses the alternative; that gap is named in <c>docs/lifecycle.md</c>.
+    /// state. The record is immutable, so a caller could copy a request with a different state and
+    /// never meet the table; <c>state-written-only-by-the-lifecycle</c> in the invariant lint
+    /// refuses that copy where the state is named as a literal. What it does not reach, and why, is
+    /// in <c>docs/lifecycle.md</c>.
     /// </para>
     /// </summary>
     /// <param name="request">The request to move.</param>

--- a/docs/api.md
+++ b/docs/api.md
@@ -159,6 +159,59 @@ is move it and the store refuses a write made against a revision that has moved 
 What a queue must show for a decision to be possible is #59, so this is what the queue can show
 rather than a settled answer to what it should.
 
+## Deciding on one
+
+    POST MediaRequests/v1/Requests/{id}/Approve
+    POST MediaRequests/v1/Requests/{id}/Decline
+
+One endpoint per operation rather than one taking a target state. The path says in a log what was
+done, a caller cannot ask for one move and get another, and the decline reason is a required field on
+exactly the operation that needs it rather than a field that is required when another field holds a
+particular value.
+
+There are two of them and not four. Marking something fulfilled is not here because the table makes
+that the plugin's own move, on something it observed in the library, and a person marking it would be
+making the state say something about the library that the library does not say; #42 is where it is
+detected instead. Cancelling is not here because there is no state to cancel into, refused on #113.
+
+**The move is `RequestLifecycle`'s and this API decides none of it.** Which states can be approved or
+declined from, who may make each move, and the single history entry a move appends are the model's,
+so the endpoint cannot be the surface that knows one rule fewer than the page or the bridge does.
+
+Both bodies carry the revision the caller read the request at, from the queue row. It is required,
+and a body without one is refused rather than read as a revision nobody sent: two administrators with
+the queue open will decide the same request in the same minute, and a write against whatever the
+store holds by the time it arrives is exactly the decision silently lost.
+
+A decline carries a reason from a short list, decided on #113, and `Other` requires the note beside
+it. A decline with no reason reads as arbitrary to the person who asked, and what they do next is ask
+for the same title again.
+
+### What comes back
+
+A move that was made answers `200` with the queue row at its new revision, so a page can redraw that
+row without reading the queue again.
+
+A move that was refused answers with the refusal, which carries a value a client branches on, a
+sentence for the person, and the row as the store holds it now.
+
+| Refusal                       | Status | What happened                                             |
+| ----------------------------- | ------ | --------------------------------------------------------- |
+| `MovedSinceItWasRead`         | `409`  | Somebody moved it between the read and this call.         |
+| `TheTableRefusesTheMove`      | `409`  | The transition table has no such move from where it is.   |
+| `TheRequestNamesNothing`      | `409`  | It carries no identifier, so only a decline is available. |
+| `TheCallerMayNotMakeThisMove` | `403`  | The table allows the move and does not admit this caller. |
+
+A request the store does not hold answers `404`, and a body that cannot be acted on answers `400`
+naming the field, which is the same shape the create endpoint uses. Which status code each class of
+failure gets across the whole API is #56, and this is what refusing a move needs rather than a
+settled answer for everything.
+
+`MovedSinceItWasRead` is answered for a request that moved into a state the move is illegal from,
+rather than `TheTableRefusesTheMove`. Both are refusals and they tell an operator different things:
+one says somebody else got there first and here is what they did, the other says this request can
+never be approved. The second would be false.
+
 ## The parameters both reads take
 
 | Parameter    | Meaning                                            | Default       |
@@ -187,11 +240,20 @@ Every endpoint carries a policy of its own, and the controller carries one as th
 them. An endpoint with no policy of its own is reachable under whatever its class happens to declare
 on the day it is added, and a class attribute is edited by somebody who is not reading the endpoint.
 
-| Endpoint             | Policy                 | Who that is          |
-| -------------------- | ---------------------- | -------------------- |
-| `POST Requests`      | `DefaultAuthorization` | any signed-in person |
-| `GET Requests`       | `DefaultAuthorization` | any signed-in person |
-| `GET Requests/Queue` | `RequiresElevation`    | an administrator     |
+| Endpoint                     | Policy                 | Who that is          |
+| ---------------------------- | ---------------------- | -------------------- |
+| `POST Requests`              | `DefaultAuthorization` | any signed-in person |
+| `GET Requests`               | `DefaultAuthorization` | any signed-in person |
+| `GET Requests/Queue`         | `RequiresElevation`    | an administrator     |
+| `POST Requests/{id}/Approve` | `RequiresElevation`    | an administrator     |
+| `POST Requests/{id}/Decline` | `RequiresElevation`    | an administrator     |
+
+The two decisions carry the same policy as the queue, and that is the endpoint agreeing with the
+model rather than deciding anything: every cell of the table these two can reach admits an
+administrator and nobody else, so an endpoint open to any signed-in person would refuse each such
+call one layer down. A permission answered in two places is a permission that comes to be answered
+two ways, and `TheOnlyCallerTheseEndpointsBuildIsAdmittedByEveryMoveTheyCanMake` in the suite is what
+reds if the table stops agreeing.
 
 **Nothing here is anonymous.** A request has to be attributable to somebody to exist at all, and a
 queue is a list of who asked for what, so there is no answer this plugin gives that is safe to hand a
@@ -219,6 +281,9 @@ asked for, which is a weaker disclosure than a row and still a disclosure, is op
 ## What is not decided here
 
 - Whether a user may ever be told that a title has already been asked for is open between #51 and #71.
-- The shape of an error and which status code each failure gets is #56.
-- What each endpoint does is #52, #54 and #55.
+- The shape of an error and which status code each failure gets is #56. What the two decisions answer
+  with is above, and it is what refusing a move needs rather than one shape for the whole API.
+- The capability endpoint is #55.
+- Deciding on several requests in one call is #62. Nothing here does it, and a client that wants it
+  today makes one call per request.
 - Whether these endpoints appear in the server's published API documentation is #57.

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -101,14 +101,26 @@ one is a request for the right one, and it is a new request because the old one 
 asked for and got an answer. A library that no longer holds the media is an observation, which the
 `Availability` field on the record already carries with the time it was made.
 
-## What is not enforced
+## What holds the two doors, and what it does not reach
 
 `RequestLifecycle.Move` and `RequestLifecycle.Decline` are the two places in the plugin that change
-a state, and both refuse a move this table refuses. Nothing stops a caller writing
-`with { State = ... }` on the record instead: the record is immutable, and immutability makes a move
-produce a new value rather than making it go through here. There are no callers yet, so the property
-holds today by there being nothing to hold it against. The invariant lint in #28 is where a rule
-refusing that shape would live, and this paragraph is what it does not yet do.
+a state, and both refuse a move this table refuses. Nothing in the type system says so: the record is
+immutable, and immutability makes a move produce a new value rather than making it go through here,
+so a surface can copy a request with a different state and never meet the table at all.
+
+`state-written-only-by-the-lifecycle` in the invariant lint refuses that copy where the state is
+named as a literal, anywhere under `Jellyfin.Plugin.Requests/`, and it carries a fixture, so the rule
+going quiet reds the gate rather than passing. That is the shape a surface reaches for when it has a
+state in mind and the model in the way.
+
+What the rule does not reach is a state put in a variable first and written from there. Refusing that
+means refusing the assignment itself, which is how every projection of a request into a response
+shape is written, and the rule would then red on correct code. The bound is real and the review is
+where that spelling is caught.
+
+It also does not reach the test project, on purpose. A store's conformance suite puts requests into
+states the table would not move them into from where they are, because what it tests is the store
+rather than the move.
 
 ## The history
 

--- a/tools/opengrep/fixtures/lifecycle/ApprovesWithoutTheModel.cs
+++ b/tools/opengrep/fixtures/lifecycle/ApprovesWithoutTheModel.cs
@@ -1,0 +1,27 @@
+// Fixture for state-written-only-by-the-lifecycle. This file is in no project
+// and is never compiled; it exists so the rule can be watched refusing the
+// mistake it names.
+//
+// The near-miss is an endpoint that has the request, has the state it wants, and
+// writes it. It compiles, the request comes back in the state the caller asked
+// for, and the queue looks right. What is gone is everything the model does
+// around a move: the transition table never refuses the cell, nobody asks
+// whether this caller may make it, and the history gains no entry, so the
+// request afterwards reads as though it arrived approved.
+
+namespace Jellyfin.Plugin.Requests.Api;
+
+public sealed class FixtureDecisionsController
+{
+    // Legal neighbour, left here on purpose: reading a state off a request and
+    // putting it in a response shape is how every row this plugin serves is
+    // built, and the rule has to stay quiet on it. What holds that is the scan
+    // over the tree rather than this file, because the real projections are in
+    // the controller and the gate reds on them if this rule ever widens.
+    public static FixtureRow Row(MediaRequest request)
+        => new FixtureRow { State = request.State };
+
+    // The regression.
+    public static MediaRequest Approve(MediaRequest request)
+        => request with { State = RequestState.Approved };
+}

--- a/tools/opengrep/rules.yaml
+++ b/tools/opengrep/rules.yaml
@@ -396,3 +396,48 @@ rules:
       include:
         - "Jellyfin.Plugin.Requests/**/*.cs"
         - "tools/opengrep/fixtures/policy/**/*.cs"
+
+  # Invariant (model, #54): a request's state is written by RequestLifecycle and
+  # by nothing else. Decided in docs/lifecycle.md, which until now carried this
+  # as the paragraph headed "What is not enforced": the record is immutable, so
+  # a move produces a new value rather than going through the two methods that
+  # make one, and a surface could write its own. What that walks past is the
+  # transition table, the check on who may make the move, and the one history
+  # entry a move appends, which is three of this plugin's rules at once.
+  #
+  # What is refused is a state literal written onto a request. That is the shape
+  # a surface reaches for when it has a state in mind and the model in the way,
+  # and it is one line every time it is written, so a spelling spread over
+  # several lines is not a way around it.
+  #
+  # What is NOT refused, and is named here so the rule is not read as wider than
+  # it is: a state held in a variable first, then written. Refusing that means
+  # refusing the token `State =`, which is how every projection of a request into
+  # a response shape is written and would red the gate on correct code.
+  #
+  # The test project is deliberately outside the path list. A store's conformance
+  # suite has to put a request into a state the lifecycle would not move it into
+  # from where it is, because what it is testing is the store rather than the
+  # move, and those requests are fixtures rather than decisions anybody made.
+  #
+  # RequestLifecycle needs no exclusion, which is worth saying because every
+  # other rule here has one. It writes the state it was handed rather than one it
+  # names, so the one place allowed to make a move does not match the pattern for
+  # making one badly. What that costs is that the rule cannot be read out of the
+  # file it holds: the pattern is quoted nowhere in the plugin, this comment
+  # included, because a comment quoting it would be refused by the rule it
+  # documents.
+  - id: state-written-only-by-the-lifecycle
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      Do not write a request's state here. RequestLifecycle.Move and
+      RequestLifecycle.Decline are the two doors, and they carry the transition
+      table, who may make the move, and the one history entry a move appends
+      (#54). A state written straight onto the record walks past all three.
+    patterns:
+      - pattern: 'State = RequestState.'
+    paths:
+      include:
+        - "Jellyfin.Plugin.Requests/**/*.cs"
+        - "tools/opengrep/fixtures/lifecycle/**/*.cs"


### PR DESCRIPTION
Closes #54.

The queue could be read and nothing could be decided. This adds the two operations that decide a
request, as calls into the model rather than as writes around it.

    POST MediaRequests/v1/Requests/{id}/Approve
    POST MediaRequests/v1/Requests/{id}/Decline

One endpoint per operation, so the path says in a log what was done, a caller cannot ask for one move
and get another, and the decline reason is required on exactly the operation that needs it rather
than on a field that is required when another field holds a particular value.

Two and not the four the issue lists. Marking something fulfilled is the plugin's own move on
something it observed in the library, and a person making it would be making the state say something
the library does not say; #42 is where that is detected. Cancelling has no state to move into,
refused on #113. Both absences are written into `docs/api.md` beside the endpoints rather than left
for a reader to notice.

## The means

C# in the existing plugin and test projects, which is the means every other endpoint here is written
in. It carries the three rules: the properties are refusable by the analyzers, the suite and the
lint; each guard below was watched failing; and every number in this body carries the command that
produced it. Nothing outside this repository forces a different one, and no language, runtime or
dependency is added.

## What holds each condition of the issue

**Every operation is a call into the model, and no controller assigns a state directly.**
`RequestLifecycle.Move` and `RequestLifecycle.Decline` are the only things that move a request here,
so the transition table, who may make the move and the one history entry per move are the model's
answers. `state-written-only-by-the-lifecycle` in `tools/opengrep/rules.yaml` refuses the shortcut in
the source: a state literal written straight onto a request, anywhere under
`Jellyfin.Plugin.Requests/`. It carries a fixture in `tools/opengrep/fixtures/lifecycle/`, so a
pattern that stopped matching reds the gate rather than passing quietly.

What the rule does not reach is a state put in a variable first and written from there. Refusing that
means refusing the assignment itself, which is how every response shape in this plugin is built, and
the rule would then red on correct code. The bound is written at the rule and in `docs/lifecycle.md`,
which until now carried this invariant as the paragraph headed "what is not enforced". The test
project is outside the path list on purpose: a store's conformance suite puts requests into states
the table would not move them into from where they are, because what it tests is the store.

**A decline without a reason is refused.** #41 decided the reason is required and `DeclineReason` is
what it decided. The endpoint refuses a missing reason, a value outside the enumeration, and `Other`
with nothing beside it, each naming the field that is wrong.

**Acting on a request that moved since it was read is refused with a response the caller can act on.**
The body carries the revision the operator's screen was drawn from. It is checked before the model is
asked and again by the store. The second is what makes the write safe; the first is what makes the
answer true, because a request fulfilled between the read and the call would otherwise come back as a
move the table refuses, telling an operator this request can never be approved when what happened is
that somebody else moved it. A refusal carries a value the client branches on, the sentence for the
person, and the row as the store holds it now.

**Every operation appends exactly one history entry.** `ApprovingAnOpenRequestMovesItAndAppendsOneEntry`
and `DecliningCarriesTheReasonAndAppendsOneEntry` assert one entry with its pair of states, its time
and who made it. `EachDecisionAppendsOneEntryAndNoMore` asserts two entries and no more over a
sequence, which is where an entry appended by the wrong layer would show and a single call would not.

## The runs

At the commit being pushed, on this machine.

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    0 Warnung(en)
    0 Fehler

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!: Fehler: 0, erfolgreich: 281, gesamt: 281 (net9.0)
    Bestanden!: Fehler: 0, erfolgreich: 281, gesamt: 281 (net10.0)

## Each guard watched failing

Four mutations, one per guard, each reverted afterwards. The filter is
`--filter "FullyQualifiedName~ActOnARequestTests"` on `net9.0`, which is 18 legs.

The revision is not checked before the model is asked:

    ARequestThatMovedIntoAStateTheTableRefusesIsRefusedAsMoved [FAIL]
    Fehler: 1, erfolgreich: 17, gesamt: 18

That leg is the whole reason the check is there rather than only in the store. The other conflict leg
stays green under this mutation, because the store still refuses the write. What is lost is the
answer being true, and only that leg says so.

The decline reason is not required:

    ADeclineThatSaysNothingIsRefused(field: "Reason", reason: null, note: "A note without a reason") [FAIL]
    ADeclineThatSaysNothingIsRefused(field: "Reason", reason: 97, note: null) [FAIL]
    ADeclineThatSaysNothingIsRefused(field: "Note", reason: Other, note: null) [FAIL]
    ADeclineThatSaysNothingIsRefused(field: "Note", reason: Other, note: "   ") [FAIL]
    Fehler: 4, erfolgreich: 14, gesamt: 18

A write overtaken in flight is not answered, so the store's refusal escapes the endpoint:

    ADecisionOvertakenWhileItIsBeingWrittenIsRefused [FAIL]
    Fehler: 1, erfolgreich: 17, gesamt: 18

The model call is replaced by a state written in the controller, which is the mistake the lint rule
names:

    ADecisionOnARequestThatMovedIsRefusedWithWhatTheQueueHoldsNow [FAIL]
    AMoveTheTableRefusesIsRefusedWithTheTablesOwnReason [FAIL]
    ARequestThatNamesNothingCanOnlyBeDeclined [FAIL]
    ApprovingAnOpenRequestMovesItAndAppendsOneEntry [FAIL]
    EachDecisionAppendsOneEntryAndNoMore [FAIL]
    Fehler: 5, erfolgreich: 13, gesamt: 18

## What is not covered here

The arm answering `TheCallerMayNotMakeThisMove` is reached by no test. Both endpoints require
elevation, so the only caller they build is an administrator, and every legal cell into `Approved` or
`Declined` is a decision cell that admits one, so no call can produce it today.
`TheOnlyCallerTheseEndpointsBuildIsAdmittedByEveryMoveTheyCanMake` holds exactly that and reds the
day a cell in the table stops admitting an administrator, which is the day the arm answers instead of
a stack trace. That is an argument from the table plus a test that reads it, not a leg that exercised
the arm, and it is written this way rather than covered.

The invariant lint was not run on this machine. The pinned release the gate installs is a manylinux
binary and this is Windows, so nothing here watched the new rule fire and the two steps in
`Repo Invariant Lint` are what answered it. Both are green on this head, and the second one prints
which rules bit:

    == rules the fixtures made fire
    ...
    state-written-only-by-the-lifecycle
    ...
    every declared rule fired on a fixture

The first step is the other half: the same rule set over the tree with the fixtures excluded, and no
finding. So the rule refuses its fixture and refuses nothing that is here.

No server was started. The headless rule in `docs/testing.md` refuses one, so what is held here is
that each endpoint carries the policy written down for it, in `EndpointPolicyTests` over the built
assembly. The server evaluating that policy and turning a caller away is the server's, and it is
already an entry in that document's refusal list.

Deciding on several requests in one call is #62 and is not here. A client that wants it today makes
one call per request, which is stated in `docs/api.md` rather than left to be discovered.

This change is 1240 lines added, well past the point where review quality falls off, and the hygiene
check says so. It is one topic and splitting it makes two halves neither of which is reviewable
alone: the endpoints without their proofs, or proofs of something that is not there. Most of the
count is documentation comments and the test file, which is the shape of every change on this board.

    git diff --shortstat origin/master...HEAD
    13 files changed, 1240 insertions(+), 21 deletions(-)

Nobody else has read this change. The evidence above stands in place of a second reader rather than
beside one.
