### PR TITLE
Publish what these endpoints answer, in the shape they answer it (#57)

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Api/PublishedApiDocumentTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/PublishedApiDocumentTests.cs
@@ -1,0 +1,467 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Api;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.ApplicationParts;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Api;
+
+/// <summary>
+/// What a caller who never reads this source can find out about these endpoints.
+/// <para>
+/// Jellyfin builds its published API document from the description set ASP.NET derives from the
+/// controllers it has loaded, this plugin's included. Everything a generator can put in that
+/// document about an endpoint comes from that set: the path, the verb, the parameters and where each
+/// one is read from, and the shape and status code of every answer. So the set is what these legs
+/// read.
+/// </para>
+/// <para>
+/// <b>The bound, because it is easy to read this as more than it is.</b> This is the input a
+/// document is generated from and not the document. It is derived here from the plugin assembly by
+/// itself, so what it cannot see is the server: whether the server loads this plugin's controllers
+/// into its own application parts at all, and what its generator then writes. The first is the
+/// subject of the recorded first-load run in <c>docs/testing.md</c>, and the second is the server's.
+/// Between them and this there is no route in the tree that fetches a generated document, which is
+/// said in <c>docs/api.md</c> rather than left for a reader to discover.
+/// </para>
+/// <para>
+/// What it does catch is the failure this is for: an endpoint that answers with a shape or a status
+/// code the document does not name. That reads as a working API to anybody generating a client from
+/// it, and the client breaks on the first refusal rather than on the first call.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class PublishedApiDocumentTests
+{
+    private static readonly Guid Asker = new Guid("c7000000-0000-0000-0000-000000000001");
+    private static readonly Guid Operator = new Guid("c7000000-0000-0000-0000-000000000002");
+    private static readonly DateTimeOffset Started = new DateTimeOffset(2026, 8, 10, 9, 0, 0, TimeSpan.Zero);
+
+    /// <summary>
+    /// Every operation a caller can find in the document, with what it takes and what it answers.
+    /// <para>
+    /// An endpoint added without a line here fails, which is the point: an endpoint nobody annotated
+    /// is one a per-endpoint test cannot miss because no per-endpoint test knows it exists. So is a
+    /// parameter that quietly moved from the path to the query, and an answer whose shape changed
+    /// under a caller reading the document.
+    /// </para>
+    /// <para>
+    /// The lines are in the order the comparison sorts them, which is by the whole line. A line put
+    /// where a reader would put it fails until it is moved, which is noise rather than a finding,
+    /// and the alternative is a comparison that cannot say which operation is missing.
+    /// </para>
+    /// </summary>
+    private static readonly string[] Expected =
+    [
+        // One person's own requests. The parameters are the same six the queue takes, because the
+        // difference between the two reads is what the store is asked rather than what the caller
+        // may ask for.
+        "GET MediaRequests/v1/Requests"
+            + " (descending@Query:Boolean, kind@Query:RequestedItemKind[], order@Query:RequestQueryOrder, skip@Query:Int32, state@Query:RequestState[], take@Query:Int32)"
+            + " -> 200:RequestsPage<MyRequest>, 400:RequestFailure, 403:RequestFailure, 503:RequestFailure",
+
+        // The whole queue. No 403 here, and that is not an omission: this endpoint never asks who
+        // is calling, so there is no call it refuses for naming nobody. Who may reach it at all is
+        // the server's evaluation of the elevation policy, which is not part of any answer.
+        "GET MediaRequests/v1/Requests/Queue"
+            + " (descending@Query:Boolean, kind@Query:RequestedItemKind[], order@Query:RequestQueryOrder, skip@Query:Int32, state@Query:RequestState[], take@Query:Int32)"
+            + " -> 200:RequestsPage<QueuedRequest>, 400:RequestFailure, 503:RequestFailure",
+
+        // Asking for something. Two success codes with one shape: 201 is a new request and 200 is
+        // one that was joined or was already the caller's, and a client tells them apart by the
+        // status or by the outcome in the body.
+        "POST MediaRequests/v1/Requests"
+            + " (body@Body:CreateRequestBody)"
+            + " -> 200:CreatedRequest, 201:CreatedRequest, 400:RequestFailure, 403:RequestFailure, 503:RequestFailure",
+
+        // Saying yes.
+        "POST MediaRequests/v1/Requests/{id}/Approve"
+            + " (body@Body:ApproveRequestBody, id@Path:Guid)"
+            + " -> 200:QueuedRequest, 400:RequestFailure, 403:RequestFailure, 404:RequestFailure, 409:RequestFailure, 503:RequestFailure",
+
+        // Saying no, which takes the same shape of answer and one more field on the way in.
+        "POST MediaRequests/v1/Requests/{id}/Decline"
+            + " (body@Body:DeclineRequestBody, id@Path:Guid)"
+            + " -> 200:QueuedRequest, 400:RequestFailure, 403:RequestFailure, 404:RequestFailure, 409:RequestFailure, 503:RequestFailure"
+    ];
+
+    private readonly SequentialIdentifierSource _identifiers = new SequentialIdentifierSource();
+
+    /// <summary>
+    /// The document lists exactly the operations written down, with their parameters and their
+    /// answers.
+    /// </summary>
+    [Fact]
+    public void TheDocumentListsTheOperationsWrittenDownForIt()
+    {
+        // Joined rather than compared as two sequences, because a collection failure prints the
+        // difference with the middle elided and the whole list is what somebody repairing this
+        // needs to read.
+        Assert.Equal(
+            string.Join(" | ", Expected),
+            string.Join(" | ", Published()),
+            StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Nothing the plugin serves is missing from the document.
+    /// <para>
+    /// The leg above compares against a list somebody wrote. This one compares against the assembly,
+    /// so an endpoint hidden from the document, by <see cref="ApiExplorerSettingsAttribute"/> or by
+    /// a route the description set could not build, fails here even if the written list was updated
+    /// to match. An endpoint that is reachable and undocumented is the one a caller finds by
+    /// accident and depends on.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void EveryEndpointTheAssemblyCarriesIsInTheDocument()
+    {
+        var carried = Actions()
+            .Select(action => Verb(action.Method) + " " + action.Method.Name)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        var documented = Descriptions()
+            .Select(description => description.HttpMethod + " " + ((ControllerActionDescriptor)description.ActionDescriptor).MethodInfo.Name)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(string.Join(" | ", carried), string.Join(" | ", documented), StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Every failure in the document is published as the shape this API actually answers with.
+    /// <para>
+    /// This is the near miss, and it is one word rather than one character. A
+    /// <c>[ProducesResponseType(StatusCodes.Status400BadRequest)]</c> that names no type is not an
+    /// endpoint with no documented failure: under <see cref="ApiControllerAttribute"/> the framework
+    /// fills the shape in for you, and what it fills in is <c>ProblemDetails</c>, which nothing here
+    /// returns. A client generated from that document parses every refusal into the wrong type and
+    /// finds out at the first one.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void EveryFailureIsPublishedAsTheShapeThisApiAnswersWith()
+    {
+        var wrong = Descriptions()
+            .SelectMany(description => description.SupportedResponseTypes
+                .Where(response => response.StatusCode >= 400)
+                .Where(response => response.Type != typeof(RequestFailure))
+                .Select(response => string.Format(
+                    CultureInfo.InvariantCulture,
+                    "{0} {1} publishes {2} for {3}",
+                    description.HttpMethod,
+                    description.RelativePath,
+                    Named(response.Type),
+                    response.StatusCode)))
+            .OrderBy(line => line, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal([], wrong);
+    }
+
+    /// <summary>
+    /// The status codes published for an endpoint are the ones it answers with, in both directions.
+    /// <para>
+    /// This is the leg the written list above cannot be. The list is a list, and a list agrees with
+    /// whatever somebody put in it; this walks each endpoint through every answer it has and
+    /// compares what came back against what the document promises. A status an endpoint answers with
+    /// and does not publish is a refusal a client never planned for, and a status it publishes and
+    /// never answers with is a branch somebody wrote for nothing.
+    /// </para>
+    /// <para>
+    /// One arm is deliberately not walked and it changes no set. Both decisions publish <c>403</c>,
+    /// and two failures share it: a call that names no person, which is walked here, and a caller
+    /// the transition table does not admit, which no call these endpoints build can produce because
+    /// both require elevation. <c>ErrorSurfaceTests</c> is where that is written down and
+    /// <c>TheOnlyCallerTheseEndpointsBuildIsAdmittedByEveryMoveTheyCanMake</c> is what reds when it
+    /// stops being true.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task EveryStatusAnEndpointAnswersWithIsOneTheDocumentPublishes()
+    {
+        var answered = await AnsweredAsync().ConfigureAwait(true);
+
+        var published = Descriptions()
+            .ToDictionary(
+                description => description.HttpMethod + " " + description.RelativePath,
+                description => description.SupportedResponseTypes
+                    .Select(response => response.StatusCode)
+                    .Distinct()
+                    .OrderBy(status => status)
+                    .ToArray(),
+                StringComparer.Ordinal);
+
+        foreach (var endpoint in answered.Keys.OrderBy(key => key, StringComparer.Ordinal))
+        {
+            Assert.Equal(
+                string.Join(", ", published[endpoint]),
+                string.Join(", ", answered[endpoint].OrderBy(status => status)));
+        }
+
+        // And every endpoint in the document was walked, so the loop above cannot pass by covering
+        // a subset of them.
+        Assert.Equal(
+            string.Join(" | ", published.Keys.OrderBy(key => key, StringComparer.Ordinal)),
+            string.Join(" | ", answered.Keys.OrderBy(key => key, StringComparer.Ordinal)),
+            StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Every status code each endpoint answers with, taken from calls that produce them rather than
+    /// from a list.
+    /// </summary>
+    /// <returns>The statuses, by endpoint, spelled the way the document spells the endpoint.</returns>
+    private async Task<Dictionary<string, HashSet<int>>> AnsweredAsync()
+    {
+        var answered = new Dictionary<string, HashSet<int>>(StringComparer.Ordinal);
+        var store = new InMemoryRequestStore();
+        var unreadable = new StoreThatCannotBeRead();
+
+        const string Create = "POST MediaRequests/v1/Requests";
+        const string Mine = "GET MediaRequests/v1/Requests";
+        const string Queue = "GET MediaRequests/v1/Requests/Queue";
+        const string Approve = "POST MediaRequests/v1/Requests/{id}/Approve";
+        const string Decline = "POST MediaRequests/v1/Requests/{id}/Decline";
+
+        // Asking for something. The same body twice: the first is a new request and the second is
+        // the caller already waiting for it, which is the endpoint's other success code.
+        Saw(Create, await ControllerFor(store, Asker).CreateAsync(AFilm(), CancellationToken.None).ConfigureAwait(true));
+        Saw(Create, await ControllerFor(store, Asker).CreateAsync(AFilm(), CancellationToken.None).ConfigureAwait(true));
+        Saw(Create, await ControllerFor(store, Asker).CreateAsync(new CreateRequestBody { Title = "No kind" }, CancellationToken.None).ConfigureAwait(true));
+        Saw(Create, await ControllerFor(store, caller: null).CreateAsync(AFilm(), CancellationToken.None).ConfigureAwait(true));
+        Saw(Create, await ControllerFor(unreadable, Asker).CreateAsync(AFilm(), CancellationToken.None).ConfigureAwait(true));
+
+        Saw(Mine, await ControllerFor(store, Asker).MineAsync(cancellationToken: CancellationToken.None).ConfigureAwait(true));
+        Saw(Mine, await ControllerFor(store, Asker).MineAsync(take: RequestsController.MaximumPageSize + 1, cancellationToken: CancellationToken.None).ConfigureAwait(true));
+        Saw(Mine, await ControllerFor(store, caller: null).MineAsync(cancellationToken: CancellationToken.None).ConfigureAwait(true));
+        Saw(Mine, await ControllerFor(unreadable, Asker).MineAsync(cancellationToken: CancellationToken.None).ConfigureAwait(true));
+
+        Saw(Queue, await ControllerFor(store, Operator).QueueAsync(cancellationToken: CancellationToken.None).ConfigureAwait(true));
+        Saw(Queue, await ControllerFor(store, Operator).QueueAsync(take: RequestsController.MaximumPageSize + 1, cancellationToken: CancellationToken.None).ConfigureAwait(true));
+        Saw(Queue, await ControllerFor(unreadable, Operator).QueueAsync(cancellationToken: CancellationToken.None).ConfigureAwait(true));
+
+        var toApprove = await store.AddAsync(AnAsk(), CancellationToken.None).ConfigureAwait(true);
+        var toDecline = await store.AddAsync(AnAsk(), CancellationToken.None).ConfigureAwait(true);
+        var absent = _identifiers.NewId();
+
+        Saw(Approve, await ControllerFor(store, Operator).ApproveAsync(toApprove.Request.Id, new ApproveRequestBody { Revision = toApprove.Revision }, CancellationToken.None).ConfigureAwait(true));
+        Saw(Approve, await ControllerFor(store, Operator).ApproveAsync(toApprove.Request.Id, new ApproveRequestBody(), CancellationToken.None).ConfigureAwait(true));
+        Saw(Approve, await ControllerFor(store, caller: null).ApproveAsync(toApprove.Request.Id, new ApproveRequestBody { Revision = 1 }, CancellationToken.None).ConfigureAwait(true));
+        Saw(Approve, await ControllerFor(store, Operator).ApproveAsync(absent, new ApproveRequestBody { Revision = 1 }, CancellationToken.None).ConfigureAwait(true));
+        Saw(Approve, await ControllerFor(store, Operator).ApproveAsync(toDecline.Request.Id, new ApproveRequestBody { Revision = toDecline.Revision + 7 }, CancellationToken.None).ConfigureAwait(true));
+        Saw(Approve, await ControllerFor(unreadable, Operator).ApproveAsync(toDecline.Request.Id, new ApproveRequestBody { Revision = 1 }, CancellationToken.None).ConfigureAwait(true));
+
+        Saw(Decline, await ControllerFor(store, Operator).DeclineAsync(toDecline.Request.Id, new DeclineRequestBody { Revision = toDecline.Revision, Reason = DeclineReason.NotWanted }, CancellationToken.None).ConfigureAwait(true));
+        Saw(Decline, await ControllerFor(store, Operator).DeclineAsync(toDecline.Request.Id, new DeclineRequestBody { Revision = toDecline.Revision }, CancellationToken.None).ConfigureAwait(true));
+        Saw(Decline, await ControllerFor(store, caller: null).DeclineAsync(toDecline.Request.Id, new DeclineRequestBody { Revision = 1, Reason = DeclineReason.NotWanted }, CancellationToken.None).ConfigureAwait(true));
+        Saw(Decline, await ControllerFor(store, Operator).DeclineAsync(absent, new DeclineRequestBody { Revision = 1, Reason = DeclineReason.NotWanted }, CancellationToken.None).ConfigureAwait(true));
+        Saw(Decline, await ControllerFor(store, Operator).DeclineAsync(toApprove.Request.Id, new DeclineRequestBody { Revision = toApprove.Revision + 7, Reason = DeclineReason.NotWanted }, CancellationToken.None).ConfigureAwait(true));
+        Saw(Decline, await ControllerFor(unreadable, Operator).DeclineAsync(toApprove.Request.Id, new DeclineRequestBody { Revision = 1, Reason = DeclineReason.NotWanted }, CancellationToken.None).ConfigureAwait(true));
+
+        return answered;
+
+        void Saw<T>(string endpoint, ActionResult<T> came)
+        {
+            if (!answered.TryGetValue(endpoint, out var statuses))
+            {
+                statuses = [];
+                answered[endpoint] = statuses;
+            }
+
+            statuses.Add(Status(came));
+        }
+    }
+
+    /// <summary>
+    /// The status code an action answered with.
+    /// </summary>
+    /// <typeparam name="T">What the action answers with when it succeeds.</typeparam>
+    /// <param name="came">What the action returned.</param>
+    /// <returns>The status code.</returns>
+    private static int Status<T>(ActionResult<T> came)
+    {
+        var result = Assert.IsAssignableFrom<ObjectResult>(came.Result);
+
+        // An Ok() carries no explicit status, and 200 is what the framework writes for one.
+        return result.StatusCode ?? 200;
+    }
+
+    /// <summary>
+    /// The description set a document generator reads, derived from the plugin assembly.
+    /// <para>
+    /// The application parts are built here rather than discovered, because discovery reads the
+    /// entry assembly and the entry assembly under a test run is the test host.
+    /// </para>
+    /// </summary>
+    /// <returns>Every operation the plugin publishes.</returns>
+    private static ApiDescription[] Descriptions()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var parts = new ApplicationPartManager();
+        parts.ApplicationParts.Add(new AssemblyPart(typeof(RequestsControllerBase).Assembly));
+        services.AddSingleton(parts);
+        services.AddControllers();
+
+        using var provider = services.BuildServiceProvider();
+
+        return [.. provider
+            .GetRequiredService<IApiDescriptionGroupCollectionProvider>()
+            .ApiDescriptionGroups
+            .Items
+            .SelectMany(group => group.Items)];
+    }
+
+    /// <summary>
+    /// One operation as a caller reading the document sees it: what it is, what it takes and what it
+    /// answers with.
+    /// <para>
+    /// A parameter's type is the one the action declares rather than the one the description carries,
+    /// and the difference is not cosmetic. The description reports a scalar enumeration read from the
+    /// query as the type it arrives as, and which type that is moved between the two runtimes this
+    /// plugin is built for: <c>order</c> comes through as <c>String</c> on one and as
+    /// <c>RequestQueryOrder</c> on the other, off the same source. Writing the runtime's answer down
+    /// would mean one of the two lines failing on a difference nobody here made. Where each parameter
+    /// is read from is taken from the description, because that is a fact about the endpoint rather
+    /// than about the runtime, and it is the half that moves when somebody changes a route.
+    /// </para>
+    /// </summary>
+    /// <returns>The lines, sorted.</returns>
+    private static string[] Published()
+        => [.. Descriptions()
+            .Select(description => string.Format(
+                CultureInfo.InvariantCulture,
+                "{0} {1} ({2}) -> {3}",
+                description.HttpMethod,
+                description.RelativePath,
+                string.Join(
+                    ", ",
+                    description.ParameterDescriptions
+                        .Select(parameter => string.Format(
+                            CultureInfo.InvariantCulture,
+                            "{0}@{1}:{2}",
+                            parameter.Name,
+                            parameter.Source.Id,
+                            Named(parameter.ParameterDescriptor?.ParameterType ?? parameter.Type)))
+                        .OrderBy(parameter => parameter, StringComparer.Ordinal)),
+                string.Join(
+                    ", ",
+                    description.SupportedResponseTypes
+                        .Select(response => string.Format(
+                            CultureInfo.InvariantCulture,
+                            "{0}:{1}",
+                            response.StatusCode,
+                            Named(response.Type)))
+                        .OrderBy(response => response, StringComparer.Ordinal))))
+            .OrderBy(line => line, StringComparer.Ordinal)];
+
+    /// <summary>
+    /// A type as a reader would write it, generic arguments included, because
+    /// <c>RequestsPage`1</c> does not say which page it is.
+    /// </summary>
+    /// <param name="type">The type.</param>
+    /// <returns>The name.</returns>
+    private static string Named(Type? type)
+    {
+        if (type is null)
+        {
+            return "(none)";
+        }
+
+        if (!type.IsGenericType)
+        {
+            return type.IsArray
+                ? Named(type.GetElementType()) + "[]"
+                : type.Name;
+        }
+
+        return string.Format(
+            CultureInfo.InvariantCulture,
+            "{0}<{1}>",
+            type.Name[..type.Name.IndexOf('`', StringComparison.Ordinal)],
+            string.Join(", ", type.GetGenericArguments().Select(Named)));
+    }
+
+    /// <summary>
+    /// Every action on every controller the plugin ships, which is every method carrying a verb.
+    /// </summary>
+    /// <returns>The actions.</returns>
+    private static (Type Type, MethodInfo Method)[] Actions()
+        => [.. typeof(RequestsControllerBase).Assembly
+            .GetTypes()
+            .Where(type => typeof(ControllerBase).IsAssignableFrom(type))
+            .Where(type => !type.IsAbstract)
+            .SelectMany(type => type
+                .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                .Where(method => method.GetCustomAttributes<HttpMethodAttribute>(inherit: false).Any())
+                .Select(method => (Type: type, Method: method)))];
+
+    /// <summary>
+    /// The verb an action answers under.
+    /// </summary>
+    /// <param name="method">The action.</param>
+    /// <returns>The verb.</returns>
+    private static string Verb(MethodInfo method)
+        => method.GetCustomAttributes<HttpMethodAttribute>(inherit: false)
+            .Single()
+            .HttpMethods
+            .Single();
+
+    /// <summary>
+    /// A controller wired to one store and one identity.
+    /// </summary>
+    /// <param name="store">Where requests are kept.</param>
+    /// <param name="caller">Who the server says is calling.</param>
+    /// <returns>The controller under test.</returns>
+    private RequestsController ControllerFor(IRequestStore store, Guid? caller)
+        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller));
+
+    /// <summary>
+    /// A request as the store holds one.
+    /// </summary>
+    /// <returns>The request.</returns>
+    private MediaRequest AnAsk() => new MediaRequest
+    {
+        Id = _identifiers.NewId(),
+        RequestedByUserId = Asker,
+        RequestedAt = Started,
+        StateChangedAt = Started,
+        Kind = RequestedItemKind.Movie,
+        DisplayTitle = "The Conversation",
+        DisplayYear = 1974,
+        ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tmdb"] = "603" }
+    };
+
+    /// <summary>
+    /// A body asking for a film.
+    /// </summary>
+    /// <returns>The body.</returns>
+    private static CreateRequestBody AFilm() => new CreateRequestBody
+    {
+        Kind = RequestedItemKind.Movie,
+        Title = "The Conversation",
+        Year = 1974,
+        ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tmdb"] = "605" }
+    };
+}

--- a/Jellyfin.Plugin.Requests/Api/RequestsController.cs
+++ b/Jellyfin.Plugin.Requests/Api/RequestsController.cs
@@ -128,9 +128,11 @@ public sealed class RequestsController : RequestsControllerBase
     /// </returns>
     [HttpPost("Requests")]
     [Authorize(Policy = AuthenticatedUserPolicy)]
-    [ProducesResponseType(StatusCodes.Status201Created)]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType<CreatedRequest>(StatusCodes.Status201Created)]
+    [ProducesResponseType<CreatedRequest>(StatusCodes.Status200OK)]
+    [ProducesResponseType<RequestFailure>(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType<RequestFailure>(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType<RequestFailure>(StatusCodes.Status503ServiceUnavailable)]
     public async Task<ActionResult<CreatedRequest>> CreateAsync(
         [FromBody] CreateRequestBody body,
         CancellationToken cancellationToken)
@@ -215,8 +217,10 @@ public sealed class RequestsController : RequestsControllerBase
     /// <returns>The page, and how many of the caller's requests matched.</returns>
     [HttpGet("Requests")]
     [Authorize(Policy = AuthenticatedUserPolicy)]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType<RequestsPage<MyRequest>>(StatusCodes.Status200OK)]
+    [ProducesResponseType<RequestFailure>(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType<RequestFailure>(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType<RequestFailure>(StatusCodes.Status503ServiceUnavailable)]
     public async Task<ActionResult<RequestsPage<MyRequest>>> MineAsync(
         [FromQuery] RequestState[]? state = null,
         [FromQuery] RequestedItemKind[]? kind = null,
@@ -288,8 +292,9 @@ public sealed class RequestsController : RequestsControllerBase
     /// <returns>The page, and how many requests matched.</returns>
     [HttpGet("Requests/Queue")]
     [Authorize(Policy = AdministratorPolicy)]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType<RequestsPage<QueuedRequest>>(StatusCodes.Status200OK)]
+    [ProducesResponseType<RequestFailure>(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType<RequestFailure>(StatusCodes.Status503ServiceUnavailable)]
     public async Task<ActionResult<RequestsPage<QueuedRequest>>> QueueAsync(
         [FromQuery] RequestState[]? state = null,
         [FromQuery] RequestedItemKind[]? kind = null,
@@ -342,11 +347,12 @@ public sealed class RequestsController : RequestsControllerBase
     /// </returns>
     [HttpPost("Requests/{id}/Approve")]
     [Authorize(Policy = AdministratorPolicy)]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    [ProducesResponseType<QueuedRequest>(StatusCodes.Status200OK)]
+    [ProducesResponseType<RequestFailure>(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType<RequestFailure>(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType<RequestFailure>(StatusCodes.Status404NotFound)]
+    [ProducesResponseType<RequestFailure>(StatusCodes.Status409Conflict)]
+    [ProducesResponseType<RequestFailure>(StatusCodes.Status503ServiceUnavailable)]
     public async Task<ActionResult<QueuedRequest>> ApproveAsync(
         Guid id,
         [FromBody] ApproveRequestBody body,
@@ -389,11 +395,12 @@ public sealed class RequestsController : RequestsControllerBase
     /// </returns>
     [HttpPost("Requests/{id}/Decline")]
     [Authorize(Policy = AdministratorPolicy)]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    [ProducesResponseType<QueuedRequest>(StatusCodes.Status200OK)]
+    [ProducesResponseType<RequestFailure>(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType<RequestFailure>(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType<RequestFailure>(StatusCodes.Status404NotFound)]
+    [ProducesResponseType<RequestFailure>(StatusCodes.Status409Conflict)]
+    [ProducesResponseType<RequestFailure>(StatusCodes.Status503ServiceUnavailable)]
     public async Task<ActionResult<QueuedRequest>> DeclineAsync(
         Guid id,
         [FromBody] DeclineRequestBody body,

--- a/docs/api.md
+++ b/docs/api.md
@@ -94,6 +94,73 @@ reads the built assembly rather than the source text: every controller type in t
 from `RequestsControllerBase` and declares no route of its own. A controller written in a file the
 rule's path list does not reach would pass the lint and fail there.
 
+## The published document
+
+The server generates one API document from every controller it has loaded, this plugin's included,
+and serves it beside its own endpoints:
+
+    api-docs/openapi.json
+
+with `api-docs/swagger` and `api-docs/redoc` as the two browsable forms of the same thing. Those
+paths are the server's rather than this plugin's, and they are the same on both claimed lines:
+
+    gh api repos/jellyfin/jellyfin/contents/Jellyfin.Server/Extensions/ApiApplicationBuilderExtensions.cs?ref=v10.11.0 --jq .content | base64 -d | grep -n "RouteTemplate\|RoutePrefix"
+    39:                    c.RouteTemplate = "{documentName}/openapi.json";
+    50:                    c.RoutePrefix = "api-docs/swagger";
+    57:                    c.RoutePrefix = "api-docs/redoc";
+
+**That document is the reference, and this one is the reasons.** Every path, every parameter and
+where it is read from, and the shape and status code of every answer are in it, generated from the
+endpoints rather than typed by somebody. What is written here instead is why each of them is the way
+it is, which is the half a generator cannot produce. Where the two disagree the document is right and
+this file is stale, which is the whole reason for not restating it.
+
+### Every failure carries this API's own shape
+
+A response type that names no shape is not an undocumented failure. Under `[ApiController]` the
+framework fills one in, and what it fills in is `ProblemDetails`, which nothing here returns. A client
+generated from a document saying that parses every refusal into the wrong type and finds out at the
+first refusal rather than at the first call. So every status at or above 400 is published as
+`RequestFailure`, which is the shape the table above describes.
+
+### What holds it
+
+`PublishedApiDocumentTests` reads the description set a generator is given and holds four things: the
+operations are exactly the ones written down, with their parameters and their answers; every endpoint
+the assembly carries is in that set, so one hidden from the document and still reachable reds; every
+failure is published as `RequestFailure`; and the status codes published for an endpoint are the ones
+it answers with, taken from calls that produce them rather than from a list, in both directions.
+
+**What that is not.** It is the input a document is generated from and not the document, derived from
+the plugin assembly by itself. Two things sit between it and what a caller fetches: whether the server
+loads these controllers into its own application parts, which is the subject of the recorded first-load
+run in `docs/testing.md`, and what its generator writes from them. No route in this tree fetches a
+generated document from a running server, and nothing here claims one.
+
+### The summaries do not reach it, and this is why
+
+Every endpoint here carries an XML summary and every parameter has one, and none of them is expected
+to reach the generated document. That is read off the server's own source rather than out of a
+document, because no route in this tree fetches one, so it is where the prose is taken from rather
+than an observation of a document without it:
+
+    gh api repos/jellyfin/jellyfin/contents/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs --jq .content | base64 -d | sed -n '221,230p'
+                    // Add all xml doc files to swagger generator.
+                    var xmlFiles = Directory.EnumerateFiles(
+                        AppContext.BaseDirectory,
+                        "*.xml",
+                        SearchOption.TopDirectoryOnly);
+
+                    foreach (var xmlFile in xmlFiles)
+                    {
+                        c.IncludeXmlComments(xmlFile);
+                    }
+
+The generator is handed the XML files sitting in the server's own directory, and a plugin's assembly
+is not in that directory. So the prose a caller gets about these endpoints is what is written here,
+and the document gives them the shapes. That is a limit of the route rather than a decision, and it is
+written down so nobody spends an afternoon wondering why a summary they wrote is not showing up.
+
 ## Asking for something
 
     POST MediaRequests/v1/Requests
@@ -325,4 +392,3 @@ asked for, which is a weaker disclosure than a row and still a disclosure, is op
 - The capability endpoint is #55.
 - Deciding on several requests in one call is #62. Nothing here does it, and a client that wants it
   today makes one call per request.
-- Whether these endpoints appear in the server's published API documentation is #57.


### PR DESCRIPTION
Closes #57.

## What was wrong

Jellyfin generates one API document from every controller it has loaded, and a caller who never reads this source finds these endpoints there. What that document said about them was wrong in one place and short in another, and both read as a working API right up to the first refusal.

**The failures were published as `ProblemDetails`.** Under `[ApiController]`, a `ProducesResponseType` that names no type does not leave the shape undocumented. It fills one in, and the one it fills in is the framework's rather than this plugin's. Nothing here has ever returned `ProblemDetails`; every refusal is a `RequestFailure`. A client generated from that document parses every refusal into the wrong type and finds out at the first one.

**Three status codes were absent.** Nothing published the `503` that answers a store which cannot be read, on any of the five endpoints, and neither read endpoint published the `403` that answers a call naming no person. Both are answers a client has to have a branch for.

Read off the description set before the change:

    GET  MediaRequests/v1/Requests             200:RequestsPage`1, 400:ProblemDetails
    GET  MediaRequests/v1/Requests/Queue       200:RequestsPage`1, 400:ProblemDetails
    POST MediaRequests/v1/Requests             201:CreatedRequest, 200:CreatedRequest, 400:ProblemDetails
    POST MediaRequests/v1/Requests/{id}/Approve  200:QueuedRequest, 400,403,404,409:ProblemDetails
    POST MediaRequests/v1/Requests/{id}/Decline  200:QueuedRequest, 400,403,404,409:ProblemDetails

## What it says now

Every success names the shape it returns and every status at or above `400` names `RequestFailure`:

    GET  MediaRequests/v1/Requests              200:RequestsPage<MyRequest>,    400, 403, 503
    GET  MediaRequests/v1/Requests/Queue        200:RequestsPage<QueuedRequest>, 400, 503
    POST MediaRequests/v1/Requests              200 and 201:CreatedRequest,     400, 403, 503
    POST MediaRequests/v1/Requests/{id}/Approve 200:QueuedRequest,              400, 403, 404, 409, 503
    POST MediaRequests/v1/Requests/{id}/Decline 200:QueuedRequest,              400, 403, 404, 409, 503

The queue has no `403` and that is not an omission: it never asks who is calling, so there is no call it refuses for naming nobody. Who may reach it at all is the server evaluating the elevation policy, which is not part of any answer.

## The test, and what it reads

`PublishedApiDocumentTests` builds the description set ASP.NET derives from the plugin assembly, which is the whole of what a document generator is given, and holds four things:

- the operations are exactly the ones written down, with their parameters, where each is read from, and the shape of every answer;
- every endpoint the assembly carries is in that set, so one hidden from the document and still reachable reds even if the written list was updated to match;
- every failure is published as `RequestFailure`;
- the status codes published for an endpoint are the ones it answers with, in both directions, taken from twenty-five calls that produce them rather than from a list.

The last leg is the one a written list cannot be, and it is what found the three missing codes: a list agrees with whatever somebody put in it.

## That the guards bite

One change to the controller at a time, the rest watched:

    DOTNET_CLI_UI_LANGUAGE=en dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -f net9.0 \
        --filter "FullyQualifiedName~PublishedApiDocumentTests"

| The change made                                                     | What went red                                                                             |
| ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| `503` dropped from `GET Requests/Queue`, which still answers it      | `EveryStatusAnEndpointAnswersWithIsOneTheDocumentPublishes`, `TheDocumentListsTheOperationsWrittenDownForIt` |
| the `400` on `GET Requests` written untyped                          | `EveryFailureIsPublishedAsTheShapeThisApiAnswersWith`, `TheDocumentListsTheOperationsWrittenDownForIt` |
| `Decline` hidden with `[ApiExplorerSettings(IgnoreApi = true)]`      | `EveryEndpointTheAssemblyCarriesIsInTheDocument` and two others                            |
| a `404` published on `GET Requests`, which never answers one         | `EveryStatusAnEndpointAnswersWithIsOneTheDocumentPublishes`, `TheDocumentListsTheOperationsWrittenDownForIt` |

The second row is the near miss the whole change is about, and it is one word rather than one character: dropping `<RequestFailure>` from an attribute does not remove a promise, it makes a different one.

Every row was run on both target frameworks and reds identically on each.

## One thing the first attempt got wrong

A parameter's type was read from the description set, and the two runtimes do not agree on what a scalar enumeration read from the query is. `order` comes through as `RequestQueryOrder` on .NET 10 and as `String` on the ASP.NET 9 the runner has, off the same source, so the leg passed here and failed there on a difference nobody made. It now takes the type the action declares, which is stable, and keeps taking *where* each parameter is read from out of the description, because that is a fact about the endpoint rather than about the runtime and it is the half that moves when a route changes.

## The suite

    DOTNET_CLI_UI_LANGUAGE=en dotnet test Jellyfin.Plugin.Requests.sln --configuration Release --nologo
    Passed!  - Failed:     0, Passed:   304, Skipped:     0, Total:   304, Duration: 20 s - Jellyfin.Plugin.Requests.Tests.dll (net9.0)
    Passed!  - Failed:     0, Passed:   304, Skipped:     0, Total:   304, Duration: 19 s - Jellyfin.Plugin.Requests.Tests.dll (net10.0)

## The document

`docs/api.md` now points at the generated one and says which half is whose: the shapes, the codes and the parameters are the document's, and the reasons stay here. Where the two disagree the document is right and the file is stale, which is the reason for not restating it.

It also carries two things the suite cannot see, both read off the server's own source with the command in the document rather than from memory: the paths the document is served at, which are the same on both claimed lines, and why the XML summaries do not reach it. The generator is handed the XML files in the server's own directory, and a plugin's assembly is not there.

## The means

No new one. Four xUnit facts in the existing suite, using `Microsoft.AspNetCore.Mvc.ApiExplorer` out of the shared framework the plugin already compiles against. No package reference is added to either project.

## What this does not cover

This reads the input a document is generated from, not a document. Two things sit between it and what a caller fetches: whether the server loads these controllers into its own application parts, which is the recorded first-load run's subject in `docs/testing.md`, and what the server's generator writes from them. No route in this tree fetches a generated document from a running server, and neither the test nor the document claims one.

## Reading

This change had no second reader. The four mutation runs, the suite, and the two commands quoted in `docs/api.md` are the evidence standing in place of one.
