### PR TITLE
Name a person to the external service by the operator's table, never by their name

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Bridge/BackendAccountTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Bridge/BackendAccountTests.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Jellyfin.Plugin.Requests.Bridge;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Bridge;
+
+/// <summary>
+/// Whose name a request carries on the external service, and what a person who is not on the
+/// operator's table gets instead.
+/// <para>
+/// The two failures these legs stand against are opposite. One is a Jellyfin user's name arriving at
+/// a system they never signed up to. The other is every request over there coming from one account,
+/// so that side cannot tell who asked and nobody here notices, because the queue on this side is
+/// still right.
+/// </para>
+/// </summary>
+public class BackendAccountTests
+{
+    private static readonly Guid Anna = new Guid("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid Bram = new Guid("22222222-2222-2222-2222-222222222222");
+
+    /// <summary>
+    /// A fresh install has mapped nobody. This is the shipping answer rather than a state on the way
+    /// to one, and it is the reason the leg below is the ordinary case rather than an edge one.
+    /// </summary>
+    [Fact]
+    public void AFreshInstallHasMappedNobody()
+    {
+        Assert.Equal(0, BackendAccounts.Empty.Count);
+    }
+
+    /// <summary>
+    /// Somebody the operator has not mapped is attributed to the service's own account, which is a
+    /// value that says so rather than an absence each caller would answer differently.
+    /// </summary>
+    [Fact]
+    public void SomebodyTheOperatorHasNotMappedGoesUnderTheServiceAccount()
+    {
+        var account = BackendAccounts.Empty.For(Anna);
+
+        Assert.Equal(BackendAccount.TheServiceAccount, account);
+        Assert.False(account.CarriesWhoAsked);
+        Assert.Null(account.Name);
+    }
+
+    /// <summary>
+    /// Somebody the operator mapped carries the account the operator wrote, exactly as they wrote
+    /// it. Nothing normalises it: an account name over there is that service's string and not this
+    /// plugin's to tidy.
+    /// </summary>
+    [Fact]
+    public void SomebodyTheOperatorMappedCarriesTheAccountTheOperatorWrote()
+    {
+        var accounts = new BackendAccounts(new Dictionary<Guid, string> { [Anna] = "anna.on.the.service" });
+
+        var account = accounts.For(Anna);
+
+        Assert.Equal("anna.on.the.service", account.Name);
+        Assert.True(account.CarriesWhoAsked);
+    }
+
+    /// <summary>
+    /// One person being mapped does not map the rest. Without this leg the two above pass for an
+    /// implementation that answers with whichever row it read last.
+    /// </summary>
+    [Fact]
+    public void MappingOnePersonLeavesEverybodyElseUnmapped()
+    {
+        var accounts = new BackendAccounts(new Dictionary<Guid, string> { [Anna] = "anna.on.the.service" });
+
+        Assert.Equal(BackendAccount.TheServiceAccount, accounts.For(Bram));
+    }
+
+    /// <summary>
+    /// Nothing is resolved from what a person is called. The lookup takes a user identifier and
+    /// there is no other way in, so matching by name is a shape this type does not have rather than
+    /// a behaviour somebody has to remember not to add. Two people with similar names would
+    /// otherwise be attributed each other's requests, and the first sign of it is one of them seeing
+    /// something that is not theirs.
+    /// </summary>
+    [Fact]
+    public void NothingIsResolvedFromWhatAPersonIsCalled()
+    {
+        var lookups = typeof(BackendAccounts)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(method => string.Equals(method.Name, nameof(BackendAccounts.For), StringComparison.Ordinal))
+            .ToArray();
+
+        var taken = lookups
+            .SelectMany(method => method.GetParameters())
+            .Select(parameter => parameter.ParameterType.Name)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Single(lookups);
+        Assert.Equal([nameof(Guid)], taken);
+    }
+
+    /// <summary>
+    /// The account carries nothing but what the operator typed. This is the guard on the sentence in
+    /// the documentation about what leaves the server: a field added here later that held a Jellyfin
+    /// display name would send it to the service on the next submission and read as an improvement
+    /// in the diff.
+    /// </summary>
+    [Fact]
+    public void TheAccountCarriesNothingButWhatTheOperatorTyped()
+    {
+        var carried = typeof(BackendAccount)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Select(property => string.Concat(property.Name, " is ", property.PropertyType.Name))
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        string[] expected = ["CarriesWhoAsked is Boolean", "Name is String"];
+
+        Assert.Equal(expected, carried);
+    }
+
+    /// <summary>
+    /// A row naming no user is refused. Honouring one would be an account that every unmapped person
+    /// is attributed to, arriving through a row somebody left half filled in.
+    /// </summary>
+    [Fact]
+    public void ARowNamingNoUserIsRefused()
+    {
+        var table = new Dictionary<Guid, string> { [Guid.Empty] = "somebody" };
+
+        Assert.Throws<ArgumentException>(() => new BackendAccounts(table));
+    }
+
+    /// <summary>
+    /// A row naming no account is refused. Removing the row is how a person is left unmapped, and a
+    /// blank account is a row that was started rather than a decision to attribute nothing.
+    /// </summary>
+    /// <param name="blank">An account name that is not one.</param>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ARowNamingNoAccountIsRefused(string blank)
+    {
+        var table = new Dictionary<Guid, string> { [Anna] = blank };
+
+        var refused = Assert.Throws<ArgumentException>(() => new BackendAccounts(table));
+
+        Assert.Contains(Anna.ToString(), refused.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The table is copied rather than held. A caller that kept the dictionary it passed in could
+    /// otherwise add a person to the mapping afterwards, and what the service is told about who
+    /// asked would change under a submission already being made.
+    /// </summary>
+    [Fact]
+    public void TheTableIsCopiedRatherThanHeld()
+    {
+        var table = new Dictionary<Guid, string> { [Anna] = "anna.on.the.service" };
+        var accounts = new BackendAccounts(table);
+
+        table[Bram] = "bram.on.the.service";
+
+        Assert.Equal(BackendAccount.TheServiceAccount, accounts.For(Bram));
+        Assert.Equal(1, accounts.Count);
+    }
+}

--- a/Jellyfin.Plugin.Requests/Bridge/BackendAccount.cs
+++ b/Jellyfin.Plugin.Requests/Bridge/BackendAccount.cs
@@ -1,0 +1,49 @@
+namespace Jellyfin.Plugin.Requests.Bridge;
+
+/// <summary>
+/// Whose name a request carries on the external service.
+/// <para>
+/// Two answers and no third. Either the operator mapped this person to an account over there, in
+/// which case the submission carries the name the operator wrote, or they did not, in which case it
+/// goes under the service's own account and that service is told nothing about who asked.
+/// </para>
+/// <para>
+/// <b>Nothing on this record comes from the Jellyfin user.</b> The only string it can hold is one an
+/// operator typed into the mapping, which is what keeps a Jellyfin display name out of a system
+/// somebody never signed up to. <c>TheAccountCarriesNothingButWhatTheOperatorTyped</c> refuses a
+/// field added later that would carry one.
+/// </para>
+/// </summary>
+public sealed record BackendAccount
+{
+    /// <summary>
+    /// Gets the account every submission goes under where the person who asked is not mapped to one.
+    /// <para>
+    /// It is a value rather than the absence of one. "Unmapped" is a case an operator can read in
+    /// the documentation and predict, and a null handed around instead would be a fallback nobody
+    /// chose reached by whatever each caller did with it.
+    /// </para>
+    /// </summary>
+    public static BackendAccount TheServiceAccount { get; } = new BackendAccount();
+
+    /// <summary>
+    /// Gets the account on the external service, exactly as the operator wrote it in the mapping,
+    /// or <see langword="null"/> where this person is not mapped and the service's own account is
+    /// what carries the request.
+    /// </summary>
+    public string? Name { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the service is told who asked. Where it is false the request
+    /// arrives over there under the service's own account, so that side knows a request was made and
+    /// not by whom.
+    /// </summary>
+    public bool CarriesWhoAsked => Name is not null;
+
+    /// <summary>
+    /// One account on the external service.
+    /// </summary>
+    /// <param name="name">The account, as the operator wrote it.</param>
+    /// <returns>The account.</returns>
+    public static BackendAccount Named(string name) => new BackendAccount { Name = name };
+}

--- a/Jellyfin.Plugin.Requests/Bridge/BackendAccounts.cs
+++ b/Jellyfin.Plugin.Requests/Bridge/BackendAccounts.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Jellyfin.Plugin.Requests.Bridge;
+
+/// <summary>
+/// The table an operator keeps of who is who on the external service, and the one rule for reading
+/// it.
+/// <para>
+/// It is empty on a fresh install, which is the shipping answer rather than a state on the way to
+/// one: an operator who configures a bridge and stops there has every request arrive over there
+/// under the service's own account, and that service is told nothing about the people on this
+/// server. Attribution is a thing they turn on per person, by writing a line, and the line says what
+/// leaves.
+/// </para>
+/// <para>
+/// <b>A person is found by their identifier and never by their name.</b> The lookup takes a user
+/// identifier and there is no overload that takes anything else, so matching by name is not a
+/// behaviour that can be switched on here; it is a shape this type does not have.
+/// <c>NothingIsResolvedFromWhatAPersonIsCalled</c> is the guard on that. Two people with similar
+/// names would otherwise be attributed each other's requests, and nobody finds out until one of them
+/// sees something that is not theirs.
+/// </para>
+/// <para>
+/// Where the table is kept, and how an operator edits it, arrives with the adapter that reads it in
+/// #82. Nothing on this side reads it yet, so a settings field for it now would be somewhere to type
+/// something nothing uses. <c>docs/bridge.md</c> carries the decision, the two shapes it was chosen
+/// over, and what each of them costs.
+/// </para>
+/// </summary>
+public sealed class BackendAccounts
+{
+    private readonly Dictionary<Guid, string> _byUser;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BackendAccounts"/> class.
+    /// </summary>
+    /// <param name="byUser">
+    /// The account on the external service for each person the operator has mapped, by Jellyfin user
+    /// identifier.
+    /// </param>
+    /// <exception cref="ArgumentNullException">Where no table was given.</exception>
+    /// <exception cref="ArgumentException">
+    /// Where a row names no user, or names an account that is nothing but space. Both are a row
+    /// somebody meant to fill in, and honouring either would attribute a request to an account
+    /// nobody chose.
+    /// </exception>
+    public BackendAccounts(IReadOnlyDictionary<Guid, string> byUser)
+    {
+        ArgumentNullException.ThrowIfNull(byUser);
+
+        _byUser = new Dictionary<Guid, string>(byUser.Count);
+
+        foreach (var row in byUser)
+        {
+            if (row.Key == Guid.Empty)
+            {
+                throw new ArgumentException(
+                    "A row of the account mapping names no user. A row that names nobody would be an account every unmapped person is attributed to.",
+                    nameof(byUser));
+            }
+
+            if (string.IsNullOrWhiteSpace(row.Value))
+            {
+                throw new ArgumentException(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        "The account mapping has a row with no account on it, for user {0}. Removing the row is how somebody is left unmapped; a blank account is a row that was started and not finished.",
+                        row.Key),
+                    nameof(byUser));
+            }
+
+            _byUser[row.Key] = row.Value;
+        }
+    }
+
+    /// <summary>
+    /// Gets the table an install runs before an operator has written anything in it, which is what
+    /// every install runs today.
+    /// </summary>
+    public static BackendAccounts Empty { get; } = new BackendAccounts(new Dictionary<Guid, string>());
+
+    /// <summary>
+    /// Gets how many people the operator has mapped.
+    /// </summary>
+    public int Count => _byUser.Count;
+
+    /// <summary>
+    /// Whose name a request from one person carries on the external service.
+    /// </summary>
+    /// <param name="user">The Jellyfin user who asked, by identifier.</param>
+    /// <returns>
+    /// The account the operator mapped them to, or <see cref="BackendAccount.TheServiceAccount"/>
+    /// where they mapped nobody. The second is an answer rather than a failure: it is what every
+    /// install gives until somebody writes a row.
+    /// </returns>
+    public BackendAccount For(Guid user)
+        => _byUser.TryGetValue(user, out var account)
+            ? BackendAccount.Named(account)
+            : BackendAccount.TheServiceAccount;
+}

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -76,6 +76,52 @@ history, and the person it belongs to is told something untrue about their own r
 Case is ignored when a word is looked up, because two adapters written against one service will spell
 one word two ways and both mean what the service meant. Nothing else is normalised.
 
+## Whose name a request carries over there
+
+The external service has its own users, and something has to decide whose name a submitted request
+arrives under. Three shapes were available and the decision on #113 is the first of them.
+
+| Shape                             | Chosen          | What it costs                                                                                                                              |
+| --------------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| A mapping an operator keeps       | yes             | somebody has to keep it current, and a person who is not in it is not attributed                                                           |
+| One shared account for everything | as the fallback | that side cannot tell who asked, so its own queue reads as though the plugin asked for everything                                          |
+| Matching by the person's name     | no              | it is wrong the first time two people have similar names, and it is wrong in the direction that attributes one person's request to another |
+
+**Matching by name is not built, rather than built and switched off.** The lookup in
+[`BackendAccounts`](../Jellyfin.Plugin.Requests/Bridge/BackendAccounts.cs) takes a Jellyfin user
+identifier and there is no other way in, which `NothingIsResolvedFromWhatAPersonIsCalled` refuses a
+change to. The failure it stands against is one nobody notices from this side: the queue here stays
+correct while somebody over there is credited with a request that is not theirs, and the first sign
+of it is that person seeing it.
+
+**The mapping is empty on a fresh install.** That is the shipping answer and not a state on the way
+to one. An operator who configures a bridge and writes no rows has every request arrive over there
+under the service's own account, so the service is told that a request was made and not by whom.
+Attribution is turned on one person at a time, by writing a row, and writing the row is what says
+that person's account name may leave.
+
+Where the table is kept and how it is edited arrives with the adapter that reads it, in #82. Nothing
+on this side reads it today, so a settings field for it now would be somewhere to type something
+nothing uses.
+
+### What leaves the server when a bridge is configured
+
+Nothing leaves any server today, because the only bridge in this tree is the one with nothing behind
+it and it makes no call. What the shape above allows to leave, once an adapter exists, is this:
+
+- **The account name the operator wrote**, for a person who has a row. It is that operator's own
+  string for that service, passed through as they typed it.
+- **Nothing at all about a person who has no row.** No Jellyfin user name, no Jellyfin user
+  identifier, and no electronic mail address. The request arrives under the service's own account.
+
+The account record carries the operator's string and nothing else, and
+`TheAccountCarriesNothingButWhatTheOperatorTyped` refuses a field added to it later. That matters
+because a field holding a display name would start sending it on the next submission and would read
+as an improvement in the diff.
+
+What a request itself carries to the service, as opposed to whose name it carries, is #82's, and it
+is not decided here.
+
 ## What needs a bridge
 
 Nothing does, and that is a claim the suite refuses to let drift rather than a sentence somebody


### PR DESCRIPTION
Closes #84.

Decision 10 on #113 is answered: a table I keep, empty by default, with the service's own
account as the fallback for anybody not in it, and no matching by name. Nothing in this tree carried
that answer, so this writes it down and builds the one rule that reads it.

## Matching by name is not built, rather than built and switched off

`BackendAccounts.For` takes a Jellyfin user identifier and there is no other way in. That is the
whole of the guard: a lookup from what a person is called is a shape this type does not have.

The failure it stands against is invisible from this side. Two people with similar names are
attributed each other's requests on the service, the queue here stays correct throughout, and the
first sign of it is one of them seeing something that is not theirs.

## The empty table is the shipping answer

An operator who configures a bridge and writes no rows has every request arrive over there under the
service's own account, so that side is told a request was made and not by whom. Writing a row is what
says an account name may leave. `BackendAccount.TheServiceAccount` is a value rather than a null, so
"unmapped" is a case an operator can read and predict instead of one each caller answers its own way.

Where the table is kept and how it is edited arrives with the adapter that reads it, in #82. Nothing
reads it today, so a settings field for it now would be somewhere to type something nothing uses, and
that is the shape `PluginConfiguration` was deliberately kept clear of.

## What leaves the server

`docs/bridge.md` now carries the account of it: my own string for a mapped person, and
nothing at all about an unmapped one, with no Jellyfin user name, identifier or address in either
case. `TheAccountCarriesNothingButWhatTheOperatorTyped` refuses a field added to the record later,
because a field holding a display name would start sending it on the next submission and would read
as an improvement in the diff.

## The build and the suite

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
        0 Warnung(en)
        0 Fehler

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler: 0, erfolgreich: 433, gesamt: 433 (net9.0)
    Bestanden!   : Fehler: 0, erfolgreich: 433, gesamt: 433 (net10.0)

## Every guard was watched failing

Each run is `dotnet test Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj -f net9.0 --configuration Release --filter FullyQualifiedName~BackendAccountTests`, with one thing broken. The class is 10 tests green with nothing broken.

The unmapped answer leaking the Jellyfin identifier instead of using the service account, which is the mistake that looks like an improvement:

    BackendAccountTests.MappingOnePersonLeavesEverybodyElseUnmapped [FAIL]
    BackendAccountTests.SomebodyTheOperatorHasNotMappedGoesUnderTheServiceAccount [FAIL]
    BackendAccountTests.TheTableIsCopiedRatherThanHeld [FAIL]
    Fehler: 3, erfolgreich: 7, gesamt: 10

A lookup by what a person is called added beside the one that takes an identifier:

    BackendAccountTests.NothingIsResolvedFromWhatAPersonIsCalled [FAIL]
    Fehler: 1, erfolgreich: 9, gesamt: 10

A Jellyfin display name added to the account record:

    BackendAccountTests.TheAccountCarriesNothingButWhatTheOperatorTyped [FAIL]
    Fehler: 1, erfolgreich: 9, gesamt: 10

A row with a blank account honoured instead of refused:

    BackendAccountTests.ARowNamingNoAccountIsRefused [FAIL]
    Fehler: 2, erfolgreich: 8, gesamt: 10

## Formatting

    npx --yes prettier@3.6.2 --check bridge.md
    All matched files use Prettier code style!

Run on a copy with the line endings the gate's checkout has, because this machine's working tree is
CRLF and every markdown file reads as unformatted locally whatever it holds.

## What is not claimed

**No external service was contacted and none can be from this tree.** The words this bridge maps were
already this board's own statement of the vocabulary rather than a measurement of one, and nothing
here changes that. What a submission actually carries to a service, as opposed to whose name it
carries, is #82's and is not decided here.

**Nothing reads this table yet**, so this is the rule and the record rather than a working
attribution path. The adapter in #82 is what makes it reachable.

## One reader

**This change has had no second reader.** The evidence above stands in place of one.
