### PR TITLE
Say in the README what this refuses to do, and record the seam's refusal to hand state back

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,46 @@ server for a film or a series it does not have, an administrator sees the ask in
 a queue and answers it, and the request keeps its own state and history on the
 server rather than in somebody's chat log.
 
+## What it does not do
+
+Three things this is regularly expected to do and does not. Each was decided
+rather than left out, which is why they are here rather than in an issue nobody
+finds.
+
+It does not fetch media. Approving a request moves a record from one state to
+another and reaches nothing that downloads anything. What makes the film turn up
+is whatever the operator already runs, and this plugin notices it arriving by
+watching the server's own library.
+
+It does not manage a download client. There is no connection to one and none is
+planned. Where an operator runs an external request service, an approved request
+can be handed to that service and the service is what talks to whatever fetches;
+that handover, and the words the two sides have to agree on, are in
+[docs/bridge.md](docs/bridge.md).
+
+It ships no way to find a title the server does not have. On a server with no
+browsing sibling plugin installed there is no gesture on a television client
+that creates a request at all. The reason is that the sibling owns the catalogue
+and this plugin calls no metadata source, and that is refused rather than
+promised: `no-call-to-a-metadata-source` in `tools/opengrep/rules.yaml` refuses
+the server's provider interfaces and the addresses a plugin would otherwise call
+directly, and carries the fixture it is watched refusing.
+
 ## This is not finished
 
-There is no release, no package and nothing to install. Most of the plugin does
-not exist yet: what the tree holds is the scaffolding a Jellyfin plugin starts
-from, with the build retargeted at the two server lines below. Nothing here
-should be pointed at a server you care about.
+One release exists, and no plugin catalogue serves it:
+
+    gh release list --repo Flowfin/jellyfin-plugin-requests --json tagName --jq '.[].tagName'
+    0.1.0.0-stable
+
+[docs/RELEASING.md](docs/RELEASING.md) says the same about itself: a GitHub
+release is the whole output, and nothing feeds a catalogue until a manifest
+generator is added. The archive that release carries is built for the one server
+line `build.yaml` names, so an operator on the other line has nothing to install
+even by hand. The packaged install path has not been tried on any server, on
+either line.
+
+Nothing here should be pointed at a server you care about.
 
 The plan is on the issue tracker, cut into milestones. Each issue says what is
 wrong, what the evidence is and what has to be true for it to be closed.
@@ -23,15 +57,38 @@ wrong, what the evidence is and what has to be true for it to be closed.
 ## Server lines
 
 Two server generations are claimed, and each gets its own package because a
-plugin compiled for one runtime does not load on the other.
+plugin compiled for one runtime does not load on the other. Claimed is not
+published: the section above says which of the two the one release carries.
 
 | Line           | Runtime | Packaging metadata | Oldest server claimed |
 | -------------- | ------- | ------------------ | --------------------- |
 | Jellyfin 10.11 | .NET 9  | `build.yaml`       | 10.11.0.0             |
 | Jellyfin 12.0  | .NET 10 | `build-jf12.yaml`  | 12.0.0.0              |
 
-Those numbers are the `targetAbi` and `framework` fields of the two files named
-in the table, and they are what the project file multi-targets against.
+Those numbers are read out of the two files rather than restated from memory, so
+an edit to either shows up as a difference between this table and what the
+command prints:
+
+    git grep -nE '^(version|targetAbi|framework):' -- build.yaml build-jf12.yaml
+    build-jf12.yaml:13:version: "0.1.0.0"
+    build-jf12.yaml:15:targetAbi: "12.0.0.0"
+    build-jf12.yaml:16:framework: "net10.0"
+    build.yaml:5:version: "0.1.0.0"
+    build.yaml:10:targetAbi: "10.11.0.0"
+    build.yaml:11:framework: "net9.0"
+
+The `framework` of each line is what the project file multi-targets against. The
+`version` both files carry is one number held in one place, and a test refuses a
+disagreement between it and the assembly rather than trusting three copies to be
+edited together:
+
+    git grep -n '<PluginVersion>' -- Directory.Build.props
+    Directory.Build.props:11:        <PluginVersion>0.1.0.0</PluginVersion>
+
+That test is `PluginVersionMatchesThePackagingMetadata` in
+`Jellyfin.Plugin.Requests.Tests/PackagingMetadataTests.cs`, and
+[docs/versioning.md](docs/versioning.md) is where the scheme and what each field
+means to somebody who already has this installed are written down.
 
 An assembly built for each line has been installed on a server of that line and
 reported `Active` by the server itself. The transcript of that run, the images

--- a/docs/seam.md
+++ b/docs/seam.md
@@ -92,6 +92,45 @@ suite cannot say is that a socket was blocked while it ran; what it says instead
 assembly references nothing that could open one, which is the exact reference list in
 `SiblingIndependenceTests` and fails on any addition.
 
+## No read crosses back, and that is a refusal rather than a gap
+
+There is an obvious feature on the other side of this seam that is not going to be built. A browsing
+surface showing that a title has already been asked for would stop a user asking twice, and it reads
+well. It needs the browsing side to read request state out of this one.
+
+The contract is one way. A handover carries a want across and nothing is learned back except that it
+was accepted. A query in the other direction would make each side hold a piece of the other's state,
+which is the arrangement both boards are avoiding and the reason the contract is shaped this way at
+all. So this side offers the seam no way to read request state, and the duplicate case is answered
+where the handover happens instead: the same want arriving twice produces one request, which is
+#116, and the sibling's own repeat handling does the rest on its side.
+
+The user's answer to what happened to their request comes from this plugin's own surface, decided in
+[`docs/surface.md`](surface.md) and reaching the same clients: the channel for a client that renders
+one, the page for a browser. Not from the seam, and not from anything the sibling draws.
+
+### Refusing a read over the seam is not the same as nothing being able to read
+
+The second statement is the wider one and it is false today, so it is written here rather than left
+for somebody to infer from the first.
+
+`IRequestStore` is public, and the plugin registers it into the container the server hands it:
+
+    git grep -n 'AddSingleton<IRequestStore>' -- Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
+    Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs:52:        serviceCollection.AddSingleton<IRequestStore>(provider => new FileRequestStore(
+
+That collection is the server's own, not one this plugin keeps to itself, so the registration sits
+where everything else in the process can be resolved from. What the interface answers is not
+narrowed by who is asking: `GetAllAsync` returns every request in the store and `PageAsync` answers
+a query over all of them.
+
+What this does not say is that another plugin can reach it. Naming a type means having the type, and
+whether a second plugin in one process can name this one is the assembly-loading question #117 asks
+and nobody here has measured. So what is written down is an exposure of unmeasured reachability,
+which is neither a leak that has been shown nor a safety anybody has earned. The rule the API keeps,
+that a caller reads their own requests and never another person's, is enforced at the endpoints in
+`docs/api.md` and not by the store beneath them.
+
 ## What this document does not yet hold
 
 Named here so the absence is read as absence rather than as a decision nobody wrote down. Each is


### PR DESCRIPTION
Two documents, both of which were missing a refusal that a reader would otherwise
read as an oversight.

Closes #101.
Part of #91.

## The README

#101 asks the README to answer four questions in the first screen. It answered
two of them and left out what this plugin deliberately does not do, which is the
section that keeps the same three reports off the tracker. That section is now
there: it fetches no media, it manages no download client, and it ships no way to
find a title the server does not have. The third carries the rule that refuses
it rather than a promise, `no-call-to-a-metadata-source` in
`tools/opengrep/rules.yaml`.

Two sentences in it were false rather than incomplete, and a reader trusting them
would have concluded the opposite of the truth in both cases. "There is no
release, no package and nothing to install" and "what the tree holds is the
scaffolding a Jellyfin plugin starts from":

    gh release list --repo Flowfin/jellyfin-plugin-requests --json tagName --jq '.[].tagName'
    0.1.0.0-stable

The replacement says what that release is and what it is not. Nothing serves it
as a catalogue, which is what `docs/RELEASING.md` says of itself, and the archive
is built for the one line `build.yaml` names, so an operator on the other line
has nothing to install even by hand. The packaged install path has still not been
tried on any server, and that sentence survives unchanged.

The second done-condition asks that every version the README names match the
packaging metadata, checked by a command it cites. It asserted the correspondence
in prose, so a later edit to either file moved the two apart with nothing saying
so. The table now carries the command and its output:

    git grep -nE '^(version|targetAbi|framework):' -- build.yaml build-jf12.yaml
    build-jf12.yaml:13:version: "0.1.0.0"
    build-jf12.yaml:15:targetAbi: "12.0.0.0"
    build-jf12.yaml:16:framework: "net10.0"
    build.yaml:5:version: "0.1.0.0"
    build.yaml:10:targetAbi: "10.11.0.0"
    build.yaml:11:framework: "net9.0"

    git grep -n '<PluginVersion>' -- Directory.Build.props
    Directory.Build.props:11:        <PluginVersion>0.1.0.0</PluginVersion>

The third condition holds and is unchanged:

    git grep -in template -- README.md ; echo "exit=$?"
    exit=1

## The seam document

#91 refuses a feature and asks that the refusal be recorded so it reads as a
decision. `docs/seam.md` listed four absences and this was not among them. The
new section states it, gives the reason the contract is one way, and names this
plugin's own surface in `docs/surface.md` as where a user's answer comes from.
That is the first and third conditions.

The second condition is not met, so #91 stays open. It says no interface
this plugin exposes lets a caller in the server process read another user's
request state, and that is false:

    git grep -n 'AddSingleton<IRequestStore>' -- Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
    Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs:52:        serviceCollection.AddSingleton<IRequestStore>(provider => new FileRequestStore(

`IRequestStore` is public, the collection it is registered into is the server's
own, and what it answers is not narrowed by who is asking: `GetAllAsync` returns
every request in the store and `PageAsync` answers a query over all of them. The
document says that in those terms rather than leaving a reader to infer safety
from the refusal above it. What it does not claim is that another plugin can
reach it, because naming the type means having the type and whether a second
plugin in one process can is the assembly loading question in #117, unmeasured
here. So it is written as an exposure of unmeasured reachability, which is
neither a leak that has been shown nor a safety anybody has earned.

## Evidence

Both target frameworks, at the head of this branch:

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    0 warnings, 0 errors

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Failed: 0, passed: 433, skipped: 0, total: 433 (net10.0)
    Failed: 0, passed: 433, skipped: 0, total: 433 (net9.0)

    npx --yes prettier@3.6.2 --check "README.md" "docs/seam.md"
    All matched files use Prettier code style!

## What this does not carry

No test changed and none was added, because both files are documents and nothing
in this tree reads either of them. The claims above are checkable by the commands
beside them and by nothing else.

This change had no second reader. The commands above are here in place of one.
