### PR TITLE
Detect fulfilment from the library rather than by hand

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Doubles/FakeLibrary.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/FakeLibrary.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Fulfilment;
+using Jellyfin.Plugin.Requests.Model;
+
+namespace Jellyfin.Plugin.Requests.Tests.Doubles;
+
+/// <summary>
+/// A library the suite puts titles into, standing in for the server's.
+/// <para>
+/// It answers the same two questions <see cref="ILibrary"/> declares and nothing else, which is the
+/// whole reason that interface exists: the server's own library interface is not the same interface
+/// on the two server lines this plugin builds for, so a double for it would be two doubles proving
+/// two different things.
+/// </para>
+/// <para>
+/// A title is held under one provider identifier and matches a request that names it under any
+/// spelling of the provider name, which is the rule the real lookup is written to.
+/// </para>
+/// </summary>
+internal sealed class FakeLibrary : ILibrary
+{
+    private readonly Dictionary<(RequestedItemKind Kind, string Provider, string Value), List<int>> _held = [];
+
+    /// <inheritdoc />
+    public event EventHandler<LibraryChangeEventArgs>? Changed;
+
+    /// <summary>
+    /// Gets how many times the library has been asked what it holds. A sweep that writes nothing
+    /// still looks, and a test about writes has to be able to tell the two apart.
+    /// </summary>
+    public int Lookups { get; private set; }
+
+    /// <summary>
+    /// Puts a title in the library.
+    /// </summary>
+    /// <param name="kind">What sort of thing it is.</param>
+    /// <param name="provider">The provider naming it.</param>
+    /// <param name="value">The identifier under that provider.</param>
+    /// <param name="seasons">
+    /// The seasons the server has files for, on a series. Empty on a film, and empty on a series
+    /// with nothing under it yet.
+    /// </param>
+    public void Put(RequestedItemKind kind, string provider, string value, params int[] seasons)
+        => _held[(kind, provider.ToUpperInvariant(), value)] = [.. seasons];
+
+    /// <summary>
+    /// Takes a title back out, which is what an operator deleting a file leaves behind.
+    /// </summary>
+    /// <param name="kind">What sort of thing it was.</param>
+    /// <param name="provider">The provider naming it.</param>
+    /// <param name="value">The identifier under that provider.</param>
+    public void Remove(RequestedItemKind kind, string provider, string value)
+        => _held.Remove((kind, provider.ToUpperInvariant(), value));
+
+    /// <summary>
+    /// Raises what the server raises when the library gains or loses something.
+    /// </summary>
+    /// <param name="kind">What sort of thing changed.</param>
+    /// <param name="providerIds">The identifiers the item carries.</param>
+    public void Raise(RequestedItemKind kind, IReadOnlyDictionary<string, string> providerIds)
+        => Changed?.Invoke(this, new LibraryChangeEventArgs(kind, providerIds));
+
+    /// <inheritdoc />
+    public Task<LibraryHolding> HoldingOfAsync(
+        RequestedItemKind kind,
+        IReadOnlyDictionary<string, string> providerIds,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(providerIds);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        Lookups++;
+
+        var seasons = providerIds
+            .Select(identifier => _held.TryGetValue(
+                (kind, identifier.Key.ToUpperInvariant(), identifier.Value), out var found) ? found : null)
+            .FirstOrDefault(found => found is not null);
+
+        return Task.FromResult(seasons is null
+            ? LibraryHolding.Nothing
+            : new LibraryHolding { Held = true, SeasonsHeld = seasons });
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/Doubles/RecordedProgress.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/RecordedProgress.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.Requests.Tests.Doubles;
+
+/// <summary>
+/// The progress a scheduled task reports, as a list a test can read. The server shows this on its
+/// task page, so a run that reports nothing looks stuck to whoever is watching it.
+/// </summary>
+internal sealed class RecordedProgress : IProgress<double>
+{
+    private readonly List<double> _reported = [];
+
+    /// <summary>
+    /// Gets everything reported, in order.
+    /// </summary>
+    public IReadOnlyList<double> Reported => _reported;
+
+    /// <inheritdoc />
+    public void Report(double value) => _reported.Add(value);
+}

--- a/Jellyfin.Plugin.Requests.Tests/Doubles/StoreThatRefusesTheFirstLookup.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/StoreThatRefusesTheFirstLookup.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+
+namespace Jellyfin.Plugin.Requests.Tests.Doubles;
+
+/// <summary>
+/// A store that refuses the first lookup by identifier and then behaves. It stands for the one
+/// library item whose handling goes wrong, so a test can watch what happens to the ones behind it
+/// rather than to it.
+/// <para>
+/// Refusing every lookup would prove the loop reported a failure and prove nothing about whether it
+/// carried on, which is the property that matters when a scan raises thousands of these.
+/// </para>
+/// </summary>
+internal sealed class StoreThatRefusesTheFirstLookup : IRequestStore
+{
+    private readonly IRequestStore _inner;
+    private bool _refused;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StoreThatRefusesTheFirstLookup"/> class.
+    /// </summary>
+    /// <param name="inner">The store that actually holds the requests.</param>
+    public StoreThatRefusesTheFirstLookup(IRequestStore inner)
+    {
+        _inner = inner;
+    }
+
+    /// <inheritdoc />
+    public Task<StoredRequest?> GetAsync(Guid id, CancellationToken cancellationToken)
+        => _inner.GetAsync(id, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<StoredRequest>> GetAllAsync(CancellationToken cancellationToken)
+        => _inner.GetAllAsync(cancellationToken);
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<StoredRequest>> FindForUserAsync(Guid userId, CancellationToken cancellationToken)
+        => _inner.FindForUserAsync(userId, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<StoredRequest>> FindByProviderIdentifierAsync(
+        RequestedItemKind kind,
+        string provider,
+        string value,
+        CancellationToken cancellationToken)
+    {
+        if (!_refused)
+        {
+            _refused = true;
+
+            throw new InvalidOperationException("The store could not be read for this lookup.");
+        }
+
+        return _inner.FindByProviderIdentifierAsync(kind, provider, value, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<RequestPage> PageAsync(RequestQuery query, CancellationToken cancellationToken)
+        => _inner.PageAsync(query, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<StoredRequest> AddAsync(MediaRequest request, CancellationToken cancellationToken)
+        => _inner.AddAsync(request, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<StoredRequest> ReplaceAsync(
+        MediaRequest request,
+        long expectedRevision,
+        CancellationToken cancellationToken)
+        => _inner.ReplaceAsync(request, expectedRevision, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<bool> RemoveAsync(Guid id, long expectedRevision, CancellationToken cancellationToken)
+        => _inner.RemoveAsync(id, expectedRevision, cancellationToken);
+}

--- a/Jellyfin.Plugin.Requests.Tests/Fulfilment/BothPathsTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Fulfilment/BothPathsTests.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Fulfilment;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using MediaBrowser.Model.Tasks;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Fulfilment;
+
+/// <summary>
+/// The fourth condition on #42: the match runs on a library event and on a schedule, and neither
+/// path is the only one that works.
+/// <para>
+/// Each of the two is exercised with the other one absent, which is what "neither is the only one"
+/// means. A test that started both and asserted the outcome would pass with either of them removed,
+/// and the failure this condition exists against is exactly that: a server that was off when the
+/// file arrived hears no event, and a server that is running should not wait hours to notice.
+/// </para>
+/// </summary>
+public class BothPathsTests
+{
+    private static readonly DateTimeOffset Asked = new DateTimeOffset(2026, 3, 1, 12, 0, 0, TimeSpan.Zero);
+
+    /// <summary>
+    /// The scheduled task, with nothing subscribed to the library at all, moves a request whose
+    /// title arrived while nobody was listening.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task TheScheduledRunFulfilsWithNothingListeningToTheLibrary()
+    {
+        var store = new InMemoryRequestStore();
+        var library = new FakeLibrary();
+        var task = new FulfilmentTask(Sweep(store, library));
+
+        await store.AddAsync(Request(), CancellationToken.None);
+        library.Put(RequestedItemKind.Movie, "Tmdb", "603");
+
+        var progress = new RecordedProgress();
+        await task.ExecuteAsync(progress, CancellationToken.None);
+
+        Assert.Equal(RequestState.Fulfilled, (await Only(store)).State);
+        Assert.Equal([0d, 100d], progress.Reported);
+    }
+
+    /// <summary>
+    /// The library event, with the scheduled task never run, moves the same request. Stopping the
+    /// watcher is what says the queued change has been handled, so nothing here waits for time to
+    /// pass.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task TheLibraryEventFulfilsWithTheScheduledRunNeverExecuted()
+    {
+        var store = new InMemoryRequestStore();
+        var library = new FakeLibrary();
+
+        using var watcher = new LibraryWatcher(library, Sweep(store, library), new RecordingLogger());
+
+        await store.AddAsync(Request(), CancellationToken.None);
+        library.Put(RequestedItemKind.Movie, "Tmdb", "603");
+
+        await watcher.StartAsync(CancellationToken.None);
+        library.Raise(RequestedItemKind.Movie, Identifiers());
+        await watcher.StopAsync(CancellationToken.None);
+
+        Assert.Equal(RequestState.Fulfilled, (await Only(store)).State);
+    }
+
+    /// <summary>
+    /// A change raised before the watcher started, or after it stopped, is not handled by it. That
+    /// is the gap the scheduled run closes, and it is asserted rather than argued so the two paths
+    /// are known to be needed rather than believed to be.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task AChangeRaisedWhileNothingIsListeningIsCaughtByTheScheduledRunInstead()
+    {
+        var store = new InMemoryRequestStore();
+        var library = new FakeLibrary();
+        var sweep = Sweep(store, library);
+
+        using var watcher = new LibraryWatcher(library, sweep, new RecordingLogger());
+
+        await store.AddAsync(Request(), CancellationToken.None);
+        library.Put(RequestedItemKind.Movie, "Tmdb", "603");
+
+        // The server was not running when the file arrived, which is the whole case.
+        library.Raise(RequestedItemKind.Movie, Identifiers());
+
+        await watcher.StartAsync(CancellationToken.None);
+        await watcher.StopAsync(CancellationToken.None);
+
+        Assert.Equal(RequestState.Open, (await Only(store)).State);
+
+        await new FulfilmentTask(sweep).ExecuteAsync(new RecordedProgress(), CancellationToken.None);
+
+        Assert.Equal(RequestState.Fulfilled, (await Only(store)).State);
+    }
+
+    /// <summary>
+    /// One library item that throws does not stop the ones behind it in the queue. A scan raises
+    /// thousands of these and the loop handling them is the only thing handling any of them.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task OneChangeThatFailsDoesNotStopTheNextOne()
+    {
+        var store = new InMemoryRequestStore();
+        var library = new FakeLibrary();
+        var log = new RecordingLogger();
+        var refusing = new StoreThatRefusesTheFirstLookup(store);
+
+        using var watcher = new LibraryWatcher(
+            library,
+            new FulfilmentSweep(refusing, library, new TestClock(Asked), log),
+            log);
+
+        await store.AddAsync(Request(), CancellationToken.None);
+        library.Put(RequestedItemKind.Movie, "Tmdb", "603");
+
+        await watcher.StartAsync(CancellationToken.None);
+        library.Raise(RequestedItemKind.Movie, Identifiers());
+        library.Raise(RequestedItemKind.Movie, Identifiers());
+        await watcher.StopAsync(CancellationToken.None);
+
+        Assert.Equal(RequestState.Fulfilled, (await Only(store)).State);
+        Assert.NotEmpty(log.At(Microsoft.Extensions.Logging.LogLevel.Error));
+    }
+
+    /// <summary>
+    /// The task tells the server to run it at startup as well as on an interval, because the gap it
+    /// exists to close is the one a server that was off has just been through.
+    /// </summary>
+    [Fact]
+    public void TheScheduledRunHappensAtStartupAndOnAnInterval()
+    {
+        var triggers = new FulfilmentTask(
+            Sweep(new InMemoryRequestStore(), new FakeLibrary())).GetDefaultTriggers().ToList();
+
+        Assert.Contains(triggers, trigger => trigger.Type == TaskTriggerInfoType.StartupTrigger);
+        Assert.Contains(
+            triggers,
+            trigger => trigger.Type == TaskTriggerInfoType.IntervalTrigger && trigger.IntervalTicks > 0);
+    }
+
+    private static FulfilmentSweep Sweep(IRequestStore store, ILibrary library)
+        => new FulfilmentSweep(store, library, new TestClock(Asked), new RecordingLogger());
+
+    private static async Task<MediaRequest> Only(InMemoryRequestStore store)
+        => (await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true)).Single().Request;
+
+    private static Dictionary<string, string> Identifiers()
+        => new Dictionary<string, string>(StringComparer.Ordinal) { ["Tmdb"] = "603" };
+
+    private static MediaRequest Request()
+        => new MediaRequest
+        {
+            Id = new Guid("2b8f4c61-0d75-4a39-9e26-3f5a8c1d7b04"),
+            RequestedByUserId = new Guid("7a4e2f18-6b0c-4d39-95e7-1f8a3c6d2b40"),
+            RequestedAt = Asked,
+            StateChangedAt = Asked,
+            Kind = RequestedItemKind.Movie,
+            DisplayTitle = "The one that was asked for",
+            ProviderIds = Identifiers()
+        };
+}

--- a/Jellyfin.Plugin.Requests.Tests/Fulfilment/FulfilmentRuleTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Fulfilment/FulfilmentRuleTests.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using Jellyfin.Plugin.Requests.Fulfilment;
+using Jellyfin.Plugin.Requests.Model;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Fulfilment;
+
+/// <summary>
+/// What the library holding for a request means, which is the rule #42 asks to be stated rather
+/// than rounded. The partly satisfied series is the case the whole rule exists for and it has a
+/// value of its own here, so a request waiting on three seasons with one of them present reads as
+/// partial rather than as arrived or as missing.
+/// </summary>
+public class FulfilmentRuleTests
+{
+    /// <summary>
+    /// A film the server does not have is absent, and one it has is present. There is no third
+    /// answer for a film, because there is no part of one to have arrived.
+    /// </summary>
+    /// <param name="held">Whether the server holds it.</param>
+    /// <param name="expected">What that means.</param>
+    [Theory]
+    [InlineData(false, LibraryAvailability.Absent)]
+    [InlineData(true, LibraryAvailability.Present)]
+    public void AFilmIsPresentOrAbsentAndNothingElse(bool held, LibraryAvailability expected)
+    {
+        var film = Request(RequestedItemKind.Movie);
+        var holding = held ? new LibraryHolding { Held = true } : LibraryHolding.Nothing;
+
+        Assert.Equal(expected, FulfilmentRule.AvailabilityOf(film, holding));
+    }
+
+    /// <summary>
+    /// A request that named seasons is judged against those seasons and against nothing else.
+    /// Every one present is present, some of them is partial, and none of them is absent even
+    /// though the programme itself is in the library.
+    /// </summary>
+    /// <param name="asked">The seasons the request named.</param>
+    /// <param name="arrived">The seasons the server has files for.</param>
+    /// <param name="expected">What that means for this request.</param>
+    [Theory]
+    [InlineData(new[] { 2, 3 }, new[] { 2, 3 }, LibraryAvailability.Present)]
+    [InlineData(new[] { 2, 3 }, new[] { 2 }, LibraryAvailability.Partial)]
+    [InlineData(new[] { 2, 3 }, new[] { 1 }, LibraryAvailability.Absent)]
+    [InlineData(new[] { 2, 3 }, new int[0], LibraryAvailability.Absent)]
+    [InlineData(new[] { 1 }, new[] { 1, 2, 3 }, LibraryAvailability.Present)]
+    public void ASeriesIsJudgedAgainstTheSeasonsThatWereAskedFor(
+        int[] asked,
+        int[] arrived,
+        LibraryAvailability expected)
+    {
+        var series = Request(RequestedItemKind.Series) with { Seasons = asked };
+        var holding = new LibraryHolding { Held = true, SeasonsHeld = arrived };
+
+        Assert.Equal(expected, FulfilmentRule.AvailabilityOf(series, holding));
+    }
+
+    /// <summary>
+    /// A request for the programme rather than for named seasons is present the moment the server
+    /// holds the programme, whatever is under it.
+    /// <para>
+    /// This is the stated rule and it is the only one available. Nothing here can learn how many
+    /// seasons a programme has, because this plugin calls no metadata source, so a completeness test
+    /// would be written against a number nobody can produce. What it costs is that somebody who
+    /// asked for a programme and got its first season sees a fulfilled request, and what they do
+    /// about that is ask for the seasons they want by name.
+    /// </para>
+    /// </summary>
+    /// <param name="arrived">The seasons the server has files for.</param>
+    [Theory]
+    [InlineData(new int[0])]
+    [InlineData(new[] { 1 })]
+    [InlineData(new[] { 1, 2, 3 })]
+    public void ASeriesAskedForWholeIsPresentAsSoonAsTheServerHoldsIt(int[] arrived)
+    {
+        var whole = Request(RequestedItemKind.Series);
+        var holding = new LibraryHolding { Held = true, SeasonsHeld = arrived };
+
+        Assert.Empty(whole.Seasons);
+        Assert.Equal(LibraryAvailability.Present, FulfilmentRule.AvailabilityOf(whole, holding));
+    }
+
+    /// <summary>
+    /// The reading above is the one <see cref="RequestIdentity"/> already makes, and the two would
+    /// contradict each other if this rule read an empty season set as anything else: a request for
+    /// the whole programme covers a request for one of its seasons, so it cannot also be a request
+    /// that no arrival satisfies.
+    /// </summary>
+    [Fact]
+    public void TheEmptySeasonSetMeansTheSameThingHereAsItDoesToIdentity()
+    {
+        var whole = Request(RequestedItemKind.Series);
+        var oneSeason = Request(RequestedItemKind.Series) with { Seasons = new[] { 2 } };
+
+        Assert.Equal(RequestMatch.Same, RequestIdentity.Compare(whole, oneSeason));
+        Assert.Equal(
+            LibraryAvailability.Present,
+            FulfilmentRule.AvailabilityOf(whole, new LibraryHolding { Held = true, SeasonsHeld = [2] }));
+    }
+
+    /// <summary>
+    /// A series the server does not hold at all is absent, whether the request named seasons or not.
+    /// </summary>
+    [Fact]
+    public void ASeriesTheServerDoesNotHoldIsAbsent()
+    {
+        var whole = Request(RequestedItemKind.Series);
+        var named = Request(RequestedItemKind.Series) with { Seasons = new[] { 1 } };
+
+        Assert.Equal(LibraryAvailability.Absent, FulfilmentRule.AvailabilityOf(whole, LibraryHolding.Nothing));
+        Assert.Equal(LibraryAvailability.Absent, FulfilmentRule.AvailabilityOf(named, LibraryHolding.Nothing));
+    }
+
+    /// <summary>
+    /// The rule never answers unknown. Unknown is the absence of a look, and something that looked
+    /// has to say what it saw.
+    /// </summary>
+    [Fact]
+    public void NothingTheRuleAnswersIsUnknown()
+    {
+        foreach (var kind in Enum.GetValues<RequestedItemKind>())
+        {
+            foreach (var holding in new[] { LibraryHolding.Nothing, new LibraryHolding { Held = true } })
+            {
+                Assert.NotEqual(LibraryAvailability.Unknown, FulfilmentRule.AvailabilityOf(Request(kind), holding));
+            }
+        }
+    }
+
+    private static MediaRequest Request(RequestedItemKind kind)
+    {
+        var asked = new DateTimeOffset(2026, 3, 1, 12, 0, 0, TimeSpan.Zero);
+
+        return new MediaRequest
+        {
+            Id = new Guid("2b8f4c61-0d75-4a39-9e26-3f5a8c1d7b04"),
+            RequestedByUserId = new Guid("7a4e2f18-6b0c-4d39-95e7-1f8a3c6d2b40"),
+            RequestedAt = asked,
+            StateChangedAt = asked,
+            Kind = kind,
+            DisplayTitle = "Tinker Tailor Soldier Spy",
+            ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tvdb"] = "76648" }
+        };
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/Fulfilment/FulfilmentSweepTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Fulfilment/FulfilmentSweepTests.cs
@@ -1,0 +1,342 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Fulfilment;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Fulfilment;
+
+/// <summary>
+/// Fulfilment detected from the library rather than ticked by hand, which is #42.
+/// <para>
+/// The moves are asserted per media kind, because a film is one library item and a series is a set
+/// of them and the two are the same code only if nothing about them differs. The removal case is
+/// here as well: it is a decision this repository took rather than an oversight, and the assertion
+/// is that a title leaving does not move a request back.
+/// </para>
+/// </summary>
+public class FulfilmentSweepTests
+{
+    private static readonly DateTimeOffset Asked = new DateTimeOffset(2026, 3, 1, 12, 0, 0, TimeSpan.Zero);
+    private static readonly Guid Requester = new Guid("7a4e2f18-6b0c-4d39-95e7-1f8a3c6d2b40");
+
+    /// <summary>The two seasons the series requests below ask for.</summary>
+    private static readonly int[] TwoSeasons = [1, 2];
+
+    /// <summary>
+    /// A film that has arrived moves an open request to fulfilled, with the plugin as the actor and
+    /// no person recorded, because nobody decided anything.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task AFilmThatArrivedFulfilsTheOpenRequestForIt()
+    {
+        var store = new InMemoryRequestStore();
+        var library = new FakeLibrary();
+        var clock = new TestClock(Asked);
+        var sweep = Sweep(store, library, clock);
+
+        await store.AddAsync(Request(RequestedItemKind.Movie, "Tmdb", "603"), CancellationToken.None);
+        library.Put(RequestedItemKind.Movie, "Tmdb", "603");
+        clock.Advance(TimeSpan.FromHours(3));
+
+        Assert.Equal(1, await sweep.SweepAsync(CancellationToken.None));
+
+        var after = await Only(store);
+
+        Assert.Equal(RequestState.Fulfilled, after.State);
+        Assert.Equal(LibraryAvailability.Present, after.Availability);
+        Assert.Equal(clock.UtcNow, after.AvailabilityCheckedAt);
+        Assert.Null(after.StateChangedByUserId);
+        Assert.Equal(RequestState.Fulfilled, Assert.Single(after.History).To);
+    }
+
+    /// <summary>
+    /// A series whose seasons have all arrived moves an approved request to fulfilled. The same code
+    /// as the film above and a different shape of answer from the library, which is why it is
+    /// asserted rather than assumed to follow.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task ASeriesWhoseSeasonsArrivedFulfilsTheApprovedRequestForIt()
+    {
+        var store = new InMemoryRequestStore();
+        var library = new FakeLibrary();
+        var clock = new TestClock(Asked);
+        var sweep = Sweep(store, library, clock);
+
+        var approved = RequestLifecycle.Move(
+            Request(RequestedItemKind.Series, "Tvdb", "76648") with { Seasons = TwoSeasons },
+            RequestState.Approved,
+            Asked,
+            RequestCaller.Administrator(Requester));
+
+        await store.AddAsync(approved, CancellationToken.None);
+        library.Put(RequestedItemKind.Series, "Tvdb", "76648", 1, 2);
+
+        Assert.Equal(1, await sweep.SweepAsync(CancellationToken.None));
+        Assert.Equal(RequestState.Fulfilled, (await Only(store)).State);
+    }
+
+    /// <summary>
+    /// A series with one of the two seasons it asked for is partial, and partial is not a move. The
+    /// request stays where it was and the queue says something true about it, which is the whole
+    /// point of having a third value rather than rounding to arrived or missing.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task ASeriesWithSomeOfItsSeasonsIsPartialAndDoesNotMove()
+    {
+        var store = new InMemoryRequestStore();
+        var library = new FakeLibrary();
+        var sweep = Sweep(store, library, new TestClock(Asked));
+
+        await store.AddAsync(
+            Request(RequestedItemKind.Series, "Tvdb", "76648") with { Seasons = TwoSeasons },
+            CancellationToken.None);
+
+        library.Put(RequestedItemKind.Series, "Tvdb", "76648", 1);
+
+        Assert.Equal(0, await sweep.SweepAsync(CancellationToken.None));
+
+        var after = await Only(store);
+
+        Assert.Equal(RequestState.Open, after.State);
+        Assert.Equal(LibraryAvailability.Partial, after.Availability);
+    }
+
+    /// <summary>
+    /// The item being removed again does not take the request back out of fulfilled. A library that
+    /// stops holding something is an observation and not a decision being undone, so what changes is
+    /// the availability and the request stays where it is with a row that says both.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task RemovingTheItemLeavesTheRequestFulfilledAndSaysTheServerNoLongerHoldsIt()
+    {
+        var store = new InMemoryRequestStore();
+        var library = new FakeLibrary();
+        var clock = new TestClock(Asked);
+        var sweep = Sweep(store, library, clock);
+
+        await store.AddAsync(Request(RequestedItemKind.Movie, "Tmdb", "603"), CancellationToken.None);
+        library.Put(RequestedItemKind.Movie, "Tmdb", "603");
+        await sweep.SweepAsync(CancellationToken.None);
+
+        library.Remove(RequestedItemKind.Movie, "Tmdb", "603");
+        clock.Advance(TimeSpan.FromDays(2));
+
+        Assert.Equal(0, await sweep.SweepAsync(CancellationToken.None));
+
+        var after = await Only(store);
+
+        Assert.Equal(RequestState.Fulfilled, after.State);
+        Assert.Equal(LibraryAvailability.Absent, after.Availability);
+        Assert.Equal(clock.UtcNow, after.AvailabilityCheckedAt);
+        Assert.Single(after.History);
+    }
+
+    /// <summary>
+    /// A declined request whose title has since arrived records that the server holds it and stays
+    /// declined. The table refuses that move, and this is the sweep asking the table rather than
+    /// carrying its own list of states.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task ADeclinedRequestRecordsTheArrivalAndStaysDeclined()
+    {
+        var store = new InMemoryRequestStore();
+        var library = new FakeLibrary();
+        var sweep = Sweep(store, library, new TestClock(Asked));
+
+        var declined = RequestLifecycle.Decline(
+            Request(RequestedItemKind.Movie, "Tmdb", "603"),
+            DeclineReason.NotWanted,
+            note: null,
+            Asked,
+            RequestCaller.Administrator(Requester));
+
+        await store.AddAsync(declined, CancellationToken.None);
+        library.Put(RequestedItemKind.Movie, "Tmdb", "603");
+
+        Assert.Equal(0, await sweep.SweepAsync(CancellationToken.None));
+
+        var after = await Only(store);
+
+        Assert.Equal(RequestState.Declined, after.State);
+        Assert.Equal(LibraryAvailability.Present, after.Availability);
+    }
+
+    /// <summary>
+    /// A request nobody identified is not looked up and is not written. There is nothing to look it
+    /// up by, so calling it absent would be a claim nothing checked.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task ARequestWithNoProviderIdentifierIsLeftUnknownRatherThanCalledAbsent()
+    {
+        var store = new InMemoryRequestStore();
+        var library = new FakeLibrary();
+        var sweep = Sweep(store, library, new TestClock(Asked));
+
+        await store.AddAsync(
+            Request(RequestedItemKind.Movie, "Tmdb", "603") with
+            {
+                ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal)
+            },
+            CancellationToken.None);
+
+        Assert.Equal(0, await sweep.SweepAsync(CancellationToken.None));
+        Assert.Equal(0, library.Lookups);
+
+        var after = await Only(store);
+
+        Assert.Equal(LibraryAvailability.Unknown, after.Availability);
+        Assert.Null(after.AvailabilityCheckedAt);
+    }
+
+    /// <summary>
+    /// A second sweep that sees the same thing writes nothing. The store is one document, so a run
+    /// that rewrote every request for no new fact would rewrite the whole of it on a schedule.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task ASecondSweepSeeingTheSameThingWritesNothing()
+    {
+        var store = new InMemoryRequestStore();
+        var library = new FakeLibrary();
+        var clock = new TestClock(Asked);
+        var sweep = Sweep(store, library, clock);
+
+        await store.AddAsync(Request(RequestedItemKind.Movie, "Tmdb", "603"), CancellationToken.None);
+        await sweep.SweepAsync(CancellationToken.None);
+
+        var revision = (await store.GetAllAsync(CancellationToken.None)).Single().Revision;
+
+        clock.Advance(TimeSpan.FromDays(1));
+        await sweep.SweepAsync(CancellationToken.None);
+
+        var again = (await store.GetAllAsync(CancellationToken.None)).Single();
+
+        Assert.Equal(revision, again.Revision);
+        Assert.Equal(2, library.Lookups);
+    }
+
+    /// <summary>
+    /// The event path finds the request by the identifier the library item carries, and moves it the
+    /// same way the sweep does. A request matching two of the item's identifiers is looked at once.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task AChangedItemFulfilsTheRequestsNamingItAndLooksAtEachOnlyOnce()
+    {
+        var store = new InMemoryRequestStore();
+        var library = new FakeLibrary();
+        var sweep = Sweep(store, library, new TestClock(Asked));
+
+        await store.AddAsync(
+            Request(RequestedItemKind.Movie, "Tmdb", "603") with
+            {
+                ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["Tmdb"] = "603",
+                    ["Imdb"] = "tt0133093"
+                }
+            },
+            CancellationToken.None);
+
+        library.Put(RequestedItemKind.Movie, "Tmdb", "603");
+
+        var changed = new LibraryChangeEventArgs(
+            RequestedItemKind.Movie,
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["Tmdb"] = "603",
+                ["Imdb"] = "tt0133093"
+            });
+
+        Assert.Equal(1, await sweep.ItemChangedAsync(changed, CancellationToken.None));
+        Assert.Equal(1, library.Lookups);
+        Assert.Equal(RequestState.Fulfilled, (await Only(store)).State);
+    }
+
+    /// <summary>
+    /// A library event about something nobody asked for touches nothing. Most of what a scan raises
+    /// is this case.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task AChangedItemNobodyAskedForTouchesNothing()
+    {
+        var store = new InMemoryRequestStore();
+        var library = new FakeLibrary();
+        var sweep = Sweep(store, library, new TestClock(Asked));
+
+        await store.AddAsync(Request(RequestedItemKind.Movie, "Tmdb", "603"), CancellationToken.None);
+
+        var changed = new LibraryChangeEventArgs(
+            RequestedItemKind.Movie,
+            new Dictionary<string, string>(StringComparer.Ordinal) { ["Tmdb"] = "999" });
+
+        Assert.Equal(0, await sweep.ItemChangedAsync(changed, CancellationToken.None));
+        Assert.Equal(0, library.Lookups);
+        Assert.Equal(RequestState.Open, (await Only(store)).State);
+    }
+
+    /// <summary>
+    /// A request that somebody else moved between the read and the write keeps their move. The
+    /// observation is dropped rather than retried, because a sweep that retried would write over the
+    /// decision an operator has just made.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task AnObservationLosesToADecisionMadeWhileItWasBeingMade()
+    {
+        var store = new InMemoryRequestStore();
+        var library = new FakeLibrary();
+        var moving = new StoreThatMovesARequestUnderTheWrite(
+            store,
+            held => RequestLifecycle.Decline(
+                held,
+                DeclineReason.NoRoomForIt,
+                note: null,
+                Asked,
+                RequestCaller.Administrator(Requester)));
+
+        var sweep = new FulfilmentSweep(moving, library, new TestClock(Asked), new RecordingLogger());
+
+        await store.AddAsync(Request(RequestedItemKind.Movie, "Tmdb", "603"), CancellationToken.None);
+        library.Put(RequestedItemKind.Movie, "Tmdb", "603");
+
+        Assert.Equal(0, await sweep.SweepAsync(CancellationToken.None));
+
+        var after = await Only(store);
+
+        Assert.Equal(RequestState.Declined, after.State);
+        Assert.Equal(LibraryAvailability.Unknown, after.Availability);
+    }
+
+    private static FulfilmentSweep Sweep(IRequestStore store, ILibrary library, TestClock clock)
+        => new FulfilmentSweep(store, library, clock, new RecordingLogger());
+
+    private static async Task<MediaRequest> Only(InMemoryRequestStore store)
+        => (await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true)).Single().Request;
+
+    private static MediaRequest Request(RequestedItemKind kind, string provider, string value)
+        => new MediaRequest
+        {
+            Id = new Guid("2b8f4c61-0d75-4a39-9e26-3f5a8c1d7b04"),
+            RequestedByUserId = Requester,
+            RequestedAt = Asked,
+            StateChangedAt = Asked,
+            Kind = kind,
+            DisplayTitle = "The one that was asked for",
+            ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { [provider] = value }
+        };
+}

--- a/Jellyfin.Plugin.Requests.Tests/Fulfilment/LibraryItemIdentityTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Fulfilment/LibraryItemIdentityTests.cs
@@ -1,0 +1,109 @@
+using System.Collections.Generic;
+using Jellyfin.Plugin.Requests.Fulfilment;
+using Jellyfin.Plugin.Requests.Model;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Fulfilment;
+
+/// <summary>
+/// The translation between the server's library types and this plugin's vocabulary, against the
+/// server's real types rather than against a description of them.
+/// </summary>
+public class LibraryItemIdentityTests
+{
+    /// <summary>
+    /// A film in the library is a film here, carrying the identifiers it was scanned with.
+    /// </summary>
+    [Fact]
+    public void AFilmIsAFilmAndKeepsItsIdentifiers()
+    {
+        var change = LibraryItemIdentity.Of(new Movie
+        {
+            Name = "The Matrix",
+            ProviderIds = new Dictionary<string, string> { ["Tmdb"] = "603" }
+        });
+
+        Assert.NotNull(change);
+        Assert.Equal(RequestedItemKind.Movie, change.Kind);
+        Assert.Equal("603", change.ProviderIds["Tmdb"]);
+    }
+
+    /// <summary>
+    /// A programme is a series here. The identifiers are read back under a differently spelled
+    /// provider name, because that is the rule identity is written to and a translation that
+    /// answered only the exact spelling would quietly narrow it.
+    /// </summary>
+    [Fact]
+    public void AProgrammeIsASeriesAndItsProviderNameIsReadWithoutCase()
+    {
+        var change = LibraryItemIdentity.Of(new Series
+        {
+            Name = "Tinker Tailor Soldier Spy",
+            ProviderIds = new Dictionary<string, string> { ["Tvdb"] = "76648" }
+        });
+
+        Assert.NotNull(change);
+        Assert.Equal(RequestedItemKind.Series, change.Kind);
+        Assert.Equal("76648", change.ProviderIds["tvdb"]);
+    }
+
+    /// <summary>
+    /// The answer is a copy. A library item is a live object the server goes on writing to, and this
+    /// answer is put in a queue and read later on another thread.
+    /// </summary>
+    [Fact]
+    public void TheIdentifiersAreCopiedRatherThanTheItemsOwn()
+    {
+        var film = new Movie
+        {
+            Name = "The Matrix",
+            ProviderIds = new Dictionary<string, string> { ["Tmdb"] = "603" }
+        };
+
+        var change = LibraryItemIdentity.Of(film);
+
+        film.ProviderIds["Tmdb"] = "something else";
+
+        Assert.NotNull(change);
+        Assert.Equal("603", change.ProviderIds["Tmdb"]);
+    }
+
+    /// <summary>
+    /// An item nobody identified answers with no identifiers rather than with nothing, so the caller
+    /// finds no request rather than having to test for a missing map.
+    /// </summary>
+    [Fact]
+    public void AnItemNobodyIdentifiedAnswersWithAnEmptySet()
+    {
+        var change = LibraryItemIdentity.Of(new Movie { Name = "Something off a disk" });
+
+        Assert.NotNull(change);
+        Assert.Empty(change.ProviderIds);
+    }
+
+    /// <summary>
+    /// Something a request cannot name answers nothing. The two kinds a record can express are the
+    /// two answered, and a library holds a great deal that is neither.
+    /// </summary>
+    /// <param name="item">A library item of a kind no request names.</param>
+    [Theory]
+    [MemberData(nameof(ItemsNoRequestNames))]
+    public void SomethingNoRequestCanNameAnswersNothing(BaseItem item)
+        => Assert.Null(LibraryItemIdentity.Of(item));
+
+    /// <summary>
+    /// Gets library items of kinds this plugin's records cannot express.
+    /// </summary>
+    /// <returns>One item per row.</returns>
+    public static TheoryData<BaseItem> ItemsNoRequestNames() => new TheoryData<BaseItem>
+    {
+        new Season { Name = "Season 1" },
+        new Episode { Name = "The one with the mole" },
+        new Audio { Name = "A song" },
+        new Folder { Name = "A folder" }
+    };
+}

--- a/Jellyfin.Plugin.Requests.Tests/SiblingIndependenceTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/SiblingIndependenceTests.cs
@@ -35,6 +35,10 @@ public class SiblingIndependenceTests
     /// </summary>
     private static readonly string[] AllowedReferences =
     [
+        // The library query the fulfilment check makes names the kinds of item it wants back, and
+        // that enumeration lives here rather than beside the library interface it is passed to. It
+        // arrives with the server's own libraries and is excluded from the install with them.
+        "Jellyfin.Data",
         "MediaBrowser.Common",
         "MediaBrowser.Controller",
         "MediaBrowser.Model",
@@ -51,6 +55,12 @@ public class SiblingIndependenceTests
         "Microsoft.AspNetCore.Http.Abstractions",
         "Microsoft.AspNetCore.Mvc.Core",
         "Microsoft.Extensions.DependencyInjection.Abstractions",
+
+        // The thing that listens for a library arrival has to be running before the first one rather
+        // than when somebody first asks for it, and a hosted service is how the server starts and
+        // stops such a thing. This is the abstraction only; the host is the generic host the server
+        // already is, and this assembly is part of the runtime it runs on.
+        "Microsoft.Extensions.Hosting.Abstractions",
 
         // The store refuses to open a file it cannot read, and the caller that sees the exception is
         // whichever request happened to be first while the person who can act on it is reading the
@@ -76,7 +86,13 @@ public class SiblingIndependenceTests
         // The store's calls are asynchronous and it holds one lock across a write, so the
         // cancellation token, the task and the lock all come from here. It arrives with the store
         // rather than with any decision of its own.
-        "System.Threading"
+        "System.Threading",
+
+        // A library event is raised on the thread that is scanning the library, so what handles it
+        // puts it in a queue and returns rather than holding that scan behind a store read and a
+        // store write per item. The queue is the runtime's own rather than a list and a lock written
+        // here, and it is part of the runtime the server already runs on.
+        "System.Threading.Channels"
     ];
 
     /// <summary>

--- a/Jellyfin.Plugin.Requests/Fulfilment/FulfilmentRule.cs
+++ b/Jellyfin.Plugin.Requests/Fulfilment/FulfilmentRule.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Linq;
+using Jellyfin.Plugin.Requests.Model;
+
+namespace Jellyfin.Plugin.Requests.Fulfilment;
+
+/// <summary>
+/// What the library holding for a request means, as one function. Everything that looks at the
+/// library decides here, so the event path and the scheduled path cannot answer the same request
+/// differently.
+/// <para>
+/// <b>A film is present or it is absent.</b> There is no third answer, because there is no part of
+/// a film to have arrived.
+/// </para>
+/// <para>
+/// <b>A series is judged against the seasons that were asked for and against nothing else.</b> A
+/// request naming seasons two and three is present when the server holds both, partial when it
+/// holds one, and absent when it holds neither. This is the rule for a partly satisfied series, and
+/// it rounds in no direction: <see cref="LibraryAvailability.Partial"/> is a value of its own,
+/// the state does not move on it, and the request stays where it was until every season asked for
+/// is there.
+/// </para>
+/// <para>
+/// <b>A series request naming no season is present the moment the server holds the series.</b> That
+/// is the convention <see cref="MediaRequest.Seasons"/> already carries, where empty means the whole
+/// programme, and it is the only answer available: this plugin calls no metadata source, decided in
+/// #92, so nothing here can learn how many seasons a programme has and a completeness test would be
+/// written against a number nobody can produce. The alternative was considered and is worse. Holding
+/// such a request short of present forever would leave it in a state nobody can end, because the
+/// transition table admits only an observation into
+/// <see cref="RequestState.Fulfilled"/> and no person may make that move.
+/// </para>
+/// <para>
+/// What that costs is real and is not softened: somebody who asked for a programme and got its first
+/// season sees a fulfilled request. What they do about it is ask for the seasons they want by name,
+/// which is a request this rule then judges exactly. The same reading is what
+/// <see cref="RequestIdentity.Compare"/> already makes, where a request for the whole programme
+/// covers a request for one of its seasons, and the two would contradict each other if this rule
+/// read the empty set as anything else.
+/// </para>
+/// <para>
+/// <b>Nothing here decides whether a request moves.</b> It says what the library shows. Which states
+/// may reach <see cref="RequestState.Fulfilled"/> is <see cref="RequestLifecycle.Table"/>'s answer
+/// and is asked there, so a state added to the model needs no edit in this file.
+/// </para>
+/// </summary>
+public static class FulfilmentRule
+{
+    /// <summary>
+    /// What a holding says about a request.
+    /// </summary>
+    /// <param name="request">The request being judged.</param>
+    /// <param name="holding">What the server holds of the title it names.</param>
+    /// <returns>
+    /// The availability to record. Never <see cref="LibraryAvailability.Unknown"/>: this is the
+    /// answer of something that looked, and "nothing has looked" is the absence of a call to it.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Where the request or the holding is missing.</exception>
+    public static LibraryAvailability AvailabilityOf(MediaRequest request, LibraryHolding holding)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(holding);
+
+        if (!holding.Held)
+        {
+            return LibraryAvailability.Absent;
+        }
+
+        // A film has no parts, and a series asked for as a whole is asked for as a whole. Both are
+        // answered by the title being there, and neither has a season set to compare.
+        if (request.Kind != RequestedItemKind.Series || request.Seasons.Count == 0)
+        {
+            return LibraryAvailability.Present;
+        }
+
+        var arrived = request.Seasons.Count(season => holding.SeasonsHeld.Contains(season));
+
+        if (arrived == 0)
+        {
+            // The server holds the programme and none of the seasons this request is about. That is
+            // absent for this request, and saying otherwise would make a queue row read as though
+            // something had arrived for the person waiting on it.
+            return LibraryAvailability.Absent;
+        }
+
+        return arrived == request.Seasons.Count
+            ? LibraryAvailability.Present
+            : LibraryAvailability.Partial;
+    }
+}

--- a/Jellyfin.Plugin.Requests/Fulfilment/FulfilmentSweep.cs
+++ b/Jellyfin.Plugin.Requests/Fulfilment/FulfilmentSweep.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Time;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.Requests.Fulfilment;
+
+/// <summary>
+/// Looks at the library on behalf of requests and writes down what it saw. This is the whole of
+/// #42: a request is fulfilled because the server holds what was asked for, never because somebody
+/// remembered to say so.
+/// <para>
+/// Two ways in and one thing done. <see cref="SweepAsync"/> walks the store and is what the
+/// scheduled task calls; <see cref="ItemChangedAsync"/> takes one title and is what the library
+/// event calls. Both end in the same private step, so the two paths cannot disagree, and neither is
+/// the only one that works: a server that was stopped when the file arrived catches up on the
+/// schedule, and a server that is running does not wait for it.
+/// </para>
+/// <para>
+/// <b>Removing the item does not move anything back.</b> A title leaving the library is an
+/// observation and not a decision being undone, which is what
+/// <see cref="RequestLifecycle.Table"/> already says by refusing every move out of
+/// <see cref="RequestState.Fulfilled"/>. So a removal is recorded where an observation belongs, in
+/// <see cref="MediaRequest.Availability"/>, and the request stays fulfilled with a row that now
+/// reads "fulfilled, and the server no longer holds it". An operator seeing that decides what to do;
+/// nothing here decides it for them.
+/// </para>
+/// <para>
+/// <b>What is written and when.</b> An observation is written only where it differs from the one the
+/// request already carries, or where it moves the request. A sweep that wrote every request every
+/// time would rewrite the whole store on every run for no new fact, and the store is one document.
+/// What that costs is the precision of <see cref="MediaRequest.AvailabilityCheckedAt"/>: it says
+/// when the availability now recorded was established, so it answers whether anything has ever
+/// looked and not how long ago the last look was.
+/// </para>
+/// <para>
+/// <b>A request carrying no provider identifier is skipped.</b> There is nothing to look it up by,
+/// so its availability stays <see cref="LibraryAvailability.Unknown"/> rather than becoming an
+/// absence nothing checked. That is the same answer <see cref="RequestIdentity"/> gives such a
+/// request, and <see cref="RequestLifecycle"/> already refuses to move it anywhere but declined.
+/// </para>
+/// </summary>
+public sealed class FulfilmentSweep
+{
+    private readonly IRequestStore _store;
+    private readonly ILibrary _library;
+    private readonly IClock _clock;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FulfilmentSweep"/> class.
+    /// </summary>
+    /// <param name="store">Where the requests are.</param>
+    /// <param name="library">What the server holds.</param>
+    /// <param name="clock">The injected clock, so an observation's time is one a test can set.</param>
+    /// <param name="logger">The server's log, where a refused write is reported.</param>
+    /// <exception cref="ArgumentNullException">Where anything it needs is missing.</exception>
+    public FulfilmentSweep(
+        IRequestStore store,
+        ILibrary library,
+        IClock clock,
+        ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(library);
+        ArgumentNullException.ThrowIfNull(clock);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _store = store;
+        _library = library;
+        _clock = clock;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Looks at the library for every request the store holds.
+    /// <para>
+    /// Every request, in every state, and not only the ones that can still move. A declined request
+    /// whose title has since arrived is exactly the row an operator wants to see before they change
+    /// their mind, and a fulfilled one whose title has gone is the row that explains a complaint.
+    /// Which of them the table then lets move is asked of the table.
+    /// </para>
+    /// </summary>
+    /// <param name="cancellationToken">Cancels the sweep between requests.</param>
+    /// <returns>How many requests this run moved to fulfilled.</returns>
+    public async Task<int> SweepAsync(CancellationToken cancellationToken)
+    {
+        var held = await _store.GetAllAsync(cancellationToken).ConfigureAwait(false);
+        var fulfilled = 0;
+
+        foreach (var stored in held)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (await LookAsync(stored, cancellationToken).ConfigureAwait(false))
+            {
+                fulfilled++;
+            }
+        }
+
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug(
+                "Looked at the library for {Count} request(s) and moved {Fulfilled} to fulfilled.",
+                held.Count,
+                fulfilled);
+        }
+
+        return fulfilled;
+    }
+
+    /// <summary>
+    /// Looks at the library for the requests naming one title, which is what a library event is
+    /// worth acting on.
+    /// <para>
+    /// The store is asked once per identifier the item carries, because a request may have been made
+    /// with only one of them. The same request answering under two identifiers is looked at once.
+    /// </para>
+    /// </summary>
+    /// <param name="change">The title the library gained or lost.</param>
+    /// <param name="cancellationToken">Cancels the work between requests.</param>
+    /// <returns>How many requests this moved to fulfilled.</returns>
+    /// <exception cref="ArgumentNullException">Where no change was given.</exception>
+    public async Task<int> ItemChangedAsync(LibraryChangeEventArgs change, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(change);
+
+        var matched = new Dictionary<Guid, StoredRequest>();
+
+        foreach (var identifier in change.ProviderIds)
+        {
+            if (string.IsNullOrWhiteSpace(identifier.Key) || string.IsNullOrWhiteSpace(identifier.Value))
+            {
+                continue;
+            }
+
+            var found = await _store.FindByProviderIdentifierAsync(
+                change.Kind,
+                identifier.Key,
+                identifier.Value,
+                cancellationToken).ConfigureAwait(false);
+
+            foreach (var stored in found)
+            {
+                matched[stored.Request.Id] = stored;
+            }
+        }
+
+        var fulfilled = 0;
+
+        foreach (var stored in matched.Values)
+        {
+            if (await LookAsync(stored, cancellationToken).ConfigureAwait(false))
+            {
+                fulfilled++;
+            }
+        }
+
+        return fulfilled;
+    }
+
+    /// <summary>
+    /// The one step both paths end in: ask the library, decide with
+    /// <see cref="FulfilmentRule"/>, and write only where something is new.
+    /// </summary>
+    /// <param name="stored">The request and the revision it was read at.</param>
+    /// <param name="cancellationToken">Cancels the lookup and the write.</param>
+    /// <returns><see langword="true"/> where this moved the request to fulfilled.</returns>
+    private async Task<bool> LookAsync(StoredRequest stored, CancellationToken cancellationToken)
+    {
+        var request = stored.Request;
+
+        if (request.ProviderIds.Count == 0)
+        {
+            return false;
+        }
+
+        var holding = await _library.HoldingOfAsync(
+            request.Kind,
+            request.ProviderIds,
+            cancellationToken).ConfigureAwait(false);
+
+        var availability = FulfilmentRule.AvailabilityOf(request, holding);
+
+        // The table decides which states may reach fulfilled, so a state added to the model is a
+        // row there rather than a condition here. An approved request that has arrived moves; a
+        // declined one whose title has arrived does not, because approving it first is the move
+        // that says a person changed the answer.
+        var moves = availability == LibraryAvailability.Present
+            && RequestLifecycle.IsLegal(request.State, RequestState.Fulfilled);
+
+        if (availability == request.Availability && !moves)
+        {
+            return false;
+        }
+
+        var at = _clock.UtcNow;
+        var observed = request with { Availability = availability, AvailabilityCheckedAt = at };
+
+        if (moves)
+        {
+            observed = RequestLifecycle.Move(observed, RequestState.Fulfilled, at, RequestCaller.Plugin);
+        }
+
+        try
+        {
+            await _store.ReplaceAsync(observed, stored.Revision, cancellationToken).ConfigureAwait(false);
+        }
+        catch (RequestConcurrencyException)
+        {
+            // Somebody moved this request between the read and the write, so what was decided above
+            // was decided against a request that no longer exists in that shape. Nothing is retried
+            // here: the next look reads the request as it now is and decides again, and a retry loop
+            // in a sweep is a way to write over a decision an operator has just made.
+            _logger.LogDebug(
+                "A request moved while the library was being looked at for it, so this observation was dropped and the next look will make it again.");
+
+            return false;
+        }
+
+        return moves;
+    }
+}

--- a/Jellyfin.Plugin.Requests/Fulfilment/FulfilmentTask.cs
+++ b/Jellyfin.Plugin.Requests/Fulfilment/FulfilmentTask.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Model.Tasks;
+
+namespace Jellyfin.Plugin.Requests.Fulfilment;
+
+/// <summary>
+/// The scheduled half of #42: a run the server starts on its own, so a library that changed while
+/// this plugin was not listening is still noticed.
+/// <para>
+/// It exists because the event path cannot be complete. A server that was stopped when the file
+/// arrived gets no event for it, an event raised while the plugin was loading is one nobody was
+/// subscribed for, and an episode landing under a series that is already in the library moves what
+/// a partly satisfied request is waiting for without the series itself changing. None of those is
+/// an edge case on a machine that gets restarted, and each of them is a request that would sit open
+/// forever with the event path alone.
+/// </para>
+/// <para>
+/// It is deliberately not the only path either. Waiting hours to be told that the thing you asked
+/// for arrived is the delay that makes people ask an operator instead, which is what this plugin
+/// exists to stop.
+/// </para>
+/// </summary>
+public sealed class FulfilmentTask : IScheduledTask
+{
+    /// <summary>
+    /// How often the server runs this on its own. Six hours is a compromise stated rather than
+    /// tuned: the event path is what makes an arrival prompt, and this run is the one that catches
+    /// what the event path missed, so it is set to notice a missed arrival within a day without
+    /// walking the store every few minutes for nothing.
+    /// </summary>
+    private static readonly TimeSpan Interval = TimeSpan.FromHours(6);
+
+    private readonly FulfilmentSweep _sweep;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FulfilmentTask"/> class.
+    /// </summary>
+    /// <param name="sweep">The one thing that looks at the library, shared with the event path.</param>
+    /// <exception cref="ArgumentNullException">Where no sweep was given.</exception>
+    public FulfilmentTask(FulfilmentSweep sweep)
+    {
+        ArgumentNullException.ThrowIfNull(sweep);
+
+        _sweep = sweep;
+    }
+
+    /// <inheritdoc />
+    public string Name => "Check requests against the library";
+
+    /// <inheritdoc />
+    public string Description =>
+        "Looks at what the library holds for every request and moves the ones that have arrived to fulfilled.";
+
+    /// <inheritdoc />
+    public string Category => "Requests";
+
+    /// <summary>
+    /// Gets the identifier the server keeps this task's schedule under. It is written out rather
+    /// than derived from the type name, because a rename of the class would otherwise silently
+    /// discard an interval an operator had changed.
+    /// </summary>
+    public string Key => "RequestsLibraryFulfilment";
+
+    /// <inheritdoc />
+    public IEnumerable<TaskTriggerInfo> GetDefaultTriggers() =>
+    [
+        // Startup as well as the interval, because the gap this task exists to close is the one a
+        // server that was off has just been through.
+        new TaskTriggerInfo { Type = TaskTriggerInfoType.StartupTrigger },
+        new TaskTriggerInfo { Type = TaskTriggerInfoType.IntervalTrigger, IntervalTicks = Interval.Ticks }
+    ];
+
+    /// <inheritdoc />
+    public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(progress);
+
+        progress.Report(0);
+
+        await _sweep.SweepAsync(cancellationToken).ConfigureAwait(false);
+
+        progress.Report(100);
+    }
+}

--- a/Jellyfin.Plugin.Requests/Fulfilment/ILibrary.cs
+++ b/Jellyfin.Plugin.Requests/Fulfilment/ILibrary.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Model;
+
+namespace Jellyfin.Plugin.Requests.Fulfilment;
+
+/// <summary>
+/// The server's library, reduced to the two things this plugin asks of it: what it holds of one
+/// title, and when it gained or lost something.
+/// <para>
+/// It is a seam of this plugin's own rather than the server's own interface, and the reason is
+/// specific rather than a preference for indirection. The server's library interface is not the
+/// same interface on the two server lines this plugin is built for: members exist on one and not
+/// on the other. Anything standing in for it would therefore have to be written twice, once per
+/// line, and a double that differs per line proves a different thing on each. This interface has
+/// two members and they are the same on both lines, so one double stands for it everywhere and
+/// every rule below it is decided by the suite rather than by a server.
+/// </para>
+/// <para>
+/// What that leaves outside the suite is <see cref="ServerLibrary"/>, which is the translation
+/// between this interface and the server's. It is named here rather than left to be discovered:
+/// nothing in this repository runs it, and what it does is checked by reading it.
+/// </para>
+/// </summary>
+public interface ILibrary
+{
+    /// <summary>
+    /// Raised when the library gains or loses a title. The handler is called on whatever thread the
+    /// server raised the event on, so a subscriber does its work elsewhere rather than holding up a
+    /// library scan.
+    /// </summary>
+    event EventHandler<LibraryChangeEventArgs> Changed;
+
+    /// <summary>
+    /// What the server holds of one title.
+    /// </summary>
+    /// <param name="kind">What sort of thing is being asked about.</param>
+    /// <param name="providerIds">
+    /// The external identifiers to look it up by, keyed by provider name. A title matches where any
+    /// one of them matches, for the reason <see cref="RequestIdentity"/> gives: a request may carry
+    /// only the identifier the client that made it happened to know.
+    /// </param>
+    /// <param name="cancellationToken">Cancels the lookup.</param>
+    /// <returns>
+    /// What is held, or <see cref="LibraryHolding.Nothing"/> where the server has none of it. An
+    /// empty set of identifiers is answered with <see cref="LibraryHolding.Nothing"/> rather than
+    /// with an exception, because a library item carrying no identifier is ordinary.
+    /// </returns>
+    Task<LibraryHolding> HoldingOfAsync(
+        RequestedItemKind kind,
+        IReadOnlyDictionary<string, string> providerIds,
+        CancellationToken cancellationToken);
+}

--- a/Jellyfin.Plugin.Requests/Fulfilment/LibraryChangeEventArgs.cs
+++ b/Jellyfin.Plugin.Requests/Fulfilment/LibraryChangeEventArgs.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using Jellyfin.Plugin.Requests.Model;
+
+namespace Jellyfin.Plugin.Requests.Fulfilment;
+
+/// <summary>
+/// A title the server has just gained or lost, reduced to the two things a request is matched on.
+/// <para>
+/// It carries no direction. Arriving and leaving are the same event to everything downstream,
+/// because what happens next is a fresh look at what the library holds now rather than an
+/// adjustment applied to what it held before. A rule that added on an arrival and subtracted on a
+/// departure would be wrong the first time an event is delivered twice or missed once, and both of
+/// those happen on a server that was restarted in the middle of a scan.
+/// </para>
+/// <para>
+/// It derives from <see cref="EventArgs"/> because it is carried by an event, which is the shape
+/// the analysers require of one and the shape a reader expects.
+/// </para>
+/// </summary>
+public sealed class LibraryChangeEventArgs : EventArgs
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LibraryChangeEventArgs"/> class.
+    /// </summary>
+    /// <param name="kind">What sort of thing changed.</param>
+    /// <param name="providerIds">
+    /// The external identifiers the item carries, keyed by provider name. Empty is possible and
+    /// means nothing can be matched against it, which is a fact about that library item rather than
+    /// an error.
+    /// </param>
+    /// <exception cref="ArgumentNullException">Where no identifiers were given.</exception>
+    public LibraryChangeEventArgs(RequestedItemKind kind, IReadOnlyDictionary<string, string> providerIds)
+    {
+        ArgumentNullException.ThrowIfNull(providerIds);
+
+        Kind = kind;
+        ProviderIds = providerIds;
+    }
+
+    /// <summary>
+    /// Gets what sort of thing changed.
+    /// </summary>
+    public RequestedItemKind Kind { get; }
+
+    /// <summary>
+    /// Gets the external identifiers the item carries, keyed by provider name.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> ProviderIds { get; }
+}

--- a/Jellyfin.Plugin.Requests/Fulfilment/LibraryHolding.cs
+++ b/Jellyfin.Plugin.Requests/Fulfilment/LibraryHolding.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.Requests.Fulfilment;
+
+/// <summary>
+/// What the server holds of one title, as an answer rather than as a list of library items.
+/// <para>
+/// It is this shape rather than a library item because everything downstream of it decides a rule,
+/// and a rule written against a library item is a rule that cannot be tested without a library. Two
+/// facts are enough for every rule in <see cref="FulfilmentRule"/>: whether the title is there at
+/// all, and which seasons of it are.
+/// </para>
+/// <para>
+/// <see cref="SeasonsHeld"/> is what the server has files for, and it is never what the series is
+/// known to have upstream. This plugin calls no metadata source, decided in #92, so nothing here
+/// can count the seasons that exist; it can only count the ones that arrived.
+/// </para>
+/// </summary>
+public sealed record LibraryHolding
+{
+    /// <summary>
+    /// Gets the answer for a title the server does not have. Named rather than written out at each
+    /// call site, because "not held" is the answer most lookups give and a shape repeated at every
+    /// one of them is a shape one of them will get wrong.
+    /// </summary>
+    public static LibraryHolding Nothing { get; } = new LibraryHolding();
+
+    /// <summary>
+    /// Gets a value indicating whether the server holds the title at all. False is the whole answer:
+    /// where it is false, <see cref="SeasonsHeld"/> is empty and says nothing.
+    /// </summary>
+    public bool Held { get; init; }
+
+    /// <summary>
+    /// Gets the season numbers the server has files for, in no particular order and without repeats.
+    /// Empty on a film, which has no seasons, and empty on a series the server holds with nothing
+    /// under it yet.
+    /// </summary>
+    public IReadOnlyList<int> SeasonsHeld { get; init; } = [];
+}

--- a/Jellyfin.Plugin.Requests/Fulfilment/LibraryItemIdentity.cs
+++ b/Jellyfin.Plugin.Requests/Fulfilment/LibraryItemIdentity.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using Jellyfin.Plugin.Requests.Model;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
+
+namespace Jellyfin.Plugin.Requests.Fulfilment;
+
+/// <summary>
+/// What one library item is, in the vocabulary a request is written in. This is the translation
+/// between the server's model and this plugin's, and it is a function of its own so that it can be
+/// tested against the server's real library types with no server running.
+/// <para>
+/// Only the two kinds a request can name are answered, because <see cref="RequestedItemKind"/> has
+/// two values and inventing a third here would produce a change nothing downstream can match. Which
+/// kinds an install accepts is a separate question and is #95's; this says what the server just
+/// told us about.
+/// </para>
+/// <para>
+/// A season and an episode answer nothing, and that is deliberate rather than an omission. What a
+/// request names is the series, so an episode has to be resolved to its parent before it means
+/// anything here, and reaching a parent is a question for the server's library rather than for a
+/// function. <see cref="ServerLibrary"/> does that resolution and hands the series in.
+/// </para>
+/// <para>
+/// The identifiers are copied rather than referenced. A library item is a live object the server
+/// goes on writing to, and this answer is put in a queue and read later on another thread.
+/// </para>
+/// </summary>
+public static class LibraryItemIdentity
+{
+    /// <summary>
+    /// What a library item is, or <see langword="null"/> where it is nothing a request can name.
+    /// </summary>
+    /// <param name="item">The library item the server raised an event about.</param>
+    /// <returns>The kind and the identifiers, or <see langword="null"/>.</returns>
+    /// <exception cref="ArgumentNullException">Where no item was given.</exception>
+    public static LibraryChangeEventArgs? Of(BaseItem item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+
+        return item switch
+        {
+            Movie => new LibraryChangeEventArgs(RequestedItemKind.Movie, Identifiers(item)),
+            Series => new LibraryChangeEventArgs(RequestedItemKind.Series, Identifiers(item)),
+            _ => null
+        };
+    }
+
+    /// <summary>
+    /// The item's external identifiers, as a map nothing else can change afterwards.
+    /// <para>
+    /// Absent and empty are one answer. An item nobody has identified matches no request, and the
+    /// caller learns that by getting an empty map rather than by testing for a missing one. The map
+    /// ignores case in the provider name, which is the rule <see cref="RequestIdentity"/> states and
+    /// the reason it states it: the same provider is spelled two ways by two callers and neither is
+    /// wrong.
+    /// </para>
+    /// </summary>
+    /// <param name="item">The library item.</param>
+    /// <returns>The identifiers.</returns>
+    private static Dictionary<string, string> Identifiers(BaseItem item)
+        => item.ProviderIds is null
+            ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            : new Dictionary<string, string>(item.ProviderIds, StringComparer.OrdinalIgnoreCase);
+}

--- a/Jellyfin.Plugin.Requests/Fulfilment/LibraryWatcher.cs
+++ b/Jellyfin.Plugin.Requests/Fulfilment/LibraryWatcher.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.Requests.Fulfilment;
+
+/// <summary>
+/// The event half of #42: what the server tells this plugin the moment the library gains or loses
+/// something, turned into a look at the requests that name it.
+/// <para>
+/// The event is handled by putting it in a queue and returning. The server raises it on the thread
+/// that is scanning the library, and doing the work there would hold up that scan behind a store
+/// read and a store write per item; a scan of a library somebody has just added is thousands of
+/// items. The queue has no bound because dropping a library event silently is the failure this
+/// class exists to prevent, and what fills it is a scan that ends.
+/// </para>
+/// <para>
+/// Stopping drains rather than abandons. The server's shutdown token bounds it, so a drain that
+/// cannot finish in the time the server allows is cut off and the scheduled run catches what was
+/// left. That is also what makes this testable without waiting: a test starts it, raises what it
+/// wants, stops it, and the stop is the point at which everything raised has been handled.
+/// </para>
+/// </summary>
+public sealed class LibraryWatcher : IHostedService, IDisposable
+{
+    private readonly Channel<LibraryChangeEventArgs> _queue =
+        Channel.CreateUnbounded<LibraryChangeEventArgs>(new UnboundedChannelOptions { SingleReader = true });
+
+    private readonly ILibrary _library;
+    private readonly FulfilmentSweep _sweep;
+    private readonly ILogger _logger;
+
+    private Task? _draining;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LibraryWatcher"/> class.
+    /// </summary>
+    /// <param name="library">What raises the change and answers what is held.</param>
+    /// <param name="sweep">The one thing that looks at the library, shared with the scheduled path.</param>
+    /// <param name="logger">The server's log, where a failure to handle one change is reported.</param>
+    /// <exception cref="ArgumentNullException">Where anything it needs is missing.</exception>
+    public LibraryWatcher(ILibrary library, FulfilmentSweep sweep, ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(library);
+        ArgumentNullException.ThrowIfNull(sweep);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _library = library;
+        _sweep = sweep;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _library.Changed += OnChanged;
+        _draining = DrainAsync();
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        _library.Changed -= OnChanged;
+
+        // Completing the writer is what ends the drain. Unsubscribing first means nothing can be
+        // written after it, so the loop below finishes what is already queued and then returns.
+        _queue.Writer.TryComplete();
+
+        if (_draining is null)
+        {
+            return;
+        }
+
+        await _draining.WaitAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _library.Changed -= OnChanged;
+        _queue.Writer.TryComplete();
+    }
+
+    private void OnChanged(object? sender, LibraryChangeEventArgs change)
+    {
+        // TryWrite on an unbounded channel fails only after the writer has been completed, which is
+        // a change raised while the server is stopping. There is nothing left to do with it and the
+        // scheduled run will see the library as it ends up.
+        _queue.Writer.TryWrite(change);
+    }
+
+    private async Task DrainAsync()
+    {
+        await foreach (var change in _queue.Reader.ReadAllAsync().ConfigureAwait(false))
+        {
+            try
+            {
+                await _sweep.ItemChangedAsync(change, CancellationToken.None).ConfigureAwait(false);
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception reason)
+#pragma warning restore CA1031
+            {
+                // One library item that could not be handled must not end the loop, because the loop
+                // is the only thing handling every other item. What went wrong is written where an
+                // operator reads it, and the scheduled run looks at the same request again.
+                _logger.LogError(
+                    reason,
+                    "Looking at the library for a request that changed did not finish. The scheduled run will look again.");
+            }
+        }
+    }
+}

--- a/Jellyfin.Plugin.Requests/Fulfilment/ServerLibrary.cs
+++ b/Jellyfin.Plugin.Requests/Fulfilment/ServerLibrary.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Data.Enums;
+using Jellyfin.Plugin.Requests.Model;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Library;
+
+namespace Jellyfin.Plugin.Requests.Fulfilment;
+
+/// <summary>
+/// <see cref="ILibrary"/> over the server's own library, and the one part of #42 the suite does not
+/// reach.
+/// <para>
+/// That is stated rather than left to be noticed. The server's library interface differs between the
+/// two server lines this plugin is built for, so anything standing in for it would have to be
+/// written twice and would prove a different thing on each. This class is therefore held to as
+/// little as it can be: it translates a query and an event and decides nothing, and every rule that
+/// could be got wrong lives on the other side of <see cref="ILibrary"/> where the suite reaches it.
+/// What is left here is checked by reading it and by the plugin loading on a server of each claimed
+/// line, which is #20's procedure.
+/// </para>
+/// </summary>
+public sealed class ServerLibrary : ILibrary, IDisposable
+{
+    private readonly ILibraryManager _library;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ServerLibrary"/> class.
+    /// </summary>
+    /// <param name="library">The server's library.</param>
+    /// <exception cref="ArgumentNullException">Where no library was given.</exception>
+    public ServerLibrary(ILibraryManager library)
+    {
+        ArgumentNullException.ThrowIfNull(library);
+
+        _library = library;
+        _library.ItemAdded += OnItemChanged;
+        _library.ItemRemoved += OnItemChanged;
+    }
+
+    /// <inheritdoc />
+    public event EventHandler<LibraryChangeEventArgs>? Changed;
+
+    /// <inheritdoc />
+    public Task<LibraryHolding> HoldingOfAsync(
+        RequestedItemKind kind,
+        IReadOnlyDictionary<string, string> providerIds,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(providerIds);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (providerIds.Count == 0)
+        {
+            return Task.FromResult(LibraryHolding.Nothing);
+        }
+
+        var wanted = kind == RequestedItemKind.Series ? BaseItemKind.Series : BaseItemKind.Movie;
+
+        var found = _library.GetItemList(new InternalItemsQuery
+        {
+            IncludeItemTypes = [wanted],
+            HasAnyProviderId = new Dictionary<string, string>(providerIds, StringComparer.OrdinalIgnoreCase),
+
+            // Everything under every library rather than one folder, because a request names a title
+            // and not a place somebody keeps it.
+            Recursive = true,
+
+            // The server creates rows for media it knows about and does not have, and counting one
+            // of those as arrived is the exact failure this whole path exists to avoid.
+            IsVirtualItem = false
+        });
+
+        if (found.Count == 0)
+        {
+            return Task.FromResult(LibraryHolding.Nothing);
+        }
+
+        return Task.FromResult(new LibraryHolding
+        {
+            Held = true,
+            SeasonsHeld = kind == RequestedItemKind.Series ? SeasonsUnder(found) : []
+        });
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _library.ItemAdded -= OnItemChanged;
+        _library.ItemRemoved -= OnItemChanged;
+    }
+
+    /// <summary>
+    /// The season numbers the server has files for, across every library item that answered to the
+    /// identifiers. Several can answer where the same programme sits in two libraries, and the union
+    /// is the honest answer: the person who asked can watch a season that is in either of them.
+    /// </summary>
+    /// <param name="series">The series items that matched.</param>
+    /// <returns>The season numbers, without repeats.</returns>
+    private IReadOnlyList<int> SeasonsUnder(IReadOnlyList<BaseItem> series)
+    {
+        var numbers = new HashSet<int>();
+
+        foreach (var one in series)
+        {
+            var seasons = _library.GetItemList(new InternalItemsQuery
+            {
+                ParentId = one.Id,
+                IncludeItemTypes = [BaseItemKind.Season],
+                IsVirtualItem = false
+            });
+
+            foreach (var season in seasons.OfType<Season>())
+            {
+                if (season.IndexNumber is int number)
+                {
+                    numbers.Add(number);
+                }
+            }
+        }
+
+        return [.. numbers];
+    }
+
+    private void OnItemChanged(object? sender, ItemChangeEventArgs e)
+    {
+        if (e?.Item is null)
+        {
+            return;
+        }
+
+        // A season or an episode is resolved to the programme it belongs to, because that is what a
+        // request names. A removal can leave the parent unreachable, and then there is nothing to
+        // raise and the scheduled run is what notices.
+        var item = e.Item switch
+        {
+            Season season => _library.GetItemById(season.SeriesId),
+            Episode episode => _library.GetItemById(episode.SeriesId),
+            _ => e.Item
+        };
+
+        if (item is null)
+        {
+            return;
+        }
+
+        var change = LibraryItemIdentity.Of(item);
+
+        if (change is not null)
+        {
+            Changed?.Invoke(this, change);
+        }
+    }
+}

--- a/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
@@ -1,11 +1,13 @@
 using System;
 using Jellyfin.Plugin.Requests.Api;
 using Jellyfin.Plugin.Requests.Bridge;
+using Jellyfin.Plugin.Requests.Fulfilment;
 using Jellyfin.Plugin.Requests.Identity;
 using Jellyfin.Plugin.Requests.Storage;
 using Jellyfin.Plugin.Requests.Time;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Plugins;
+using MediaBrowser.Model.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -63,5 +65,34 @@ public sealed class PluginServiceRegistrator : IPluginServiceRegistrator
         // service exists before deciding what to do. An adapter, when there is one, replaces this
         // registration and nothing else.
         serviceCollection.AddSingleton<IRequestBackend, NoRequestBackend>();
+
+        // The server's library, as the two questions this plugin asks of it. One per server, because
+        // the instance subscribes to the library's own events and a second subscription would look
+        // at every arrival twice.
+        serviceCollection.AddSingleton<ILibrary, ServerLibrary>();
+
+        // The logger is named for the type that writes through it, which is what puts this plugin's
+        // own category beside the rest in an operator's log. It is handed in rather than resolved by
+        // the container's generic rule, because both types take a plain logger for the same reason
+        // the store does: a test hands one in without a container.
+        serviceCollection.AddSingleton(provider => new FulfilmentSweep(
+            provider.GetRequiredService<IRequestStore>(),
+            provider.GetRequiredService<ILibrary>(),
+            provider.GetRequiredService<IClock>(),
+            provider.GetRequiredService<ILogger<FulfilmentSweep>>()));
+
+        // The event half of the fulfilment check. A hosted service rather than something built when
+        // somebody first asks for it, because it has to be subscribed before the first library event
+        // rather than after the first request, and because the server is what tells it to stop.
+        serviceCollection.AddHostedService(provider => new LibraryWatcher(
+            provider.GetRequiredService<ILibrary>(),
+            provider.GetRequiredService<FulfilmentSweep>(),
+            provider.GetRequiredService<ILogger<LibraryWatcher>>()));
+
+        // The scheduled half. The server finds a scheduled task by scanning the plugin's assembly
+        // rather than by reading this container, so nothing here is what makes it run; it is
+        // registered so that the one it constructs is built from the same objects as everything
+        // above rather than from a second set.
+        serviceCollection.AddSingleton<IScheduledTask, FulfilmentTask>();
     }
 }


### PR DESCRIPTION
Closes #42.

A request was only ever fulfilled by somebody moving it there by hand, and no surface offers that
move: the transition table admits an observation into `Fulfilled` and no person at all. So a request
whose title had actually arrived sat in the queue looking undecided, which is the "to-do list"
failure the issue names.

## The means

C#, in this repository's own project, because the thing being built is a service the Jellyfin server
constructs and a scheduled task the server runs, and both are interfaces the host declares. Nothing
else could carry either.

## The four conditions

**A library item that matches an open or approved request moves it to fulfilled, with a test per
media kind.** `AFilmThatArrivedFulfilsTheOpenRequestForIt` and
`ASeriesWhoseSeasonsArrivedFulfilsTheApprovedRequestForIt`. The move goes through
`RequestLifecycle.Move` with `RequestCaller.Plugin`, so it appends one history entry and records no
person. Which states may reach `Fulfilled` is asked of `RequestLifecycle.IsLegal` rather than listed
in the sweep, so a state added to the model needs no edit there.

**A partly satisfied series request is expressed by a stated rule.** The rule is in
`FulfilmentRule` and is two sentences:

- A request naming seasons is present when every one of them is in the library, partial when some
  are, and absent when none is, even though the programme itself is there. Partial is not a move.
- A request naming no season is present as soon as the server holds the programme.

The second is the one worth arguing with, and why it reads that way is in the type's own
documentation. Nothing here can learn how many seasons a programme has, because this plugin calls no
metadata source, so a completeness test would compare against a number nobody can produce. It is
also the reading `RequestIdentity.Compare` already makes, where a request for the programme covers a
request for one of its seasons, and the two would contradict each other otherwise;
`TheEmptySeasonSetMeansTheSameThingHereAsItDoesToIdentity` asserts both together. What it costs is
that somebody who asked for a programme and got its first season sees a fulfilled request, and what
they do about that is ask for the seasons they want by name.

The alternative was to hold such a request short of present, and it is worse: nothing could then
ever end it, because no person may make that move.

**Removing the matched item is handled by a stated rule and a test.** It does not move anything back.
A title leaving the library is an observation, which is what the table already says by refusing every
move out of `Fulfilled`, so what changes is `Availability` and the request stays where it is with a
row that reads "fulfilled, and the server no longer holds it".
`RemovingTheItemLeavesTheRequestFulfilledAndSaysTheServerNoLongerHoldsIt`.

**The match runs on a library event and on a schedule, and neither path is the only one that works.**
`BothPathsTests` exercises each with the other absent, because a test that started both would pass
with either removed. `AChangeRaisedWhileNothingIsListeningIsCaughtByTheScheduledRunInstead` is the
case the schedule exists for.

## Two more rules this had to take

A request carrying no provider identifier is not looked up, so its availability stays `Unknown`
rather than becoming an absence nothing checked.

An observation is written only where it differs from the one the request already carries, or where it
moves the request. The store is one document, so a sweep that wrote every request every run would
rewrite the whole of it on a schedule for no new fact. What that costs is stated in `FulfilmentSweep`:
`AvailabilityCheckedAt` says when the recorded availability was established, so it answers whether
anything has ever looked and not how long ago the last look was.

## Every guard was watched failing

Each was broken at the source, the suite run, and the change put back.

    // FulfilmentRule: partial rounded up to present
    dotnet test Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj -f net9.0 --configuration Release --filter "FullyQualifiedName~Fulfilment"
    FulfilmentRuleTests.ASeriesIsJudgedAgainstTheSeasonsThatWereAskedFor(asked: [2, 3], arrived: [2], expected: Partial) [FAIL]
    FulfilmentSweepTests.ASeriesWithSomeOfItsSeasonsIsPartialAndDoesNotMove [FAIL]
    Fehler: 2, erfolgreich: 34, gesamt: 36

    // FulfilmentRule: a whole-programme request held at partial
    FulfilmentRuleTests.ASeriesAskedForWholeIsPresentAsSoonAsTheServerHoldsIt(arrived: []) [FAIL]
    FulfilmentRuleTests.ASeriesAskedForWholeIsPresentAsSoonAsTheServerHoldsIt(arrived: [1]) [FAIL]
    FulfilmentRuleTests.ASeriesAskedForWholeIsPresentAsSoonAsTheServerHoldsIt(arrived: [1, 2, 3]) [FAIL]
    FulfilmentRuleTests.TheEmptySeasonSetMeansTheSameThingHereAsItDoesToIdentity [FAIL]
    Fehler: 4, erfolgreich: 32, gesamt: 36

    // FulfilmentSweep: a fulfilled request no longer looked at, so a removal is never seen
    FulfilmentSweepTests.RemovingTheItemLeavesTheRequestFulfilledAndSaysTheServerNoLongerHoldsIt [FAIL]
    Fehler: 1, erfolgreich: 35, gesamt: 36

    // FulfilmentSweep: the skip for an unidentified request and the write rule both removed
    FulfilmentSweepTests.ARequestWithNoProviderIdentifierIsLeftUnknownRatherThanCalledAbsent [FAIL]
    FulfilmentSweepTests.ASecondSweepSeeingTheSameThingWritesNothing [FAIL]
    Fehler: 2, erfolgreich: 34, gesamt: 36

    // FulfilmentTask: the scheduled run made to do nothing
    BothPathsTests.TheScheduledRunFulfilsWithNothingListeningToTheLibrary [FAIL]
    BothPathsTests.AChangeRaisedWhileNothingIsListeningIsCaughtByTheScheduledRunInstead [FAIL]
    Fehler: 2, erfolgreich: 3, gesamt: 5

    // LibraryWatcher: the subscription removed
    BothPathsTests.TheLibraryEventFulfilsWithTheScheduledRunNeverExecuted [FAIL]
    BothPathsTests.OneChangeThatFailsDoesNotStopTheNextOne [FAIL]
    Fehler: 2, erfolgreich: 3, gesamt: 5

The reference list refused this change for real rather than in an experiment. Three names had to be
added to `SiblingIndependenceTests` before the suite would go green:

    Assert.Equal() Failure: Values differ
    Actual: Jellyfin.Data | ... | Microsoft.Extensions.Hosting.Abstractions | ... | System.Threading.Channels

None of the three is a package. The library query's item kinds arrive with the server's own
libraries, and the hosted service and the queue are part of the runtime the server already runs on.
Neither lockfile moved, which `git status` after the build shows.

## Where it stands

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Der Buildvorgang wurde erfolgreich ausgefuehrt.
    0 Warnung(en)
    0 Fehler

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!: Fehler: 0, erfolgreich: 357, uebersprungen: 0, gesamt: 357 (net9.0)
    Bestanden!: Fehler: 0, erfolgreich: 357, uebersprungen: 0, gesamt: 357 (net10.0)

Fifty-three tests more than the mainline's 304 on the same command.

## What is not covered

`ServerLibrary` is the translation between this plugin's two-member library interface and the
server's own, and no test in this repository runs it. That is deliberate and it is why the interface
exists: the server's library interface is not the same interface on the two claimed server lines, so
anything standing in for it would have to be written twice and would prove a different thing on each.
What is left in that class is a query, an event subscription and a parent lookup, with no rule in it;
every rule is on the other side of the seam where the suite reaches it. Checking it against a running
server is #20's procedure and has not been run for this change.

The event path notices a film or a programme arriving. A season or an episode is resolved to its
programme through the server's library, and where a removal has left that parent unreachable there is
nothing to raise; the scheduled run is what notices in that case.

There is no second reader on this board tonight. The evidence above stands in place of one.
