### PR TITLE
Refuse a feature that only works with an external service (#87)

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Bridge/NoBackendCompletenessTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Bridge/NoBackendCompletenessTests.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Jellyfin.Plugin.Requests.Bridge;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Bridge;
+
+/// <summary>
+/// The claim on the front of this board is that the whole thing works with or without an external
+/// service behind it. A claim like that decays quietly: something gets built assuming a bridge, and
+/// the install with none loses it without anybody noticing.
+/// <para>
+/// What makes it refusable is that a feature needing a bridge is a feature that <b>takes</b> the
+/// bridge, and taking it is a fact about a type that can be read off the assembly. So the register
+/// in <c>docs/bridge.md</c> is over what touches <see cref="IRequestBackend"/>, and the column
+/// beside each entry is where the judgement a machine cannot make is written down for a reader.
+/// </para>
+/// <para>
+/// The expected register below is written out by hand as well, because a comparison between the
+/// document and the assembly alone would pass the day both move together and nobody argued about
+/// the entry that was added.
+/// </para>
+/// </summary>
+public class NoBackendCompletenessTests
+{
+    /// <summary>
+    /// Everything in the plugin that touches the bridge. One entry today, and each is a place that
+    /// has to keep working on a server with no external service.
+    /// </summary>
+    private static readonly string[] Expected = ["CapabilitiesController"];
+
+    /// <summary>
+    /// Everything that takes the bridge is named in the register, and nothing is named there that
+    /// does not take it.
+    /// <para>
+    /// Both directions. An unnamed type is the feature this issue exists against, arriving without
+    /// anybody saying what it does on a server with no service. A named type that no longer takes
+    /// the bridge is a register that has started describing something else, and the reader who
+    /// trusts it is the operator deciding whether they need a service at all.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void EverythingThatTakesTheBridgeIsInTheRegister()
+    {
+        Assert.Equal(
+            string.Join(" | ", Expected.OrderBy(name => name, StringComparer.Ordinal)),
+            string.Join(" | ", Documented()),
+            StringComparer.Ordinal);
+
+        Assert.Equal(
+            string.Join(" | ", Expected.OrderBy(name => name, StringComparer.Ordinal)),
+            string.Join(" | ", TakesTheBridge()),
+            StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Every entry says what it does without a bridge. An entry with an empty column is a name in a
+    /// table, and the whole value of the register is the sentence beside the name.
+    /// </summary>
+    [Fact]
+    public void EveryEntrySaysWhatItDoesWithoutOne()
+    {
+        var silent = Register()
+            .Where(entry => entry.Value.Length == 0)
+            .Select(entry => entry.Key)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal([], silent);
+    }
+
+    /// <summary>
+    /// One implementation of the bridge ships, and it is the one for a server that has none. That is
+    /// the other half of the same claim: a second implementation in this assembly would be something
+    /// an install could resolve instead, and the register above says nothing about which one a
+    /// server got.
+    /// </summary>
+    [Fact]
+    public void TheOnlyBridgeThisPluginShipsIsTheOneWithNothingBehindIt()
+    {
+        var implementations = typeof(IRequestBackend).Assembly
+            .GetTypes()
+            .Where(type => typeof(IRequestBackend).IsAssignableFrom(type))
+            .Where(type => !type.IsAbstract && !type.IsInterface)
+            .Select(type => type.Name)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal([nameof(NoRequestBackend)], implementations);
+    }
+
+    /// <summary>
+    /// Every type in the plugin that takes the bridge, read off the assembly. Constructors, fields
+    /// and properties, because those are the three ways a type holds one; the interface and its
+    /// implementations are not included, since a bridge is not a thing that needs a bridge.
+    /// </summary>
+    /// <returns>The type names, in name order.</returns>
+    private static string[] TakesTheBridge()
+        => [.. typeof(IRequestBackend).Assembly
+            .GetTypes()
+            .Where(type => !typeof(IRequestBackend).IsAssignableFrom(type))
+            .Where(Holds)
+            .Select(type => type.Name)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(name => name, StringComparer.Ordinal)];
+
+    /// <summary>
+    /// Whether one type takes the bridge in any of the three ways a type can hold one.
+    /// </summary>
+    /// <param name="type">The type.</param>
+    /// <returns><see langword="true"/> where it does.</returns>
+    private static bool Holds(Type type)
+    {
+        const BindingFlags Everything =
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static
+            | BindingFlags.DeclaredOnly;
+
+        return type.GetConstructors(Everything)
+                .SelectMany(constructor => constructor.GetParameters())
+                .Any(parameter => parameter.ParameterType == typeof(IRequestBackend))
+            || type.GetFields(Everything).Any(field => field.FieldType == typeof(IRequestBackend))
+            || type.GetProperties(Everything).Any(property => property.PropertyType == typeof(IRequestBackend));
+    }
+
+    /// <summary>
+    /// The names the register holds, in the order the table lists them.
+    /// </summary>
+    /// <returns>The names.</returns>
+    private static string[] Documented() => [.. Register().Keys];
+
+    /// <summary>
+    /// The register in <c>docs/bridge.md</c>: what touches the bridge, and what it does without one.
+    /// </summary>
+    /// <returns>The entries, in the table's own order.</returns>
+    private static Dictionary<string, string> Register()
+    {
+        var rows = MarkedSection("needs-a-bridge").Where(line => line.StartsWith('|')).ToArray();
+
+        // The header names the columns and the dashes under it are the table's own furniture.
+        return rows
+            .Skip(2)
+            .Select(SplitRow)
+            .ToDictionary(row => row[0].Trim('`'), row => row[1], StringComparer.Ordinal);
+    }
+
+    private static string[] SplitRow(string row)
+        => [.. row.Trim('|').Split('|').Select(cell => cell.Trim())];
+
+    /// <summary>
+    /// Reads the lines the document marks off for one section.
+    /// </summary>
+    /// <param name="name">The name in the marker comments.</param>
+    /// <returns>The trimmed lines between the markers.</returns>
+    private static string[] MarkedSection(string name)
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "docs", "bridge.md");
+        Assert.True(File.Exists(path), FormattableString.Invariant($"{path} was not copied next to the suite."));
+
+        var opening = FormattableString.Invariant($"<!-- {name} begins -->");
+        var closing = FormattableString.Invariant($"<!-- {name} ends -->");
+        var inside = false;
+        var lines = new List<string>();
+
+        foreach (var line in File.ReadLines(path))
+        {
+            if (line.Trim().Equals(opening, StringComparison.Ordinal))
+            {
+                inside = true;
+                continue;
+            }
+
+            if (line.Trim().Equals(closing, StringComparison.Ordinal))
+            {
+                inside = false;
+                continue;
+            }
+
+            if (inside && line.Trim().Length > 0)
+            {
+                lines.Add(line.Trim());
+            }
+        }
+
+        Assert.True(lines.Count > 0, FormattableString.Invariant($"docs/bridge.md has no {name} section."));
+
+        return [.. lines];
+    }
+}

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -76,6 +76,33 @@ history, and the person it belongs to is told something untrue about their own r
 Case is ignored when a word is looked up, because two adapters written against one service will spell
 one word two ways and both mean what the service meant. Nothing else is normalised.
 
+## What needs a bridge
+
+Nothing does, and that is a claim the suite refuses to let drift rather than a sentence somebody
+wrote once. The register below is every part of this plugin that touches the bridge at all, with
+what it does on a server that has none, which is most of them.
+
+`NoBackendCompletenessTests` compares this table against the assembly. Anything that takes
+`IRequestBackend` and is not named here reds the suite, so a feature that only works with a bridge
+cannot arrive quietly: it either gets a line in this table saying so, or the change does not land.
+
+<!-- needs-a-bridge begins -->
+
+| What                     | Without a bridge                                |
+| ------------------------ | ----------------------------------------------- |
+| `CapabilitiesController` | Answers, and says that no bridge is configured. |
+
+<!-- needs-a-bridge ends -->
+
+The register is deliberately not a list of features. A feature that needs a bridge is one that takes
+the bridge, and taking it is a fact about a type that reflection can read; "which features need a
+service" is a judgement nobody can check. So the check is over what touches it, and the column is
+where the judgement is written down for a reader.
+
+The other half of the same claim is that only one implementation ships. Every server this plugin runs
+on resolves `NoRequestBackend` until an adapter replaces that one registration, and the suite refuses
+a second implementation arriving in the plugin assembly unnamed for the same reason.
+
 ## Where the list of words came from
 
 The words above are the ones issue #81 names for the Overseerr form, which is the form the first


### PR DESCRIPTION
Closes #87.

The claim this protects is that the plugin is complete with no external request service behind it. It has been true so far because almost nothing touches the bridge, which is not a state to leave a claim resting on: the failure the issue names is the feature built assuming a bridge, on a board where most installs have none.

## What makes it refusable

A feature that needs a bridge is a feature that **takes** the bridge, and taking one is a fact about a type that can be read off the assembly. So `docs/bridge.md` carries a register of everything that touches `IRequestBackend`, with what each does on a server that has none, and `NoBackendCompletenessTests` compares that register against the built assembly in both directions.

| What                     | Without a bridge                                |
| ------------------------ | ----------------------------------------------- |
| `CapabilitiesController` | Answers, and says that no bridge is configured. |

One entry, and nothing in this plugin needs a service today. That is the second condition met with a short and deliberate list rather than with a sentence.

The judgement stays with a person and only the judgement. Which features need a service is not something reflection can decide; what it can decide is what holds a bridge, and the column beside each name is where a reader finds the answer.

## What the suite refuses

**A bridge-only feature arriving with no line in the register.** A production type taking `IRequestBackend` in its constructor:

    EverythingThatTakesTheBridgeIsInTheRegister [FAIL]
    Actual:   CapabilitiesController | SubmitOnApproval

**A register that has stopped describing the tree.** The row deleted from the document:

    EverythingThatTakesTheBridgeIsInTheRegister [FAIL]

Both edits were reverted. At the committed tree:

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler:     0, erfolgreich:   408, uebersprungen:     0, gesamt:   408 (net9.0)
    Bestanden!   : Fehler:     0, erfolgreich:   408, uebersprungen:     0, gesamt:   408 (net10.0)

    npx --yes prettier@3.6.2 --check docs/bridge.md
    All matched files use Prettier code style!

The third leg holds the other half of the claim: the only implementation this assembly ships is the one for a server with no service, so a second one cannot arrive and leave the register describing whichever a server happened to resolve.

## What is not claimed

**The first condition is met by construction rather than by a run that proves it.** The suite's whole user-facing set runs against the null bridge because that is the only bridge in the assembly and nothing else resolves one. There is no separate run of the suite "with a bridge" to compare it against, and there could not be until an adapter exists.

**The register is over types, not over behaviours.** Something that needed a service without ever holding the interface, by reading configuration and refusing, would not be caught. Nothing in the tree does that, and the cheapest place to catch it if it ever arrives is the same table, by hand, in review.

## The means

C# reflection over the built assembly, beside the markdown a reader gets. It is the same shape the rest of this board uses for a claim about the tree: the document is printed for a person and compared against the thing it describes, so neither side can move alone.

## Reader

This had no second reader. The evidence is in its place: the commands are here with their output, and each guard is quoted with the change that turned it red.