### PR TITLE
One table for what the external service's words mean here (#81)

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Bridge/BackendStateMappingTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Bridge/BackendStateMappingTests.cs
@@ -1,0 +1,280 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using Jellyfin.Plugin.Requests.Bridge;
+using Jellyfin.Plugin.Requests.Model;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Bridge;
+
+/// <summary>
+/// What the external service's words mean here, word by word, and the three things that make the
+/// mapping a table rather than an adapter's opinion: every word answers what this list says, a word
+/// nobody has seen is answered as unseen rather than guessed at, and the table printed in the
+/// documentation is the one the code reads.
+/// <para>
+/// The expected answers below are written out by hand rather than derived from
+/// <see cref="BackendStates.Table"/>. Derived ones would compare the table with itself and pass for
+/// whatever it happened to say, including the day somebody wires availability over there to
+/// fulfilment here.
+/// </para>
+/// </summary>
+public class BackendStateMappingTests
+{
+    /// <summary>
+    /// Every word the table holds, with what it does here, asserted against this list rather than
+    /// against the table. Six lines is the whole mapping, and a change to any of them is a change to
+    /// this list with a reason in the commit that made it.
+    /// </summary>
+    /// <param name="vocabulary">Which of the service's two lists the word was read from.</param>
+    /// <param name="word">The word the service reported.</param>
+    /// <param name="expected">The state this side moves the request into, or nothing.</param>
+    [Theory]
+
+    // The service's own approval step and its agreement with a decision already made here say
+    // nothing this side acts on. Only a fetch that will not arrive does.
+    [InlineData(BackendVocabulary.RequestStatus, "PENDING", null)]
+    [InlineData(BackendVocabulary.RequestStatus, "APPROVED", null)]
+    [InlineData(BackendVocabulary.RequestStatus, "DECLINED", RequestState.Failed)]
+    [InlineData(BackendVocabulary.RequestStatus, "FAILED", RequestState.Failed)]
+
+    // Finished there is not fulfilled here. Fulfilment is what this server's library says, and both
+    // of these are the words somebody in a hurry would wire straight to it.
+    [InlineData(BackendVocabulary.RequestStatus, "COMPLETED", null)]
+    [InlineData(BackendVocabulary.MediaStatus, "AVAILABLE", null)]
+    public void TheMappingSaysWhatThisListSays(BackendVocabulary vocabulary, string word, RequestState? expected)
+    {
+        var row = BackendStates.Lookup(vocabulary, new BackendReport { Reported = word });
+
+        Assert.NotNull(row);
+        Assert.Equal(expected, row.MoveTo);
+    }
+
+    /// <summary>
+    /// The table holds those six words and no others, and no word twice in one list. Without this a
+    /// row added later is invisible: the theory above still passes, because it only asks about the
+    /// words it names.
+    /// </summary>
+    [Fact]
+    public void TheTableHoldsEveryWordOnThatListAndNothingElse()
+    {
+        var expected = new[]
+        {
+            "RequestStatus PENDING",
+            "RequestStatus APPROVED",
+            "RequestStatus DECLINED",
+            "RequestStatus FAILED",
+            "RequestStatus COMPLETED",
+            "MediaStatus AVAILABLE"
+        };
+
+        var held = BackendStates.Table
+            .Select(row => string.Concat(row.Vocabulary.ToString(), " ", row.Reported))
+            .ToArray();
+
+        Assert.Equal(expected, held);
+        Assert.Equal(expected.Length, held.Distinct(StringComparer.Ordinal).Count());
+    }
+
+    /// <summary>
+    /// A word the table has never seen moves nothing, and it is answered as unseen rather than by
+    /// the nearest row that looks about right. This is the guard against a default case: a request
+    /// put into a state nobody chose reads exactly like one an operator moved, in the queue and in
+    /// the history, and the person it belongs to is told something untrue about their own request.
+    /// </summary>
+    /// <param name="word">A word from the service that this table does not hold.</param>
+    [Theory]
+    [InlineData("BLACKLISTED")]
+    [InlineData("DELETED")]
+    [InlineData("PROCESSING")]
+    public void AWordThisTableHasNeverSeenIsAnsweredAsUnseen(string word)
+    {
+        Assert.Null(BackendStates.Lookup(BackendVocabulary.RequestStatus, new BackendReport { Reported = word }));
+    }
+
+    /// <summary>
+    /// Seen and inert is not the same answer as never seen. Both leave the request where it is
+    /// today, so a caller that collapsed them would look correct until somebody wanted to report
+    /// which words a service is sending that this plugin does not understand.
+    /// </summary>
+    [Fact]
+    public void AWordThatMovesNothingIsADifferentAnswerFromAWordNobodyHasSeen()
+    {
+        var inert = BackendStates.Lookup(
+            BackendVocabulary.RequestStatus,
+            new BackendReport { Reported = "COMPLETED" });
+
+        var unseen = BackendStates.Lookup(
+            BackendVocabulary.RequestStatus,
+            new BackendReport { Reported = "PROCESSING" });
+
+        Assert.NotNull(inert);
+        Assert.Null(inert.MoveTo);
+        Assert.Null(unseen);
+    }
+
+    /// <summary>
+    /// The list a word was read from is part of the question. The two lists share a word, so a
+    /// lookup that ignored the list would answer "where the request stands" with the row for "what
+    /// the service holds", which is the mistake this whole enumeration exists against.
+    /// </summary>
+    [Fact]
+    public void TheSameWordInTheOtherListIsNotTheSameRow()
+    {
+        var report = new BackendReport { Reported = "PENDING" };
+
+        Assert.NotNull(BackendStates.Lookup(BackendVocabulary.RequestStatus, report));
+        Assert.Null(BackendStates.Lookup(BackendVocabulary.MediaStatus, report));
+    }
+
+    /// <summary>
+    /// Case is ignored, because two adapters written against one service will spell one word two
+    /// ways and both mean what the service meant.
+    /// </summary>
+    /// <param name="word">The word as some adapter spelled it.</param>
+    [Theory]
+    [InlineData("failed")]
+    [InlineData("Failed")]
+    [InlineData("FaIlEd")]
+    public void CaseIsIgnoredWhenAWordIsLookedUp(string word)
+    {
+        var row = BackendStates.Lookup(BackendVocabulary.RequestStatus, new BackendReport { Reported = word });
+
+        Assert.NotNull(row);
+        Assert.Equal(RequestState.Failed, row.MoveTo);
+    }
+
+    /// <summary>
+    /// Every row that moves something names a move the transition table allows and admits the plugin
+    /// as the caller for, out of the state a submitted request is in.
+    /// <para>
+    /// This is the row's own bound and it is checked rather than reviewed. A decline over there
+    /// looks like a decline here and mapping it that way would produce a move only an administrator
+    /// may make, so the reconciliation in #83 would throw on a state the service reports in the
+    /// ordinary course of its work. Approved is the state to check from because nothing is handed to
+    /// the service before an operator approves it.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void EveryRowThatMovesSomethingNamesAMoveThePluginMayMake()
+    {
+        var refused = BackendStates.Table
+            .Where(row => row.MoveTo is not null)
+            .Select(row => new { row.Reported, Cell = RequestLifecycle.Cell(RequestState.Approved, row.MoveTo!.Value) })
+            .Where(pair => !pair.Cell.IsLegal || (pair.Cell.Permitted & RequestActor.Plugin) == RequestActor.None)
+            .Select(pair => string.Concat(pair.Reported, " to ", pair.Cell.To.ToString()))
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal([], refused);
+    }
+
+    /// <summary>
+    /// Every row carries a reason, and the reason is a sentence rather than a restatement of the
+    /// row. A row whose reason is blank is the row a later reader cannot argue with.
+    /// </summary>
+    [Fact]
+    public void EveryRowSaysWhyItReadsTheWayItDoes()
+    {
+        Assert.DoesNotContain(BackendStates.Table, row => string.IsNullOrWhiteSpace(row.Why));
+    }
+
+    /// <summary>
+    /// The mapping printed in <c>docs/bridge.md</c> is the table in the code, row for row and in the
+    /// table's own order.
+    /// </summary>
+    [Fact]
+    public void TheDocumentedMappingIsTheTableInTheCode()
+    {
+        var rows = MarkedSection("mapping").Where(line => line.StartsWith('|')).ToArray();
+
+        // The row of dashes under the header is the table's own furniture, and the header says what
+        // the columns are rather than what the mapping is. Everything after them is a row, so a row
+        // deleted from the document fails the comparison at the end rather than being skipped here.
+        var documented = rows.Skip(2).Select(row => string.Join(' ', SplitRow(row))).ToArray();
+
+        var expected = BackendStates.Table
+            .Select(row => string.Concat(row.Vocabulary.ToString(), " ", row.Reported, " ", Move(row)))
+            .ToArray();
+
+        Assert.Equal(expected, documented);
+    }
+
+    /// <summary>
+    /// The reasons printed in <c>docs/bridge.md</c> are the reasons in the code, one bullet per row,
+    /// in the table's own order. The rows above say what happens and this says why, and the why is
+    /// the half a reader arrives for when the two systems disagree.
+    /// </summary>
+    [Fact]
+    public void TheDocumentedReasonsAreTheReasonsInTheCode()
+    {
+        var expected = BackendStates.Table
+            .Select(row => string.Format(
+                CultureInfo.InvariantCulture,
+                "- **{0} {1}**: {2}. {3}",
+                row.Vocabulary,
+                row.Reported,
+                Move(row),
+                row.Why))
+            .ToArray();
+
+        var documented = MarkedSection("reasons")
+            .Where(line => line.StartsWith("- **", StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.Equal(expected, documented);
+    }
+
+    /// <summary>
+    /// How a row's destination is written for a reader: the state's own name, or the word for a row
+    /// that moves nothing.
+    /// </summary>
+    /// <param name="row">The row.</param>
+    /// <returns>What the document prints in that column.</returns>
+    private static string Move(BackendStateMapping row) => row.MoveTo?.ToString() ?? "none";
+
+    private static string[] SplitRow(string row)
+        => [.. row.Trim('|').Split('|').Select(cell => cell.Trim())];
+
+    /// <summary>
+    /// Reads the lines the document marks off for one section.
+    /// </summary>
+    /// <param name="name">The name in the marker comments.</param>
+    /// <returns>The trimmed lines between the markers.</returns>
+    private static string[] MarkedSection(string name)
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "docs", "bridge.md");
+        Assert.True(File.Exists(path), FormattableString.Invariant($"{path} was not copied next to the suite."));
+
+        var opening = FormattableString.Invariant($"<!-- {name} begins -->");
+        var closing = FormattableString.Invariant($"<!-- {name} ends -->");
+        var inside = false;
+        var lines = new List<string>();
+
+        foreach (var line in File.ReadLines(path))
+        {
+            if (line.Trim().Equals(opening, StringComparison.Ordinal))
+            {
+                inside = true;
+                continue;
+            }
+
+            if (line.Trim().Equals(closing, StringComparison.Ordinal))
+            {
+                inside = false;
+                continue;
+            }
+
+            if (inside && line.Trim().Length > 0)
+            {
+                lines.Add(line.Trim());
+            }
+        }
+
+        Assert.True(lines.Count > 0, FormattableString.Invariant($"docs/bridge.md has no {name} section."));
+
+        return [.. lines];
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj
+++ b/Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj
@@ -50,6 +50,10 @@
     <!-- The lifecycle document, next to the suite, so the transition table printed for a reader is
          compared against the table the code reads rather than against a copy of it in a test. -->
     <None Include="../docs/lifecycle.md" Link="docs/lifecycle.md" CopyToOutputDirectory="PreserveNewest" />
+    <!-- The bridge document, for the same reason: the mapping between the external service's words
+         and this plugin's states is printed for a reader out of the table the code reads, and the
+         two are compared rather than kept in step by hand. -->
+    <None Include="../docs/bridge.md" Link="docs/bridge.md" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.Requests/Bridge/BackendStateMapping.cs
+++ b/Jellyfin.Plugin.Requests/Bridge/BackendStateMapping.cs
@@ -1,0 +1,45 @@
+using Jellyfin.Plugin.Requests.Model;
+
+namespace Jellyfin.Plugin.Requests.Bridge;
+
+/// <summary>
+/// One row of <see cref="BackendStates.Table"/>: a word the external service uses, which of its two
+/// lists that word came from, what this side does about it, and why.
+/// <para>
+/// A row that changes nothing here is a row rather than an absence, for the same reason a refused
+/// cell of the transition table is one. The question a reader arrives with is "the service says
+/// COMPLETED, why is my request not fulfilled", and a table holding only the words that move
+/// something answers a question nobody asked and leaves that one to whoever remembers the argument.
+/// </para>
+/// </summary>
+public sealed record BackendStateMapping
+{
+    /// <summary>
+    /// Gets which of the service's two lists this word belongs to.
+    /// </summary>
+    public required BackendVocabulary Vocabulary { get; init; }
+
+    /// <summary>
+    /// Gets the word the service uses, as the service spells it.
+    /// </summary>
+    public required string Reported { get; init; }
+
+    /// <summary>
+    /// Gets the state this plugin moves the request into on hearing that word, or
+    /// <see langword="null"/> where it moves nothing.
+    /// <para>
+    /// Nothing to move is the ordinary answer and not a gap. The service is downstream of a decision
+    /// an operator already made here and upstream of a library check that runs here, so most of what
+    /// it can say is either something this side already knows or something only this server's own
+    /// library may say.
+    /// </para>
+    /// </summary>
+    public required RequestState? MoveTo { get; init; }
+
+    /// <summary>
+    /// Gets the reason this row reads the way it does, in one sentence. This is printed in
+    /// <c>docs/bridge.md</c> and is what a person reads when the two systems disagree, so it says
+    /// why rather than restating the row.
+    /// </summary>
+    public required string Why { get; init; }
+}

--- a/Jellyfin.Plugin.Requests/Bridge/BackendStates.cs
+++ b/Jellyfin.Plugin.Requests/Bridge/BackendStates.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Jellyfin.Plugin.Requests.Model;
+
+namespace Jellyfin.Plugin.Requests.Bridge;
+
+/// <summary>
+/// What the external service's words mean on this side, as a table.
+/// <para>
+/// It is a table rather than a switch inside an adapter because the mapping is where a bridge
+/// quietly goes wrong: the two models do not line up, the mismatch looks like a detail, and a
+/// request sits in the wrong state for a week before anybody notices. A table can be read by a
+/// person, printed into <c>docs/bridge.md</c> and tested row by row, including the rows that move
+/// nothing. A second adapter gets rows here rather than a mapping of its own, so two adapters
+/// cannot disagree about what a word means with nothing saying which is right.
+/// </para>
+/// <para>
+/// <b>Most rows move nothing, and that is the finding rather than an omission.</b> The service sits
+/// downstream of a decision an operator already made here and upstream of a library check that runs
+/// here. So it can tell this side that its own approval step has run, which this side does not act
+/// on; that it has finished, which is not the same fact as this server holding the media; or that
+/// it has given up, which is the one thing this side could not otherwise know. Only the last of
+/// those moves a request.
+/// </para>
+/// <para>
+/// <b>A word this table does not hold moves nothing and says so.</b> <see cref="Lookup"/> answers
+/// <see langword="null"/> for it, which is a different answer from a row that moves nothing: the
+/// first is "never seen", the second is "seen and deliberately inert". There is no default case
+/// that guesses, because a guess here is a request put into a state nobody chose, and the whole
+/// cost of being wrong lands on somebody who cannot see why. What a caller does with an unseen word
+/// is #83's, and refusing to invent one is this table's.
+/// </para>
+/// <para>
+/// <b>Which words the service uses is fixed by this board and was not read off a running service.</b>
+/// The list is the one #81 names for the Overseerr form, which #113 chose as the form the first
+/// adapter is written against. Nothing here reached a service to confirm it, and nothing in this
+/// tree could. That is what the unseen rule is for, and <c>docs/bridge.md</c> says the same in the
+/// place a reader would otherwise assume the list was measured.
+/// </para>
+/// </summary>
+public static class BackendStates
+{
+    /// <summary>
+    /// Gets every word the external service uses, what this side does about it, and why. This is the
+    /// source the table and the reasons in <c>docs/bridge.md</c> are printed from, and
+    /// <c>TheDocumentedMappingIsTheTableInTheCode</c> and
+    /// <c>TheDocumentedReasonsAreTheReasonsInTheCode</c> refuse the two disagreeing.
+    /// </summary>
+    public static IReadOnlyList<BackendStateMapping> Table { get; } = BuildTable();
+
+    /// <summary>
+    /// Looks up what one report means here.
+    /// </summary>
+    /// <param name="vocabulary">Which of the service's two lists the adapter read the word from.</param>
+    /// <param name="report">What the service said, in its own words.</param>
+    /// <returns>
+    /// The row for that word, or <see langword="null"/> where this table has never seen it. A row
+    /// whose <see cref="BackendStateMapping.MoveTo"/> is <see langword="null"/> is not the same
+    /// answer: that word is known and moves nothing on purpose.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Where no report was given.</exception>
+    public static BackendStateMapping? Lookup(BackendVocabulary vocabulary, BackendReport report)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+
+        // Case is ignored and nothing else is. Two adapters against one service will spell the same
+        // word two ways, and both spellings mean what the service meant; anything further, such as
+        // trimming or folding separators, would be this table deciding that a word it does not hold
+        // is really one it does, which is the guess the whole class refuses.
+        return Table.FirstOrDefault(row =>
+            row.Vocabulary == vocabulary
+            && string.Equals(row.Reported, report.Reported, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static ReadOnlyCollection<BackendStateMapping> BuildTable()
+    {
+        const string TheLibrarySaysFulfilled =
+            "The service having finished is not this server holding the media. Fulfilled is the library's word here, observed by the sweep when the person who asked can actually watch it, and taking the service's word for it would fulfil requests on a server whose library never received anything.";
+
+        var table = new List<BackendStateMapping>
+        {
+            Inert(
+                BackendVocabulary.RequestStatus,
+                "PENDING",
+                "The service is waiting for its own approval step. Nothing is handed to it until an operator here has already approved the request, so this word says where the service stands and nothing about where the request stands."),
+            Inert(
+                BackendVocabulary.RequestStatus,
+                "APPROVED",
+                "The service agrees with the decision this side already made, and a request cannot be approved twice. The row exists so that agreement is an answer rather than a word nothing recognises."),
+            Moves(
+                BackendVocabulary.RequestStatus,
+                "DECLINED",
+                RequestState.Failed,
+                "The service will not fetch it, so it was sent onward and will not arrive by that route. It is not a decline here: a decline is an operator's answer and carries a reason, and from failed an operator can still decline it or send it onward again."),
+            Moves(
+                BackendVocabulary.RequestStatus,
+                "FAILED",
+                RequestState.Failed,
+                "The thing doing the fetching gave up, which is what this state names and the reason it exists."),
+            Inert(BackendVocabulary.RequestStatus, "COMPLETED", TheLibrarySaysFulfilled),
+            Inert(
+                BackendVocabulary.MediaStatus,
+                "AVAILABLE",
+                "Available there is available on whatever that service can see, which is neither this server's library nor this user's access to it. It has a row of its own because it is the word most likely to be wired straight to fulfilled by somebody in a hurry.")
+        };
+
+        return new ReadOnlyCollection<BackendStateMapping>(table);
+    }
+
+    private static BackendStateMapping Moves(
+        BackendVocabulary vocabulary,
+        string reported,
+        RequestState moveTo,
+        string why)
+        => new() { Vocabulary = vocabulary, Reported = reported, MoveTo = moveTo, Why = why };
+
+    /// <summary>
+    /// A word that changes nothing here. It is a helper of its own rather than
+    /// <see cref="Moves"/> with a null destination, so that a row moving nothing reads as a decision
+    /// somebody took and cannot be produced by leaving an argument out.
+    /// </summary>
+    /// <param name="vocabulary">Which of the service's two lists the word belongs to.</param>
+    /// <param name="reported">The word, as the service spells it.</param>
+    /// <param name="why">Why hearing it moves nothing.</param>
+    /// <returns>The row.</returns>
+    private static BackendStateMapping Inert(BackendVocabulary vocabulary, string reported, string why)
+        => new() { Vocabulary = vocabulary, Reported = reported, MoveTo = null, Why = why };
+}

--- a/Jellyfin.Plugin.Requests/Bridge/BackendVocabulary.cs
+++ b/Jellyfin.Plugin.Requests/Bridge/BackendVocabulary.cs
@@ -1,0 +1,30 @@
+namespace Jellyfin.Plugin.Requests.Bridge;
+
+/// <summary>
+/// Which of the external service's two lists of words a report was read out of.
+/// <para>
+/// The service keeps a request status and a media status, and they are independent: a request it
+/// has finished with and media it holds are different facts about different things. Both are lists
+/// of words, and the two lists share a word, so a report carrying only the word is ambiguous and a
+/// table keyed only on the word would answer one question with the other one's row.
+/// </para>
+/// <para>
+/// This is what an adapter says instead of guessing. It knows which field it read, because it read
+/// it, and carrying that one value forward is cheaper than every later reader inferring it.
+/// </para>
+/// </summary>
+public enum BackendVocabulary
+{
+    /// <summary>
+    /// The service's word for where the request itself stands: whether its own approval step has
+    /// run, and whether the fetch it started is still going.
+    /// </summary>
+    RequestStatus = 0,
+
+    /// <summary>
+    /// The service's word for what it holds of the media. Availability there is not availability
+    /// here, which is the mistake <see cref="BackendStates"/> exists to make hard: this server's
+    /// library is what says a request is fulfilled.
+    /// </summary>
+    MediaStatus = 1
+}

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -1,0 +1,89 @@
+# The bridge to an external request service
+
+Most servers run nothing of the sort, and on those this plugin is the whole system. Where an
+operator does run one, an approved request can be handed to it and the two systems then hold an
+opinion each about the same thing. This page is about the one place those opinions have to be
+reconciled: what the service's words mean here.
+
+It is not the whole of the bridge. The interface is
+[`IRequestBackend`](../Jellyfin.Plugin.Requests/Bridge/IRequestBackend.cs), the implementation every
+server without a service runs is
+[`NoRequestBackend`](../Jellyfin.Plugin.Requests/Bridge/NoRequestBackend.cs), and how a submission is
+made, what happens when the service misbehaves and where a credential lives are separate questions
+this page does not answer.
+
+## The mapping
+
+The table is data, in
+[`BackendStates.Table`](../Jellyfin.Plugin.Requests/Bridge/BackendStates.cs), and everything below is
+printed from it: `BackendStateMappingTests` compares the rows and the reasons on this page against
+that table and fails if either side changes without the other.
+
+The service keeps two lists of words. `RequestStatus` is where the request stands with it, and
+`MediaStatus` is what it holds of the media. They are independent, and they share a word, so a report
+carries which list it was read from as well as the word itself.
+
+<!-- mapping begins -->
+
+| Vocabulary    | Word      | This side |
+| ------------- | --------- | --------- |
+| RequestStatus | PENDING   | none      |
+| RequestStatus | APPROVED  | none      |
+| RequestStatus | DECLINED  | Failed    |
+| RequestStatus | FAILED    | Failed    |
+| RequestStatus | COMPLETED | none      |
+| MediaStatus   | AVAILABLE | none      |
+
+<!-- mapping ends -->
+
+Four of the six move nothing. That is the finding rather than a set of gaps, and it follows from
+where the service sits: downstream of a decision an operator already made here, and upstream of a
+library check that runs here. The one thing it can say that this side could not otherwise know is
+that the fetch will not arrive.
+
+`none` is not "unsupported". It is a word this table holds, and holding it is what keeps it from
+falling to the rule below.
+
+## Why each row reads the way it does
+
+<!-- reasons begins -->
+
+- **RequestStatus PENDING**: none. The service is waiting for its own approval step. Nothing is handed to it until an operator here has already approved the request, so this word says where the service stands and nothing about where the request stands.
+- **RequestStatus APPROVED**: none. The service agrees with the decision this side already made, and a request cannot be approved twice. The row exists so that agreement is an answer rather than a word nothing recognises.
+- **RequestStatus DECLINED**: Failed. The service will not fetch it, so it was sent onward and will not arrive by that route. It is not a decline here: a decline is an operator's answer and carries a reason, and from failed an operator can still decline it or send it onward again.
+- **RequestStatus FAILED**: Failed. The thing doing the fetching gave up, which is what this state names and the reason it exists.
+- **RequestStatus COMPLETED**: none. The service having finished is not this server holding the media. Fulfilled is the library's word here, observed by the sweep when the person who asked can actually watch it, and taking the service's word for it would fulfil requests on a server whose library never received anything.
+- **MediaStatus AVAILABLE**: none. Available there is available on whatever that service can see, which is neither this server's library nor this user's access to it. It has a row of its own because it is the word most likely to be wired straight to fulfilled by somebody in a hurry.
+
+<!-- reasons ends -->
+
+Every row that moves something names a move the transition table allows and admits the plugin as the
+caller for. That is checked rather than reviewed, so a row added later cannot ask for a move only an
+operator may make. It is why a decline over there is `Failed` here and not `Declined`: declining is a
+decision, decisions belong to a person, and the plugin is not one. `docs/lifecycle.md` is where that
+split is argued.
+
+## A word this table has not seen
+
+Nothing moves, and the word is reported as unseen rather than turned into the nearest state that
+looks about right. `BackendStates.Lookup` answers with no row at all for it, which is a different
+answer from a row that moves nothing, and there is no default case anywhere behind it.
+
+The reason to be strict here is that the cost of a guess lands somewhere nobody can see it. A request
+put into a state nobody chose reads exactly like a request an operator moved, in the queue and in the
+history, and the person it belongs to is told something untrue about their own request.
+
+Case is ignored when a word is looked up, because two adapters written against one service will spell
+one word two ways and both mean what the service meant. Nothing else is normalised.
+
+## Where the list of words came from
+
+The words above are the ones issue #81 names for the Overseerr form, which is the form the first
+adapter is written against, decided on #113. **They were not read off a running service, and nothing
+in this tree can read one.** No fixture here was captured from a service, no schema was fetched, and
+the suite makes no outbound call.
+
+So the list is this board's own statement of the vocabulary rather than a measurement of it, and the
+rule for an unseen word is what stands between that and a wrong answer. Whoever writes the adapter in
+#82 is the first person in a position to compare the two, and a word that arrives from a real service
+and is not here is a row this table is missing rather than a fault in the service.


### PR DESCRIPTION
Closes #81.

A bridge goes wrong at the mapping. The two models do not line up, the mismatch looks like a detail, and a request sits in the wrong state for a week before anybody notices. This lands the mapping as data, in `BackendStates.Table`, with a row per word the service uses including the words that move nothing, and prints it into `docs/bridge.md` out of that same table.

## What the table says

Four of the six rows move nothing. That follows from where the service sits rather than being a set of gaps: downstream of a decision an operator already made here, and upstream of a library check that runs here. The one thing it can say that this side could not otherwise know is that the fetch will not arrive.

A decline over there maps to `Failed` and not to `Declined`. Declining is a decision, decisions belong to a person, and the plugin is not one. `EveryRowThatMovesSomethingNamesAMoveThePluginMayMake` refuses any row naming a move `RequestLifecycle.Table` does not admit `RequestActor.Plugin` for out of `Approved`, so the reconciliation in #83 cannot be handed a mapping that throws on a word the service sends in the ordinary course of its work.

`COMPLETED` and `AVAILABLE` move nothing, because fulfilment is this server's library's word (#42) and not the service's.

## The word nobody has seen

`BackendStates.Lookup` answers with no row at all, which is a different answer from a row that moves nothing. There is no default case behind it. A request put into a state nobody chose reads exactly like one an operator moved, in the queue and in the history, and the person it belongs to is then told something untrue about their own request.

## Evidence

Both frameworks, at the head of this branch:

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler:     0, erfolgreich:   383, uebersprungen:     0, gesamt:   383 (net9.0)
    Bestanden!   : Fehler:     0, erfolgreich:   383, uebersprungen:     0, gesamt:   383 (net10.0)

    npx --yes prettier@3.6.2 --check "docs/bridge.md"
    All matched files use Prettier code style!

The guards were watched failing, each for the mistake it is written against.

The near-miss for the mapping is one word: `DECLINED` mapped to `RequestState.Declined` instead of `RequestState.Failed`, which is the reading somebody arrives with. Four tests red, the other fifteen unmoved:

    EveryRowThatMovesSomethingNamesAMoveThePluginMayMake [FAIL]
    TheDocumentedMappingIsTheTableInTheCode [FAIL]
    TheDocumentedReasonsAreTheReasonsInTheCode [FAIL]
    TheMappingSaysWhatThisListSays(vocabulary: RequestStatus, word: "DECLINED", expected: Failed) [FAIL]

The near-miss for the unseen rule is the default case the issue forbids: falling back to the first row of the vocabulary when nothing matched. Five red:

    AWordThatMovesNothingIsADifferentAnswerFromAWordNobodyHasSeen [FAIL]
    AWordThisTableHasNeverSeenIsAnsweredAsUnseen(word: "BLACKLISTED") [FAIL]
    AWordThisTableHasNeverSeenIsAnsweredAsUnseen(word: "DELETED") [FAIL]
    AWordThisTableHasNeverSeenIsAnsweredAsUnseen(word: "PROCESSING") [FAIL]
    TheSameWordInTheOtherListIsNotTheSameRow [FAIL]

Both edits were reverted and the suite is green above at the committed tree.

## What is not claimed

**The list of words was not read off a running service.** It is the one #81 names for the Overseerr form, which #113 chose as the form the first adapter is written against. No fixture here was captured from a service, no schema was fetched, and nothing in this tree can reach one. `docs/bridge.md` says that in the place a reader would otherwise assume the list had been measured, and the rule for an unseen word is what stands between that bound and a wrong answer. Whoever writes the adapter in #82 is the first person able to compare the two.

Nothing here submits anything, reconciles anything or opens a socket. #82, #83 and #86 are where those live.

## The means

C# in the plugin project, beside the interface it belongs to. The mapping has to be readable by the same suite that reads the transition table, because the check that gives it its teeth compares one against the other; a table in YAML or in a document would need a parallel apparatus to do that, and the reason it can be proven at all is that both are ordinary types in one assembly.

## Reader

This had no second reader. The evidence above is in its place: the commands are here with their output, and each guard is quoted with the change that turned it red.