### PR TITLE
One interface for the bridge, with the implementation most servers run behind it

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Bridge/BackendReferenceTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Bridge/BackendReferenceTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Jellyfin.Plugin.Requests.Bridge;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Bridge;
+
+/// <summary>
+/// What a bridge is allowed to hand back. The two values here are what makes the two systems
+/// reconcilable after the moment of the handover, so a half of one that says nothing is refused
+/// where it is built rather than at whichever reader remembers to check.
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public class BackendReferenceTests
+{
+    /// <summary>
+    /// A reference names a service and what that service called the request, and neither may be
+    /// empty or blank. Whitespace is refused with the empty string rather than trimmed away,
+    /// because an adapter handing over a space has a defect and quietly storing it hides the day it
+    /// started.
+    /// </summary>
+    /// <param name="service">The service half.</param>
+    /// <param name="id">The identifier half.</param>
+    [Theory]
+    [InlineData("", "418")]
+    [InlineData("   ", "418")]
+    [InlineData("overseerr", "")]
+    [InlineData("overseerr", "\t")]
+    public void AReferenceWithAnEmptyHalfIsRefused(string service, string id)
+        => Assert.Throws<ArgumentException>(() => new BackendReference { Service = service, Id = id });
+
+    /// <summary>
+    /// What a service reported is kept exactly as it arrived. Nothing here parses it, and the shape
+    /// of an identifier is the service's business.
+    /// </summary>
+    [Fact]
+    public void AReferenceKeepsBothHalvesAsTheyArrived()
+    {
+        var reference = new BackendReference { Service = "overseerr", Id = "media/418" };
+
+        Assert.Equal("overseerr", reference.Service, StringComparer.Ordinal);
+        Assert.Equal("media/418", reference.Id, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// A report carries the service's own word. An empty one is refused, because nothing known is
+    /// already expressed by there being no report, and two ways to say one thing is the pair that
+    /// leaves half the readers checking for one of them.
+    /// </summary>
+    /// <param name="reported">The word as it arrived.</param>
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void AReportWithNothingInItIsRefused(string reported)
+        => Assert.Throws<ArgumentException>(() => new BackendReport { Reported = reported });
+
+    /// <summary>
+    /// The word is carried unmapped. Turning it into one of this plugin's states is #81, and an
+    /// adapter that mapped on the way through would put that decision in every adapter.
+    /// </summary>
+    [Fact]
+    public void AReportKeepsTheServicesOwnWord()
+        => Assert.Equal(
+            "PARTIALLY_AVAILABLE",
+            new BackendReport { Reported = "PARTIALLY_AVAILABLE" }.Reported,
+            StringComparer.Ordinal);
+}

--- a/Jellyfin.Plugin.Requests.Tests/Bridge/NoRequestBackendTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Bridge/NoRequestBackendTests.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Bridge;
+using Jellyfin.Plugin.Requests.Model;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Bridge;
+
+/// <summary>
+/// The bridge most servers run. It is the shipping default rather than a placeholder, so it is
+/// tested for what it answers rather than left to be covered by whatever calls it later.
+/// <para>
+/// Two mistakes are what these tests exist against. Reporting that something answered, which would
+/// put "the external service is up" on an operator's page for a server that has none. And handing
+/// back an invented reference, which would leave rows claiming a handover that nothing can ever be
+/// asked about.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public class NoRequestBackendTests
+{
+    /// <summary>
+    /// Nothing configured is its own answer. Neither of the other two values is true of a server
+    /// with no service behind it, and an operator reading either would be told something about a
+    /// system they do not run.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task NothingIsConfiguredRatherThanReachableOrDown()
+    {
+        var reachability = await new NoRequestBackend()
+            .CheckReachableAsync(CancellationToken.None);
+
+        Assert.Equal(BackendReachability.NotConfigured, reachability);
+    }
+
+    /// <summary>
+    /// Submitting hands nothing over and says so by returning no reference. It does not throw: an
+    /// approval on a server with no service is the ordinary case rather than a failure, and a
+    /// caller that had to catch something here would be a caller with a branch for the absence.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task SubmittingKeepsNothingAndHandsBackNoReference()
+    {
+        var reference = await new NoRequestBackend()
+            .SubmitAsync(Asked(), CancellationToken.None);
+
+        Assert.Null(reference);
+    }
+
+    /// <summary>
+    /// Asked about any reference, it knows nothing. Answered rather than refused, because a
+    /// reference issued by a service an operator has since removed is a fact about the install.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task NothingIsKnownAboutAReferenceThisBridgeNeverIssued()
+    {
+        var report = await new NoRequestBackend()
+            .ReportAsync(SomeoneElsesReference(), CancellationToken.None);
+
+        Assert.Null(report);
+    }
+
+    /// <summary>
+    /// Withdrawing something it never accepted completes. The state the caller wanted is the state
+    /// the server is already in, and raising an error for that would make every caller handle a
+    /// case where nothing went wrong.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task WithdrawingSomethingItNeverAcceptedIsNotAFailure()
+    {
+        await new NoRequestBackend().WithdrawAsync(SomeoneElsesReference(), CancellationToken.None);
+    }
+
+    /// <summary>
+    /// Every operation observes a cancelled token. The default runs on most installs, so a caller
+    /// that cancels is checked against this one long before it meets an adapter, and one that
+    /// silently ignored the token would let that caller ship looking correct and hang on the first
+    /// bridge that honours one.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task EveryOperationObservesACancelledToken()
+    {
+        var backend = new NoRequestBackend();
+        using var cancelled = new CancellationTokenSource();
+        await cancelled.CancelAsync();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => backend.CheckReachableAsync(cancelled.Token));
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => backend.SubmitAsync(Asked(), cancelled.Token));
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => backend.ReportAsync(SomeoneElsesReference(), cancelled.Token));
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => backend.WithdrawAsync(SomeoneElsesReference(), cancelled.Token));
+    }
+
+    /// <summary>
+    /// One request, as a person would have asked for it.
+    /// </summary>
+    /// <returns>The request.</returns>
+    private static MediaRequest Asked()
+    {
+        var asked = new DateTimeOffset(2026, 3, 14, 21, 5, 0, TimeSpan.Zero);
+
+        return new MediaRequest
+        {
+            Id = new Guid("b8f0a5c7-1d94-4e63-9a2f-7c5b0e83d146"),
+            RequestedByUserId = new Guid("3f8c1d05-2e69-4b74-a018-9d5e7c4b6a12"),
+            RequestedAt = asked,
+            StateChangedAt = asked,
+            Kind = RequestedItemKind.Movie,
+            DisplayTitle = "Sorcerer",
+            ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tmdb"] = "11631" }
+        };
+    }
+
+    /// <summary>
+    /// A reference from a service this bridge is not. Nothing issued it here, which is the point of
+    /// asking about it.
+    /// </summary>
+    /// <returns>The reference.</returns>
+    private static BackendReference SomeoneElsesReference()
+        => new() { Service = "a service this server does not run", Id = "418" };
+}

--- a/Jellyfin.Plugin.Requests.Tests/PluginServiceRegistrationTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/PluginServiceRegistrationTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Jellyfin.Plugin.Requests.Bridge;
 using Jellyfin.Plugin.Requests.Identity;
 using Jellyfin.Plugin.Requests.Time;
 using Microsoft.Extensions.DependencyInjection;
@@ -30,6 +31,20 @@ public class PluginServiceRegistrationTests
 
         Assert.IsType<SystemClock>(provider.GetRequiredService<IClock>());
         Assert.IsType<GuidIdentifierSource>(provider.GetRequiredService<IIdentifierSource>());
+    }
+
+    /// <summary>
+    /// A fresh install gets the bridge that has no external service behind it. That is the shipping
+    /// default and the one most servers run, so a registration pointing anywhere else, or missing,
+    /// would leave the majority case resolving nothing while every test handing its own bridge in
+    /// went on passing.
+    /// </summary>
+    [Fact]
+    public void ServerGetsTheBridgeWithNoServiceBehindIt()
+    {
+        using var provider = Registered();
+
+        Assert.IsType<NoRequestBackend>(provider.GetRequiredService<IRequestBackend>());
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Requests/Bridge/BackendReachability.cs
+++ b/Jellyfin.Plugin.Requests/Bridge/BackendReachability.cs
@@ -1,0 +1,29 @@
+namespace Jellyfin.Plugin.Requests.Bridge;
+
+/// <summary>
+/// Whether there is an external request service behind this plugin, and whether it answered.
+/// <para>
+/// Three values rather than a yes or a no, because "nothing is configured" and "something is
+/// configured and did not answer" are opposite facts about a server and a caller that reduces them
+/// to one tells an operator their bridge is down on an install that never had one.
+/// </para>
+/// </summary>
+public enum BackendReachability
+{
+    /// <summary>
+    /// There is no external service behind this plugin. The ordinary state of most installs, and
+    /// nothing here is wrong: the plugin is the whole system on such a server.
+    /// </summary>
+    NotConfigured = 0,
+
+    /// <summary>
+    /// An external service is configured and answered.
+    /// </summary>
+    Reachable = 1,
+
+    /// <summary>
+    /// An external service is configured and did not answer. What follows from that is #86, which
+    /// decides what a bound retry is and what stops rather than retrying.
+    /// </summary>
+    Unreachable = 2
+}

--- a/Jellyfin.Plugin.Requests/Bridge/BackendReference.cs
+++ b/Jellyfin.Plugin.Requests/Bridge/BackendReference.cs
@@ -1,0 +1,59 @@
+using System;
+
+namespace Jellyfin.Plugin.Requests.Bridge;
+
+/// <summary>
+/// What an external service called the thing this plugin handed it, and which service said so.
+/// <para>
+/// Both halves are kept because a reference without the service it belongs to cannot be used
+/// against anything: an operator who changes which service is configured would otherwise have
+/// requests carrying identifiers that mean something somewhere else.
+/// </para>
+/// <para>
+/// The value is the service's own, unread. Nothing here parses it, compares it to a pattern or
+/// assumes it is a number, because the shape of an identifier is that service's business and a
+/// plugin that decided otherwise would break on the first service that used a word.
+/// </para>
+/// </summary>
+public sealed record BackendReference
+{
+    private readonly string _service = string.Empty;
+    private readonly string _id = string.Empty;
+
+    /// <summary>
+    /// Gets which external service issued this. Its own name for itself, as the adapter reports it.
+    /// </summary>
+    /// <exception cref="ArgumentException">Where there is nothing in it.</exception>
+    public required string Service
+    {
+        get => _service;
+        init => _service = Present(value, nameof(Service));
+    }
+
+    /// <summary>
+    /// Gets what that service called the submitted request.
+    /// </summary>
+    /// <exception cref="ArgumentException">Where there is nothing in it.</exception>
+    public required string Id
+    {
+        get => _id;
+        init => _id = Present(value, nameof(Id));
+    }
+
+    /// <summary>
+    /// Refuses an empty half. A reference is what makes the two systems reconcilable again, and one
+    /// stored with an empty side is a row that looks like a handover happened and cannot be used to
+    /// ask anybody about it. Refused where it is built rather than checked wherever it is read,
+    /// because one of those readers will eventually not check.
+    /// </summary>
+    /// <param name="value">The text as it arrived.</param>
+    /// <param name="field">The property being written, for the refusal to name.</param>
+    /// <returns>The text.</returns>
+    private static string Present(string value, string field)
+        => string.IsNullOrWhiteSpace(value)
+            ? throw new ArgumentException(
+                FormattableString.Invariant(
+                    $"A backend reference needs {field}, and an empty one names nothing anybody can be asked about."),
+                nameof(value))
+            : value;
+}

--- a/Jellyfin.Plugin.Requests/Bridge/BackendReport.cs
+++ b/Jellyfin.Plugin.Requests/Bridge/BackendReport.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace Jellyfin.Plugin.Requests.Bridge;
+
+/// <summary>
+/// What an external service says about something it was handed, in that service's own words.
+/// <para>
+/// The word is carried unmapped on purpose. Turning it into one of this plugin's states is #81, and
+/// doing it here would put the mapping inside every adapter, where two adapters would disagree
+/// about what a state means and nothing would say which was right.
+/// </para>
+/// </summary>
+public sealed record BackendReport
+{
+    private readonly string _reported = string.Empty;
+
+    /// <summary>
+    /// Gets the state the service reported, as it reported it.
+    /// </summary>
+    /// <exception cref="ArgumentException">Where there is nothing in it.</exception>
+    public required string Reported
+    {
+        get => _reported;
+        init => _reported = Present(value);
+    }
+
+    /// <summary>
+    /// Refuses an empty report. Nothing known is expressed by there being no report at all, and a
+    /// report carrying an empty word would be a second way to say the same thing, which is the pair
+    /// that leaves half the readers checking for one of them.
+    /// </summary>
+    /// <param name="value">The text as it arrived.</param>
+    /// <returns>The text.</returns>
+    private static string Present(string value)
+        => string.IsNullOrWhiteSpace(value)
+            ? throw new ArgumentException(
+                "A report with nothing in it is not a state a service reported. Where nothing is known, there is no report.",
+                nameof(value))
+            : value;
+}

--- a/Jellyfin.Plugin.Requests/Bridge/IRequestBackend.cs
+++ b/Jellyfin.Plugin.Requests/Bridge/IRequestBackend.cs
@@ -1,0 +1,79 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Model;
+
+namespace Jellyfin.Plugin.Requests.Bridge;
+
+/// <summary>
+/// Whatever else on this server fetches media, seen from here.
+/// <para>
+/// Most servers run nothing of the sort, and on those this plugin is the whole system.
+/// <see cref="NoRequestBackend"/> is what they get, and it is the shipping default rather than a
+/// stub waiting to be replaced. Having one interface with that default behind it is what keeps a
+/// second code path out of every caller: nothing above this asks whether a bridge exists before
+/// deciding what to do.
+/// </para>
+/// <para>
+/// Four operations and no more. Ask whether there is a service and whether it answered, hand a
+/// request over and keep what comes back, ask about something already handed over, and take one
+/// back. Everything else about a request stays on this side, because a plugin that also held
+/// quality profiles, root folders and download clients would be a worse copy of the thing it is
+/// talking to.
+/// </para>
+/// <para>
+/// <b>What this interface does not decide.</b> What an approval means when a submission fails is
+/// #82. What happens when the service is unreachable, refuses the credential, or is asked about a
+/// title it has never heard of is #86. How a Jellyfin user is named to the service is #84, and
+/// where the credential lives is #85. This is the shape those answers have to fit through, and it
+/// names no service, no protocol and no address on purpose.
+/// </para>
+/// <para>
+/// <b>Cancellation.</b> A cancelled call throws <see cref="System.OperationCanceledException"/>,
+/// including on the null implementation. A default that quietly ignored a token would make a caller
+/// look correct here and hang on the first adapter that honours one.
+/// </para>
+/// </summary>
+public interface IRequestBackend
+{
+    /// <summary>
+    /// Asks whether there is a service behind this plugin and whether it answered.
+    /// </summary>
+    /// <param name="cancellationToken">Cancels the check.</param>
+    /// <returns>
+    /// Which of the three states the bridge is in. Nothing configured is an answer rather than a
+    /// failure.
+    /// </returns>
+    Task<BackendReachability> CheckReachableAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Hands one request to the service and keeps whatever it calls it.
+    /// </summary>
+    /// <param name="request">The request an operator approved.</param>
+    /// <param name="cancellationToken">Cancels the submission.</param>
+    /// <returns>
+    /// What the service called it, or <see langword="null"/> where nothing was handed over and
+    /// there is therefore nothing to keep. A null answer is the ordinary one on a server with no
+    /// service configured, and it is not a failure: a failure is an exception, in #86.
+    /// </returns>
+    Task<BackendReference?> SubmitAsync(MediaRequest request, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Asks the service where something already handed to it stands.
+    /// </summary>
+    /// <param name="reference">What the service called it when it was handed over.</param>
+    /// <param name="cancellationToken">Cancels the question.</param>
+    /// <returns>
+    /// The service's own word for where it stands, or <see langword="null"/> where nothing is
+    /// known about that reference. Nothing known is an ordinary answer: a reference issued by a
+    /// service an operator has since replaced is a fact about the install rather than a defect.
+    /// </returns>
+    Task<BackendReport?> ReportAsync(BackendReference reference, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Takes something back that was handed over.
+    /// </summary>
+    /// <param name="reference">What the service called it when it was handed over.</param>
+    /// <param name="cancellationToken">Cancels the withdrawal.</param>
+    /// <returns>A task that completes when the service has been told.</returns>
+    Task WithdrawAsync(BackendReference reference, CancellationToken cancellationToken);
+}

--- a/Jellyfin.Plugin.Requests/Bridge/NoRequestBackend.cs
+++ b/Jellyfin.Plugin.Requests/Bridge/NoRequestBackend.cs
@@ -1,0 +1,64 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Model;
+
+namespace Jellyfin.Plugin.Requests.Bridge;
+
+/// <summary>
+/// The bridge on a server that has no external request service, which is most of them.
+/// <para>
+/// This is the shipping default and the implementation the majority of installs run, so it is
+/// written and tested as a real one rather than as a placeholder. A caller cannot tell from its own
+/// code whether a service is configured: it submits, it gets nothing back, and nothing anywhere
+/// above has a branch for the absence.
+/// </para>
+/// <para>
+/// Nothing here fails. There is no service to be unreachable, no credential to be refused and no
+/// title to be unknown, so the failures in #86 belong to an adapter and not to this. What it does
+/// not do is pretend: it reports that nothing is configured rather than that something answered,
+/// and it hands back no reference rather than one it invented, because a made-up reference is a row
+/// an operator would later try to reconcile against a service that never saw it.
+/// </para>
+/// </summary>
+public sealed class NoRequestBackend : IRequestBackend
+{
+    /// <inheritdoc />
+    public Task<BackendReachability> CheckReachableAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return Task.FromResult(BackendReachability.NotConfigured);
+    }
+
+    /// <inheritdoc />
+    public Task<BackendReference?> SubmitAsync(MediaRequest request, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // The request is not read and nothing is kept. An approval on such a server is a decision an
+        // operator took and a queue row they will fulfil themselves, and the plugin has nowhere to
+        // send it.
+        return Task.FromResult<BackendReference?>(null);
+    }
+
+    /// <inheritdoc />
+    public Task<BackendReport?> ReportAsync(BackendReference reference, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Nothing was ever handed over, so nothing is known about any reference. Answered rather
+        // than refused, because a caller asking about a reference from a service that has since
+        // been unconfigured is the ordinary case.
+        return Task.FromResult<BackendReport?>(null);
+    }
+
+    /// <inheritdoc />
+    public Task WithdrawAsync(BackendReference reference, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Nothing to tell. Withdrawing something nothing accepted leaves the same state it was in,
+        // which is what the caller wanted, so this is not an error to report upward.
+        return Task.CompletedTask;
+    }
+}

--- a/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
@@ -1,5 +1,6 @@
 using System;
 using Jellyfin.Plugin.Requests.Api;
+using Jellyfin.Plugin.Requests.Bridge;
 using Jellyfin.Plugin.Requests.Identity;
 using Jellyfin.Plugin.Requests.Storage;
 using Jellyfin.Plugin.Requests.Time;
@@ -55,5 +56,12 @@ public sealed class PluginServiceRegistrator : IPluginServiceRegistrator
         // takes the seam and never the server's context directly, which is what keeps an endpoint
         // testable without a running server.
         serviceCollection.AddSingleton<ICallerIdentity, ServerCallerIdentity>();
+
+        // The bridge to an external request service, which on most servers is the one that has no
+        // service behind it. Registered like the others because it is the shipping default rather
+        // than a placeholder: a fresh install resolves this and no caller above it asks whether a
+        // service exists before deciding what to do. An adapter, when there is one, replaces this
+        // registration and nothing else.
+        serviceCollection.AddSingleton<IRequestBackend, NoRequestBackend>();
     }
 }


### PR DESCRIPTION
Closes #80.

## The interface

Four operations and nothing else, which is #80's first condition. Ask whether
there is a service and whether it answered, hand a request over and keep what
comes back, ask where something already handed over stands, and take it back.

It names no service, no protocol and no address. What an approval means when a
submission fails is #82, what happens when the service is down or refuses a
credential is #86, how a Jellyfin user is named to it is #84, and where the
credential lives is #85.

Two shapes come with it. Reachability has three values rather than two, because
nothing configured and something configured that did not answer are opposite
facts about a server, and a page that showed one for the other would tell an
operator their bridge is down on an install that never had one. A report carries
the service's own word unmapped, because mapping it onto this plugin's states is
#81 and an adapter that mapped on the way through would put that decision in
every adapter.

## The default

`NoRequestBackend` is registered in `PluginServiceRegistrator`, so a fresh
install resolves it with nothing to configure. It reports that nothing is
configured, hands back no reference, knows nothing about any reference, and
completes a withdrawal. It does not invent a reference, which would leave rows
claiming a handover nothing can be asked about, and it does not report that
something answered.

It observes a cancelled token in all four operations. A default that ignored one
would let a caller that cancels look correct on every install that runs it and
hang on the first adapter that honours a token.

## The suite with no adapter configured

#80's third condition. There is no adapter in this tree, so this is the ordinary
run:

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release
    Bestanden!   : Fehler:     0, erfolgreich:   318, gesamt:   318 (net9.0)
    Bestanden!   : Fehler:     0, erfolgreich:   318, gesamt:   318 (net10.0)

304 of those existed before this change, measured on `78544d7`, and 318 is what
it leaves. The null path
has its own tests rather than being reached by something else's, in
`Bridge/NoRequestBackendTests.cs` and `Bridge/BackendReferenceTests.cs`.

## Watched failing

Four one-line changes at once, so each failure names the guard it belongs to
rather than being attributed by reading:

    dotnet test Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj -f net9.0 --configuration Release
    PluginServiceRegistrationTests.ServerGetsTheBridgeWithNoServiceBehindIt [FAIL]
    BackendReferenceTests.AReferenceWithAnEmptyHalfIsRefused(service: "overseerr", id: "") [FAIL]
    BackendReferenceTests.AReferenceWithAnEmptyHalfIsRefused(service: "", id: "418") [FAIL]
    BackendReferenceTests.AReferenceWithAnEmptyHalfIsRefused(service: "   ", id: "418") [FAIL]
    BackendReferenceTests.AReferenceWithAnEmptyHalfIsRefused(service: "overseerr", id: "\t") [FAIL]
    NoRequestBackendTests.EveryOperationObservesACancelledToken [FAIL]
    NoRequestBackendTests.NothingIsConfiguredRatherThanReachableOrDown [FAIL]
    Fehler!      : Fehler:     7, erfolgreich:   311, gesamt:   318

The four were the reachability answer changed to `Reachable`, the cancellation
check dropped from the submit path, the empty-half refusal on a reference
removed, and the registration line deleted. Nothing else moved, which is what
says each test is about its own guard.

## What this does not cover

No adapter exists, so nothing here has spoken to an external service. Whether
the four operations are the right four for the Overseerr shape is #81 and #82,
and the first adapter is where a missing operation would show.

The bridge is registered but nothing calls it yet. An approval does not submit,
which is #82.

## The means

C# in the plugin assembly, like everything else it registers with the server's
container. An interface plus a default is what the existing registrations are,
so this needs no apparatus the suite does not already have.

## Reading

No second person has read this before merge. The runs above are what stands in
place of one, and each was run at this head.


