### PR TITLE
Refuse a configuration this plugin cannot run on, at both moments one arrives

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Configuration/ConfigurationRulesTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Configuration/ConfigurationRulesTests.cs
@@ -1,0 +1,292 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Jellyfin.Plugin.Requests.Configuration;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Configuration;
+
+/// <summary>
+/// What this plugin refuses to run on, and the two moments it refuses it: a save from the settings
+/// page and a read of what is stored.
+/// <para>
+/// The values below are written as a boundary and the value one step outside it, rather than as a
+/// number somewhere in the middle. A test asserting that -50 is refused passes for an
+/// implementation that refuses everything below 40, and the mistake somebody actually makes is an
+/// off-by-one in the comparison rather than a rule pointed the wrong way.
+/// </para>
+/// </summary>
+public class ConfigurationRulesTests
+{
+    /// <summary>
+    /// The last value each rule accepts, and the first one it refuses, with the setting the refusal
+    /// has to name. One row per rule, and the row for the accepted kinds names both switches because
+    /// either of them fixes it.
+    /// </summary>
+    /// <returns>A configuration just inside the rule, one just outside it, and the settings named.</returns>
+    public static TheoryData<string, PluginConfiguration, PluginConfiguration, string[]> EachRuleAtItsBoundary()
+        => new TheoryData<string, PluginConfiguration, PluginConfiguration, string[]>
+        {
+            {
+                "the quota",
+                Fresh(configuration => configuration.OpenRequestsPerUser = ConfigurationRules.SmallestQuota),
+                Fresh(configuration => configuration.OpenRequestsPerUser = ConfigurationRules.SmallestQuota - 1),
+                [nameof(PluginConfiguration.OpenRequestsPerUser)]
+            },
+            {
+                "the retention period",
+                Fresh(configuration => configuration.FinishedRequestRetentionDays = PluginConfiguration.MinimumRetentionDays),
+                Fresh(configuration => configuration.FinishedRequestRetentionDays = PluginConfiguration.MinimumRetentionDays - 1),
+                [nameof(PluginConfiguration.FinishedRequestRetentionDays)]
+            },
+            {
+                "the accepted kinds",
+                Fresh(configuration =>
+                {
+                    configuration.AcceptsMovies = false;
+                    configuration.AcceptsSeries = true;
+                }),
+                Fresh(configuration =>
+                {
+                    configuration.AcceptsMovies = false;
+                    configuration.AcceptsSeries = false;
+                }),
+                [nameof(PluginConfiguration.AcceptsMovies), nameof(PluginConfiguration.AcceptsSeries)]
+            }
+        };
+
+    /// <summary>
+    /// A fresh install is a configuration this plugin runs on. Without this leg every other one
+    /// below passes for a rule set that refuses everything.
+    /// </summary>
+    [Fact]
+    public void AFreshInstallIsAConfigurationThisPluginCanRunOn()
+    {
+        Assert.Empty(ConfigurationRules.Problems(new PluginConfiguration()));
+        Assert.True(ConfigurationRules.CanBeHonoured(new PluginConfiguration()));
+    }
+
+    /// <summary>
+    /// The last value a rule accepts is accepted.
+    /// </summary>
+    /// <param name="rule">Which rule this row is about, so a failure says which.</param>
+    /// <param name="inside">A configuration at the last value the rule allows.</param>
+    /// <param name="outside">The first value it refuses, which this leg does not read.</param>
+    /// <param name="named">The settings the refusal names, which this leg does not read.</param>
+    [Theory]
+    [MemberData(nameof(EachRuleAtItsBoundary))]
+    public void TheLastValueEachRuleAllowsIsAccepted(
+        string rule,
+        PluginConfiguration inside,
+        PluginConfiguration outside,
+        string[] named)
+    {
+        Assert.NotEmpty(rule);
+        Assert.NotNull(outside);
+        Assert.NotEmpty(named);
+
+        Assert.Empty(ConfigurationRules.Problems(inside));
+    }
+
+    /// <summary>
+    /// The first value outside a rule is refused, and the refusal names the field rather than saying
+    /// only that something is wrong. A refusal an operator cannot act on is a refusal that sends
+    /// them to the source.
+    /// </summary>
+    /// <param name="rule">Which rule this row is about, so a failure says which.</param>
+    /// <param name="inside">The last value it allows, which this leg does not read.</param>
+    /// <param name="outside">A configuration one step outside the rule.</param>
+    /// <param name="named">The settings the refusal has to name.</param>
+    [Theory]
+    [MemberData(nameof(EachRuleAtItsBoundary))]
+    public void TheFirstValueOutsideEachRuleIsRefusedAndNamesTheField(
+        string rule,
+        PluginConfiguration inside,
+        PluginConfiguration outside,
+        string[] named)
+    {
+        Assert.NotEmpty(rule);
+        Assert.NotNull(inside);
+
+        var problems = ConfigurationRules.Problems(outside);
+
+        Assert.Equal(named, Settings(problems.Select(problem => problem.Setting)));
+        Assert.All(problems, problem => Assert.Contains(problem.Setting, problem.Why, StringComparison.Ordinal));
+        Assert.False(ConfigurationRules.CanBeHonoured(outside));
+    }
+
+    /// <summary>
+    /// Every setting is reached by a rule. This is the leg that catches a setting added later with
+    /// nothing judging it: the hostile configuration below is written by hand, so a new setting is a
+    /// name in the class that is not in the answer, and whoever adds it has to say what value of it
+    /// cannot work.
+    /// </summary>
+    [Fact]
+    public void EverySettingIsNamedByARule()
+    {
+        var hostile = new PluginConfiguration
+        {
+            OpenRequestsPerUser = 0,
+            AcceptsMovies = false,
+            AcceptsSeries = false,
+            FinishedRequestRetentionDays = 0
+        };
+
+        var declared = typeof(PluginConfiguration)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Select(setting => setting.Name)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        var named = Settings(ConfigurationRules.Problems(hostile).Select(problem => problem.Setting));
+
+        Assert.Equal(declared, named);
+    }
+
+    /// <summary>
+    /// Nothing is corrected on the way through. The rules answer about the configuration they were
+    /// given and hand back no second copy, so there is no shape in which a caller receives a value
+    /// nobody chose without being able to tell.
+    /// </summary>
+    [Fact]
+    public void AConfigurationThatIsRefusedIsNotChanged()
+    {
+        var configuration = new PluginConfiguration { OpenRequestsPerUser = -4 };
+
+        Assert.NotEmpty(ConfigurationRules.Problems(configuration));
+        Assert.Equal(-4, configuration.OpenRequestsPerUser);
+    }
+
+    /// <summary>
+    /// The refusal carries every problem rather than the first. An operator who hand-edited the file
+    /// and is told one mistake at a time restarts the server once per mistake.
+    /// </summary>
+    [Fact]
+    public void ARefusalCarriesEveryProblemRatherThanTheFirst()
+    {
+        var configuration = new PluginConfiguration
+        {
+            OpenRequestsPerUser = 0,
+            FinishedRequestRetentionDays = 1
+        };
+
+        var refused = Assert.Throws<InvalidConfigurationException>(
+            () => ConfigurationRules.RefuseWhatCannotWork(configuration));
+
+        string[] expected =
+            [nameof(PluginConfiguration.FinishedRequestRetentionDays), nameof(PluginConfiguration.OpenRequestsPerUser)];
+
+        Assert.Equal(expected, Settings(refused.Problems.Select(problem => problem.Setting)));
+
+        Assert.All(
+            refused.Problems,
+            problem => Assert.Contains(problem.Why, refused.Message, StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Saving a value this install cannot run on is refused, and nothing reaches the disk. The half
+    /// that matters is the second one: a save that is refused after the file has been replaced has
+    /// cost the operator the configuration that was working.
+    /// </summary>
+    [Fact]
+    public void SavingAValueThisInstallCannotRunOnIsRefusedAndWritesNothing()
+    {
+        using var host = new Doubles.PluginHost();
+
+        // A configuration this install can run on first, so what the refused save is measured
+        // against is a stored one rather than the absence of a file.
+        host.Plugin.UpdateConfiguration(new PluginConfiguration { OpenRequestsPerUser = 7 });
+
+        var before = host.XmlSerializer.WriteCount;
+
+        var refused = Assert.Throws<InvalidConfigurationException>(
+            () => host.Plugin.UpdateConfiguration(new PluginConfiguration { OpenRequestsPerUser = 0 }));
+
+        Assert.Equal(nameof(PluginConfiguration.OpenRequestsPerUser), Assert.Single(refused.Problems).Setting);
+        Assert.Equal(before, host.XmlSerializer.WriteCount);
+        Assert.Equal(7, host.Plugin.Configuration.OpenRequestsPerUser);
+    }
+
+    /// <summary>
+    /// A save this install can run on is taken. Without this the leg above passes for a plugin that
+    /// refuses every save.
+    /// </summary>
+    [Fact]
+    public void ASaveThisInstallCanRunOnIsTaken()
+    {
+        using var host = new Doubles.PluginHost();
+
+        var before = host.XmlSerializer.WriteCount;
+
+        host.Plugin.UpdateConfiguration(new PluginConfiguration { OpenRequestsPerUser = 3 });
+
+        Assert.Equal(3, host.Plugin.Configuration.OpenRequestsPerUser);
+        Assert.True(host.XmlSerializer.WriteCount > before);
+    }
+
+    /// <summary>
+    /// Reading a stored configuration this install cannot run on is a refusal rather than a value
+    /// somebody else chose. This is the half the settings page cannot cover: the file is editable by
+    /// hand, and a plugin that starts on a silently corrected number does something other than what
+    /// its own settings page shows.
+    /// </summary>
+    [Fact]
+    public void ReadingAStoredConfigurationThisInstallCannotRunOnIsRefused()
+    {
+        var stored = new PluginConfiguration { AcceptsMovies = false, AcceptsSeries = false };
+        var settings = new ServerInstallSettings(() => stored);
+
+        var refused = Assert.Throws<InvalidConfigurationException>(() => settings.Current);
+
+        string[] expected = [nameof(PluginConfiguration.AcceptsMovies), nameof(PluginConfiguration.AcceptsSeries)];
+
+        Assert.Equal(expected, Settings(refused.Problems.Select(problem => problem.Setting)));
+    }
+
+    /// <summary>
+    /// A stored configuration this install can run on is handed back as it is. The object itself,
+    /// rather than a copy, because a copy is where a corrected value would be able to hide.
+    /// </summary>
+    [Fact]
+    public void AStoredConfigurationThisInstallCanRunOnIsHandedBackAsItIs()
+    {
+        var stored = new PluginConfiguration { OpenRequestsPerUser = 2 };
+
+        Assert.Same(stored, new ServerInstallSettings(() => stored).Current);
+    }
+
+    /// <summary>
+    /// Asking what an install is set to before the plugin was loaded says that, rather than
+    /// answering with the defaults. An answer built out of nothing is one a caller cannot tell from
+    /// a fresh install.
+    /// </summary>
+    [Fact]
+    public void AskingBeforeThePluginWasLoadedSaysSoRatherThanAnsweringWithDefaults()
+    {
+        var settings = new ServerInstallSettings(() => null);
+
+        Assert.Throws<InvalidOperationException>(() => settings.Current);
+    }
+
+    /// <summary>
+    /// The settings a set of problems names, deduplicated and in name order, which is the shape
+    /// every comparison above is written in.
+    /// </summary>
+    /// <param name="named">The settings the problems named.</param>
+    /// <returns>The distinct names, in order.</returns>
+    private static string[] Settings(System.Collections.Generic.IEnumerable<string> named)
+        => [.. named.Distinct(StringComparer.Ordinal).OrderBy(name => name, StringComparer.Ordinal)];
+
+    /// <summary>
+    /// One configuration, with whatever this row changes about a fresh install.
+    /// </summary>
+    /// <param name="change">What this row is about.</param>
+    /// <returns>The configuration.</returns>
+    private static PluginConfiguration Fresh(Action<PluginConfiguration> change)
+    {
+        var configuration = new PluginConfiguration();
+        change(configuration);
+
+        return configuration;
+    }
+}

--- a/Jellyfin.Plugin.Requests/Configuration/ConfigurationProblem.cs
+++ b/Jellyfin.Plugin.Requests/Configuration/ConfigurationProblem.cs
@@ -1,0 +1,27 @@
+namespace Jellyfin.Plugin.Requests.Configuration;
+
+/// <summary>
+/// One thing about a configuration this plugin cannot honour, named as the field an operator has to
+/// change.
+/// <para>
+/// The field is carried as a value rather than left inside the sentence, so the settings page can
+/// put the message beside the box somebody typed in without parsing English out of it. That is the
+/// same shape <see cref="Api.RequestFailure.Field"/> uses for a body, and for the same reason: a
+/// surface that has to read a message to work out which control was wrong reads it from an example.
+/// </para>
+/// </summary>
+public sealed record ConfigurationProblem
+{
+    /// <summary>
+    /// Gets the setting that is wrong, spelled as <see cref="PluginConfiguration"/> spells it, which
+    /// is also how the stored file and the settings page spell it.
+    /// </summary>
+    public required string Setting { get; init; }
+
+    /// <summary>
+    /// Gets why this install cannot run on that value, in one sentence written for the operator who
+    /// typed it. It says what the value has to be and what goes wrong otherwise, so somebody refused
+    /// can fix it rather than guess at a number that will be accepted.
+    /// </summary>
+    public required string Why { get; init; }
+}

--- a/Jellyfin.Plugin.Requests/Configuration/ConfigurationRules.cs
+++ b/Jellyfin.Plugin.Requests/Configuration/ConfigurationRules.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Jellyfin.Plugin.Requests.Configuration;
+
+/// <summary>
+/// What a configuration has to be for this plugin to run on it, in one place, read by both moments
+/// a configuration arrives.
+/// <para>
+/// The two moments are a save from the dashboard and a load from the file. They need the same
+/// answer and they are not the same event: a plugin configuration is an XML file an operator can
+/// edit by hand, so a rule enforced only on the page is a rule an editor walks past. One set of
+/// rules read twice is what keeps the page and the file from disagreeing about what is allowed.
+/// </para>
+/// <para>
+/// <b>Nothing here corrects a value.</b> Clamping a negative quota to zero, or a short retention up
+/// to the floor, is the failure this type exists against: the install then does something other than
+/// what its settings page shows, and nobody is told which of the two is true. A refusal keeps the
+/// operator's value and says why it cannot be honoured.
+/// </para>
+/// <para>
+/// A rule names the setting it is about. Where one rule is about two settings, as the accepted kinds
+/// are, it names both, because either one of them is enough to fix it and a page that highlighted
+/// one would be pointing at half the answer.
+/// </para>
+/// </summary>
+public static class ConfigurationRules
+{
+    /// <summary>
+    /// The smallest quota that lets anybody ask for anything. Zero is not a strict install, it is an
+    /// install where the request endpoint refuses every caller while the plugin still advertises
+    /// itself, and a negative number is the same thing typed by accident.
+    /// </summary>
+    public const int SmallestQuota = 1;
+
+    /// <summary>
+    /// Everything wrong with a configuration, or an empty list where there is nothing wrong.
+    /// <para>
+    /// Every problem rather than the first. An operator who hand-edited the file and gets one
+    /// refusal at a time has to restart the server once per mistake to find out how many they made.
+    /// </para>
+    /// </summary>
+    /// <param name="configuration">The configuration to judge.</param>
+    /// <returns>One entry per setting that cannot be honoured, in the order the settings page shows them.</returns>
+    /// <exception cref="ArgumentNullException">Where no configuration was given.</exception>
+    public static IReadOnlyList<ConfigurationProblem> Problems(PluginConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var problems = new List<ConfigurationProblem>();
+
+        if (configuration.OpenRequestsPerUser < SmallestQuota)
+        {
+            problems.Add(new ConfigurationProblem
+            {
+                Setting = nameof(PluginConfiguration.OpenRequestsPerUser),
+                Why = string.Format(
+                    CultureInfo.InvariantCulture,
+                    "OpenRequestsPerUser is {0} and has to be at least {1}. Below that nobody may have a request open, so every ask is refused while the plugin still offers itself, and an operator reading the queue sees an empty one rather than a setting.",
+                    configuration.OpenRequestsPerUser,
+                    SmallestQuota)
+            });
+        }
+
+        // The two kinds are one rule, because neither switch is wrong on its own and the pair can
+        // be. Both are named: turning either back on fixes it, and the operator picks which.
+        if (!configuration.AcceptsMovies && !configuration.AcceptsSeries)
+        {
+            problems.Add(NoKindAccepted(nameof(PluginConfiguration.AcceptsMovies)));
+            problems.Add(NoKindAccepted(nameof(PluginConfiguration.AcceptsSeries)));
+        }
+
+        if (configuration.FinishedRequestRetentionDays < PluginConfiguration.MinimumRetentionDays)
+        {
+            problems.Add(new ConfigurationProblem
+            {
+                Setting = nameof(PluginConfiguration.FinishedRequestRetentionDays),
+                Why = string.Format(
+                    CultureInfo.InvariantCulture,
+                    "FinishedRequestRetentionDays is {0} and has to be at least {1}. A shorter period removes the history while people are still asking about it, and the queue then answers \"was this asked for before\" with no.",
+                    configuration.FinishedRequestRetentionDays,
+                    PluginConfiguration.MinimumRetentionDays)
+            });
+        }
+
+        return problems;
+    }
+
+    /// <summary>
+    /// Whether this plugin can run on a configuration.
+    /// </summary>
+    /// <param name="configuration">The configuration to judge.</param>
+    /// <returns><see langword="true"/> where nothing about it is refused.</returns>
+    /// <exception cref="ArgumentNullException">Where no configuration was given.</exception>
+    public static bool CanBeHonoured(PluginConfiguration configuration) => Problems(configuration).Count == 0;
+
+    /// <summary>
+    /// Refuses a configuration this plugin cannot run on, and does nothing at all otherwise.
+    /// <para>
+    /// This is what both moments call. Returning a corrected copy is the shape that is not offered,
+    /// because a caller that receives one has no way to tell it apart from the one it passed in.
+    /// </para>
+    /// </summary>
+    /// <param name="configuration">The configuration to judge.</param>
+    /// <exception cref="ArgumentNullException">Where no configuration was given.</exception>
+    /// <exception cref="InvalidConfigurationException">Where anything about it is refused.</exception>
+    public static void RefuseWhatCannotWork(PluginConfiguration configuration)
+    {
+        var problems = Problems(configuration);
+
+        if (problems.Count > 0)
+        {
+            throw new InvalidConfigurationException(problems);
+        }
+    }
+
+    private static ConfigurationProblem NoKindAccepted(string setting)
+        => new ConfigurationProblem
+        {
+            Setting = setting,
+            Why = "AcceptsMovies and AcceptsSeries are both off, and at least one kind has to be accepted. With neither there is nothing anybody can ask for, which is an install that cannot work rather than a strict one.",
+        };
+}

--- a/Jellyfin.Plugin.Requests/Configuration/InvalidConfigurationException.cs
+++ b/Jellyfin.Plugin.Requests/Configuration/InvalidConfigurationException.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Jellyfin.Plugin.Requests.Configuration;
+
+/// <summary>
+/// Thrown where a configuration cannot be honoured, on the way in from the settings page or on the
+/// way in from the file.
+/// <para>
+/// It carries the problems as values rather than only as a sentence, so a caller can name the field
+/// without reading English. The message exists as well, because the place this most often surfaces
+/// is the server's log, and a log line saying only that something was refused is a log line an
+/// operator cannot act on.
+/// </para>
+/// <para>
+/// <b>Nothing in the message names a path on the server's disk or a person.</b> A configuration
+/// refusal is pasted into an issue tracker as readily as any other log line, which is the same rule
+/// the API's failures are written under.
+/// </para>
+/// </summary>
+public sealed class InvalidConfigurationException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidConfigurationException"/> class for a set
+    /// of problems.
+    /// </summary>
+    /// <param name="problems">What cannot be honoured, one entry per setting.</param>
+    /// <exception cref="ArgumentNullException">Where no problems were given.</exception>
+    public InvalidConfigurationException(IReadOnlyList<ConfigurationProblem> problems)
+        : base(Describe(problems))
+    {
+        Problems = problems;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidConfigurationException"/> class. Present
+    /// because the analyzers ask every exception for the three ordinary constructors; the
+    /// constructor above is the one this type exists for.
+    /// </summary>
+    public InvalidConfigurationException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidConfigurationException"/> class with a
+    /// message of the caller's own. See the note on the parameterless constructor.
+    /// </summary>
+    /// <param name="message">What happened.</param>
+    public InvalidConfigurationException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidConfigurationException"/> class with a
+    /// message and an inner exception. See the note on the parameterless constructor.
+    /// </summary>
+    /// <param name="message">What happened.</param>
+    /// <param name="innerException">What it happened because of.</param>
+    public InvalidConfigurationException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    /// Gets what cannot be honoured, one entry per setting. Empty where this was built by one of the
+    /// constructors that names no problem.
+    /// </summary>
+    public IReadOnlyList<ConfigurationProblem> Problems { get; } = [];
+
+    private static string Describe(IReadOnlyList<ConfigurationProblem> problems)
+    {
+        ArgumentNullException.ThrowIfNull(problems);
+
+        return string.Concat(
+            "This plugin's settings cannot be honoured, so it is refusing them rather than running on values nobody chose. ",
+            string.Join(" ", problems.Select(problem => problem.Why)));
+    }
+}

--- a/Jellyfin.Plugin.Requests/Configuration/ServerInstallSettings.cs
+++ b/Jellyfin.Plugin.Requests/Configuration/ServerInstallSettings.cs
@@ -8,17 +8,74 @@ namespace Jellyfin.Plugin.Requests.Configuration;
 /// This is the one place that reaches for that instance. Everything above takes
 /// <see cref="IInstallSettings"/>, so the reach exists once and is testable everywhere else.
 /// </para>
+/// <para>
+/// <b>What is read is also what is judged.</b> A configuration is an XML file an operator can edit
+/// by hand, and the dashboard is not the only way one arrives, so a file holding a value the plugin
+/// cannot honour is refused here rather than quietly replaced with a number nobody chose. Refusing
+/// on the read is what makes the refusal reach every caller: nothing above this can act on a
+/// corrected value, because no corrected value is ever produced. The rules are
+/// <see cref="ConfigurationRules"/> and the save side of the same check is
+/// <c>Plugin.UpdateConfiguration</c>.
+/// </para>
+/// <para>
+/// Where an operator finds it is the server's log, through whatever asked. That is the honest limit
+/// of this: it is a refusal a person reads in a log rather than a banner on a page, and a page that
+/// says what is wrong with this install is the diagnostics view in #63.
+/// </para>
 /// </summary>
 public sealed class ServerInstallSettings : IInstallSettings
 {
+    private readonly Func<PluginConfiguration?> _stored;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ServerInstallSettings"/> class over the plugin
+    /// the host constructed. This is the one the container builds.
+    /// </summary>
+    public ServerInstallSettings()
+        : this(static () => Plugin.Instance?.Configuration)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ServerInstallSettings"/> class over some other
+    /// way of getting at the stored settings.
+    /// <para>
+    /// It exists so the refusal above can be proven without a plugin instance. The instance is a
+    /// static the host sets while it is loading, so a test that reached for it would be reading a
+    /// value any other test running beside it can replace, and the guard on the refusal would fail
+    /// for a reason nobody caused.
+    /// </para>
+    /// </summary>
+    /// <param name="stored">
+    /// What the server holds, or <see langword="null"/> where this plugin has not been loaded.
+    /// </param>
+    /// <exception cref="ArgumentNullException">Where nothing was given to read from.</exception>
+    public ServerInstallSettings(Func<PluginConfiguration?> stored)
+    {
+        ArgumentNullException.ThrowIfNull(stored);
+
+        _stored = stored;
+    }
+
     /// <inheritdoc />
     /// <exception cref="InvalidOperationException">
     /// Where the plugin has not been loaded, so there is no configuration to read. That is a host
     /// that never loaded this plugin rather than an install with nothing set, and it says so instead
     /// of answering with defaults nobody chose.
     /// </exception>
+    /// <exception cref="InvalidConfigurationException">
+    /// Where what is stored is something this plugin cannot run on.
+    /// </exception>
     public PluginConfiguration Current
-        => (Plugin.Instance ?? throw new InvalidOperationException(
-            "The settings were asked for before this plugin was loaded, so there is no configuration to read."))
-            .Configuration;
+    {
+        get
+        {
+            var configuration = _stored() ?? throw new InvalidOperationException(
+                "The settings were asked for before this plugin was loaded, so there is no configuration to read.");
+
+            ConfigurationRules.RefuseWhatCannotWork(configuration);
+
+            return configuration;
+        }
+    }
 }

--- a/Jellyfin.Plugin.Requests/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Requests/Configuration/configPage.html
@@ -133,11 +133,21 @@
 
                     document.querySelector("#RequestsConfigForm").addEventListener("submit", function (e) {
                         Dashboard.showLoadingMsg();
-                        ApiClient.getPluginConfiguration(RequestsConfig.pluginUniqueId).then(function (config) {
-                            ApiClient.updatePluginConfiguration(RequestsConfig.pluginUniqueId, read(config)).then(function (result) {
+                        ApiClient.getPluginConfiguration(RequestsConfig.pluginUniqueId)
+                            .then(function (config) {
+                                return ApiClient.updatePluginConfiguration(RequestsConfig.pluginUniqueId, read(config));
+                            })
+                            .then(function (result) {
                                 Dashboard.processPluginConfigurationUpdateResult(result);
+                            })
+                            // The plugin refuses settings it cannot run on rather than saving a
+                            // corrected version of them, so a save can come back refused. Without
+                            // this the loading indicator is hidden by nothing and the operator is
+                            // left looking at a form that appears to have been accepted.
+                            .catch(function () {
+                                Dashboard.hideLoadingMsg();
+                                RequestsShell.say(page, "These settings were refused and nothing was changed. The server log names the field and says why.");
                             });
-                        });
 
                         e.preventDefault();
                         return false;

--- a/Jellyfin.Plugin.Requests/Plugin.cs
+++ b/Jellyfin.Plugin.Requests/Plugin.cs
@@ -43,6 +43,33 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// </summary>
     public static Plugin? Instance { get; private set; }
 
+    /// <inheritdoc />
+    /// <exception cref="InvalidConfigurationException">
+    /// Where the settings that arrived are ones this plugin cannot run on. The save is refused
+    /// before anything is written, so the file on disk still holds the configuration that was
+    /// working, and an operator who typed a number by mistake has not lost the one they had.
+    /// <para>
+    /// The dashboard is not the only way a configuration arrives, so this is half of the check
+    /// rather than the whole of it. <see cref="ServerInstallSettings"/> is the other half, on the
+    /// read, and both call <see cref="ConfigurationRules"/> so the page and the file cannot be
+    /// judged by two different lists.
+    /// </para>
+    /// </exception>
+    public override void UpdateConfiguration(BasePluginConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        // Only this plugin's own shape is judged. Anything else is a caller handing the wrong type
+        // to the wrong plugin, which the base class already answers, and a second answer here would
+        // be this plugin deciding what that failure looks like.
+        if (configuration is PluginConfiguration settings)
+        {
+            ConfigurationRules.RefuseWhatCannotWork(settings);
+        }
+
+        base.UpdateConfiguration(configuration);
+    }
+
     /// <summary>
     /// The pages this plugin puts in the dashboard, and the two files they share.
     /// <para>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,7 +27,8 @@ without this page moving with it, and again if the page cannot reach one of them
 recognise in a library. Accepting a kind nothing can match would leave a person waiting on a request
 that no fulfilment check can ever answer, so the accepted set and the recognised set are the same
 set. Which kinds ship at 1.0 was decided on #113. Turning both off leaves nothing anybody can ask
-for, which is a configuration that cannot work rather than a strict one; refusing it is #96.
+for, which is a configuration that cannot work rather than a strict one, and it is refused rather
+than saved.
 
 A kind is a setting of its own rather than an entry in a list. A third kind then has to move this
 page, the class and the settings form together, instead of arriving as an appended value that
@@ -55,6 +56,30 @@ requests are answered can keep asking.
 
 Where the quota is enforced is #114, and that is not built yet either. **Nothing refuses an
 eleventh open request today.**
+
+## What is refused
+
+A plugin configuration is an XML file on the server, and the dashboard is not the only way one
+arrives: an operator can edit that file, and a restore can put an older one back. So the rules below
+are read at both moments a configuration reaches this plugin, from the same list, in
+[`ConfigurationRules`](../Jellyfin.Plugin.Requests/Configuration/ConfigurationRules.cs).
+
+| Setting                      | Refused when | Because                                                                                        |
+| ---------------------------- | ------------ | ---------------------------------------------------------------------------------------------- |
+| OpenRequestsPerUser          | below 1      | nobody may have a request open, so every ask is refused by an install that still offers itself |
+| AcceptsMovies, AcceptsSeries | both off     | there is nothing anybody can ask for                                                           |
+| FinishedRequestRetentionDays | below 30     | the history is removed while people are still asking about it                                  |
+
+**Nothing is corrected on the way in.** A quota of zero is not raised to one and a retention of five
+days is not raised to thirty. An install running a value it substituted does something other than
+what its own settings page shows, and there is nothing an operator can read that tells them which of
+the two is true. The refusal keeps the value they typed and says which field it is about.
+
+On a save, the refusal reaches the dashboard and the file on disk is not touched, so a number typed
+by mistake does not cost the configuration that was working. On a read, whatever asked what this
+install is set to is refused instead of being answered, and the sentence lands in the server's log
+naming the field. That is the honest limit of the second half: it is a log line rather than a banner
+on a page, and a page that says what is wrong with an install is #63.
 
 ## A fresh install
 


### PR DESCRIPTION
Closes #96.

A plugin configuration is an XML file an operator can edit by hand, so the dashboard is not the only
way one reaches this plugin. Nothing judged either route until now: a quota of zero, a retention
period of five days, and both media kinds switched off were all saved and then read back, and an
install would have run on values that make it unusable while its settings page went on showing them.

Nothing is corrected on the way in. Clamping a value is the tempting repair and it is the worse one:
an install that silently replaced a number does something other than what its own settings page
shows, and there is nothing an operator can read that says which of the two is true. A refusal keeps
the value that was typed and names the field it is about.

## What landed

`ConfigurationRules` holds the list once and both moments read it, so the page and the file cannot be
judged against two different lists.

| Setting                      | Refused when | Because                                                                                        |
| ---------------------------- | ------------ | ---------------------------------------------------------------------------------------------- |
| OpenRequestsPerUser          | below 1      | nobody may have a request open, so every ask is refused by an install that still offers itself |
| AcceptsMovies, AcceptsSeries | both off     | there is nothing anybody can ask for                                                           |
| FinishedRequestRetentionDays | below 30     | the history is removed while people are still asking about it                                  |

On a save, `Plugin.UpdateConfiguration` refuses before anything is written, so a number typed by
mistake does not cost the configuration that was working. On a read, `ServerInstallSettings` refuses
instead of answering, so no caller above it can act on a value nobody chose. The field is carried on
`ConfigurationProblem.Setting` as a value rather than only inside a sentence, so a surface can put
the message beside the control without parsing English out of it.

## The build and the suite

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
        0 Warnung(en)
        0 Fehler

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler: 0, erfolgreich: 423, gesamt: 423 (net9.0)
    Bestanden!   : Fehler: 0, erfolgreich: 423, gesamt: 423 (net10.0)

## Every guard was watched failing

Each run below is `dotnet test Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj -f net9.0 --configuration Release --filter "FullyQualifiedName~ConfigurationRulesTests"` with one thing broken, and the class is 15 tests green with nothing broken.

The retention rule deleted from `ConfigurationRules.Problems`:

    ConfigurationRulesTests.ARefusalCarriesEveryProblemRatherThanTheFirst [FAIL]
    ConfigurationRulesTests.TheFirstValueOutsideEachRuleIsRefusedAndNamesTheField(rule: "the retention period", ...) [FAIL]
    ConfigurationRulesTests.EverySettingIsNamedByARule [FAIL]
    Fehler: 3, erfolgreich: 12, gesamt: 15

The quota comparison off by one, `<` written as `<=`, which is the mistake somebody actually makes:

    ConfigurationRulesTests.TheLastValueEachRuleAllowsIsAccepted(rule: "the quota", ...) [FAIL]
    Fehler: 1, erfolgreich: 14, gesamt: 15

The save side no longer calling the rules:

    ConfigurationRulesTests.SavingAValueThisInstallCannotRunOnIsRefusedAndWritesNothing [FAIL]
    Fehler: 1, erfolgreich: 14, gesamt: 15

The read side no longer calling the rules:

    ConfigurationRulesTests.ReadingAStoredConfigurationThisInstallCannotRunOnIsRefused [FAIL]
    Fehler: 1, erfolgreich: 14, gesamt: 15

`EverySettingIsNamedByARule` is the leg aimed at the change nobody plans: a setting added later with
nothing judging it. The hostile configuration it uses is written out by hand, so a new setting is a
name in the class that is not in the answer, and whoever adds it has to say what value of it cannot
work.

## Formatting

`docs/configuration.md` and the settings page were checked against the version of Prettier the gate
pins, on copies with the line endings the gate's checkout has:

    npx --yes prettier@3.6.2 --check "configuration.md" "configPage.html"
    All matched files use Prettier code style!

## What is not claimed

**No server was run for this change.** The refusal on a save is proven against
`Plugin.UpdateConfiguration` with the host double, and the settings page grows a branch that says a
save was refused and nothing was changed. What that branch looks like in a real dashboard has not
been seen, because a browser run is not something this tree does.

The refusal on a read reaches an operator as a line in the server's log, through whatever asked what
this install is set to. That is a log line rather than a banner on a page. A page that says what is
wrong with an install is #63, and `docs/configuration.md` says so in place of implying more.

`docs/configuration.md` is outside the `Scope:` line of #96, which names the configuration code and
the test project. It moved because it carried two sentences saying that refusing this was #96 and
had not happened, and a document that describes the opposite of the tree is worse than one that says
nothing. The settings page is inside that scope: it is `Configuration/configPage.html`.

## One reader

**This change has had no second reader.** The evidence above stands in place of one.
