### PR TITLE
Fix the catalogue on the sibling's side, and refuse a fetch from this one

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/CatalogueSplitTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/CatalogueSplitTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Api;
+using Jellyfin.Plugin.Requests.Identity;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using Jellyfin.Plugin.Requests.Time;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+using PluginUnderTest = global::Jellyfin.Plugin.Requests.Plugin;
+
+namespace Jellyfin.Plugin.Requests.Tests;
+
+/// <summary>
+/// The catalogue is the sibling browsing plugin's, and what this side holds is a title and a year
+/// taken when somebody asked, never refreshed. Decided in #92 and written down in
+/// <c>docs/seam.md</c>.
+/// <para>
+/// What that has to survive is a server where nothing outbound resolves: no metadata source
+/// reachable, none configured, or none this plugin was ever going to call. The queue is what an
+/// operator opens every day, and a queue that needed a source to render would be blank on exactly
+/// the server this plugin is most useful on.
+/// </para>
+/// <para>
+/// What these tests do not do is block a socket while they run. Nothing here opens one, and what
+/// says so is the exact reference list in <see cref="SiblingIndependenceTests"/>, which holds no
+/// networking assembly and fails on any addition. These two legs are the other half: the rows come
+/// from the store, and nothing that could fetch can reach the render.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class CatalogueSplitTests
+{
+    private static readonly Guid Operator = new Guid("d1000000-0000-0000-0000-000000000001");
+    private static readonly Guid Asker = new Guid("d1000000-0000-0000-0000-000000000002");
+
+    /// <summary>
+    /// The queue renders the title and the year the request was stored with, exactly as stored. The
+    /// request here carries a provider identifier and a title that no longer matches what a source
+    /// would say about it, which is the case the snapshot exists for: the row reads as what the
+    /// person asked for rather than as what anybody would fetch today.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task TheQueueRendersTheStoredSnapshotAndFetchesNothingToDoIt()
+    {
+        var store = new InMemoryRequestStore();
+        var asked = new DateTimeOffset(2026, 2, 2, 9, 30, 0, TimeSpan.Zero);
+
+        await store.AddAsync(
+            new MediaRequest
+            {
+                Id = new Guid("d2000000-0000-0000-0000-00000000000a"),
+                RequestedByUserId = Asker,
+                RequestedAt = asked,
+                StateChangedAt = asked,
+                Kind = RequestedItemKind.Movie,
+                DisplayTitle = "The Wages of Fear",
+                DisplayYear = 1953,
+                ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tmdb"] = "1149" }
+            },
+            CancellationToken.None).ConfigureAwait(true);
+
+        var answered = await Controller(store).QueueAsync(cancellationToken: CancellationToken.None)
+            .ConfigureAwait(true);
+
+        var page = Assert.IsType<RequestsPage<QueuedRequest>>(
+            Assert.IsAssignableFrom<ObjectResult>(answered.Result).Value);
+        var row = Assert.Single(page.Requests);
+
+        Assert.Equal("The Wages of Fear", row.DisplayTitle, StringComparer.Ordinal);
+        Assert.Equal(1953, row.DisplayYear);
+    }
+
+    /// <summary>
+    /// The controller takes four things and none of them can fetch anything. A metadata source
+    /// arrives as something injected, so the constructor is where one would appear first, and a
+    /// fifth parameter fails here before anybody writes the call.
+    /// <para>
+    /// Written as the exact list rather than as "nothing called a provider". A name test would pass
+    /// the day somebody injects a fetcher under a name nobody predicted, which is the shape this
+    /// board already refuses in its reference list.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void NothingThatCouldFetchATitleReachesTheQueue()
+    {
+        var taken = typeof(RequestsController)
+            .GetConstructors(BindingFlags.Public | BindingFlags.Instance)
+            .Single()
+            .GetParameters()
+            .Select(parameter => parameter.ParameterType.Name);
+
+        Assert.Equal(
+            string.Join(" | ", nameof(IRequestStore), nameof(IClock), nameof(IIdentifierSource), nameof(ICallerIdentity)),
+            string.Join(" | ", taken),
+            StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// The plugin references no metadata provider assembly. The reference list in
+    /// <see cref="SiblingIndependenceTests"/> would already refuse an addition and would refuse it
+    /// as "an unexpected reference"; this one names the reason, and it also refuses the case where
+    /// somebody adds the reference to that list and to the project in one change.
+    /// </summary>
+    [Fact]
+    public void NothingThePluginReferencesIsAMetadataSource()
+    {
+        var sources = typeof(PluginUnderTest).Assembly
+            .GetReferencedAssemblies()
+            .Select(reference => reference.Name ?? string.Empty)
+            .Where(name => name.StartsWith("MediaBrowser.Providers", StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.Empty(sources);
+    }
+
+    /// <summary>
+    /// A controller reading one store, as an administrator.
+    /// </summary>
+    /// <param name="store">Where requests are kept.</param>
+    /// <returns>The controller under test.</returns>
+    private static RequestsController Controller(IRequestStore store)
+        => new RequestsController(
+            store,
+            new TestClock(new DateTimeOffset(2026, 8, 11, 8, 0, 0, TimeSpan.Zero)),
+            new SequentialIdentifierSource(),
+            new FakeCallerIdentity(Operator));
+}

--- a/docs/seam.md
+++ b/docs/seam.md
@@ -56,12 +56,47 @@ plugins. That is not duplicated work anybody has to remove: each side is watchin
 reason, one to move a request out of the queue and one for whatever that board decides, and neither
 observation depends on the other having happened.
 
+## The catalogue is the sibling's, and this side holds a snapshot
+
+Both plugins hold something that looks like a title, and left unsaid that grows into two
+catalogues, two refresh schedules and two sets of source terms to comply with.
+
+The catalogue is the sibling's, and its board says so: the source adapters, the fetched records,
+when they expire, and the surface every client browses. What this plugin holds is a title and a
+year per request, taken at the moment somebody asked for it and never refreshed from anywhere. That
+is not a small catalogue. It is a different thing, a record of what was asked for as it appeared
+when it was asked for.
+
+Two consequences, and both are the point rather than a cost of it.
+
+**A snapshot goes stale, and that is correct.** A film renamed upstream afterwards still reads in
+the queue and in the history as the name the person actually asked for. A queue that silently
+followed the rename would be a record of what a source says today rather than of what somebody
+wanted.
+
+**This plugin calls no metadata source at all.** It has nothing to ask and nothing to ask with, so
+the queue renders on a server where nothing outbound resolves, and the terms a source imposes on
+whoever fetches from it never reach this repository.
+
+The second consequence is refused rather than written down here. `no-call-to-a-metadata-source` in
+`tools/opengrep/rules.yaml` refuses the server's provider interfaces and the addresses of the
+sources a plugin would otherwise call directly, anywhere under `Jellyfin.Plugin.Requests/`, and it
+carries the fixture it is watched refusing. What it deliberately does not refuse is an outbound call
+in general: the notification sink in #78 and the bridge in #82 are outbound by design, and a rule
+that had to be narrowed to let those land is a rule nobody trusts afterwards.
+
+`CatalogueSplitTests` holds the rendering half. The queue is rendered from a store holding one
+request and the rows carry the stored title and year, and the same test reads the controller's
+dependencies and refuses a fifth one, because a fetch would arrive as something injected. What the
+suite cannot say is that a socket was blocked while it ran; what it says instead is that the
+assembly references nothing that could open one, which is the exact reference list in
+`SiblingIndependenceTests` and fails on any addition.
+
 ## What this document does not yet hold
 
 Named here so the absence is read as absence rather than as a decision nobody wrote down. Each is
 the closing condition of the issue beside it.
 
-- Which side owns the catalogue, and the two consequences of that split. #92.
 - What happens to a field set carrying a contract version this plugin does not know. #90.
 - The trust position of an in-process handover, and what this side checks before it believes a user
   identifier it cannot verify. #118.

--- a/tools/opengrep/fixtures/metadata/AsksAMetadataSourceForATitle.cs
+++ b/tools/opengrep/fixtures/metadata/AsksAMetadataSourceForATitle.cs
@@ -1,0 +1,33 @@
+// Fixture for no-call-to-a-metadata-source. This file is in no project and is
+// never compiled; it exists so the rule can be watched refusing the mistake it
+// names.
+//
+// The near-miss is the one somebody writes while fixing a real complaint. An
+// operator says the queue shows a film under its old name, or with no year, and
+// the shortest repair is to ask the server to look the title up again. It works
+// on the machine it was written on, it puts this plugin under a metadata
+// source's terms, and it makes the queue unreadable on the day nothing outbound
+// resolves.
+
+namespace Jellyfin.Plugin.Requests.Fixtures;
+
+internal sealed class AsksAMetadataSourceForATitle
+{
+    // Legal neighbour, left here on purpose: this is where a title comes from,
+    // and the rule has to stay quiet on it.
+    public static string Title(MediaRequest request) => request.DisplayTitle;
+
+    // The regression as it arrives through the host: the plugin asks the server
+    // to fetch or refresh the record.
+    public static async Task<string> FreshTitleAsync(IProviderManager providers, MediaRequest request)
+    {
+        var results = await providers.GetRemoteSearchResults(request.ProviderIds).ConfigureAwait(false);
+
+        return results[0].Name;
+    }
+
+    // The same regression written against the source directly, which is what
+    // somebody reaches for when the host's route looks like too much work.
+    public static Uri LookUp(string tmdbId)
+        => new Uri("https://api.themoviedb.org/3/movie/" + tmdbId);
+}

--- a/tools/opengrep/rules.yaml
+++ b/tools/opengrep/rules.yaml
@@ -441,3 +441,47 @@ rules:
       include:
         - "Jellyfin.Plugin.Requests/**/*.cs"
         - "tools/opengrep/fixtures/lifecycle/**/*.cs"
+
+  # Invariant (catalogue, #92): this plugin asks no metadata source about
+  # anything. Decided in #92 and stated in docs/seam.md: the catalogue belongs to
+  # the sibling browsing plugin, and what this side holds is a title and a year
+  # taken at the moment of the request and never refreshed. Two catalogues on one
+  # server is a cost nobody would choose twice, and fetching from a source also
+  # brings that source's terms onto whoever fetched.
+  #
+  # What it reaches: the server's own provider interfaces, which are how a plugin
+  # asks the host to fetch or refresh metadata, and the addresses of the sources
+  # a plugin would otherwise call directly. The message names the snapshot,
+  # because the repair is almost always to read what the request already carries.
+  #
+  # What it does not reach, on purpose: an outbound call in general. The
+  # notification sink in #78 and the bridge in #82 are outbound by design, so a
+  # rule refusing every HTTP client here would have to be narrowed by whoever
+  # lands them, and a rule narrowed to let work through is one nobody trusts
+  # afterwards. What keeps an HTTP stack from arriving unnoticed is the exact
+  # reference list in SiblingIndependenceTests, which fails on any addition.
+  - id: no-call-to-a-metadata-source
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      Do not ask a metadata source about a title here. The catalogue is the
+      sibling browsing plugin's (#92), and what this plugin holds is the display
+      snapshot taken when the request was made, which is what lets the queue
+      render with nothing outbound reachable.
+    patterns:
+      - pattern-either:
+          - pattern: IProviderManager
+          - pattern: IRemoteMetadataProvider
+          - pattern: IRemoteImageProvider
+          - pattern: IMetadataProvider
+          - pattern: MediaBrowser.Providers
+          - pattern: api.themoviedb.org
+          - pattern: api.thetvdb.com
+          - pattern: api4.thetvdb.com
+          - pattern: webservice.fanart.tv
+          - pattern: musicbrainz.org
+          - pattern: omdbapi.com
+    paths:
+      include:
+        - "Jellyfin.Plugin.Requests/**/*.cs"
+        - "tools/opengrep/fixtures/metadata/**/*.cs"


### PR DESCRIPTION
Closes #92.

## The split, and both consequences

`docs/seam.md` now says which side owns the catalogue and what this side holds
instead. The catalogue is the sibling's: the source adapters, the fetched
records, their expiry and the browsing surface. This plugin holds a title and a
year per request, taken when somebody asked and never refreshed.

A snapshot goes stale and that is correct, so a film renamed upstream still
reads as the name the person actually asked for. And this plugin calls no
metadata source at all, which is what lets the queue render on a server where
nothing outbound resolves, and what keeps a source's terms off this repository.

## The rule

`no-call-to-a-metadata-source` in `tools/opengrep/rules.yaml`, with the fixture
it is watched refusing in `tools/opengrep/fixtures/metadata/`. It reaches the
server's provider interfaces, which is how a plugin asks the host to fetch or
refresh, and the addresses of the sources a plugin would otherwise call
directly.

What it does not reach is an outbound call in general, and that is deliberate:
the notification sink in #78 and the bridge in #82 are outbound by design, so a
rule refusing every HTTP client here would have to be narrowed by whoever lands
them, and a rule narrowed to let work through is one nobody trusts afterwards.
What keeps an HTTP stack from arriving unnoticed is the exact reference list in
`SiblingIndependenceTests`, which fails on any addition.

The proof that the rule bites is the gate's own second step: `Enforce greppable
invariants` scans the fixtures and fails unless every declared rule fired on
one, and scans the tree with the fixtures excluded and fails on any finding.
Opengrep is not installed on the machine this was written on, so that pair
running green here is the evidence rather than a local run.

## The rendering half

`CatalogueSplitTests`, three legs. The queue renders one stored request and the
row carries the stored title and year. The controller's dependencies are read
back as an exact list, because a fetcher arrives as something injected before
anybody writes the call. And the plugin references no metadata provider
assembly.

Two of the three were watched failing, on net9.0. The row mapping was changed to
a title nothing stored, and a second public constructor was added taking a fifth
thing:

    dotnet test Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj -f net9.0 --configuration Release
    CatalogueSplitTests.NothingThatCouldFetchATitleReachesTheQueue [FAIL]
    CatalogueSplitTests.TheQueueRendersTheStoredSnapshotAndFetchesNothingToDoIt [FAIL]
    Fehler!      : Fehler:     2, erfolgreich:   319, gesamt:   321

Nothing else moved under the row mutation, which says the stored title had no
other assertion on it before this.

The third could not be reddened the same way: introducing a metadata provider
reference means adding a package this tree does not carry. What was shown is
that it reads the live reference set rather than a written list, by pointing it
at a name that is referenced:

    CatalogueSplitTests.NothingThePluginReferencesIsAMetadataSource [FAIL]
    Fehler!      : Fehler:     1, erfolgreich:   320, gesamt:   321

That is a weaker demonstration than the other two and is named as one here and
in the commit message.

## The suite

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release
    Bestanden!   : Fehler:     0, erfolgreich:   321, gesamt:   321 (net9.0)
    Bestanden!   : Fehler:     0, erfolgreich:   321, gesamt:   321 (net10.0)

## What this does not cover

No socket was blocked while the queue rendered. Nothing in the assembly can open
one, and the exact reference list is what says so; that is an argument from the
reference set plus the injected dependency list rather than a network that was
switched off.

The rule reaches the host's provider interfaces and the source addresses named
in it. A source reached under a name nobody has written yet is not refused by
it, which is what the fixture and the reference list are the second and third
layers for.

## The means

The rule is a pattern in the tree's existing invariant lint rather than a new
apparatus, because it is a token that must not appear rather than a property of
running code. The rendering half is a test in the suite that already exists,
against the controller the queue actually calls.

## Reading

No second person has read this before merge. The runs above are what stands in
place of one, and each was run at this head.
