### PR TITLE
Build the dashboard page shell

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/DashboardPagesTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/DashboardPagesTests.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using MediaBrowser.Model.Plugins;
+using Xunit;
+
+using PluginUnderTest = global::Jellyfin.Plugin.Requests.Plugin;
+
+namespace Jellyfin.Plugin.Requests.Tests;
+
+/// <summary>
+/// The pages this plugin puts in the dashboard, checked against the assembly they are served out
+/// of.
+/// <para>
+/// The failure these exist against is silent in every earlier route. A registration naming a
+/// resource the assembly does not carry builds clean, installs clean, and is a blank page in the
+/// dashboard of somebody's server. So is a page asking for a shared file under a name nothing
+/// registered.
+/// </para>
+/// </summary>
+public class DashboardPagesTests
+{
+    /// <summary>
+    /// Every registration names a resource the built assembly actually carries. This is the check
+    /// the namespace rename broke once and would break again: the path is derived from the
+    /// namespace at run time and the resource name is derived from it by the build, so the two
+    /// agree only while nothing has moved.
+    /// </summary>
+    [Fact]
+    public void PagesAreServedFromResourcesTheAssemblyCarries()
+    {
+        using var host = new PluginHost();
+
+        var embedded = typeof(PluginUnderTest).Assembly.GetManifestResourceNames();
+        var missing = host.Plugin
+            .GetPages()
+            .Select(page => page.EmbeddedResourcePath)
+            .Where(path => !embedded.Contains(path, StringComparer.Ordinal))
+            .ToArray();
+
+        Assert.Empty(missing);
+    }
+
+    /// <summary>
+    /// The queue and the settings are two pages rather than one, and each is registered once. Two
+    /// registrations under one name is a page the dashboard picks one of, and which one it picks is
+    /// not something this repository decides.
+    /// </summary>
+    [Fact]
+    public void TheQueueAndTheSettingsAreSeparatePagesAndEveryNameIsRegisteredOnce()
+    {
+        using var host = new PluginHost();
+
+        var pages = host.Plugin.GetPages().ToArray();
+        var names = pages.Select(page => page.Name).ToArray();
+
+        Assert.Contains(PluginUnderTest.QueuePageName, names, StringComparer.Ordinal);
+        Assert.Contains(host.Plugin.Name, names, StringComparer.Ordinal);
+        Assert.NotEqual(PluginUnderTest.QueuePageName, host.Plugin.Name, StringComparer.Ordinal);
+        Assert.Equal(names.Length, names.Distinct(StringComparer.Ordinal).Count());
+    }
+
+    /// <summary>
+    /// The queue asks to be in the dashboard's own menu and the settings do not. An operator opens
+    /// the queue every day, and a queue reachable only by finding the plugin in a list is a queue
+    /// they open through the settings page they were not looking for.
+    /// </summary>
+    [Fact]
+    public void OnlyTheQueueAsksForAPlaceInTheDashboardMenu()
+    {
+        using var host = new PluginHost();
+
+        var inMenu = host.Plugin
+            .GetPages()
+            .Where(page => page.EnableInMainMenu)
+            .Select(page => page.Name)
+            .ToArray();
+
+        Assert.Equal([PluginUnderTest.QueuePageName], inMenu);
+    }
+
+    /// <summary>
+    /// Every shared file a page fetches by name is registered under that name. A page asking for
+    /// one that is not is a page whose stylesheet or script is a 404, which leaves the page loading
+    /// and doing nothing.
+    /// </summary>
+    [Fact]
+    public void EveryNameThePagesAskForIsARegisteredPage()
+    {
+        using var host = new PluginHost();
+
+        var registered = host.Plugin.GetPages().Select(page => page.Name).ToArray();
+        var asked = host.Plugin
+            .GetPages()
+            .Where(page => page.EmbeddedResourcePath.EndsWith(".html", StringComparison.Ordinal))
+            .SelectMany(page => NamesFetchedBy(Text(page.EmbeddedResourcePath)))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        var unregistered = asked.Where(name => !registered.Contains(name, StringComparer.Ordinal)).ToArray();
+
+        Assert.NotEmpty(asked);
+        Assert.Empty(unregistered);
+    }
+
+    /// <summary>
+    /// The shared script names the same pages the plugin registered. The strip of links is drawn
+    /// from that list, so a page renamed in one place and not the other is a link to nothing, and
+    /// the page that link was for highlights none of its entries.
+    /// </summary>
+    [Fact]
+    public void TheSharedScriptNamesThePagesThatAreRegistered()
+    {
+        using var host = new PluginHost();
+
+        var script = Text(host.Plugin
+            .GetPages()
+            .Single(page => string.Equals(page.Name, "Requests.js", StringComparison.Ordinal))
+            .EmbeddedResourcePath);
+
+        var registered = host.Plugin
+            .GetPages()
+            .Where(page => page.EmbeddedResourcePath.EndsWith(".html", StringComparison.Ordinal))
+            .Select(page => page.Name);
+
+        foreach (var name in registered)
+        {
+            Assert.Contains("name: \"" + name + "\"", script, StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>
+    /// Every link the strip draws is a hash route.
+    /// <para>
+    /// That is the half of "navigation without a full page reload" this repository can check. A link
+    /// to a document address is what makes the dashboard load itself again and lose whatever the
+    /// operator had open; a hash route is a change of fragment, which is what the dashboard's own
+    /// router answers by swapping the content. What the router then does is the dashboard's
+    /// behaviour and is not measured here, because measuring it means driving a browser, which
+    /// <c>docs/testing.md</c> refuses.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void EveryLinkTheStripDrawsIsAHashRoute()
+    {
+        using var host = new PluginHost();
+
+        var script = Text(host.Plugin
+            .GetPages()
+            .Single(page => string.Equals(page.Name, "Requests.js", StringComparison.Ordinal))
+            .EmbeddedResourcePath);
+
+        var assignments = script
+            .Split('\n')
+            .Select(line => line.Trim())
+            .Where(line => line.StartsWith("link.href", StringComparison.Ordinal))
+            .ToArray();
+
+        var elsewhere = assignments
+            .Where(line => !line.StartsWith("link.href = \"#/", StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.NotEmpty(assignments);
+        Assert.Empty(elsewhere);
+    }
+
+    /// <summary>
+    /// Nothing the pages carry loads anything from outside this server. A page that fetches a
+    /// framework from somewhere else puts the dashboard of a media server behind whoever is serving
+    /// it that day, and this milestone's rule is that the pages use only what the server already
+    /// provides.
+    /// </summary>
+    [Fact]
+    public void NothingThePagesLoadComesFromOutsideThisServer()
+    {
+        using var host = new PluginHost();
+
+        var offSite = host.Plugin
+            .GetPages()
+            .Select(page => new { page.Name, Body = Text(page.EmbeddedResourcePath) })
+            .Where(page => page.Body.Contains("//", StringComparison.Ordinal))
+            .Where(page => page.Body.Contains("http://", StringComparison.OrdinalIgnoreCase)
+                || page.Body.Contains("https://", StringComparison.OrdinalIgnoreCase))
+            .Select(page => page.Name)
+            .ToArray();
+
+        Assert.Empty(offSite);
+    }
+
+    /// <summary>
+    /// The names the pages fetch through the dashboard's configuration-page endpoint, read out of
+    /// the page itself rather than restated here.
+    /// </summary>
+    /// <param name="body">The page as it is embedded.</param>
+    /// <returns>Every name it asks for.</returns>
+    private static IEnumerable<string> NamesFetchedBy(string body)
+    {
+        const string Marker = "\"web/ConfigurationPage\", { name: \"";
+
+        var at = body.IndexOf(Marker, StringComparison.Ordinal);
+
+        while (at >= 0)
+        {
+            var start = at + Marker.Length;
+            var end = body.IndexOf('"', start);
+
+            if (end < 0)
+            {
+                yield break;
+            }
+
+            yield return body[start..end];
+
+            at = body.IndexOf(Marker, end, StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>
+    /// One embedded file, as text.
+    /// </summary>
+    /// <param name="resource">The manifest resource name.</param>
+    /// <returns>What the assembly carries under it.</returns>
+    private static string Text(string resource)
+    {
+        using var stream = typeof(PluginUnderTest).Assembly.GetManifestResourceStream(resource)
+            ?? throw new InvalidOperationException($"The assembly carries no resource named {resource}.");
+
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+
+        return reader.ReadToEnd();
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/PluginConstructionTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/PluginConstructionTests.cs
@@ -59,14 +59,21 @@ public class PluginConstructionTests
     /// The configuration page the dashboard asks for comes from the plugin instance, not from the
     /// assembly metadata alone, so this is the instance-level counterpart of the resource check in
     /// <see cref="PluginContractTests"/>.
+    /// <para>
+    /// It is about the settings page in particular: that is the one the dashboard sends somebody to
+    /// when they press a plugin's settings, and it is reached under the plugin's own name. The other
+    /// pages, and the rule that every registration names a resource the assembly carries, are
+    /// <see cref="DashboardPagesTests"/>.
+    /// </para>
     /// </summary>
     [Fact]
     public void GetPagesNamesTheEmbeddedConfigurationPage()
     {
         using var host = new PluginHost();
 
-        var pages = host.Plugin.GetPages().ToList();
-        var page = Assert.Single(pages);
+        var page = Assert.Single(
+            host.Plugin.GetPages(),
+            entry => string.Equals(entry.Name, host.Plugin.Name, StringComparison.Ordinal));
 
         Assert.IsType<PluginPageInfo>(page);
         Assert.Contains(

--- a/Jellyfin.Plugin.Requests/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Requests/Configuration/configPage.html
@@ -8,6 +8,12 @@
         <div id="RequestsConfigPage" data-role="page" class="page type-interior pluginConfigurationPage" data-require="emby-input,emby-button,emby-select,emby-checkbox">
             <div data-role="content">
                 <div class="content-primary">
+                    <div class="requestsShell"></div>
+
+                    <h2>Settings</h2>
+
+                    <p class="requestsMessage" role="status"></p>
+
                     <form id="RequestsConfigForm">
                         <p>This plugin has no settings yet. The configuration surface is designed in M12; the sample settings this page started with were removed rather than kept, so nothing here carries a shape the design did not choose.</p>
                         <div>
@@ -23,24 +29,57 @@
                     pluginUniqueId: "0f9c9107-b31b-459e-81fa-6d35dac25e79",
                 };
 
-                document.querySelector("#RequestsConfigPage").addEventListener("pageshow", function () {
-                    Dashboard.showLoadingMsg();
-                    ApiClient.getPluginConfiguration(RequestsConfig.pluginUniqueId).then(function () {
-                        Dashboard.hideLoadingMsg();
-                    });
-                });
+                (function () {
+                    var page = document.querySelector("#RequestsConfigPage");
 
-                document.querySelector("#RequestsConfigForm").addEventListener("submit", function (e) {
-                    Dashboard.showLoadingMsg();
-                    ApiClient.getPluginConfiguration(RequestsConfig.pluginUniqueId).then(function (config) {
-                        ApiClient.updatePluginConfiguration(RequestsConfig.pluginUniqueId, config).then(function (result) {
-                            Dashboard.processPluginConfigurationUpdateResult(result);
+                    // The shared script is fetched through the same endpoint the dashboard fetches
+                    // this page from, because an embedded resource is reachable only under a name
+                    // the plugin registered.
+                    function shell() {
+                        if (window.RequestsShell) {
+                            return Promise.resolve();
+                        }
+
+                        return new Promise(function (resolve, reject) {
+                            var script = document.createElement("script");
+                            script.src = ApiClient.getUrl("web/ConfigurationPage", { name: "Requests.js" });
+                            script.onload = resolve;
+                            script.onerror = function () {
+                                reject(new Error("The shared script for this plugin's pages could not be loaded."));
+                            };
+                            document.head.appendChild(script);
                         });
+                    }
+
+                    page.addEventListener("pageshow", function () {
+                        Dashboard.showLoadingMsg();
+
+                        shell()
+                            .then(function () {
+                                RequestsShell.attach(page, "Requests");
+
+                                return ApiClient.getPluginConfiguration(RequestsConfig.pluginUniqueId);
+                            })
+                            .then(function () {
+                                Dashboard.hideLoadingMsg();
+                            })
+                            .catch(function () {
+                                Dashboard.hideLoadingMsg();
+                            });
                     });
 
-                    e.preventDefault();
-                    return false;
-                });
+                    document.querySelector("#RequestsConfigForm").addEventListener("submit", function (e) {
+                        Dashboard.showLoadingMsg();
+                        ApiClient.getPluginConfiguration(RequestsConfig.pluginUniqueId).then(function (config) {
+                            ApiClient.updatePluginConfiguration(RequestsConfig.pluginUniqueId, config).then(function (result) {
+                                Dashboard.processPluginConfigurationUpdateResult(result);
+                            });
+                        });
+
+                        e.preventDefault();
+                        return false;
+                    });
+                })();
             </script>
         </div>
     </body>

--- a/Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.csproj
+++ b/Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.csproj
@@ -31,6 +31,15 @@
   <ItemGroup>
     <None Remove="Configuration\configPage.html" />
     <EmbeddedResource Include="Configuration\configPage.html" />
+    <!-- The queue page and the two files both pages share. Each is reachable only under a name the
+         plugin registers in GetPages, and PagesAreServedFromResourcesTheAssemblyCarries refuses a
+         registration whose resource is not here. -->
+    <None Remove="Web\queue.html" />
+    <EmbeddedResource Include="Web\queue.html" />
+    <None Remove="Web\shell.js" />
+    <EmbeddedResource Include="Web\shell.js" />
+    <None Remove="Web\shell.css" />
+    <EmbeddedResource Include="Web\shell.css" />
   </ItemGroup>
 
 </Project>

--- a/Jellyfin.Plugin.Requests/Plugin.cs
+++ b/Jellyfin.Plugin.Requests/Plugin.cs
@@ -15,6 +15,13 @@ namespace Jellyfin.Plugin.Requests;
 public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 {
     /// <summary>
+    /// The name the queue page is registered and fetched under. It is a constant because the page
+    /// itself names it when it marks which link in the shared strip is the current one, and two
+    /// spellings of one page name is a strip that highlights nothing.
+    /// </summary>
+    public const string QueuePageName = "RequestsQueue";
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="Plugin"/> class.
     /// </summary>
     /// <param name="applicationPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
@@ -36,16 +43,61 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// </summary>
     public static Plugin? Instance { get; private set; }
 
-    /// <inheritdoc />
+    /// <summary>
+    /// The pages this plugin puts in the dashboard, and the two files they share.
+    /// <para>
+    /// Two pages rather than one, because an operator opens the queue every day and the settings
+    /// twice, and one page carrying both would put the settings in the way of the work. The queue
+    /// asks to be in the dashboard's own menu for the same reason; the settings stay where the
+    /// dashboard already puts a plugin's settings, which is the plugin list.
+    /// </para>
+    /// <para>
+    /// The stylesheet and the script are registered as pages as well. An embedded resource is
+    /// reachable only under a name registered here, so a shared file that is not in this list is a
+    /// file neither page can fetch. Their registered names carry an extension because that is what
+    /// the two pages ask for them by, and nothing else reads them.
+    /// </para>
+    /// <para>
+    /// <see cref="Name"/> stays the name of the settings page. The dashboard sends somebody who
+    /// presses a plugin's settings to the page registered under the plugin's own name, so moving it
+    /// to the queue would put the queue behind a button that says settings.
+    /// </para>
+    /// </summary>
+    /// <returns>The pages, in the order they were registered.</returns>
     public IEnumerable<PluginPageInfo> GetPages()
     {
         return
         [
+            Page(Name, "Configuration.configPage.html"),
             new PluginPageInfo
             {
-                Name = Name,
-                EmbeddedResourcePath = string.Format(CultureInfo.InvariantCulture, "{0}.Configuration.configPage.html", GetType().Namespace)
-            }
+                Name = QueuePageName,
+                EmbeddedResourcePath = Resource("Web.queue.html"),
+                DisplayName = "Requests",
+                EnableInMainMenu = true,
+                MenuIcon = "playlist_add_check"
+            },
+            Page("Requests.js", "Web.shell.js"),
+            Page("Requests.css", "Web.shell.css")
         ];
     }
+
+    /// <summary>
+    /// One registered page, built from the resource path the assembly actually carries.
+    /// </summary>
+    /// <param name="name">The name the dashboard fetches it under.</param>
+    /// <param name="resource">The resource, relative to this plugin's namespace.</param>
+    /// <returns>The page.</returns>
+    private PluginPageInfo Page(string name, string resource)
+        => new PluginPageInfo { Name = name, EmbeddedResourcePath = Resource(resource) };
+
+    /// <summary>
+    /// The manifest resource name for one embedded file. Built from the namespace at run time
+    /// rather than written out, because the path is derived from the namespace by the build and a
+    /// copy of it here would be a second spelling that a rename leaves behind.
+    /// </summary>
+    /// <param name="resource">The resource, relative to this plugin's namespace.</param>
+    /// <returns>The full resource name.</returns>
+    private string Resource(string resource)
+        => string.Format(CultureInfo.InvariantCulture, "{0}.{1}", GetType().Namespace, resource);
 }

--- a/Jellyfin.Plugin.Requests/Web/queue.html
+++ b/Jellyfin.Plugin.Requests/Web/queue.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>Requests</title>
+    </head>
+    <body>
+        <div id="RequestsQueuePage" data-role="page" class="page type-interior pluginConfigurationPage" data-require="emby-button">
+            <div data-role="content">
+                <div class="content-primary">
+                    <div class="requestsShell"></div>
+
+                    <h2>Queue</h2>
+
+                    <p class="requestsMessage" role="status"></p>
+
+                    <!--
+                        The rows an operator works through, with the filter, the sort and the paging
+                        that make a long queue usable, are #60, and acting on them is #61 and #62.
+                        This page is the shell those are built into.
+
+                        Nothing here reads the queue yet, and that is not only because the rows are
+                        somebody else's issue. Every endpoint this plugin serves answers 500 on a
+                        real server today, because the policy the controller names is not one the
+                        server registers; the run that measured it is in this change's pull request
+                        and the repair is #51's. A page shipped now with a call in it would show an
+                        operator an error every time they opened it.
+                    -->
+                    <p>The queue view is not built yet.</p>
+                </div>
+            </div>
+
+            <script type="text/javascript">
+                (function () {
+                    var page = document.querySelector("#RequestsQueuePage");
+
+                    // Loaded through the same endpoint the dashboard fetches this page from, because
+                    // an embedded resource is reachable only under a name the plugin registered.
+                    function shell() {
+                        if (window.RequestsShell) {
+                            return Promise.resolve();
+                        }
+
+                        return new Promise(function (resolve, reject) {
+                            var script = document.createElement("script");
+                            script.src = ApiClient.getUrl("web/ConfigurationPage", { name: "Requests.js" });
+                            script.onload = resolve;
+                            script.onerror = function () {
+                                reject(new Error("The shared script for this plugin's pages could not be loaded."));
+                            };
+                            document.head.appendChild(script);
+                        });
+                    }
+
+                    page.addEventListener("pageshow", function () {
+                        Dashboard.showLoadingMsg();
+
+                        shell()
+                            .then(function () {
+                                RequestsShell.attach(page, "RequestsQueue");
+                                Dashboard.hideLoadingMsg();
+                            })
+                            .catch(function () {
+                                Dashboard.hideLoadingMsg();
+                            });
+                    });
+                })();
+            </script>
+        </div>
+    </body>
+</html>

--- a/Jellyfin.Plugin.Requests/Web/shell.css
+++ b/Jellyfin.Plugin.Requests/Web/shell.css
@@ -1,0 +1,52 @@
+/*
+ * The shell both plugin pages share: a strip of links at the top and the frame the page's own
+ * content sits in.
+ *
+ * It styles almost nothing. The dashboard already has a look, and a plugin page that brings its own
+ * is a page that stops matching the server the day the server's theme changes. What is here is the
+ * layout the dashboard has no class for: the strip, which link in it is the current one, and the
+ * one line that says something went wrong. Colours are the dashboard's own custom properties where
+ * it defines them, with a plain fallback for a theme that does not.
+ */
+
+.requestsShell {
+    margin-bottom: 1.5em;
+}
+
+.requestsShellNav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5em;
+    border-bottom: 1px solid rgba(127, 127, 127, 0.4);
+    padding-bottom: 0.5em;
+}
+
+.requestsShellNav a {
+    padding: 0.4em 0.8em;
+    text-decoration: none;
+    border-radius: 0.2em;
+    color: inherit;
+}
+
+.requestsShellNav a:hover,
+.requestsShellNav a:focus {
+    background: rgba(127, 127, 127, 0.2);
+}
+
+/*
+ * The current page is marked by more than colour. A strip where the only difference is a shade is
+ * a strip somebody using a high-contrast theme cannot read, and the operator surface is held to the
+ * same rules as the rest of the tree.
+ */
+.requestsShellNav a[aria-current="page"] {
+    font-weight: bold;
+    box-shadow: inset 0 -2px 0 0 currentColor;
+}
+
+.requestsMessage {
+    margin: 1em 0;
+}
+
+.requestsMessage:empty {
+    display: none;
+}

--- a/Jellyfin.Plugin.Requests/Web/shell.js
+++ b/Jellyfin.Plugin.Requests/Web/shell.js
@@ -1,0 +1,143 @@
+/*
+ * What both plugin pages share: the strip of links between them, the stylesheet load, and the small
+ * amount of code that talks to this plugin's API.
+ *
+ * It is a global object rather than a module. A plugin page is injected into the dashboard's own
+ * document rather than loaded as a document of its own, so `import` has no base to resolve against
+ * and a module graph would be a second loader inside a page the dashboard already loaded. This is
+ * the shape the server's own configuration pages use.
+ *
+ * Nothing here is a framework and nothing is fetched from anywhere. The two things it uses,
+ * `ApiClient` and `Dashboard`, are the dashboard's own and are already on the page.
+ */
+
+var RequestsShell = {
+    /*
+     * Where this plugin's API lives. The version segment is part of the path on purpose, so a caller
+     * pinned to it keeps the shape it expects; the rule for changing it is docs/api.md. It is written
+     * once here because a page that spells its own base path is a page that keeps a stale one.
+     */
+    apiBase: "MediaRequests/v1",
+
+    /*
+     * The pages, in the order the strip shows them. The queue is first because it is the one an
+     * operator opens every day and the settings are the ones they open twice.
+     */
+    pages: [
+        { name: "RequestsQueue", label: "Queue" },
+        { name: "Requests", label: "Settings" },
+    ],
+
+    /*
+     * Puts the shell on a page and returns when it is there.
+     *
+     * `current` is the registered page name of the page calling this, which is what decides the link
+     * that is marked rather than the page working it out from the address: the dashboard's address is
+     * a hash route and reading it means parsing one, which is a second place the page names can drift
+     * apart.
+     */
+    attach: function (page, current) {
+        RequestsShell.loadStyle();
+
+        var host = page.querySelector(".requestsShell");
+
+        if (!host) {
+            return;
+        }
+
+        var nav = document.createElement("nav");
+        nav.className = "requestsShellNav";
+        nav.setAttribute("aria-label", "Requests");
+
+        RequestsShell.pages.forEach(function (entry) {
+            var link = document.createElement("a");
+
+            /*
+             * A hash route rather than a page address. The dashboard is one document and its router
+             * answers a hash change by swapping the content, so this moves between the two pages without
+             * the reload that would throw away whatever the operator had open.
+             */
+            link.href = "#/configurationpage?name=" + encodeURIComponent(entry.name);
+            link.textContent = entry.label;
+
+            if (entry.name === current) {
+                link.setAttribute("aria-current", "page");
+            }
+
+            nav.appendChild(link);
+        });
+
+        host.replaceChildren(nav);
+    },
+
+    /*
+     * The shared stylesheet, loaded once however many pages ask for it. Each plugin page is fetched
+     * on its own, so without the guard a move between the two adds a second copy of the same link
+     * element every time.
+     */
+    loadStyle: function () {
+        if (document.querySelector("link[data-requests-shell]")) {
+            return;
+        }
+
+        // Named `sheet` rather than `link`, because `link` is what the strip's anchors are called
+        // above and EveryLinkTheStripDrawsIsAHashRoute reads those assignments out of this file. Two
+        // different things under one name would make that check read a stylesheet address as a
+        // navigation target.
+        var sheet = document.createElement("link");
+        sheet.rel = "stylesheet";
+        sheet.type = "text/css";
+        sheet.dataset.requestsShell = "true";
+        sheet.href = ApiClient.getUrl("web/ConfigurationPage", { name: "Requests.css" });
+
+        document.head.appendChild(sheet);
+    },
+
+    /*
+     * A read from this plugin's API, with the session the dashboard is already signed in with.
+     *
+     * `ApiClient.ajax` rather than `fetch`, because the endpoints carry a policy and none of them is
+     * reachable without a session: the client is what holds the token and adds the header, and a bare
+     * fetch would be a second place that has to know how this server authenticates.
+     *
+     * No page calls this yet. Every endpoint answers 500 on a real server today, because the policy
+     * the controller names is not one the server registers; that is #51's and it is measured rather
+     * than supposed. This is here so the pages that read the queue are written against one helper
+     * rather than each growing its own.
+     */
+    get: function (path) {
+        return ApiClient.ajax({
+            type: "GET",
+            url: ApiClient.getUrl(RequestsShell.apiBase + "/" + path),
+            dataType: "json",
+        });
+    },
+
+    /*
+     * A write to this plugin's API, under the same session.
+     */
+    post: function (path, body) {
+        return ApiClient.ajax({
+            type: "POST",
+            url: ApiClient.getUrl(RequestsShell.apiBase + "/" + path),
+            data: JSON.stringify(body || {}),
+            contentType: "application/json",
+            dataType: "json",
+        });
+    },
+
+    /*
+     * Puts a sentence where the operator is looking.
+     *
+     * `textContent` rather than any of the ways of writing markup. What is shown here can carry a
+     * message the server built out of text a person typed, and rendering that as markup is a
+     * scripting hole in the dashboard of a server reachable by anybody who can file a request.
+     */
+    say: function (page, text) {
+        var target = page.querySelector(".requestsMessage");
+
+        if (target) {
+            target.textContent = text;
+        }
+    },
+};


### PR DESCRIPTION
Closes #58.

The plugin put one page in the dashboard, the settings form, reached by finding the plugin in a list
and pressing settings. The queue an operator works through every day had nowhere to be.

## The means

HTML, CSS and JavaScript embedded in the assembly, because that is the only shape the server serves a
plugin page in: the dashboard fetches an embedded resource under a name the plugin registers. No
framework and no package, which is this issue's third condition and is checked rather than asserted.

## The three conditions

**Both pages load in the dashboard on both claimed server lines.** Measured with the procedure from
#20, on a server of each line, with the plugin installed into it and the server restarted.

    == the server's own plugin list
    Requests is Active, id 0f9c9107b31b459e81fa6d35dac25e79

    == every page the plugin registers, as the dashboard fetches it
    GET /web/ConfigurationPage?name=Requests -> 200
    GET /web/ConfigurationPage?name=RequestsQueue -> 200
    GET /web/ConfigurationPage?name=Requests.js -> 200
    GET /web/ConfigurationPage?name=Requests.css -> 200

    == what the dashboard reads to build its menus
    Name=Requests  DisplayName=Requests  EnableInMainMenu=False  MenuIcon=None
    Name=RequestsQueue  DisplayName=Requests  EnableInMainMenu=True  MenuIcon=playlist_add_check
    Name=Requests.js  DisplayName=Requests  EnableInMainMenu=False  MenuIcon=None
    Name=Requests.css  DisplayName=Requests  EnableInMainMenu=False  MenuIcon=None

    == the shell markup each page carries
    --- Requests
    class="requestsShell"
    name: "Requests.js"
    --- RequestsQueue
    class="requestsShell"
    name: "Requests.js"

    == done on jellyfin/jellyfin:10.11.11 (net9.0)

The same output, line for line, on `jellyfin/jellyfin:12.0-rc4 (net10.0)`.

What that measures is the server serving each page at the address the dashboard fetches it from, and
listing it in what the dashboard reads to build its menus. It is the same reading of "loads in the
dashboard" that #20's recorded runs and #16's third condition were settled on. **No browser rendered
either page.** Driving one is what `docs/testing.md` refuses, so how they look is not measured here
and no claim is made about it.

**Navigation between them works without a full page reload.** The half of this the tree can check is
checked: `EveryLinkTheStripDrawsIsAHashRoute` reads the shared script and refuses a link that is not
a fragment. A document address is what makes the dashboard load itself again and lose what the
operator had open; a fragment is what its router answers by swapping the content. **That the router
then behaves that way is the dashboard's own behaviour and is not measured here**, for the same
reason as above.

**The pages use only what the server already provides.** `NothingThePagesLoadComesFromOutsideThisServer`
refuses any address in any page or shared file. The two globals the script uses, `ApiClient` and
`Dashboard`, are the dashboard's own and are already on the page. Nothing is added to the package:
the change is four embedded files and no reference, and `SiblingIndependenceTests` is untouched.

## A defect this turned up, and why the queue page draws nothing

Every endpoint this plugin serves answers 500 on a real server of both claimed lines. The controller
names `DefaultAuthorization` as its policy, and the server registers no policy under that name.

    == the queue endpoint the queue page reads, and the shape it answers in
    Error processing request.
    HTTP 500

    == what the server logged about that call
    [ERR] Jellyfin.Api.Middleware.ExceptionMiddleware: Error processing request. URL GET /MediaRequests/v1/Requests/Queue.
    System.InvalidOperationException: The AuthorizationPolicy named: 'DefaultAuthorization' was not found.
       at Microsoft.AspNetCore.Authorization.AuthorizationPolicy.CombineAsync(...)
       at Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext context)

Identical on `jellyfin/jellyfin:10.11.11` and on `jellyfin/jellyfin:12.0-rc4`. The server builds that
requirement into its unnamed default policy rather than registering a name for it, and the names it
does register are in an assembly this plugin already references:

    grep -n "const string" MediaBrowser.Common/Api/Policies.cs
    FirstTimeSetupOrElevated, RequiresElevation, LocalAccessOnly, IgnoreParentalControl, Download,
    FirstTimeSetupOrDefault, LocalAccessOrRequiresElevation, AnonymousLanAccessPolicy,
    FirstTimeSetupOrIgnoreParentalControl, SyncPlayHasAccess, SyncPlayCreateGroup, SyncPlayJoinGroup,
    SyncPlayIsInGroup, CollectionManagement, LiveTvAccess, LiveTvManagement, SubtitleManagement,
    LyricManagement

There is no `DefaultAuthorization` among them. Repairing it is #51's and it is not made here: it is a
change to the controller and to the invariant lint rule that refuses a bare `[Authorize]`, and both
are outside what this change may touch.

That is why the queue page draws no rows. They are #60's in any case, and a page shipped now with a
call in it would show an operator an error every time they opened it. The page says the view is not
built, and the shared script carries the helper #60 and #62 will read the queue through, with the
same measurement written beside it.

## Every guard was watched failing

Each break was made at the source, the suite run, and the change put back.

    // the queue page dropped from the build, so a registration names a resource nothing carries
    PagesAreServedFromResourcesTheAssemblyCarries [FAIL]
    EveryNameThePagesAskForIsARegisteredPage [FAIL]
    NothingThePagesLoadComesFromOutsideThisServer [FAIL]

    // the queue registered under the plugin's own name as well
    TheQueueAndTheSettingsAreSeparatePagesAndEveryNameIsRegisteredOnce [FAIL]
    OnlyTheQueueAsksForAPlaceInTheDashboardMenu [FAIL]
    PluginConstructionTests.GetPagesNamesTheEmbeddedConfigurationPage [FAIL]

    // the settings page put in the dashboard menu too
    OnlyTheQueueAsksForAPlaceInTheDashboardMenu [FAIL]

    // a page asking for the shared script under a name nothing registered
    EveryNameThePagesAskForIsARegisteredPage [FAIL]

    // the shared script naming a page that is not registered
    TheSharedScriptNamesThePagesThatAreRegistered [FAIL]

    // the strip linking to a document address instead of a fragment
    EveryLinkTheStripDrawsIsAHashRoute [FAIL]

    // a page loading a script from somewhere else
    NothingThePagesLoadComesFromOutsideThisServer [FAIL]

## Where it stands

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Der Buildvorgang wurde erfolgreich ausgefuehrt.
    0 Warnung(en)
    0 Fehler

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!: Fehler: 0, erfolgreich: 364, uebersprungen: 0, gesamt: 364 (net9.0)
    Bestanden!: Fehler: 0, erfolgreich: 364, uebersprungen: 0, gesamt: 364 (net10.0)

    npx prettier@3.6.2 --check "Jellyfin.Plugin.Requests/Web/*" "Jellyfin.Plugin.Requests/Configuration/configPage.html"
    All matched files use Prettier code style!

## What is not covered

No browser rendered either page, and none of the claims above is about how they look. That is the
headless rule rather than an omission, and it is what `EveryLinkTheStripDrawsIsAHashRoute` and the
served-page runs stand in place of.

`GetPagesNamesTheEmbeddedConfigurationPage` was narrowed rather than left alone. It asserted that
`GetPages` returns exactly one page, which was true of a plugin with one. It now asserts the same
thing about the settings page in particular, and the rule that every registration names a carried
resource is in the new file, over every page rather than over one.

The settings page is unchanged apart from the shell: this plugin still has no settings, which is
M12's, and the page says so.

There is no second reader on this board tonight. The evidence above stands in place of one.
