### PR TITLE
Add the documents the checks and the reporters were already pointed at (#106)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,52 @@
+# Code of conduct
+
+## What is expected
+
+Argue with the change, not with the person who wrote it.
+
+Assume the other person is competent and working from something you have not
+seen. Most disagreements here turn out to be about a constraint one side knows
+and the other does not, and the fastest way through is to say which one you are
+working from.
+
+Say what you measured and what you assumed, and keep them apart. "I ran it and
+it failed" and "I think it would fail" are different sentences and get different
+answers.
+
+A refusal is about a change. It is not a verdict on the person, and it is not
+owed to anybody in a particular tone; a short "no, because" is more respectful
+of somebody's time than a long one that never says no.
+
+## What is not
+
+Harassment, of anybody, anywhere this project is being worked on. Personal
+attacks, insults, and comments about who somebody is rather than what they wrote.
+Sexual attention or imagery. Publishing somebody's private information. Sustained
+disruption of a discussion after being asked to stop.
+
+Any of those in a public issue, a pull request, a commit message or a review is
+in scope, whether or not it was aimed at a contributor.
+
+## Reporting
+
+Use the **Security** tab, then **Report a vulnerability**, and say at the top
+that the report is about conduct rather than a vulnerability.
+
+That form is a private channel to the maintainer and is the only one this
+repository has, which is why a conduct report shares it. It is read by the same
+person, and nothing about a report is made public without asking the person who
+sent it.
+
+## What happens then
+
+This repository is maintained by one person. A report is read, answered, and
+acted on by that person, and there is no appeal to anybody else here; that is a
+fact worth knowing before you send one rather than after.
+
+What can follow, in order: a private word, a public correction of something that
+was posted, removal of the content, and a block. Which one it is depends on what
+happened and on whether it happened again.
+
+Where the report is about the maintainer, there is nowhere in this repository to
+take it. GitHub's own abuse reporting is the route that does not run through the
+person being reported.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing
+
+Short on purpose. A contributing document nobody finishes is one nobody follows.
+
+## Sign your work
+
+Every commit carries a `Signed-off-by:` line matching its author:
+
+    git commit -s
+
+That line is an assertion about the change, and what it asserts is the Developer
+Certificate of Origin 1.1, in [DCO](DCO) at the root of this repository. Read it
+once; it is short and it is the whole of what you are certifying.
+
+The `DCO sign-off` check walks every non-merge commit in a pull request and reds
+on any one missing the trailer. A commit that already exists can be fixed
+without rewriting what it does:
+
+    git rebase --signoff <base>
+
+## Start with an issue
+
+Every change starts as an issue and lands as a pull request. An issue says what
+is wrong, what the evidence is, and what "done" means. If the evidence is a
+number, it carries the command that produced it.
+
+A pull request names its issue in the body: `Closes #12`, or `Part of #12` where
+it does not finish it. The `Deterministic pull request hygiene checks` job reads
+the body for that reference. It skips the blocking tier for a pull request from
+somebody outside this repository, so a first contribution is never refused on a
+convention nobody could have known.
+
+## What the gate expects
+
+The checks that run, which of them hold a merge, and how the set differs from
+the sibling board's, are in [docs/quality-parity.md](docs/quality-parity.md).
+That document is the answer; this one does not repeat it, because a list here
+would drift against it and a contributor would then have two answers.
+
+What is worth knowing before the first push:
+
+- The build treats warnings as errors, on both target frameworks. A warning on
+  either server line fails the build on both.
+- The suite runs against both frameworks too. A test that passes on one is half
+  a test.
+- Formatting of `html`, `css`, `js` and `md` is checked by Prettier. C# is the
+  analyzers' job and is not in that set.
+- Some rules of this tree are patterns rather than prose, in
+  `tools/opengrep/rules.yaml`. Each one carries a fixture it is watched refusing,
+  so adding a rule means adding the fixture that proves it bites.
+
+Run the build and the suite before pushing:
+
+    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
+    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
+
+Nothing runs those for you before the pull request is open.
+
+## Writing a change
+
+One topic per commit and per pull request. A commit carrying two unrelated
+changes has a message describing one of them.
+
+A commit message says what changed and what failure it prevents. Where it is a
+correction, it says what was wrong and how that was found.
+
+Tests are not optional for a change to behaviour, and a guard is expected to
+have been watched failing: delete it, run the suite, see it red, put it back.
+A test that could not have failed proves nothing.
+
+## Reporting a security problem
+
+Not here. [SECURITY.md](SECURITY.md) has the private route, and a security
+problem does not go in a public issue.
+
+## How people are expected to behave
+
+[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).

--- a/DCO
+++ b/DCO
@@ -1,0 +1,34 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj
+++ b/Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj
@@ -53,6 +53,19 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- The documents somebody arriving from outside this repository is sent to, and the check that
+         sends them. A workflow that names a file never opens it, so the only thing that can refuse
+         a gate pointing at a document nobody added is a test that opens both. The link targets are
+         here too, because following a link is what the reader does next. -->
+    <None Include="../CONTRIBUTING.md" Link="CONTRIBUTING.md" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="../SECURITY.md" Link="SECURITY.md" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="../CODE_OF_CONDUCT.md" Link="CODE_OF_CONDUCT.md" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="../DCO" Link="DCO" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="../docs/quality-parity.md" Link="docs/quality-parity.md" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="../.github/workflows/dco.yml" Link="dco.yml" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- The stored shapes an older version of this plugin wrote, kept as the bytes that version
          produced. A migration test that builds its own starting bytes agrees with the migration by
          construction, so these are files rather than string literals in a test. -->

--- a/Jellyfin.Plugin.Requests.Tests/RepositoryDocumentsTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/RepositoryDocumentsTests.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests;
+
+/// <summary>
+/// The documents somebody is pointed at, against the tree that has to hold them.
+/// <para>
+/// The failure this stands for happened here. The sign-off check refuses a commit and tells whoever
+/// wrote it to read <c>CONTRIBUTING.md</c> and <c>DCO</c>, and neither file was in the tree, so the
+/// only message that gate ever produced named two things a contributor could not open. Nothing
+/// refused it, because a workflow that names a file never opens it: the string is on an error path
+/// a green run does not reach, and a red run is read by the person who is already stuck.
+/// </para>
+/// <para>
+/// The documents are read next to the suite rather than out of the source tree, which is this
+/// project's existing way of reading a file the release path reads instead of a second copy of it.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class RepositoryDocumentsTests
+{
+    /// <summary>
+    /// The sign-off check, copied next to the suite so this reads the file the gate runs rather than
+    /// a description of it.
+    /// </summary>
+    private const string SignOffCheck = "dco.yml";
+
+    /// <summary>
+    /// A markdown link to something in this repository. The scheme test below is what keeps it off
+    /// the ones that point at the internet, which this cannot resolve and should not try to.
+    /// </summary>
+    private static readonly Regex Link = new Regex(@"\]\(([^)\s]+)\)", RegexOptions.Compiled, TimeSpan.FromSeconds(2));
+
+    /// <summary>
+    /// The documents the sign-off check names, which a contributor it turns away has to be able to
+    /// open. Each is the spelling the check uses beside the path it resolves to.
+    /// <para>
+    /// The spelling matters. <c>DCO</c> on its own is three letters that appear in the check's own
+    /// name and in half its comments, so a leg looking for that would pass over a message that had
+    /// stopped naming the file. <c>./DCO</c> is the message.
+    /// </para>
+    /// </summary>
+    /// <returns>How the check spells it, and the path in the tree.</returns>
+    public static TheoryData<string, string> DocumentsTheSignOffCheckNames()
+        => new TheoryData<string, string> { { "CONTRIBUTING.md", "CONTRIBUTING.md" }, { "./DCO", "DCO" } };
+
+    /// <summary>
+    /// The documents somebody arriving from outside this repository looks for by name.
+    /// </summary>
+    /// <returns>One document per case.</returns>
+    public static TheoryData<string> DocumentsAnArrivalLooksFor()
+        => new TheoryData<string> { "CONTRIBUTING.md", "SECURITY.md", "CODE_OF_CONDUCT.md" };
+
+    /// <summary>
+    /// Every document the sign-off check names is in the tree, and the check still names it.
+    /// <para>
+    /// Both directions, because they are the same gap arriving from two sides. A document deleted
+    /// while the check points at it is what was here; a check that stopped pointing at a document
+    /// reads as fixed, because the file is present and nothing sends anybody to it.
+    /// </para>
+    /// </summary>
+    /// <param name="named">The document as the check spells it.</param>
+    /// <param name="path">Where that resolves to in the tree.</param>
+    [Theory]
+    [MemberData(nameof(DocumentsTheSignOffCheckNames))]
+    public void EveryDocumentTheSignOffCheckNamesIsInTheTree(string named, string path)
+    {
+        Assert.True(
+            File.Exists(Beside(path)),
+            FormattableString.Invariant(
+                $"{path} is not in the tree, and the sign-off check tells a refused contributor to read it."));
+
+        Assert.NotEmpty(File.ReadAllText(Beside(path)).Trim());
+        Assert.Contains(named, File.ReadAllText(Beside(SignOffCheck)), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The documents a contributor and a reporter look for are there and say something.
+    /// </summary>
+    /// <param name="document">The document.</param>
+    [Theory]
+    [MemberData(nameof(DocumentsAnArrivalLooksFor))]
+    public void TheDocumentsAnArrivalLooksForAreInTheTree(string document)
+    {
+        Assert.True(File.Exists(Beside(document)), FormattableString.Invariant($"{document} is not in the tree."));
+        Assert.NotEmpty(File.ReadAllText(Beside(document)).Trim());
+    }
+
+    /// <summary>
+    /// Every repository path these documents link to resolves to a file that is there.
+    /// <para>
+    /// This is the same defect as the one above, generalised: a document that sends somebody to a
+    /// file which does not exist is worse than one that says nothing, because the reader spends
+    /// their time looking. It is also what holds the contributing document to pointing at
+    /// <c>docs/quality-parity.md</c> rather than at a path it invented.
+    /// </para>
+    /// </summary>
+    /// <param name="document">The document whose links are followed.</param>
+    [Theory]
+    [MemberData(nameof(DocumentsAnArrivalLooksFor))]
+    public void EveryRepositoryPathTheseDocumentsLinkToIsInTheTree(string document)
+    {
+        var links = Link.Matches(File.ReadAllText(Beside(document)))
+            .Select(match => match.Groups[1].Value)
+            .Where(target => !target.Contains("://", StringComparison.Ordinal))
+            .Where(target => !target.StartsWith('#'))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        // No assertion that there are any. Two of these three documents send a reader to a place
+        // rather than to a file, and a leg demanding a link would be satisfied by adding one.
+        var dangling = links
+            .Where(target => !File.Exists(Beside(target.Replace('/', Path.DirectorySeparatorChar))))
+            .OrderBy(target => target, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal([], dangling);
+    }
+
+    /// <summary>
+    /// The contributing document sends a reader to the parity document for what the gate requires,
+    /// and that document is there.
+    /// <para>
+    /// It points rather than restates because a list of checks written twice is two answers, and the
+    /// copy nobody runs is the one that goes stale. Whether the prose around the link restates it
+    /// anyway is a judgement the review makes; what is checkable is that the link is there and
+    /// resolves, and this is that half.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void TheContributingDocumentSendsAReaderToTheParityDocument()
+    {
+        const string Parity = "docs/quality-parity.md";
+
+        Assert.Contains(Parity, File.ReadAllText(Beside("CONTRIBUTING.md")), StringComparison.Ordinal);
+        Assert.True(File.Exists(Beside(Parity.Replace('/', Path.DirectorySeparatorChar))));
+    }
+
+    /// <summary>
+    /// One file as it sits next to the suite.
+    /// </summary>
+    /// <param name="name">Its path, relative to the repository root.</param>
+    /// <returns>The path to read.</returns>
+    private static string Beside(string name) => Path.Combine(AppContext.BaseDirectory, name);
+}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,69 @@
+# Reporting a security problem
+
+## The private route
+
+Use GitHub's private vulnerability reporting for this repository: the **Security**
+tab, then **Report a vulnerability**. It is enabled here, and it opens a draft
+advisory only you and the maintainer can read.
+
+That is the route. Do not open a public issue for a security problem, and do not
+put one in a pull request body: both are readable by anybody the moment they are
+written, including by whoever would use what you found.
+
+If you cannot reach that form, open a public issue saying only that you have
+something to report privately and nothing about what it is, and you will be given
+a route.
+
+## What to expect back
+
+You will get a reply, from one person. This repository is maintained by one
+person in their own time; there is no rota behind it and no response time is
+promised here, because a promise nobody is staffed to keep is worse than an
+honest silence about it.
+
+What is promised is the shape of the reply, in this order:
+
+- an acknowledgement that the report was read, and whether it is understood;
+- a verdict, with the reasoning: whether it is a problem in this plugin, in
+  something it depends on, or not a problem, and where the line was drawn;
+- where it is a problem, what the fix is and when it lands, and where it is not,
+  why not.
+
+Credit is offered by default and refused on request. A fix names what was fixed
+and what it prevented, in the changelog, whether or not the reporter is named.
+
+## What is in scope
+
+This plugin, in this repository: the code, the packaging metadata, the workflows,
+and anything in the tree.
+
+What is not, and where it goes instead:
+
+- Jellyfin itself, including its authentication, its API and its dashboard. Those
+  go to the Jellyfin project.
+- The server this plugin is installed on. How it is exposed, what is in front of
+  it and who can reach it are the operator's, and this plugin makes none of those
+  choices.
+- An external request service this plugin can be pointed at. That is a separate
+  product with its own reporting route.
+
+## What this plugin holds
+
+A report is easier to write against a plugin whose data you know. This one keeps
+requests: who asked, what they asked for, when, the decisions made on it and by
+whom, and the notes people wrote. People are recorded by the server's own user
+identifier and never by name.
+
+There is no telemetry. Nothing about use is collected and nothing is sent
+anywhere for this project's benefit, without exception and without a later
+review of that.
+
+Today the plugin makes no outbound call at all, which is a fact about the tree
+rather than a promise about every version:
+
+    git grep -nE 'HttpClient|WebRequest|WebSocket|Socket' -- Jellyfin.Plugin.Requests ; echo "exit=$?"
+    exit=1
+
+That will change when a bridge to an external request service exists. What goes
+to such a service is what the operator configured it to receive, and it is
+documented where that is built.


### PR DESCRIPTION
Closes #106.

The sign-off gate refuses a commit and tells whoever wrote it to read `CONTRIBUTING.md` and `./DCO`.
Neither file was in the tree, measured at the base of this branch:

    git ls-tree --name-only origin/master | grep -icE '^(CONTRIBUTING\.md|DCO|SECURITY\.md|CODE_OF_CONDUCT\.md)$'
    0

So the only message that gate has ever produced named two things a contributor cannot open, and the
certificate the trailer asserts was nowhere to be read.

## The means

Markdown at the repository root, which is where every tool and every arrival looks for these four by
name, plus one xUnit class in the suite that already exists. Nothing is added to the package: the
documents are not compiled into the plugin, and the test project copies them next to the suite the
same way it already copies the packaging files and the lifecycle document.

## What is here

`CONTRIBUTING.md` says how to sign, how to start, and what the gate expects. It points at
`docs/quality-parity.md` for the required set rather than listing it: a list written twice is two
answers, and the copy nobody runs is the one that goes stale. It names two checks by name where a
first-time contributor meets them, which is not the set.

`DCO` is the Developer Certificate of Origin 1.1, verbatim. It is the document the trailer asserts,
so it is copied rather than described.

`SECURITY.md` names the private route and says what a reporter gets back. The route is this
repository's own vulnerability reporting form, which is enabled rather than assumed:

    gh api repos/Flowfin/jellyfin-plugin-requests/private-vulnerability-reporting
    {"enabled":true}

It promises no response time. There is one pair of hands and no rota behind this repository, and a time
nobody is staffed to keep is worse than saying so plainly. What it promises instead is the shape of
the reply and the order it comes in. It also says what the plugin holds, so a report can be written
against something known, and the claim that the plugin makes no outbound call carries the command:

    git grep -nE 'HttpClient|WebRequest|WebSocket|Socket' -- Jellyfin.Plugin.Requests ; echo "exit=$?"
    exit=1

`CODE_OF_CONDUCT.md` says what is expected, what is not, and where a report goes. It shares the
security form, because that is the only private channel this repository has, and it says so rather
than implying a second one exists. It also says where a report about me goes, which is
not here.

## What refuses this coming back

`RepositoryDocumentsTests`. A workflow that names a file never opens it: the string sits on an error
path a green run does not reach, and a red run is read by the person who is already stuck. The suite
opens both ends and in both directions, so a document deleted while the check points at it, and a
check that stopped pointing at a document, each red the gate. It follows the repository links in
these documents too, because a document that sends a reader to a file which is not there costs them
the time to look for it.

The spelling the check uses is what is looked for. `DCO` on its own is three letters that appear in
that workflow's name and in half its comments, so a leg looking for those three would pass over a
message that had stopped naming the file; `./DCO` is the message.

## The runs

At the commit being pushed, on this machine.

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!: Fehler: 0, erfolgreich: 295, gesamt: 295 (net9.0)
    Bestanden!: Fehler: 0, erfolgreich: 295, gesamt: 295 (net10.0)

Prettier, on the three markdown files this adds, run against copies with the line endings the gate
sees rather than the ones this working tree has:

    npx prettier@3.6.2 --check "*.md"
    All matched files use Prettier code style!

## Each guard watched failing

Three mutations, each reverted afterwards, run against
`--filter "FullyQualifiedName~RepositoryDocumentsTests"` on `net9.0`, which is 9 legs.

The certificate is not in the tree, which is the state this issue is about. It reds before a test
runs, because the suite copies it:

    error MSB3030: Datei "...\DCO" konnte nicht kopiert werden, da die Datei nicht gefunden wurde.

The check stops naming the documents it sends people to:

    RepositoryDocumentsTests.EveryDocumentTheSignOffCheckNamesIsInTheTree(named: "CONTRIBUTING.md", path: "CONTRIBUTING.md") [FAIL]
    Fehler: 1, erfolgreich: 8, gesamt: 9

The `./DCO` leg stayed green under that same mutation, and it is right to have: the mutation edited
the error message, and a comment higher in the same file still names the file. The leg asks whether
the check names the document, not where in the file it does.

A document sends a reader to a file that is not there:

    RepositoryDocumentsTests.EveryRepositoryPathTheseDocumentsLinkToIsInTheTree(document: "CONTRIBUTING.md") [FAIL]
    Fehler: 1, erfolgreich: 8, gesamt: 9

## What is not covered here

Nothing checks that these documents say anything true. That a contributing document points at the
parity document is checkable and is checked; whether the prose around the link restates the set
anyway is a judgement, and the review is where a wrong one is caught.

Nothing checks the security route still works. That it is enabled today is the command above, run
against the repository rather than against a setting written down here, and a repository setting is
not something this change can hold.

The link check reaches the three markdown documents this adds. `README.md` and everything under
`docs/` are not in it, so a dangling link there is not refused by anything, and this does not claim
otherwise.

Nobody else has read this change. The evidence above stands in place of a second reader rather than
beside one.
