### PR TITLE
The settings, with the conservative answer as every default (#95)

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Configuration/PluginConfigurationTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Configuration/PluginConfigurationTests.cs
@@ -1,0 +1,249 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Jellyfin.Plugin.Requests.Configuration;
+using Xunit;
+
+using PluginUnderTest = global::Jellyfin.Plugin.Requests.Plugin;
+
+namespace Jellyfin.Plugin.Requests.Tests.Configuration;
+
+/// <summary>
+/// The settings an operator can change, what they are when nobody changes them, and the two ways a
+/// setting stops being usable: the page cannot reach it, or the document says something else about
+/// it.
+/// <para>
+/// The expected list below is written out by hand rather than read from the class. A list derived
+/// from the class would agree with whatever the class happened to say, including on the day a
+/// setting is added with a default nobody argued for, which is the failure this whole page is
+/// against: almost every install runs the defaults.
+/// </para>
+/// </summary>
+public class PluginConfigurationTests
+{
+    /// <summary>
+    /// Every setting this plugin has, with the value a fresh install runs. Four lines is the whole
+    /// configuration surface, and a change to any of them is a change to this list with a reason in
+    /// the commit that made it.
+    /// </summary>
+    /// <returns>Each setting and its default, as a reader of the document would write it.</returns>
+    public static TheoryData<string, string> TheSettingsAndTheirDefaults()
+        => new TheoryData<string, string>
+        {
+            { "AcceptsMovies", "true" },
+            { "AcceptsSeries", "true" },
+            { "FinishedRequestRetentionDays", "365" },
+            { "OpenRequestsPerUser", "10" }
+        };
+
+    /// <summary>
+    /// The class carries those settings and no others. Without the second half a setting added
+    /// later is invisible here: the theory below would still pass, because it only asks about the
+    /// settings it names.
+    /// </summary>
+    [Fact]
+    public void TheConfigurationIsExactlyTheSettingsOnThatList()
+    {
+        var expected = TheSettingsAndTheirDefaults()
+            .Select(row => (string)row[0])
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(expected, Names());
+    }
+
+    /// <summary>
+    /// A fresh install runs the value written on that list. This is the half that catches a default
+    /// changed while the setting stays, which no reader of a diff notices and every install feels.
+    /// </summary>
+    /// <param name="setting">The setting.</param>
+    /// <param name="expected">What it is when nobody has changed anything.</param>
+    [Theory]
+    [MemberData(nameof(TheSettingsAndTheirDefaults))]
+    public void AFreshInstallRunsTheValueOnThatList(string setting, string expected)
+    {
+        Assert.Equal(expected, Printed(Setting(setting).GetValue(new PluginConfiguration())));
+    }
+
+    /// <summary>
+    /// A fresh install is usable: somebody can ask for something, and one person cannot fill the
+    /// disk while doing it. Written as the properties rather than as the numbers, so it still says
+    /// something the day the numbers move.
+    /// </summary>
+    [Fact]
+    public void AFreshInstallAcceptsSomethingAndBoundsWhatOnePersonCanOpen()
+    {
+        var fresh = new PluginConfiguration();
+
+        Assert.True(fresh.AcceptsMovies || fresh.AcceptsSeries);
+        Assert.True(fresh.OpenRequestsPerUser > 0);
+        Assert.True(fresh.FinishedRequestRetentionDays >= PluginConfiguration.MinimumRetentionDays);
+    }
+
+    /// <summary>
+    /// Every setting is a number or a switch, so nothing here can hold an address or a credential.
+    /// <para>
+    /// This is the guard on the sentence that a fresh install sends nothing outward, and it is
+    /// written over the shape rather than over the names because a name check passes for whatever
+    /// somebody called the field. The first outbound thing to arrive will want somewhere to type an
+    /// address, and where a credential lives and what may honestly be claimed about it is #85's
+    /// decision rather than a field added while doing something else.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void NoSettingCanHoldAnAddressOrACredential()
+    {
+        var carrying = Settings()
+            .Where(setting => setting.PropertyType != typeof(int) && setting.PropertyType != typeof(bool))
+            .Select(setting => string.Concat(setting.Name, " is ", setting.PropertyType.Name))
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal([], carrying);
+    }
+
+    /// <summary>
+    /// Every setting is on the settings page, under a field named after it.
+    /// <para>
+    /// This is the condition that keeps a setting from existing where nobody can change it. A
+    /// setting an operator cannot reach is worse than one that does not exist: the document promises
+    /// it, and the only way to set it is to write the plugin's configuration file by hand on the
+    /// server.
+    /// </para>
+    /// </summary>
+    /// <param name="setting">The setting.</param>
+    /// <param name="expected">What it is on a fresh install, which this leg does not read.</param>
+    [Theory]
+    [MemberData(nameof(TheSettingsAndTheirDefaults))]
+    public void EverySettingIsReachableFromTheSettingsPage(string setting, string expected)
+    {
+        Assert.NotEmpty(expected);
+
+        var page = SettingsPage();
+
+        Assert.Contains(string.Concat("id=\"Requests", setting, "\""), page, StringComparison.Ordinal);
+        Assert.Contains(string.Concat(setting, ": \"#Requests", setting, "\""), page, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The settings printed in <c>docs/configuration.md</c> are the settings in the class, with the
+    /// defaults the class runs.
+    /// </summary>
+    [Fact]
+    public void TheDocumentedSettingsAreTheSettingsInTheCode()
+    {
+        var rows = MarkedSection("settings").Where(line => line.StartsWith('|')).ToArray();
+
+        // The header names the columns and the dashes under it are the table's own furniture.
+        // Everything after them is a setting, so one deleted from the document fails the comparison
+        // at the end rather than being skipped here.
+        var documented = rows.Skip(2).Select(row => string.Join(' ', SplitRow(row))).ToArray();
+
+        var fresh = new PluginConfiguration();
+        var expected = Settings()
+            .OrderBy(setting => setting.Name, StringComparer.Ordinal)
+            .Select(setting => string.Concat(setting.Name, " ", Printed(setting.GetValue(fresh))))
+            .ToArray();
+
+        Assert.Equal(expected, documented);
+    }
+
+    /// <summary>
+    /// The settings this class declares, in name order. The base class the server supplies is not
+    /// part of this plugin's surface and is left out of every leg above.
+    /// </summary>
+    /// <returns>One entry per setting.</returns>
+    private static PropertyInfo[] Settings()
+        => [.. typeof(PluginConfiguration)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .OrderBy(setting => setting.Name, StringComparer.Ordinal)];
+
+    private static string[] Names() => [.. Settings().Select(setting => setting.Name)];
+
+    private static PropertyInfo Setting(string name)
+        => Settings().Single(setting => string.Equals(setting.Name, name, StringComparison.Ordinal));
+
+    /// <summary>
+    /// One value as the document writes it. A switch is written the way the page and the stored
+    /// configuration write it rather than the way this language prints it, because the document is
+    /// read by somebody looking at one of those two.
+    /// </summary>
+    /// <param name="value">The value a fresh install carries.</param>
+    /// <returns>What the document holds for it.</returns>
+    private static string Printed(object? value)
+        => value switch
+        {
+            bool switched => switched ? "true" : "false",
+            null => throw new InvalidOperationException("A setting with no value has no default to document."),
+            _ => Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty
+        };
+
+    /// <summary>
+    /// The settings page as the assembly carries it, rather than as the file sits in the tree. A
+    /// page that is not embedded is a page the dashboard cannot serve, whatever the tree holds.
+    /// </summary>
+    /// <returns>The page.</returns>
+    private static string SettingsPage()
+    {
+        using var host = new Doubles.PluginHost();
+
+        var resource = host.Plugin
+            .GetPages()
+            .Single(page => string.Equals(page.Name, host.Plugin.Name, StringComparison.Ordinal))
+            .EmbeddedResourcePath;
+
+        using var stream = typeof(PluginUnderTest).Assembly.GetManifestResourceStream(resource)
+            ?? throw new InvalidOperationException($"The assembly carries no resource named {resource}.");
+
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+
+        return reader.ReadToEnd();
+    }
+
+    private static string[] SplitRow(string row)
+        => [.. row.Trim('|').Split('|').Select(cell => cell.Trim())];
+
+    /// <summary>
+    /// Reads the lines the document marks off for one section.
+    /// </summary>
+    /// <param name="name">The name in the marker comments.</param>
+    /// <returns>The trimmed lines between the markers.</returns>
+    private static string[] MarkedSection(string name)
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "docs", "configuration.md");
+        Assert.True(File.Exists(path), FormattableString.Invariant($"{path} was not copied next to the suite."));
+
+        var opening = FormattableString.Invariant($"<!-- {name} begins -->");
+        var closing = FormattableString.Invariant($"<!-- {name} ends -->");
+        var inside = false;
+        var lines = new List<string>();
+
+        foreach (var line in File.ReadLines(path))
+        {
+            if (line.Trim().Equals(opening, StringComparison.Ordinal))
+            {
+                inside = true;
+                continue;
+            }
+
+            if (line.Trim().Equals(closing, StringComparison.Ordinal))
+            {
+                inside = false;
+                continue;
+            }
+
+            if (inside && line.Trim().Length > 0)
+            {
+                lines.Add(line.Trim());
+            }
+        }
+
+        Assert.True(lines.Count > 0, FormattableString.Invariant($"docs/configuration.md has no {name} section."));
+
+        return [.. lines];
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj
+++ b/Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj
@@ -54,6 +54,9 @@
          and this plugin's states is printed for a reader out of the table the code reads, and the
          two are compared rather than kept in step by hand. -->
     <None Include="../docs/bridge.md" Link="docs/bridge.md" CopyToOutputDirectory="PreserveNewest" />
+    <!-- The configuration document, for the same reason again: the settings and the value a fresh
+         install runs for each are printed for an operator out of the class the plugin reads. -->
+    <None Include="../docs/configuration.md" Link="docs/configuration.md" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs
@@ -3,11 +3,98 @@ using MediaBrowser.Model.Plugins;
 namespace Jellyfin.Plugin.Requests.Configuration;
 
 /// <summary>
-/// Plugin configuration. The sample settings this project started with were deleted rather than
-/// renamed, so this class carries no settings of its own yet: the configuration surface is designed
-/// in M12, and a setting kept here to keep the page populated would have handed that design a shape
-/// it never chose.
+/// What an operator can change about this install, and what it does when they change nothing.
+/// <para>
+/// <b>Almost every install runs the defaults, so the defaults are the product.</b> Each one below is
+/// the conservative answer: a bounded number of open requests rather than none, the two media kinds
+/// this version knows how to recognise in a library, and a retention period that keeps a year of
+/// history rather than everything forever. <c>docs/configuration.md</c> carries the same list with
+/// the reason each default is the safe one, and a test compares the two.
+/// </para>
+/// <para>
+/// <b>What is deliberately not here is as much of the design as what is.</b> A setting nobody can
+/// act on yet is a shape handed to whoever implements the thing behind it, and this class started
+/// empty precisely so that would not happen twice.
+/// </para>
+/// <para>
+/// There is no automatic-approval setting. Approval is required, decided on #113, and automatic
+/// approval arrives there as a per-user setting rather than a switch for the whole server, so a
+/// boolean added now would be the wrong shape rather than an early version of the right one.
+/// </para>
+/// <para>
+/// There are no notification switches. Every path they would switch is unbuilt, a fresh install
+/// sends nothing outward because there is nothing that could, and #79 is where the switches land
+/// beside the paths they turn off.
+/// </para>
+/// <para>
+/// There is no bridge address and no credential. The only implementation of the bridge in this tree
+/// is the one for a server that has none, so a field for an address would be a place to type
+/// something nothing reads. #82 brings the adapter and #85 decides where a credential is kept and
+/// what may be claimed about it.
+/// </para>
 /// </summary>
 public class PluginConfiguration : BasePluginConfiguration
 {
+    /// <summary>
+    /// The shortest retention period an operator may set, in days.
+    /// <para>
+    /// It is a constant here rather than a number written into the sweep and again into the
+    /// validation, because two copies of a floor are two answers the day one is changed. Nothing in
+    /// this class refuses a value below it: a configuration class is data the dashboard writes, and
+    /// refusing what cannot work is #96.
+    /// </para>
+    /// <para>
+    /// The floor exists so that retention cannot be set to nothing. Zero would delete the history
+    /// silently and leave a queue that answers "was this asked for before" with no, which is the
+    /// one question a year of history is kept for.
+    /// </para>
+    /// </summary>
+    public const int MinimumRetentionDays = 30;
+
+    /// <summary>
+    /// Gets or sets how many requests one person may have open at once.
+    /// <para>
+    /// Bounded rather than unlimited, because the quota is the only thing standing between one user
+    /// and the whole disk, and a limit introduced later has to be enforced against habits people
+    /// already have. Ten is a number somebody has to be trying to reach, and an operator who wants
+    /// more moves one field.
+    /// </para>
+    /// <para>
+    /// It counts open requests and not requests ever made, so a person whose asks are answered can
+    /// keep asking. Where this is enforced is #114.
+    /// </para>
+    /// </summary>
+    public int OpenRequestsPerUser { get; set; } = 10;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether films may be asked for.
+    /// </summary>
+    public bool AcceptsMovies { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether series may be asked for.
+    /// <para>
+    /// A kind is a setting of its own rather than a list, so a third kind is a visible change in the
+    /// three places that have to move together: this class, the page and the document. A list would
+    /// let one arrive by being appended somewhere and reach a fulfilment check that has no rule for
+    /// it.
+    /// </para>
+    /// </summary>
+    public bool AcceptsSeries { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets how long a finished request is kept, in days.
+    /// <para>
+    /// A request record says a named person asked for a named title on a date, which is more
+    /// revealing than most of what a media server holds, and it accumulates forever unless something
+    /// removes it. A year is the span in which somebody asks "did I already ask for this", which is
+    /// what the history is kept for at all.
+    /// </para>
+    /// <para>
+    /// The number is here rather than in the code, decided on #113, so an operator with a different
+    /// answer changes a field instead of asking for a release. <see cref="MinimumRetentionDays"/> is
+    /// the floor under it, and what removes an expired request is #49.
+    /// </para>
+    /// </summary>
+    public int FinishedRequestRetentionDays { get; set; } = 365;
 }

--- a/Jellyfin.Plugin.Requests/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Requests/Configuration/configPage.html
@@ -15,7 +15,33 @@
                     <p class="requestsMessage" role="status"></p>
 
                     <form id="RequestsConfigForm">
-                        <p>This plugin has no settings yet. The configuration surface is designed in M12; the sample settings this page started with were removed rather than kept, so nothing here carries a shape the design did not choose.</p>
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="RequestsOpenRequestsPerUser">Open requests per person</label>
+                            <input is="emby-input" type="number" id="RequestsOpenRequestsPerUser" min="1" step="1" required />
+                            <div class="fieldDescription">How many requests one person may have waiting at once. This is what stands between one person and the whole disk.</div>
+                        </div>
+
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label>
+                                <input is="emby-checkbox" type="checkbox" id="RequestsAcceptsMovies" />
+                                <span>Accept requests for films</span>
+                            </label>
+                            <div class="fieldDescription checkboxFieldDescription">Turning both kinds off leaves nothing anybody can ask for.</div>
+                        </div>
+
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label>
+                                <input is="emby-checkbox" type="checkbox" id="RequestsAcceptsSeries" />
+                                <span>Accept requests for series</span>
+                            </label>
+                        </div>
+
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="RequestsFinishedRequestRetentionDays">Keep finished requests for, in days</label>
+                            <input is="emby-input" type="number" id="RequestsFinishedRequestRetentionDays" min="30" step="1" required />
+                            <div class="fieldDescription">A finished request names a person, a title and a date. After this many days it is removed. Thirty days is the shortest period allowed, so the history cannot be switched off by setting this to nothing.</div>
+                        </div>
+
                         <div>
                             <button is="emby-button" type="submit" class="raised button-submit block emby-button">
                                 <span>Save</span>
@@ -24,6 +50,7 @@
                     </form>
                 </div>
             </div>
+
             <script type="text/javascript">
                 var RequestsConfig = {
                     pluginUniqueId: "0f9c9107-b31b-459e-81fa-6d35dac25e79",
@@ -51,6 +78,41 @@
                         });
                     }
 
+                    // One place names a setting and the field it is edited in. A second list would
+                    // be the thing that goes stale when a setting is added, and the setting would
+                    // then be one the page cannot reach while the page still looks complete.
+                    var numbers = {
+                        OpenRequestsPerUser: "#RequestsOpenRequestsPerUser",
+                        FinishedRequestRetentionDays: "#RequestsFinishedRequestRetentionDays",
+                    };
+
+                    var switches = {
+                        AcceptsMovies: "#RequestsAcceptsMovies",
+                        AcceptsSeries: "#RequestsAcceptsSeries",
+                    };
+
+                    function show(config) {
+                        Object.keys(numbers).forEach(function (setting) {
+                            page.querySelector(numbers[setting]).value = config[setting];
+                        });
+
+                        Object.keys(switches).forEach(function (setting) {
+                            page.querySelector(switches[setting]).checked = config[setting];
+                        });
+                    }
+
+                    function read(config) {
+                        Object.keys(numbers).forEach(function (setting) {
+                            config[setting] = parseInt(page.querySelector(numbers[setting]).value, 10);
+                        });
+
+                        Object.keys(switches).forEach(function (setting) {
+                            config[setting] = page.querySelector(switches[setting]).checked;
+                        });
+
+                        return config;
+                    }
+
                     page.addEventListener("pageshow", function () {
                         Dashboard.showLoadingMsg();
 
@@ -60,7 +122,8 @@
 
                                 return ApiClient.getPluginConfiguration(RequestsConfig.pluginUniqueId);
                             })
-                            .then(function () {
+                            .then(function (config) {
+                                show(config);
                                 Dashboard.hideLoadingMsg();
                             })
                             .catch(function () {
@@ -71,7 +134,7 @@
                     document.querySelector("#RequestsConfigForm").addEventListener("submit", function (e) {
                         Dashboard.showLoadingMsg();
                         ApiClient.getPluginConfiguration(RequestsConfig.pluginUniqueId).then(function (config) {
-                            ApiClient.updatePluginConfiguration(RequestsConfig.pluginUniqueId, config).then(function (result) {
+                            ApiClient.updatePluginConfiguration(RequestsConfig.pluginUniqueId, read(config)).then(function (result) {
                                 Dashboard.processPluginConfigurationUpdateResult(result);
                             });
                         });

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,82 @@
+# Configuration
+
+Almost every install runs the defaults, so the defaults are the product. This page is the list of
+what an operator can change, what happens when they change nothing, and why each default is the
+conservative answer rather than the convenient one.
+
+The settings are in
+[`PluginConfiguration`](../Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs), edited on
+the plugin's settings page in the dashboard. The table below is compared against that class by
+`PluginConfigurationTests`, which fails if a setting is added, removed or given a different default
+without this page moving with it, and again if the page cannot reach one of them.
+
+## The settings
+
+<!-- settings begins -->
+
+| Setting                      | Default |
+| ---------------------------- | ------- |
+| AcceptsMovies                | true    |
+| AcceptsSeries                | true    |
+| FinishedRequestRetentionDays | 365     |
+| OpenRequestsPerUser          | 10      |
+
+<!-- settings ends -->
+
+**AcceptsMovies** and **AcceptsSeries** are on, and they are the two kinds this version knows how to
+recognise in a library. Accepting a kind nothing can match would leave a person waiting on a request
+that no fulfilment check can ever answer, so the accepted set and the recognised set are the same
+set. Which kinds ship at 1.0 was decided on #113. Turning both off leaves nothing anybody can ask
+for, which is a configuration that cannot work rather than a strict one; refusing it is #96.
+
+A kind is a setting of its own rather than an entry in a list. A third kind then has to move this
+page, the class and the settings form together, instead of arriving as an appended value that
+reaches a fulfilment check with no rule for it.
+
+**FinishedRequestRetentionDays** is 365, and the floor under it is 30. A request record says that a
+named person asked for a named title on a date. That is personal data, it is more revealing than
+most of what a media server holds, and it accumulates forever unless something removes it. A year is
+the span in which somebody asks "did I already ask for this", which is what keeping any history is
+for. The number was decided on #113 and is a field rather than a constant so an operator with a
+different answer changes it without waiting for a release. The floor is there so retention cannot be
+set to nothing: zero would delete the history quietly and leave the queue answering that question
+with no.
+
+What removes an expired request is #49, and it is not built yet. **Until it is, nothing enforces this
+number**, and a server running this plugin keeps every finished request. That is a gap rather than a
+setting an operator can rely on, and it is written here rather than left for somebody to discover
+from a store that never shrinks.
+
+**OpenRequestsPerUser** is 10. The quota is the only thing between one person and the whole disk,
+and a limit introduced after people have habits is enforced against those habits rather than in
+front of them, which is why it ships from the start rather than later. Ten is a number somebody has
+to be trying to reach. It counts what is open rather than what was ever asked, so a person whose
+requests are answered can keep asking.
+
+Where the quota is enforced is #114, and that is not built yet either. **Nothing refuses an
+eleventh open request today.**
+
+## A fresh install
+
+Nothing has to be configured for the plugin to be usable: a person can ask for a film or a series,
+an operator sees it in the queue and answers it, and the library is what says a request was
+fulfilled.
+
+Nothing is sent anywhere. There is no address to send to, no credential to hold and no switch that
+would turn sending on, because none of the paths that would carry it exist yet: the outbound
+notification sink is #78 and the bridge adapter is #82. `NoRequestBackend` is what a server without
+an external request service runs, and it is what every server runs today.
+
+## What is deliberately not a setting
+
+**Whether a request needs approval.** Approval is required. Automatic approval was decided on #113
+as a per-user setting rather than a switch for the whole server, so a boolean here would be the
+wrong shape rather than an early version of the right one.
+
+**Notification switches.** Every path they would turn off is unbuilt. Switches for paths that do not
+exist would be settings an operator can change with no effect, which is worse than their absence.
+They land with the paths, in #79.
+
+**A bridge address and a credential.** The only bridge in this tree is the one for a server that has
+none. A field for an address would be somewhere to type something nothing reads. #82 brings the
+adapter, and #85 decides where a credential is kept and what may honestly be claimed about it.


### PR DESCRIPTION
Closes #95.

Almost every install runs the defaults, so the defaults are the product. Four settings, each the conservative answer, on the settings page and in `docs/configuration.md` with the reason each default is the safe one.

| Setting                      | Default |
| ---------------------------- | ------- |
| AcceptsMovies                | true    |
| AcceptsSeries                | true    |
| FinishedRequestRetentionDays | 365     |
| OpenRequestsPerUser          | 10      |

The two kinds are the ones this version can recognise in a library, so the accepted set and the recognisable set are the same set and nobody waits on a request no fulfilment check can answer. The retention period and the kinds are the answers taken on #113; `MinimumRetentionDays` is a floor of thirty days so retention cannot be set to nothing, and it is one constant rather than a number written into the sweep and again into the validation.

## What the suite refuses

**A setting the page cannot reach.** Each setting is asserted present on the embedded page under a field named after it. The near-miss is one character: renaming the series checkbox to `RequestsAcceptsSerie`. One test red, eleven unmoved.

    EverySettingIsReachableFromTheSettingsPage(setting: "AcceptsSeries", expected: "true") [FAIL]

**A default changed under the document.** Retention set to 30 in the class:

    AFreshInstallRunsTheValueOnThatList(setting: "FinishedRequestRetentionDays", expected: "365") [FAIL]
    TheDocumentedSettingsAreTheSettingsInTheCode [FAIL]

**A setting that could hold an address or a credential.** Adding `public string BridgeAddress` to the class:

    NoSettingCanHoldAnAddressOrACredential [FAIL]
    TheConfigurationIsExactlyTheSettingsOnThatList [FAIL]
    TheDocumentedSettingsAreTheSettingsInTheCode [FAIL]

That last guard is written over the shape rather than over the names, because a name check passes for whatever somebody calls the field. Every setting is an `int` or a `bool`, so nothing here can hold either, and #85 gets to decide where a credential lives instead of inheriting a field added while doing something else.

All three edits were reverted. At the committed tree:

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler:     0, erfolgreich:   395, uebersprungen:     0, gesamt:   395 (net9.0)
    Bestanden!   : Fehler:     0, erfolgreich:   395, uebersprungen:     0, gesamt:   395 (net10.0)

## What is not claimed

**Nothing enforces either number yet.** The quota is enforced in #114 and an expired request is removed in #49, and neither is built, so an eleventh open request is accepted today and a finished request is kept forever. `docs/configuration.md` says both in those words rather than leaving an operator to find out from a store that never shrinks.

**The floor under retention is documented and not refused.** A configuration class is data the dashboard writes; refusing what cannot work is #96, and that is also where two kinds switched off is caught.

**The page was not opened in a dashboard.** What is checked is the embedded resource: that every setting has a field named after it, and that the page names the setting when it reads and writes it. Driving a browser is refused by `docs/testing.md`, so how the fields render is not measured here.

Three settings this issue lists are deliberately absent, each with the reason in the class where somebody would otherwise add it: no automatic-approval switch, because approval is required and automatic approval was decided as a per-user setting; no notification switches, because every path they would turn off is unbuilt (#79); no bridge address, because the only bridge in this tree is the one for a server that has none (#82, #85).

## The means

C# and the plugin's own settings page, which is what the server's dashboard reads and writes through `ApiClient.getPluginConfiguration`. The settings have to be a `BasePluginConfiguration` for the host to persist them at all, so the means is forced at that boundary and held to it; the document beside it is markdown because it is read by an operator rather than by a program, and the one thing a program does read out of it is the table, which the suite compares against the class.

## Reader

This had no second reader. The evidence is in its place: the commands are here with their output, and each guard is quoted with the change that turned it red.