### PR TITLE
Say where the queue lives, and prove a backup of it restores (#99)

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Storage/FileRequestStoreRestoreTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Storage/FileRequestStoreRestoreTests.cs
@@ -1,0 +1,337 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Storage;
+
+/// <summary>
+/// A backup taken off one machine and opened on another. This is a different question from the one
+/// <see cref="FileRequestStoreVersionTests"/> asks, and the difference is the directory: those legs
+/// read a file where it already sits, and an operator restoring a backup puts bytes into a data
+/// folder that has never held a request and starts a plugin over them.
+/// <para>
+/// What has to hold for a backup to be worth taking. The file has to be somewhere a backup of the
+/// server's data directory reaches, which is the first leg. Everything the store held when the bytes
+/// were captured has to come back, and the restored directory has to be a working store afterwards
+/// rather than a readable one. And the case an operator actually meets, restoring onto a plugin that
+/// is not the version the backup came from, has to end in one of two places: read, or refused whole.
+/// Never half read.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class FileRequestStoreRestoreTests : IDisposable
+{
+    /// <summary>
+    /// The file of bytes the store wrote before it carried a version, which is the nearest thing
+    /// this tree has to a capture from an older plugin. Where it came from, and why no shipped
+    /// version's output exists to use instead, is in <c>docs/storage.md</c>.
+    /// </summary>
+    private const string UnversionedFixture = "Storage/Fixtures/unversioned-written-at-592e517.json";
+
+    private readonly List<FileRequestStore> _stores = [];
+    private readonly List<string> _directories = [];
+
+    /// <summary>
+    /// Removes every store this test made and the directory each one wrote in.
+    /// </summary>
+    public void Dispose()
+    {
+        foreach (var store in _stores)
+        {
+            store.Dispose();
+        }
+
+        foreach (var directory in _directories)
+        {
+            TestRunDirectory.Remove(directory);
+        }
+    }
+
+    /// <summary>
+    /// The store file sits inside the plugin's own data folder, and that folder sits under the
+    /// directory the server keeps its own data in. This is the whole of what makes a backup of the
+    /// server's data directory a backup of the queue, and it is asserted rather than described
+    /// because the sentence in <c>docs/storage.md</c> is what an operator plans a backup from.
+    /// </summary>
+    [Fact]
+    public void TheStoreFileIsInsideThePluginsOwnDataFolderUnderTheServersDataDirectory()
+    {
+        using var host = new PluginHost();
+
+        var dataFolder = host.Plugin.DataFolderPath;
+        var pluginsPath = host.ApplicationPaths.PluginsPath;
+        var programData = host.ApplicationPaths.ProgramDataPath;
+
+        Assert.Equal(pluginsPath, Path.GetDirectoryName(dataFolder));
+        Assert.Equal(programData, Path.GetDirectoryName(pluginsPath));
+
+        // The names are compared against literals rather than against the constants that produce
+        // them. A comparison against the constant passes whatever the constant says, and what
+        // docs/storage.md tells an operator to copy is a name rather than a symbol.
+        Assert.Equal("Jellyfin.Plugin.Requests", Path.GetFileName(dataFolder));
+
+        var store = NewStore(dataFolder, out _);
+        Assert.Equal(dataFolder, Path.GetDirectoryName(store.FilePath));
+        Assert.Equal("requests.json", Path.GetFileName(store.FilePath));
+        Assert.Equal("requests.json.writing", Path.GetFileName(store.PendingFilePath));
+
+        // The configuration is a second file in a second place. An operator told to back up the
+        // queue and not the settings restores a queue onto defaults.
+        Assert.Equal(
+            host.ApplicationPaths.PluginConfigurationsPath,
+            Path.GetDirectoryName(host.Plugin.ConfigurationFilePath));
+        Assert.Equal("Jellyfin.Plugin.Requests.xml", Path.GetFileName(host.Plugin.ConfigurationFilePath));
+        Assert.Equal(programData, Path.GetDirectoryName(host.ApplicationPaths.PluginConfigurationsPath));
+    }
+
+    /// <summary>
+    /// Bytes captured off one data folder and put into another that has never held a request. Every
+    /// request comes back at the revision it was captured at, and the directory is a store afterwards
+    /// rather than a document: a write lands and survives the store being opened again.
+    /// <para>
+    /// The revisions are checked because they are what a write is accepted against. A restore that
+    /// brought the requests back and reset their revisions would leave every caller holding a read
+    /// that the store no longer agrees with, and the first approval after a restore would be refused
+    /// for a reason nobody could see.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AStoreRestoredIntoAFreshDataFolderHoldsWhatItHeldWhenItWasCaptured()
+    {
+        var captured = ADirectory();
+        var source = NewStore(captured, out _);
+
+        await source.AddAsync(ARequest(1), CancellationToken.None).ConfigureAwait(true);
+        var second = await source.AddAsync(ARequest(2), CancellationToken.None).ConfigureAwait(true);
+        await source.AddAsync(ARequest(3), CancellationToken.None).ConfigureAwait(true);
+
+        // One of them is moved, so the capture holds a request at a revision above the one an added
+        // request starts at.
+        var approved = await source.ReplaceAsync(
+            second.Request with { State = RequestState.Approved },
+            second.Revision,
+            CancellationToken.None).ConfigureAwait(true);
+        Assert.Equal(2, approved.Revision);
+
+        var bytes = await File.ReadAllBytesAsync(source.FilePath, CancellationToken.None).ConfigureAwait(true);
+
+        var restored = ADirectory();
+        await SeedAsync(restored, bytes).ConfigureAwait(true);
+        var opened = NewStore(restored, out _);
+
+        var held = await opened.GetAllAsync(CancellationToken.None).ConfigureAwait(true);
+        Assert.Equal(3, held.Count);
+
+        foreach (var ordinal in new[] { 1, 2, 3 })
+        {
+            var back = await opened.GetAsync(Identifier(ordinal), CancellationToken.None).ConfigureAwait(true);
+            Assert.NotNull(back);
+            Assert.Equal(ARequest(ordinal).DisplayTitle, back.Value.Request.DisplayTitle);
+            Assert.Equal(ordinal == 2 ? 2 : 1, back.Value.Revision);
+            Assert.Equal(
+                ordinal == 2 ? RequestState.Approved : RequestState.Open,
+                back.Value.Request.State);
+        }
+
+        // A store rather than a document: it takes a write, and the write is there when it is
+        // opened again over the same directory.
+        await opened.AddAsync(ARequest(4), CancellationToken.None).ConfigureAwait(true);
+        var reopened = NewStore(restored, out _);
+        Assert.Equal(4, (await reopened.GetAllAsync(CancellationToken.None).ConfigureAwait(true)).Count);
+    }
+
+    /// <summary>
+    /// The case this issue exists for: a backup restored onto a plugin that is not the version it
+    /// was captured from, arriving from the direction that works. The shape written before the store
+    /// carried a version is read into a fresh data folder, both requests come back, and the restored
+    /// directory takes a write afterwards.
+    /// <para>
+    /// The forward migration itself is <see cref="FileRequestStoreVersionTests"/>'s. What is asserted
+    /// here is that it survives the restore, which is the step where a file arrives in a directory
+    /// holding nothing else.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AStoreCapturedFromAnOlderShapeIsReadableAndWritableAfterBeingRestored()
+    {
+        var restored = ADirectory();
+        await SeedAsync(restored, await FixtureAsync().ConfigureAwait(true)).ConfigureAwait(true);
+
+        var opened = NewStore(restored, out var log);
+        var held = await opened.GetAllAsync(CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Equal(2, held.Count);
+        Assert.Contains(
+            log.At(LogLevel.Information),
+            line => line.Message.Contains("migrated to version", StringComparison.Ordinal));
+
+        await opened.AddAsync(ARequest(9), CancellationToken.None).ConfigureAwait(true);
+
+        var reopened = NewStore(restored, out _);
+        Assert.Equal(3, (await reopened.GetAllAsync(CancellationToken.None).ConfigureAwait(true)).Count);
+    }
+
+    /// <summary>
+    /// The same case arriving from the other direction: a backup taken off a newer plugin and
+    /// restored onto an older one. It is refused, and the point of the leg is the word "partly" -
+    /// the entry in that file is one this version would understand perfectly well, and it is still
+    /// not served, because a set that is missing whatever the reader did not recognise is a set an
+    /// operator would act on believing it whole.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AStoreCapturedFromANewerVersionIsRefusedWholeRatherThanPartlyRestored()
+    {
+        var restored = ADirectory();
+
+        var newer = FileRequestStore.OnDiskVersion + 1;
+        var readable = ARequest(1);
+
+        var document = string.Format(
+            CultureInfo.InvariantCulture,
+            "{{\"Version\":{0},\"Requests\":[{{\"Revision\":1,\"Request\":{{\"Id\":\"{1}\",\"RequestedByUserId\":\"{2}\",\"RequestedAt\":\"2026-08-08T08:00:00+00:00\",\"Kind\":0,\"DisplayTitle\":\"{3}\",\"State\":0,\"StateChangedAt\":\"2026-08-08T08:00:00+00:00\"}}}}],\"SomethingThisVersionHasNeverHeardOf\":true}}",
+            newer,
+            readable.Id,
+            readable.RequestedByUserId,
+            readable.DisplayTitle);
+
+        var written = Encoding.UTF8.GetBytes(document);
+        var path = await SeedAsync(restored, written).ConfigureAwait(true);
+
+        var opened = NewStore(restored, out var log);
+
+        // Not "returns the one entry it could read". Every read refuses, including the one that
+        // asks about the request the file plainly holds.
+        await Assert.ThrowsAsync<RequestStoreLoadException>(
+            () => opened.GetAllAsync(CancellationToken.None)).ConfigureAwait(true);
+        await Assert.ThrowsAsync<RequestStoreLoadException>(
+            () => opened.GetAsync(readable.Id, CancellationToken.None)).ConfigureAwait(true);
+        await Assert.ThrowsAsync<RequestStoreLoadException>(
+            () => opened.FindForUserAsync(readable.RequestedByUserId, CancellationToken.None)).ConfigureAwait(true);
+
+        Assert.NotEmpty(log.At(LogLevel.Error));
+
+        // And the backup is still the backup. An operator who reinstalls the newer plugin has lost
+        // nothing by having tried the older one over these bytes.
+        var onDisk = await File.ReadAllBytesAsync(path, CancellationToken.None).ConfigureAwait(true);
+        Assert.True(written.SequenceEqual(onDisk));
+    }
+
+    /// <summary>
+    /// A backup that swept up the file a write was being built in restores as the queue and not as
+    /// the half-written thing beside it. This is what lets <c>docs/storage.md</c> say the pending
+    /// file need not be in a backup and does no harm when it is.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task APendingFileCarriedIntoTheBackupIsNotWhatIsRestored()
+    {
+        var captured = ADirectory();
+        var source = NewStore(captured, out _);
+        await source.AddAsync(ARequest(1), CancellationToken.None).ConfigureAwait(true);
+
+        var bytes = await File.ReadAllBytesAsync(source.FilePath, CancellationToken.None).ConfigureAwait(true);
+
+        var restored = ADirectory();
+        await SeedAsync(restored, bytes).ConfigureAwait(true);
+
+        // A complete document holding a different set, sitting where a write in flight would leave
+        // one. A restore that read it would answer with a queue the operator never had.
+        var stale = NewStore(ADirectory(), out _);
+        await stale.AddAsync(ARequest(2), CancellationToken.None).ConfigureAwait(true);
+        await stale.AddAsync(ARequest(3), CancellationToken.None).ConfigureAwait(true);
+        await File.WriteAllBytesAsync(
+            Path.Combine(restored, FileRequestStore.PendingFileName),
+            await File.ReadAllBytesAsync(stale.FilePath, CancellationToken.None).ConfigureAwait(true),
+            CancellationToken.None).ConfigureAwait(true);
+
+        var opened = NewStore(restored, out _);
+        var held = await opened.GetAllAsync(CancellationToken.None).ConfigureAwait(true);
+
+        var only = Assert.Single(held);
+        Assert.Equal(Identifier(1), only.Request.Id);
+    }
+
+    /// <summary>
+    /// A request with a predictable identifier, so a leg can say which records survived a restore
+    /// rather than only how many.
+    /// </summary>
+    /// <param name="ordinal">Which one.</param>
+    /// <returns>A newly asked-for request.</returns>
+    private static MediaRequest ARequest(int ordinal)
+    {
+        var asked = new DateTimeOffset(2026, 8, 8, 8, 0, 0, TimeSpan.Zero);
+
+        return new MediaRequest
+        {
+            Id = Identifier(ordinal),
+            RequestedByUserId = new Guid("b31d0f9a-5c2e-4a71-8f6b-0d4c3e2a1b58"),
+            RequestedAt = asked,
+            StateChangedAt = asked,
+            Kind = RequestedItemKind.Movie,
+            DisplayTitle = string.Format(CultureInfo.InvariantCulture, "The Conversation {0}", ordinal)
+        };
+    }
+
+    /// <summary>
+    /// The identifier the ordinal names.
+    /// </summary>
+    /// <param name="ordinal">Which one.</param>
+    /// <returns>The identifier.</returns>
+    private static Guid Identifier(int ordinal)
+        => new Guid(string.Format(CultureInfo.InvariantCulture, "00000000-0000-0000-0000-{0:D12}", ordinal));
+
+    /// <summary>
+    /// The fixture's bytes, read from beside the suite.
+    /// </summary>
+    /// <returns>The bytes.</returns>
+    private static Task<byte[]> FixtureAsync()
+        => File.ReadAllBytesAsync(
+            Path.Combine(AppContext.BaseDirectory, UnversionedFixture),
+            CancellationToken.None);
+
+    /// <summary>
+    /// Puts bytes where a store opened over that directory will find them, which is what restoring a
+    /// backup is.
+    /// </summary>
+    /// <param name="directory">The data folder being restored into.</param>
+    /// <param name="bytes">What the backup holds.</param>
+    /// <returns>The path they were written to.</returns>
+    private static async Task<string> SeedAsync(string directory, byte[] bytes)
+    {
+        var path = Path.Combine(directory, FileRequestStore.FileName);
+        await File.WriteAllBytesAsync(path, bytes, CancellationToken.None).ConfigureAwait(false);
+        return path;
+    }
+
+    private string ADirectory()
+    {
+        var directory = TestRunDirectory.CreateSubdirectory();
+        _directories.Add(directory);
+        return directory;
+    }
+
+    private FileRequestStore NewStore(string directory, out RecordingLogger log)
+    {
+        log = new RecordingLogger();
+        var store = new FileRequestStore(directory, log);
+        _stores.Add(store);
+        return store;
+    }
+}

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -202,6 +202,90 @@ Whoever builds the next package should keep that package's own output as the nex
 moment it is built. After a field has been added there is no way to produce those bytes again except
 by hand, which is the thing this rule is against.
 
+## Backing up, and restoring
+
+### What is on the disk, and where
+
+Two files, both under the directory the server keeps its own data in, so a backup of that directory
+is a backup of this plugin and an operator has nothing extra to configure:
+
+| What              | Where                                                    | In a backup |
+| ----------------- | -------------------------------------------------------- | ----------- |
+| The queue         | `plugins/Jellyfin.Plugin.Requests/requests.json`         | Required    |
+| The settings      | `plugin-configurations/Jellyfin.Plugin.Requests.xml`     | Required    |
+| A write in flight | `plugins/Jellyfin.Plugin.Requests/requests.json.writing` | Not needed  |
+
+The paths are relative to the server's data directory. Where that directory is differs by
+installation and by operating system, and this document does not name it: the server is the
+authority for its own paths.
+
+The layout under it is not a guess. The first leg of `FileRequestStoreRestoreTests` reads the
+plugin's data folder and its configuration path off the host, and compares each name against the
+literal in the table above rather than against the constant that produces it, so a rename reds
+rather than agreeing with itself:
+
+    DOTNET_CLI_UI_LANGUAGE=en dotnet test Jellyfin.Plugin.Requests.sln -f net9.0 \
+        --filter "FullyQualifiedName~FileRequestStoreRestoreTests"
+    Passed!  - Failed: 0, Passed: 5, Skipped: 0, Total: 5, Duration: 200 ms
+
+One step in that chain is read by nothing. That the store is built over the plugin's own data folder
+at all is one line in `PluginServiceRegistrator`, and no test asserts it, because the plugin instance
+that line reads is a static that any other test class can replace while a leg is running and a leg
+built on it would fail for reasons nobody caused. It is a line to read rather than a property the
+suite holds.
+
+The third row is the file a write is built in before it replaces the queue. It is listed so a backup
+that swept it up is not read as a problem: a restore that carries one ignores it and reads the queue,
+which is `APendingFileCarriedIntoTheBackupIsNotWhatIsRestored`.
+
+### Restoring
+
+Putting the file back into a data folder that holds nothing is the whole procedure, and the store is
+opened over it as though it had always been there. What comes back is what was captured, revisions
+included, and the directory is a store afterwards rather than a document: it takes writes, and they
+survive the next restart. `AStoreRestoredIntoAFreshDataFolderHoldsWhatItHeldWhenItWasCaptured` is
+that leg, and it checks the revisions because a restore that reset them would refuse the first
+approval afterwards against a read no caller could see was stale.
+
+The case worth planning for is a restore onto a plugin that is not the version the backup came from,
+and the two directions are not symmetric.
+
+**A restore onto a newer plugin works.** An older shape is migrated forward as the file is read, under the
+rule above, and the restored directory is writable immediately.
+`AStoreCapturedFromAnOlderShapeIsReadableAndWritableAfterBeingRestored` restores the fixture into an
+empty data folder, reads both requests and writes a third.
+
+**A restore onto an older plugin is refused, whole.** A file carrying a version this plugin does not read is
+not partly restored, and the point is the word partly: entries that this version would understand
+perfectly well are still not served, because a queue missing whatever the reader did not recognise is
+a queue an operator decides from believing it complete.
+`AStoreCapturedFromANewerVersionIsRefusedWholeRatherThanPartlyRestored` puts a readable entry inside
+an unreadable document and asserts that every read refuses it, that the refusal is in the log, and
+that the backup is byte for byte what it was. Install the newer plugin again and nothing has been
+lost.
+
+Each of the five legs was proven to bite by a one-line change to the store, one at a time, with the
+other four left passing:
+
+| The change made to the store                                           | What went red               |
+| ---------------------------------------------------------------------- | --------------------------- |
+| `FileName` renamed to `queue.json`                                     | the paths leg               |
+| every entry loaded at revision 1 rather than the one it was written at | the capture-and-restore leg |
+| the shape written before the version existed read as an empty queue    | the older-shape leg         |
+| `document.Version > OnDiskVersion` off by one                          | the refused-whole leg       |
+| a load resuming the file a write was being built in                    | the pending-file leg        |
+
+### What this does not cover
+
+Nothing here restores across two shipped versions of the plugin, because there are none to restore
+across: no released version has ever written a request file, which is the same absence the fixture
+rule above names. The hop between shipped versions is #97, and the fixture it needs is captured at
+release time or not at all.
+
+Nothing here has been run against a server's own backup and restore feature. What is asserted is
+about the files and the store that reads them, and an operator who takes their backup some other way
+is covered by the same table.
+
 ## It adds no package reference
 
 The chosen medium needs nothing that is not already in the runtime. The plugin project's package


### PR DESCRIPTION
Closes #99.

## What was missing

An operator backing up a Jellyfin server backs up its data directory. Whether that captured this plugin's requests was written down nowhere, and the first restore is where they would have found out. The store landed with #44 and #46 and the version rule with #47; what none of them said is where the bytes sit and what happens when they arrive somewhere else.

## Where the data is

`docs/storage.md` now carries the table, with the paths relative to the server's data directory:

| What              | Where                                                    | In a backup |
| ----------------- | -------------------------------------------------------- | ----------- |
| The queue         | `plugins/Jellyfin.Plugin.Requests/requests.json`         | Required    |
| The settings      | `plugin-configurations/Jellyfin.Plugin.Requests.xml`     | Required    |
| A write in flight | `plugins/Jellyfin.Plugin.Requests/requests.json.writing` | Not needed  |

Where the server's data directory itself is differs by installation and by operating system, and the document does not name it: the server is the authority for its own paths.

The settings row is there because an operator told to back up the queue and not the settings restores a queue onto defaults. The third row is listed so a backup that swept up the pending file is not read as a problem.

The layout is asserted rather than described. The first leg reads the plugin's data folder and the configuration path off the host and compares each name against the literal the table prints, not against the constant that produces it, because a comparison against the constant passes whatever the constant says.

One step in that chain is read by nothing, and the document says so: that the store is built over the plugin's own data folder at all is one line in `PluginServiceRegistrator`, and no leg asserts it, because the plugin instance that line reads is a static any other test class can replace while a leg is running.

## What restoring is

Putting the file into a data folder that holds nothing, and opening the store over it. What comes back is what was captured, revisions included, and the directory is a store afterwards rather than a document: it takes writes and they survive the next open. The revisions are checked because a restore that reset them would refuse the first approval afterwards against a read no caller could see was stale.

The two directions across a version are not symmetric and both are asserted.

**Onto a newer plugin it works.** The older shape is migrated forward as the file is read and the restored directory is writable at once.

**Onto an older plugin it is refused, whole.** The leg puts an entry this version would understand perfectly well inside a document carrying a version it does not, and asserts that every read refuses, that the refusal reaches the log, and that the file is byte for byte what it was. The word the leg is about is *partly*: a queue missing whatever the reader did not recognise is one an operator decides from believing it complete. Reinstalling the newer plugin loses nothing.

## That the guards bite

Five legs, five one-line changes to `FileRequestStore`, one at a time, each with the other four left passing:

    DOTNET_CLI_UI_LANGUAGE=en dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -f net9.0 \
        --filter "FullyQualifiedName~FileRequestStoreRestoreTests"

| The change made to the store                                           | What went red                                                        |
| ---------------------------------------------------------------------- | -------------------------------------------------------------------- |
| `FileName` renamed to `queue.json`                                     | `TheStoreFileIsInsideThePluginsOwnDataFolderUnderTheServersDataDirectory` |
| every entry loaded at revision 1 rather than the one it was written at | `AStoreRestoredIntoAFreshDataFolderHoldsWhatItHeldWhenItWasCaptured`  |
| the shape written before the version existed read as an empty queue    | `AStoreCapturedFromAnOlderShapeIsReadableAndWritableAfterBeingRestored` |
| `document.Version > OnDiskVersion` off by one                          | `AStoreCapturedFromANewerVersionIsRefusedWholeRatherThanPartlyRestored` |
| a load resuming the file a write was being built in                    | `APendingFileCarriedIntoTheBackupIsNotWhatIsRestored`                 |

Each run ended `Failed: 1, Passed: 4, Skipped: 0, Total: 5`, so every leg names its own failure and none of them is carried by another.

## The suite on the pushed tree

    DOTNET_CLI_UI_LANGUAGE=en dotnet test Jellyfin.Plugin.Requests.sln --configuration Release --nologo
    Passed!  - Failed:     0, Passed:   267, Skipped:     0, Total:   267, Duration: 14 s - Jellyfin.Plugin.Requests.Tests.dll (net10.0)
    Passed!  - Failed:     0, Passed:   267, Skipped:     0, Total:   267, Duration: 14 s - Jellyfin.Plugin.Requests.Tests.dll (net9.0)

## The means

No new one. The legs are xUnit facts in the existing suite and the document is markdown beside the others in `docs/`. Nothing here adds a language, a runtime or a package reference.

## What this does not cover

Nothing here restores across two shipped versions of the plugin, because there are none to restore across: no released version has ever written a request file, which is the same absence the fixture rule in `docs/storage.md` names. The hop between shipped versions is #97, and the fixture it needs is captured at release time or not at all.

Nothing here has been run against a server's own backup and restore feature. What is asserted is about the files and the store that reads them.

The third done-condition asks that a store from a newer version be refused rather than partially read. That refusal is #47's code rather than a second implementation, which is what the issue asked for; this change tests it through the restore path.

## Reading

This change had no second reader. The evidence above stands in place of one: the five mutation runs and the suite are the whole of what backs it.
