### PR TITLE
Point at the sibling's contract, and write the reach matrix as claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,23 @@ What is supported, what is only expected to work, and what a downgrade does to
 the requests a server already holds are in
 [docs/compatibility.md](docs/compatibility.md).
 
+## Which clients this reaches
+
+No cell of the reach matrix in docs/surface.md has been checked against a real
+client, and neither the channel nor the page it describes is on the mainline
+today.
+
+That sentence is the whole claim this file makes about client reach, and it is
+the sentence the matrix opens with. The matrix itself, a row per client family
+and what a user could do there, is in [docs/surface.md](docs/surface.md). It is
+not repeated here, because two copies of a table drift and the reader then has
+two answers.
+
+One line of it is worth having before installing anything. On a server with no
+browsing sibling plugin there is no way to ask for a title the server does not
+have from a television client at all. This plugin ships no title search of its
+own, and that was decided rather than overlooked.
+
 ## Building
 
 ```

--- a/docs/seam.md
+++ b/docs/seam.md
@@ -1,0 +1,70 @@
+# The seam to the discover sibling
+
+## Which document is authoritative
+
+[Flowfin/jellyfin-plugin-discover#94](https://github.com/Flowfin/jellyfin-plugin-discover/issues/94)
+is the contract, and it is the only one. It says so itself, it fixes what crosses, and it stays open
+until this board points at it. This file is that pointer.
+
+This repository writes no second contract and copies no field list out of that issue. A copy is a
+second authority from the moment the first one is edited, and the copy is the one a reader of this
+repository would find first, so it would win an argument it has no right to win. What crosses is
+read there. What this side owes against it is read here.
+
+That is also why this document names no fields. If you are looking for the field set, follow the
+link; if the link is wrong, fix the link rather than writing the fields down here.
+
+## The HTTP API is not the seam
+
+`docs/api.md` describes routes a signed-in caller reaches over HTTP. Nothing in it is the seam, and
+there is no route to hand a want over on.
+
+The two differ in every way that matters to somebody deciding which rules apply.
+
+The caller is a different thing. An API caller is a person or a script the server authenticated, and
+the request it files is attributed to that session. A seam caller is another plugin in the same
+server process, which the server does not authenticate at all because there is nothing to
+authenticate. What that costs, and what this side does about it, is #118 rather than this section.
+
+The compatibility rule is a different thing. The API carries a version in its route prefix and is a
+promise to callers outside this process, so what may change and when is decided here, in
+`docs/api.md`. The seam's shape is decided on the sibling's board, in the contract issue above, and
+a version there moves on that board's schedule and not on this one's. Reading the API's version rule
+as covering the seam would have this repository promising something it does not control.
+
+The reach is a different thing. Every endpoint sits under a policy and none is anonymous, which is
+the whole of what stands between a queue and whoever asks for it. The seam has no policy because it
+has no session. Neither statement is true of the other surface.
+
+So a change to `docs/api.md` is not a change to the seam, and a change to the contract is not a
+change to the API. Somebody who conflates them will either look for a route that does not exist or
+apply the API's rules to a call that has none of them.
+
+## Both sides watch the library, and neither tells the other
+
+This plugin decides that a request is fulfilled by watching the server's library for the thing
+arriving, in #42. The sibling watches the same library for its own reasons, on its own schedule.
+Neither one notifies the other when it sees something.
+
+That is deliberate and it is what keeps the handover one way. One message crosses, when a user asks
+for something on a surface this plugin does not own. Nothing crosses back to say the thing turned
+up, because the side that cares can see it for itself, and a notification that is not needed is a
+second thing to keep in step and a second thing to be wrong.
+
+The consequence worth stating is that an arrival is observed twice on a server running both
+plugins. That is not duplicated work anybody has to remove: each side is watching for a different
+reason, one to move a request out of the queue and one for whatever that board decides, and neither
+observation depends on the other having happened.
+
+## What this document does not yet hold
+
+Named here so the absence is read as absence rather than as a decision nobody wrote down. Each is
+the closing condition of the issue beside it.
+
+- Which side owns the catalogue, and the two consequences of that split. #92.
+- What happens to a field set carrying a contract version this plugin does not know. #90.
+- The trust position of an in-process handover, and what this side checks before it believes a user
+  identifier it cannot verify. #118.
+- How each side finds the other. #89.
+- What an undone gesture does, which today is nothing, because the contract carries no message for
+  it. #68.

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -71,10 +71,11 @@ it.
 
 Nothing here is softened, and the parts that are claims rather than measurements say so.
 
-**No cell of the reach matrix has been checked against a real client in this repository.** The matrix
-is #72 and it does not exist yet. Until it does, which client families render a channel, and how,
-is a claim taken from the plan rather than a thing anybody here has run. Do not read the section
-above as a measurement of reach.
+**Nothing here has been measured against a client.** The reach matrix is below and it opens with
+the sentence that says so; every cell of it that says a user could do something carries the word
+untested. Which client families render a channel, and how, is a claim taken from the plan rather
+than a thing anybody here has run. Do not read the section above, or the table below, as a
+measurement of reach.
 
 **A client with no browser cannot open the page.** That is what the page is: a document served over
 HTTP to a signed-in session. A client that draws its own interface and offers no way to open a URL
@@ -91,6 +92,83 @@ the sibling discover plugin owns the catalogue and this plugin calls no metadata
 nothing to ask with. The gesture that creates a request arrives from the sibling, which is #68 and
 #89.
 
+## The reach matrix
+
+No cell of the reach matrix in docs/surface.md has been checked against a real client, and neither
+the channel nor the page it describes is on the mainline today.
+
+That sentence is the first thing in this section because the table under it looks like a
+capability list and is not one. It is what the decision above would reach if it were built, written
+down so that a user on a client that renders none of it can find that out here instead of by trying.
+The same sentence is in `README.md`, word for word, so the two cannot drift apart quietly. Line
+breaks differ because the two files wrap at different widths, so the comparison collapses whitespace
+before it looks. Each file becomes one line, so the count is 1 where the sentence is present and 0
+where a word of it has moved:
+
+    for f in README.md docs/surface.md; do printf '%s: ' "$f"; tr -s '[:space:]' ' ' < "$f" \
+      | grep -c 'No cell of the reach matrix in docs/surface.md has been checked against a real client, and neither the channel nor the page it describes is on the mainline today.'; done
+    README.md: 1
+    docs/surface.md: 1
+
+The rows are client families grouped by what draws the interface, not by vendor, because the two
+things that decide reach here are whether the client renders a channel and whether it can open a
+URL. Two clients that share both answers share a row.
+
+| Client family                               | See their own requests     | Ask for something new  | Cancel one they asked for |
+| ------------------------------------------- | -------------------------- | ---------------------- | ------------------------- |
+| Browser                                     | page and channel, untested | sibling only, untested | page, untested            |
+| Desktop client wrapping the web interface   | page and channel, untested | sibling only, untested | page, untested            |
+| Android phone and tablet                    | channel, untested          | sibling only, untested | nothing                   |
+| Android TV and Fire TV                      | channel, untested          | sibling only, untested | nothing                   |
+| iPhone and iPad                             | channel, untested          | sibling only, untested | nothing                   |
+| Apple TV                                    | channel, untested          | sibling only, untested | nothing                   |
+| Roku                                        | channel, untested          | sibling only, untested | nothing                   |
+| LG webOS television                         | channel, untested          | sibling only, untested | nothing                   |
+| Samsung Tizen television                    | channel, untested          | sibling only, untested | nothing                   |
+| Kodi                                        | channel, untested          | sibling only, untested | nothing                   |
+| A script or another program against the API | the API                    | the API                | no route today            |
+
+What the cells mean.
+
+`untested` means nobody in this repository has opened that client and looked. It is not a
+prediction that the cell works; it is the admission that it has not been tried, and it stands on
+every cell that says a user could do something on a client. When a cell is checked against a real
+client, the word is replaced by the client and the version it was checked on, so a checked cell and
+an untested one can never be read as the same thing.
+
+The cells that say `nothing` or `no route today` are the other kind and are not marked. They say
+what does not exist, which no client can contradict, and writing them the same way as a claim about
+a client would hide the difference between something nobody has tried and something nobody has
+built.
+
+`page and channel` is the browser rows, which reach both surfaces. `channel` is every client that
+renders a channel, and whether a given client does is exactly what has not been tried.
+
+`sibling only` is the sharpest cell and the one that is certain rather than untested. This plugin
+ships no way to find a title the server does not have, so there is no gesture here to make. On a
+server with the browsing sibling installed the want arrives through the seam; on a server without
+it, the answer in that column is nothing, on every row above the last. What is untested there is
+whether the sibling draws anything on that client, which is that board's measurement and not this
+one's.
+
+`nothing` in the cancel column is the cost of the folder tree. Cancelling is a per-state operation
+with a reason a person reads, and a channel renders items, so the gesture has nowhere to live there.
+A user on a television can see that they asked for something and cannot take it back from that
+client.
+
+The last row is not a client family and is in the table because leaving it out would make the API
+look like it is not reachable. It is the floor under every other row, it reaches whoever writes
+against it, and it reaches nobody else. Its three cells are read off the routes rather than from
+the plan, which is also where its `no route today` comes from: nothing on this surface cancels
+anything, and what cancelling will mean per state is #68.
+
+    git grep -oh 'Http\(Get\|Post\)("[^"]*")' -- Jellyfin.Plugin.Requests/Api/RequestsController.cs
+    HttpPost("Requests")
+    HttpGet("Requests")
+    HttpGet("Requests/Queue")
+    HttpPost("Requests/{id}/Approve")
+    HttpPost("Requests/{id}/Decline")
+
 ## What the rest of this milestone follows from
 
 Every issue after #65 in milestone 8 is read against the decision above.
@@ -104,7 +182,8 @@ Every issue after #65 in milestone 8 is read against the decision above.
 - #69, serving a page for browsers, is the page.
 - #70, what a user sees when the answer is no or not yet, is written once and rendered by both.
 - #71, never revealing a title a user is not allowed to see, applies to both.
-- #72, the reach matrix, is the measurement this page says it does not have.
+- #72, the reach matrix, is the table above. It is the shape of the measurement this page says it
+  does not have, with every cell still saying so.
 - #73, the localisation catalogue, covers the strings both surfaces show.
 
 None of them assumes a surface other than these, and none is closed as not wanted.


### PR DESCRIPTION
Closes #88.
Closes #72.

Two issues on one branch because both land documents and nothing else. Landing
them separately moves the mainline under whichever went second for no gain to a
reader of either.

## docs/seam.md

The file names Flowfin/jellyfin-plugin-discover#94 as the contract and copies
no field list out of it, which is that issue's own condition on this side and
this issue's first one. A copy here would be a second authority the moment the
first is edited, and it is the one a reader of this repository would find
first.

Beyond the pointer it holds this side's obligations and the two things a reader
of this repository would otherwise get wrong: the HTTP API is not the seam, and
both plugins watch the library for arrivals independently without telling each
other. What is not decided yet is listed with the issue that decides it, so an
absence reads as an absence.

## The reach matrix

A row per client family, a column for seeing your own requests, asking for
something new and cancelling, and the word `untested` on every cell that says a
user could do something. Nobody here has opened one of those clients and
looked, and neither the channel nor the page exists on the mainline, so no
other honest value was available.

Cells that say `nothing` or `no route today` are not marked, because they say
what has not been built rather than what has not been tried, and writing the
two the same way would hide the difference.

The row for a script is read off the routes rather than off the plan:

    git grep -oh 'Http\(Get\|Post\)("[^"]*")' -- Jellyfin.Plugin.Requests/Api/RequestsController.cs
    HttpPost("Requests")
    HttpGet("Requests")
    HttpGet("Requests/Queue")
    HttpPost("Requests/{id}/Approve")
    HttpPost("Requests/{id}/Decline")

Nothing there cancels anything, which is where the last cell comes from.

## The README claim and the matrix are one sentence

#72's third condition. The sentence is in both files rather than a table being
copied into the second one. Run at this head:

    for f in README.md docs/surface.md; do printf '%s: ' "$f"; tr -s '[:space:]' ' ' < "$f" \
      | grep -c 'No cell of the reach matrix in docs/surface.md has been checked against a real client, and neither the channel nor the page it describes is on the mainline today.'; done
    README.md: 1
    docs/surface.md: 1

Whitespace is collapsed first because the two files wrap at different widths.

## Formatting

    npx --yes prettier@3.6.2 --end-of-line auto --check "docs/*.md" "README.md"
    Checking formatting...
    All matched files use Prettier code style!

`--end-of-line auto` is this clone rather than the gate: `core.autocrlf` is true
here, so the working tree carries CRLF and what is committed is LF. The gate
runs the same version without that flag against the committed bytes.

## What this does not cover

No cell of the matrix was checked against a real client, and that is the state
the document describes rather than something hidden in it. Checking one means a
person opening that client, and each checked cell then carries the client and
the version instead of the word.

Nothing was written on the sibling board. #88 asks that its contract issue be
pointed at from here, and the pointer is this repository's document naming it.

## The means

Markdown under `docs/`, which is what every other argument in this tree is
written in, and it is reached by the formatting gate and by the repository
document tests rather than needing an apparatus of its own.

## Reading

No second person has read this before merge. The commands above are what stands
in place of one, and each was run at this head.
