### PR TITLE
One endpoint that says what this install is and what it allows (#55)

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Api/CapabilityEndpointTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/CapabilityEndpointTests.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Api;
+using Jellyfin.Plugin.Requests.Bridge;
+using Jellyfin.Plugin.Requests.Configuration;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Api;
+
+/// <summary>
+/// The endpoint something calls before it calls anything else, and the two things it must not
+/// become: a way to learn how a bridge is configured, and a way to learn anything about anybody.
+/// <para>
+/// The facts it answers are written out by hand below rather than read off the type. A list derived
+/// from the type would agree with whatever the type happened to carry, including the day a field is
+/// added that nobody argued for, and this is the one answer this plugin gives to a caller who has
+/// not yet proven they can do anything.
+/// </para>
+/// </summary>
+public class CapabilityEndpointTests
+{
+    /// <summary>
+    /// Every fact this answer carries, with the type it carries it as. Four lines is the whole
+    /// endpoint.
+    /// </summary>
+    /// <returns>One entry per fact.</returns>
+    public static TheoryData<string, string> TheFactsTheAnswerCarries()
+        => new TheoryData<string, string>
+        {
+            { "AcceptedKinds", "IReadOnlyList`1" },
+            { "ApiVersion", "String" },
+            { "AutomaticApproval", "Boolean" },
+            { "BridgeConfigured", "Boolean" }
+        };
+
+    /// <summary>
+    /// A fresh install answers, which is the condition this endpoint exists for: nothing has been
+    /// configured, and a caller still learns what it can do here.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task AFreshInstallIsDiscoverable()
+    {
+        var answer = await Asked(new PluginConfiguration(), BackendReachability.NotConfigured);
+
+        Assert.Equal("v1", answer.ApiVersion, StringComparer.Ordinal);
+        Assert.Equal([RequestedItemKind.Movie, RequestedItemKind.Series], answer.AcceptedKinds);
+        Assert.False(answer.AutomaticApproval);
+        Assert.False(answer.BridgeConfigured);
+    }
+
+    /// <summary>
+    /// The version answered is the one the routes sit under, written here as the literal a caller
+    /// reads rather than as the constant, so a version bump is a visible change in the suite as well
+    /// as in the path.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task TheVersionAnsweredIsTheOneTheRoutesSitUnder()
+    {
+        var answer = await Asked(new PluginConfiguration(), BackendReachability.NotConfigured);
+
+        Assert.Equal(RequestsControllerBase.VersionSegment, answer.ApiVersion, StringComparer.Ordinal);
+        Assert.EndsWith("/" + answer.ApiVersion, RequestsControllerBase.RoutePrefix, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A kind an operator switched off is not offered. A caller that shows a button for it produces
+    /// a refusal the person reading it cannot act on, which is the whole reason this fact is here
+    /// rather than left to the enumeration.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task AKindThisInstallDoesNotAcceptIsNotOffered()
+    {
+        var settings = new PluginConfiguration { AcceptsSeries = false };
+
+        var answer = await Asked(settings, BackendReachability.NotConfigured);
+
+        Assert.Equal([RequestedItemKind.Movie], answer.AcceptedKinds);
+    }
+
+    /// <summary>
+    /// An install that accepts nothing says so rather than falling back to everything. Whether such
+    /// a configuration should be refused at all is #96; what this refuses is the endpoint quietly
+    /// answering with the enumeration when the settings say no.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task AnInstallThatAcceptsNothingOffersNothing()
+    {
+        var settings = new PluginConfiguration { AcceptsMovies = false, AcceptsSeries = false };
+
+        var answer = await Asked(settings, BackendReachability.NotConfigured);
+
+        Assert.Empty(answer.AcceptedKinds);
+    }
+
+    /// <summary>
+    /// A bridge that is configured is reported as configured whether or not it answered when it was
+    /// asked. Those are different facts and only the first is this endpoint's: a caller cannot act
+    /// on somebody else's service being down, and telling it so would be reporting the state of a
+    /// system the person calling does not administer.
+    /// </summary>
+    /// <param name="reachability">What the bridge says about itself.</param>
+    /// <param name="expected">Whether a bridge is reported.</param>
+    /// <returns>The running test.</returns>
+    [Theory]
+    [InlineData(BackendReachability.NotConfigured, false)]
+    [InlineData(BackendReachability.Reachable, true)]
+    [InlineData(BackendReachability.Unreachable, true)]
+    public async Task ABridgeIsReportedWhenThereIsOneAndNeverHowItIsConfigured(
+        BackendReachability reachability,
+        bool expected)
+    {
+        var answer = await Asked(new PluginConfiguration(), reachability);
+
+        Assert.Equal(expected, answer.BridgeConfigured);
+    }
+
+    /// <summary>
+    /// The answer carries those four facts and no others, each as the type written down for it.
+    /// <para>
+    /// This is the leg that refuses the field added later. Every fact here is a version, a switch or
+    /// the set of kinds, so there is nothing in this shape that could hold an address, a credential
+    /// or an identifier of a person, and adding one is a red suite rather than a review somebody
+    /// might not run.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void TheAnswerCarriesThoseFactsAndNothingElse()
+    {
+        var expected = TheFactsTheAnswerCarries()
+            .Select(row => string.Concat((string)row[0], " ", (string)row[1]))
+            .OrderBy(fact => fact, StringComparer.Ordinal)
+            .ToArray();
+
+        var carried = typeof(InstallCapabilities)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Select(fact => string.Concat(fact.Name, " ", fact.PropertyType.Name))
+            .OrderBy(fact => fact, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(expected, carried);
+    }
+
+    /// <summary>
+    /// The endpoint needs no store, so nothing it answers can depend on one being readable. A
+    /// capability answer that failed because the queue could not be read would tell a caller this
+    /// plugin is absent on the one server where knowing otherwise matters most.
+    /// </summary>
+    [Fact]
+    public void TheEndpointTakesNoStore()
+    {
+        var taken = typeof(CapabilitiesController)
+            .GetConstructors()
+            .Single()
+            .GetParameters()
+            .Select(parameter => parameter.ParameterType.Name)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(["IInstallSettings", "IRequestBackend"], taken);
+    }
+
+    /// <summary>
+    /// Asks the endpoint and unwraps the answer.
+    /// </summary>
+    /// <param name="settings">What the install is set to.</param>
+    /// <param name="reachability">What the bridge says about itself.</param>
+    /// <returns>What came back.</returns>
+    private static async Task<InstallCapabilities> Asked(
+        PluginConfiguration settings,
+        BackendReachability reachability)
+    {
+        var controller = new CapabilitiesController(
+            new FakeInstallSettings(settings),
+            new FakeRequestBackend(reachability));
+
+        var came = await controller.CapabilitiesAsync(CancellationToken.None).ConfigureAwait(false);
+        var ok = Assert.IsType<OkObjectResult>(came.Result);
+
+        return Assert.IsType<InstallCapabilities>(ok.Value);
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/Api/EndpointPolicyTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/EndpointPolicyTests.cs
@@ -50,6 +50,11 @@ public sealed class EndpointPolicyTests
     /// </summary>
     private static readonly string[] Expected =
     [
+        // What this install is and what it allows. A signed-in person, because nothing this plugin
+        // answers is safe to hand a caller the server has not authenticated, and because the kinds
+        // an install accepts is a fact about somebody's server rather than about this version.
+        "CapabilitiesController.CapabilitiesAsync GET Capabilities -> DefaultAuthorization",
+
         // Saying yes. A decision is an administrator's, in the transition table and here, and the
         // two answers have to agree: an endpoint reachable by a signed-in user would refuse every
         // such call in the model, which is a permission decided in two places.

--- a/Jellyfin.Plugin.Requests.Tests/Api/PublishedApiDocumentTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/PublishedApiDocumentTests.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.Requests.Api;
+using Jellyfin.Plugin.Requests.Bridge;
 using Jellyfin.Plugin.Requests.Model;
 using Jellyfin.Plugin.Requests.Storage;
 using Jellyfin.Plugin.Requests.Tests.Doubles;
@@ -70,6 +71,11 @@ public sealed class PublishedApiDocumentTests
     /// </summary>
     private static readonly string[] Expected =
     [
+        // What this install is and what it allows, for a caller that has not called anything yet.
+        // No failure shape, because it reads no store and refuses nothing: what it answers is known
+        // before anybody configures anything.
+        "GET MediaRequests/v1/Capabilities () -> 200:InstallCapabilities",
+
         // One person's own requests. The parameters are the same six the queue takes, because the
         // difference between the two reads is what the store is asked rather than what the caller
         // may ask for.
@@ -237,11 +243,21 @@ public sealed class PublishedApiDocumentTests
         var store = new InMemoryRequestStore();
         var unreadable = new StoreThatCannotBeRead();
 
+        const string Capabilities = "GET MediaRequests/v1/Capabilities";
         const string Create = "POST MediaRequests/v1/Requests";
         const string Mine = "GET MediaRequests/v1/Requests";
         const string Queue = "GET MediaRequests/v1/Requests/Queue";
         const string Approve = "POST MediaRequests/v1/Requests/{id}/Approve";
         const string Decline = "POST MediaRequests/v1/Requests/{id}/Decline";
+
+        // What this install allows. One call and one status: it reads no store, refuses nothing and
+        // has no failure to walk, which is why it publishes one code where every other endpoint
+        // publishes five.
+        Saw(
+            Capabilities,
+            await new CapabilitiesController(new FakeInstallSettings(), new NoRequestBackend())
+                .CapabilitiesAsync(CancellationToken.None)
+                .ConfigureAwait(true));
 
         // Asking for something. The same body twice: the first is a new request and the second is
         // the caller already waiting for it, which is the endpoint's other success code.

--- a/Jellyfin.Plugin.Requests.Tests/Doubles/FakeInstallSettings.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/FakeInstallSettings.cs
@@ -1,0 +1,33 @@
+using Jellyfin.Plugin.Requests.Configuration;
+
+namespace Jellyfin.Plugin.Requests.Tests.Doubles;
+
+/// <summary>
+/// What an install is set to, decided by the test.
+/// <para>
+/// The real one reads the configuration off the plugin the host constructed, which is a static a
+/// test would have to build a plugin to reach and would then share with every other test running
+/// beside it. This holds one object and hands it back, so a test that switches a kind off switches
+/// it off for itself alone.
+/// </para>
+/// </summary>
+internal sealed class FakeInstallSettings : IInstallSettings
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FakeInstallSettings"/> class, set to what a
+    /// fresh install runs.
+    /// </summary>
+    public FakeInstallSettings()
+        : this(new PluginConfiguration())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FakeInstallSettings"/> class.
+    /// </summary>
+    /// <param name="current">What this install is set to.</param>
+    public FakeInstallSettings(PluginConfiguration current) => Current = current;
+
+    /// <inheritdoc />
+    public PluginConfiguration Current { get; }
+}

--- a/Jellyfin.Plugin.Requests.Tests/Doubles/FakeRequestBackend.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/FakeRequestBackend.cs
@@ -1,0 +1,57 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Bridge;
+using Jellyfin.Plugin.Requests.Model;
+
+namespace Jellyfin.Plugin.Requests.Tests.Doubles;
+
+/// <summary>
+/// A bridge that answers what the test says it answers.
+/// <para>
+/// The shipping default reports that nothing is configured, which is the honest answer on a server
+/// with no external service and useless for testing what happens when there is one. This is how a
+/// test says "there is a service here" without an adapter, an address or anything on the network.
+/// </para>
+/// </summary>
+internal sealed class FakeRequestBackend : IRequestBackend
+{
+    private readonly BackendReachability _reachability;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FakeRequestBackend"/> class.
+    /// </summary>
+    /// <param name="reachability">What it says when it is asked whether it is there.</param>
+    public FakeRequestBackend(BackendReachability reachability) => _reachability = reachability;
+
+    /// <inheritdoc />
+    public Task<BackendReachability> CheckReachableAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return Task.FromResult(_reachability);
+    }
+
+    /// <inheritdoc />
+    public Task<BackendReference?> SubmitAsync(MediaRequest request, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return Task.FromResult<BackendReference?>(null);
+    }
+
+    /// <inheritdoc />
+    public Task<BackendReport?> ReportAsync(BackendReference reference, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return Task.FromResult<BackendReport?>(null);
+    }
+
+    /// <inheritdoc />
+    public Task WithdrawAsync(BackendReference reference, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return Task.CompletedTask;
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/PluginServiceRegistrationTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/PluginServiceRegistrationTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Jellyfin.Plugin.Requests.Bridge;
+using Jellyfin.Plugin.Requests.Configuration;
 using Jellyfin.Plugin.Requests.Identity;
 using Jellyfin.Plugin.Requests.Time;
 using Microsoft.Extensions.DependencyInjection;
@@ -45,6 +46,20 @@ public class PluginServiceRegistrationTests
         using var provider = Registered();
 
         Assert.IsType<NoRequestBackend>(provider.GetRequiredService<IRequestBackend>());
+    }
+
+    /// <summary>
+    /// A server asking what this install is set to gets the settings the host holds, rather than a
+    /// second object nothing writes to. The dashboard replaces the configuration whole when an
+    /// operator saves the page, so anything resolving its own copy would answer with what was set
+    /// when the server started.
+    /// </summary>
+    [Fact]
+    public void ServerGetsTheSettingsTheHostHolds()
+    {
+        using var provider = Registered();
+
+        Assert.IsType<ServerInstallSettings>(provider.GetRequiredService<IInstallSettings>());
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Requests/Api/CapabilitiesController.cs
+++ b/Jellyfin.Plugin.Requests/Api/CapabilitiesController.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Bridge;
+using Jellyfin.Plugin.Requests.Configuration;
+using Jellyfin.Plugin.Requests.Model;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Jellyfin.Plugin.Requests.Api;
+
+/// <summary>
+/// The one endpoint something asks before it asks anything else.
+/// <para>
+/// Without it, a caller finds out what this plugin allows by calling and reading the refusals, and a
+/// caller that has to tell a 404 for "no such plugin" from a 404 for "no such request" is a caller
+/// that gets it wrong. A page, a script and a third-party client all need the same three facts
+/// first, and none of them is worth a round of guessing.
+/// </para>
+/// <para>
+/// <b>This is not the seam.</b> The sibling discover plugin runs in the same server process and
+/// finds this one through the server's container, decided in #89, so it never calls this and this
+/// endpoint says nothing about the seam. <c>docs/seam.md</c> is where the difference is argued.
+/// </para>
+/// <para>
+/// A controller of its own rather than another action beside the queue. It reads no request, needs
+/// no store and no clock, and putting it there would give every capability answer the store's
+/// dependencies and every store test a capability to carry.
+/// </para>
+/// </summary>
+[Authorize(Policy = AuthenticatedUserPolicy)]
+public sealed class CapabilitiesController : RequestsControllerBase
+{
+    private readonly IInstallSettings _settings;
+    private readonly IRequestBackend _backend;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CapabilitiesController"/> class.
+    /// </summary>
+    /// <param name="settings">What this install is set to.</param>
+    /// <param name="backend">The bridge, which on most servers is the one with nothing behind it.</param>
+    /// <exception cref="ArgumentNullException">Where either was not given.</exception>
+    public CapabilitiesController(IInstallSettings settings, IRequestBackend backend)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        ArgumentNullException.ThrowIfNull(backend);
+
+        _settings = settings;
+        _backend = backend;
+    }
+
+    /// <summary>
+    /// What this install is and what it allows.
+    /// </summary>
+    /// <param name="cancellationToken">Cancels the call.</param>
+    /// <returns>
+    /// The API version, the kinds this install accepts, whether an operator decides, and whether
+    /// there is a service behind the plugin. It answers on a fresh install, because every one of
+    /// those has an answer before anybody has configured anything.
+    /// </returns>
+    [HttpGet("Capabilities")]
+    [Authorize(Policy = AuthenticatedUserPolicy)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<ActionResult<InstallCapabilities>> CapabilitiesAsync(CancellationToken cancellationToken)
+    {
+        var settings = _settings.Current;
+
+        // Asked of the bridge rather than decided from which implementation the container handed
+        // back, because "nothing is configured" is the interface's own answer to this question and a
+        // type comparison here would be a second way of asking it. On every install today this is
+        // the null bridge answering without leaving the process. Where an adapter makes the call
+        // slow or makes it fail, what a bound on it looks like is #86, and this endpoint follows
+        // that rather than swallowing the failure: an answer that claimed no bridge because the
+        // bridge threw would be a lie about the install, and the operator would read it as proof
+        // their configuration never took.
+        var reachability = await _backend.CheckReachableAsync(cancellationToken).ConfigureAwait(false);
+
+        return Ok(new InstallCapabilities
+        {
+            ApiVersion = VersionSegment,
+            AcceptedKinds = Accepted(settings),
+            AutomaticApproval = false,
+            BridgeConfigured = reachability != BackendReachability.NotConfigured
+        });
+    }
+
+    /// <summary>
+    /// The kinds this install accepts, built from the settings rather than from the enumeration, so
+    /// a kind an operator switched off is one a caller is never offered.
+    /// </summary>
+    /// <param name="settings">What this install is set to.</param>
+    /// <returns>The kinds, in the enumeration's own order.</returns>
+    private static List<RequestedItemKind> Accepted(PluginConfiguration settings)
+    {
+        var kinds = new List<RequestedItemKind>();
+
+        if (settings.AcceptsMovies)
+        {
+            kinds.Add(RequestedItemKind.Movie);
+        }
+
+        if (settings.AcceptsSeries)
+        {
+            kinds.Add(RequestedItemKind.Series);
+        }
+
+        return kinds;
+    }
+}

--- a/Jellyfin.Plugin.Requests/Api/InstallCapabilities.cs
+++ b/Jellyfin.Plugin.Requests/Api/InstallCapabilities.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using Jellyfin.Plugin.Requests.Model;
+
+namespace Jellyfin.Plugin.Requests.Api;
+
+/// <summary>
+/// What this install is and what it allows, for something outside the server process that has to
+/// know before it calls anything.
+/// <para>
+/// Four facts and no more. A browser page, a script an operator wrote and a third-party client all
+/// arrive with the same three questions: is this plugin here, which shape of the API does it speak,
+/// and is there any point offering the thing I was going to offer. Anything else here would be a
+/// fact about the install that a caller did not need and could not have learned another way.
+/// </para>
+/// <para>
+/// <b>Nothing here is a credential, an address, or anything about another person.</b> That is
+/// checked over the shape rather than reviewed: every field is a version string, a switch or the set
+/// of kinds, so there is nothing this answer could carry that a caller may not already ask for
+/// directly.
+/// </para>
+/// </summary>
+public sealed record InstallCapabilities
+{
+    /// <summary>
+    /// Gets the version of the API this install speaks, which is the segment its routes sit under.
+    /// A caller that finds a version it does not know stops rather than guessing at the shape.
+    /// </summary>
+    public required string ApiVersion { get; init; }
+
+    /// <summary>
+    /// Gets the media kinds this install accepts a request for.
+    /// <para>
+    /// A caller offering a button for a kind the install refuses is a caller producing a refusal the
+    /// person reading it cannot act on. What decides this is the configuration, so it is an answer
+    /// about this server rather than about this version.
+    /// </para>
+    /// </summary>
+    public required IReadOnlyList<RequestedItemKind> AcceptedKinds { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether a request is approved without an operator looking at it.
+    /// <para>
+    /// It is here because it changes what a caller should say to the person asking: "an
+    /// administrator will look at this" is wrong on a server where nobody will. It is false on every
+    /// install today, and automatic approval arrives as a per-user setting rather than a switch for
+    /// the whole server, decided on #113.
+    /// </para>
+    /// </summary>
+    public required bool AutomaticApproval { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether an external request service sits behind this plugin.
+    /// <para>
+    /// Whether one is configured and nothing else. Not which service, not where it is, and not
+    /// whether it answered when it was last asked: the first two are the operator's business and the
+    /// third is a fact about somebody else's system that a caller here cannot act on.
+    /// </para>
+    /// </summary>
+    public required bool BridgeConfigured { get; init; }
+}

--- a/Jellyfin.Plugin.Requests/Api/RequestsController.cs
+++ b/Jellyfin.Plugin.Requests/Api/RequestsController.cs
@@ -56,20 +56,6 @@ namespace Jellyfin.Plugin.Requests.Api;
 public sealed class RequestsController : RequestsControllerBase
 {
     /// <summary>
-    /// The server's policy for a call that has to come from a signed-in user. Named as a literal
-    /// because the constant that holds it lives in the server's own web assembly, which a plugin
-    /// does not reference; the string is the contract either way.
-    /// </summary>
-    private const string AuthenticatedUserPolicy = "DefaultAuthorization";
-
-    /// <summary>
-    /// The server's policy for a call that has to come from an administrator, named as a literal for
-    /// the same reason as the one above. It is what the server's own dashboard endpoints carry, so an
-    /// endpoint under it is reachable by exactly the people who can already administer the server.
-    /// </summary>
-    private const string AdministratorPolicy = "RequiresElevation";
-
-    /// <summary>
     /// How many rows a page holds when the caller does not say. Fifty is a screen of a queue and a
     /// small answer for a client that only wanted to know whether there is anything at all.
     /// </summary>

--- a/Jellyfin.Plugin.Requests/Api/RequestsControllerBase.cs
+++ b/Jellyfin.Plugin.Requests/Api/RequestsControllerBase.cs
@@ -49,4 +49,23 @@ public abstract class RequestsControllerBase : ControllerBase
     /// </para>
     /// </summary>
     public const string RoutePrefix = "MediaRequests/" + VersionSegment;
+
+    /// <summary>
+    /// The server's policy for a call that has to come from a signed-in user. Named as a literal
+    /// because the constant that holds it lives in the server's own web assembly, which a plugin
+    /// does not reference; the string is the contract either way.
+    /// <para>
+    /// It is here rather than on one controller because there is more than one, and a second copy of
+    /// the literal beside the second controller would be a second spelling of a contract this
+    /// repository does not own.
+    /// </para>
+    /// </summary>
+    protected const string AuthenticatedUserPolicy = "DefaultAuthorization";
+
+    /// <summary>
+    /// The server's policy for a call that has to come from an administrator, named as a literal for
+    /// the same reason as the one above. It is what the server's own dashboard endpoints carry, so an
+    /// endpoint under it is reachable by exactly the people who can already administer the server.
+    /// </summary>
+    protected const string AdministratorPolicy = "RequiresElevation";
 }

--- a/Jellyfin.Plugin.Requests/Configuration/IInstallSettings.cs
+++ b/Jellyfin.Plugin.Requests/Configuration/IInstallSettings.cs
@@ -1,0 +1,27 @@
+namespace Jellyfin.Plugin.Requests.Configuration;
+
+/// <summary>
+/// What this install is set to, asked of the server rather than reached for.
+/// <para>
+/// The configuration belongs to the host: it is loaded, saved and replaced by the dashboard, and the
+/// plugin instance is where the current one lives. Something that read it through the static
+/// instance would be something no test can run without constructing a plugin, and a static an
+/// operator can change under a running test is a suite that fails for a reason nobody caused.
+/// </para>
+/// <para>
+/// So this is a seam of the same kind as the caller identity and the library: one property, answered
+/// by the server in production and by a double in the suite.
+/// </para>
+/// </summary>
+public interface IInstallSettings
+{
+    /// <summary>
+    /// Gets what this install is set to now.
+    /// <para>
+    /// Read per call rather than kept, because an operator saving the settings page replaces the
+    /// object and anything holding the old one would answer with what was configured when it
+    /// started.
+    /// </para>
+    /// </summary>
+    PluginConfiguration Current { get; }
+}

--- a/Jellyfin.Plugin.Requests/Configuration/ServerInstallSettings.cs
+++ b/Jellyfin.Plugin.Requests/Configuration/ServerInstallSettings.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Jellyfin.Plugin.Requests.Configuration;
+
+/// <summary>
+/// The settings as the server holds them, which is on the plugin instance the host constructed.
+/// <para>
+/// This is the one place that reaches for that instance. Everything above takes
+/// <see cref="IInstallSettings"/>, so the reach exists once and is testable everywhere else.
+/// </para>
+/// </summary>
+public sealed class ServerInstallSettings : IInstallSettings
+{
+    /// <inheritdoc />
+    /// <exception cref="InvalidOperationException">
+    /// Where the plugin has not been loaded, so there is no configuration to read. That is a host
+    /// that never loaded this plugin rather than an install with nothing set, and it says so instead
+    /// of answering with defaults nobody chose.
+    /// </exception>
+    public PluginConfiguration Current
+        => (Plugin.Instance ?? throw new InvalidOperationException(
+            "The settings were asked for before this plugin was loaded, so there is no configuration to read."))
+            .Configuration;
+}

--- a/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
@@ -1,6 +1,7 @@
 using System;
 using Jellyfin.Plugin.Requests.Api;
 using Jellyfin.Plugin.Requests.Bridge;
+using Jellyfin.Plugin.Requests.Configuration;
 using Jellyfin.Plugin.Requests.Fulfilment;
 using Jellyfin.Plugin.Requests.Identity;
 using Jellyfin.Plugin.Requests.Storage;
@@ -58,6 +59,12 @@ public sealed class PluginServiceRegistrator : IPluginServiceRegistrator
         // takes the seam and never the server's context directly, which is what keeps an endpoint
         // testable without a running server.
         serviceCollection.AddSingleton<ICallerIdentity, ServerCallerIdentity>();
+
+        // What this install is set to, for the same reason. The settings live on the plugin instance
+        // the host constructed and are replaced whole when an operator saves the page, so this reads
+        // them per call rather than holding one, and everything above takes the seam instead of
+        // reaching for the static.
+        serviceCollection.AddSingleton<IInstallSettings, ServerInstallSettings>();
 
         // The bridge to an external request service, which on most servers is the one that has no
         // service behind it. Registered like the others because it is the shipping default rather

--- a/docs/api.md
+++ b/docs/api.md
@@ -161,6 +161,35 @@ is not in that directory. So the prose a caller gets about these endpoints is wh
 and the document gives them the shapes. That is a limit of the route rather than a decision, and it is
 written down so nobody spends an afternoon wondering why a summary they wrote is not showing up.
 
+## Asking what this install allows
+
+    GET MediaRequests/v1/Capabilities
+
+The endpoint something calls before it calls anything else. Without it a caller learns what this
+plugin allows by calling and reading the refusals, and a caller that has to tell a `404` for "no such
+plugin" from a `404` for "no such request" is a caller that gets it wrong.
+
+Four facts and no more. `apiVersion` is the segment the routes sit under, so a caller that finds a
+version it does not know stops instead of guessing at the shape. `acceptedKinds` is what an operator
+has switched on, so nothing offers a button for a kind this server refuses. `automaticApproval` says
+whether anybody will look at a request, because "an administrator will look at this" is the wrong
+thing to tell somebody on a server where nobody will. `bridgeConfigured` says whether an external
+request service sits behind the plugin.
+
+**It carries no credential, no address and nothing about any other person.** Whether a bridge exists
+is the whole of what it says about one: not which service, not where it is, and not whether it
+answered when it was last asked. The first two are the operator's business and the third is the state
+of a system the caller does not administer. `CapabilityEndpointTests` holds the shape to those four
+fields, so a fifth is a red suite rather than a review somebody might not run.
+
+It answers on a fresh install, because every one of those facts has an answer before anybody has
+configured anything. It reads no store, so nothing it says depends on the queue being readable, and
+it publishes one status code where the other endpoints publish five.
+
+**This is not the seam.** The sibling discover plugin runs in the same server process and finds this
+one through the server's container, so it never calls this. `docs/seam.md` is where that difference
+is argued.
+
 ## Asking for something
 
     POST MediaRequests/v1/Requests
@@ -350,6 +379,7 @@ on the day it is added, and a class attribute is edited by somebody who is not r
 
 | Endpoint                     | Policy                 | Who that is          |
 | ---------------------------- | ---------------------- | -------------------- |
+| `GET Capabilities`           | `DefaultAuthorization` | any signed-in person |
 | `POST Requests`              | `DefaultAuthorization` | any signed-in person |
 | `GET Requests`               | `DefaultAuthorization` | any signed-in person |
 | `GET Requests/Queue`         | `RequiresElevation`    | an administrator     |


### PR DESCRIPTION
Closes #55.

    GET MediaRequests/v1/Capabilities

Something outside the server process has to be able to ask whether this plugin is installed, which shape of the API it speaks and what this install allows, without working it out from a 404 on every endpoint it wanted to call. A caller that has to tell a 404 for "no such plugin" from a 404 for "no such request" is a caller that gets it wrong.

Four facts and no more: the API version, the kinds this install accepts, whether anybody will look at a request, and whether an external request service sits behind the plugin.

## What it does not say

Whether a bridge is configured is the whole of what it says about one. Not which service, not where it is, and not whether it answered when it was last asked: the first two are the operator's business and the third is the state of a system the caller does not administer.

`TheAnswerCarriesThoseFactsAndNothingElse` holds the shape to the four fields with the type each carries, so nothing here can hold an address, a credential or an identifier of a person. The near-miss is the field somebody would add first, `public string BridgeService`:

    TheAnswerCarriesThoseFactsAndNothingElse [FAIL]

## What it reads

The kinds come from the settings rather than from the enumeration. The near-miss is the shortcut that reads correct until an operator switches a kind off:

    AKindThisInstallDoesNotAcceptIsNotOffered [FAIL]
    AnInstallThatAcceptsNothingOffersNothing [FAIL]

Both edits were reverted. At the committed tree:

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler:     0, erfolgreich:   405, uebersprungen:     0, gesamt:   405 (net9.0)
    Bestanden!   : Fehler:     0, erfolgreich:   405, uebersprungen:     0, gesamt:   405 (net10.0)

It reads no store, so nothing it answers depends on the queue being readable, which is the state a caller is most likely to be probing during. `TheEndpointTakesNoStore` holds that to the constructor. It answers on a fresh install, because each of the four facts has an answer before anybody configures anything.

## Two changes beside it

**The policy names move to `RequestsControllerBase`.** There is more than one controller now, and a second copy of the literal beside the second one would be a second spelling of a contract this repository does not own. The endpoint still carries its own `[Authorize]` rather than inheriting the class attribute, and `EndpointPolicyTests` carries the new line.

**What this install is set to is read through a seam,** `IInstallSettings`, of the same kind as the caller identity and the library. The configuration lives on the plugin instance the host constructed; something reading that static would be untestable without building a plugin, and a static an operator can change under a running test is a suite that fails for a reason nobody caused.

## What is not claimed

**Whether a bridge is configured is asked of the bridge, not derived from which implementation the container returned.** `NotConfigured` is the interface's own answer to that question. On every install today that is the null bridge answering without leaving the process. Where an adapter makes that call slow or makes it fail, a bound on it is #86, and this endpoint does not swallow the failure: an answer claiming no bridge because the bridge threw would be a lie about the install, and an operator would read it as proof their configuration never took.

**`automaticApproval` is false on every install and is not read from anywhere.** Approval is required, and automatic approval arrives as a per-user setting rather than a switch for the whole server, decided on #113. It is in the answer because it changes what a caller should tell the person asking, not because anything can change it today.

**Nothing was called against a running server.** What is checked is the controller, its attributes and the published description set, which is what the rest of this board's API suite checks.

## The means

C# beside the other endpoints, under the same versioned prefix, so the one thing a caller uses to decide whether to call anything else is served by the same route table as everything else and is described by the same generated document.

## Reader

This had no second reader. The evidence is in its place: the commands are here with their output, and each guard is quoted with the change that turned it red.