### PR TITLE
Let an operator answer a batch without the queue reporting it as done when it was not

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Api/ActOnManyRequestsTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/ActOnManyRequestsTests.cs
@@ -1,0 +1,661 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Api;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Api;
+
+/// <summary>
+/// Deciding on several requests in one action.
+/// <para>
+/// The actions are called directly rather than through a server, for the reason the other API tests
+/// give: the headless rule refuses a running Jellyfin, and what these judge is what an endpoint does
+/// with a body, an identity and a store.
+/// </para>
+/// <para>
+/// The failure these exist against is an operator told an action was done when part of it was
+/// refused. Every leg below asks the store what it holds afterwards rather than believing the
+/// answer the endpoint gave.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class ActOnManyRequestsTests
+{
+    private static readonly Guid Asker = new Guid("b6000000-0000-0000-0000-000000000001");
+    private static readonly Guid Operator = new Guid("b6000000-0000-0000-0000-000000000002");
+    private static readonly Guid Watcher = new Guid("b6000000-0000-0000-0000-000000000003");
+    private static readonly DateTimeOffset Started = new DateTimeOffset(2026, 8, 10, 9, 0, 0, TimeSpan.Zero);
+
+    private readonly SequentialIdentifierSource _identifiers = new SequentialIdentifierSource();
+
+    /// <summary>
+    /// Three requests approved in one action move, each entry carries the row at its new revision,
+    /// and each request holds exactly one history entry naming the person who decided.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ApprovingSeveralMovesEachOneAndReportsItsNewRow()
+    {
+        var store = new InMemoryRequestStore();
+        var open = await ThreeOpenRequestsAsync(store).ConfigureAwait(true);
+
+        var answered = await ControllerFor(store, Operator)
+            .ApproveManyAsync(new ApproveManyBody { Requests = Choosing(open) }, CancellationToken.None)
+            .ConfigureAwait(true);
+
+        var entries = Decided(answered);
+
+        Assert.Equal(open.Select(one => one.Request.Id), entries.Select(entry => entry.Id));
+
+        foreach (var (entry, before) in entries.Zip(open))
+        {
+            var row = Assert.IsType<QueuedRequest>(entry.Request);
+            Assert.Null(entry.Failure);
+            Assert.Equal(RequestState.Approved, row.State);
+            Assert.Equal(before.Revision + 1, row.Revision);
+
+            var held = await Held(store, before.Request.Id).ConfigureAwait(true);
+            Assert.Equal(RequestState.Approved, held.Request.State);
+            Assert.Equal(Operator, held.Request.StateChangedByUserId);
+
+            var history = Assert.Single(held.Request.History);
+            Assert.Equal(RequestState.Open, history.From);
+            Assert.Equal(RequestState.Approved, history.To);
+            Assert.Equal(Operator, history.ByUserId);
+        }
+    }
+
+    /// <summary>
+    /// A decline of several carries the one reason and the one note onto every request in the
+    /// action, and every one of them keeps it in its history.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task DecliningSeveralCarriesOneReasonOntoEveryOneOfThem()
+    {
+        var store = new InMemoryRequestStore();
+        var open = await ThreeOpenRequestsAsync(store).ConfigureAwait(true);
+
+        var answered = await ControllerFor(store, Operator)
+            .DeclineManyAsync(
+                new DeclineManyBody
+                {
+                    Requests = Choosing(open),
+                    Reason = DeclineReason.NoRoomForIt,
+                    Note = "The disk this would go on is full until the new one arrives."
+                },
+                CancellationToken.None)
+            .ConfigureAwait(true);
+
+        foreach (var entry in Decided(answered))
+        {
+            var row = Assert.IsType<QueuedRequest>(entry.Request);
+            Assert.Equal(RequestState.Declined, row.State);
+            Assert.Equal(DeclineReason.NoRoomForIt, row.DeclineReason);
+
+            var held = await Held(store, entry.Id).ConfigureAwait(true);
+            var history = Assert.Single(held.Request.History);
+            Assert.Equal(DeclineReason.NoRoomForIt, history.Reason);
+            Assert.Equal(
+                "The disk this would go on is full until the new one arrives.",
+                history.Note,
+                StringComparer.Ordinal);
+        }
+    }
+
+    /// <summary>
+    /// The whole point of the shape. One request moved underneath the operator and one was never
+    /// there; the action says which two and why, and the other two are decided rather than rolled
+    /// back.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task OneRefusalLeavesTheOthersDecidedAndSaysWhichAndWhy()
+    {
+        var store = new InMemoryRequestStore();
+        var open = await ThreeOpenRequestsAsync(store).ConfigureAwait(true);
+
+        // The second one is decided by somebody else between the operator reading the queue and
+        // acting on it, which is the ordinary way a revision goes stale.
+        await ControllerFor(store, Watcher)
+            .ApproveAsync(
+                open[1].Request.Id,
+                new ApproveRequestBody { Revision = open[1].Revision },
+                CancellationToken.None)
+            .ConfigureAwait(true);
+
+        var missing = new Guid("b6000000-0000-0000-0000-0000000000ff");
+
+        var chosen = Choosing(open).Append(new RequestToDecide { Id = missing, Revision = 1 }).ToArray();
+
+        var answered = await ControllerFor(store, Operator)
+            .ApproveManyAsync(new ApproveManyBody { Requests = chosen }, CancellationToken.None)
+            .ConfigureAwait(true);
+
+        var entries = Decided(answered);
+
+        Assert.Equal(4, entries.Count);
+        Assert.Equal(chosen.Select(one => one.Id!.Value), entries.Select(entry => entry.Id));
+
+        Assert.NotNull(entries[0].Request);
+        Assert.NotNull(entries[2].Request);
+
+        var stale = Assert.IsType<RequestFailure>(entries[1].Failure);
+        Assert.Equal(RequestFailureCode.MovedSinceItWasRead, stale.Code);
+        Assert.Null(entries[1].Request);
+
+        // What the store holds now comes back with the refusal, so the operator decides again
+        // against what is there rather than reading the queue a second time.
+        var current = Assert.IsType<QueuedRequest>(stale.Current);
+        Assert.Equal(RequestState.Approved, current.State);
+        Assert.Equal(Watcher, current.StateChangedByUserId);
+
+        var absent = Assert.IsType<RequestFailure>(entries[3].Failure);
+        Assert.Equal(RequestFailureCode.NoSuchRequest, absent.Code);
+
+        // The two that were not refused are done, and the refused one was not moved by this action.
+        Assert.Equal(RequestState.Approved, (await Held(store, open[0].Request.Id).ConfigureAwait(true)).Request.State);
+        Assert.Equal(RequestState.Approved, (await Held(store, open[2].Request.Id).ConfigureAwait(true)).Request.State);
+        Assert.Single((await Held(store, open[1].Request.Id).ConfigureAwait(true)).Request.History);
+    }
+
+    /// <summary>
+    /// The action and the single decision agree on every state a request can be in, for both moves.
+    /// <para>
+    /// This is the leg that says no transition rule is reachable one way and not the other. It is a
+    /// comparison of two runs over identical stores rather than a reading of the source, because
+    /// what the two paths share is a fact about the code today and the property has to survive
+    /// somebody changing it.
+    /// </para>
+    /// </summary>
+    /// <param name="from">The state the request is in when the decision arrives.</param>
+    /// <param name="approving">Whether the move is an approval or a decline.</param>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Theory]
+    [InlineData(RequestState.Open, true)]
+    [InlineData(RequestState.Approved, true)]
+    [InlineData(RequestState.Declined, true)]
+    [InlineData(RequestState.Fulfilled, true)]
+    [InlineData(RequestState.Failed, true)]
+    [InlineData(RequestState.Open, false)]
+    [InlineData(RequestState.Approved, false)]
+    [InlineData(RequestState.Declined, false)]
+    [InlineData(RequestState.Fulfilled, false)]
+    [InlineData(RequestState.Failed, false)]
+    public async Task TheActionAndTheSingleDecisionAgreeOnEveryStateARequestCanBeIn(RequestState from, bool approving)
+    {
+        var alone = new InMemoryRequestStore();
+        var together = new InMemoryRequestStore();
+
+        var one = await InStateAsync(alone, from).ConfigureAwait(true);
+        var other = await InStateAsync(together, from).ConfigureAwait(true);
+
+        var single = approving
+            ? await ControllerFor(alone, Operator)
+                .ApproveAsync(one.Request.Id, new ApproveRequestBody { Revision = one.Revision }, CancellationToken.None)
+                .ConfigureAwait(true)
+            : await ControllerFor(alone, Operator)
+                .DeclineAsync(one.Request.Id, ADecline(one.Revision), CancellationToken.None)
+                .ConfigureAwait(true);
+
+        var chosen = new[] { new RequestToDecide { Id = other.Request.Id, Revision = other.Revision } };
+
+        var many = approving
+            ? await ControllerFor(together, Operator)
+                .ApproveManyAsync(new ApproveManyBody { Requests = chosen }, CancellationToken.None)
+                .ConfigureAwait(true)
+            : await ControllerFor(together, Operator)
+                .DeclineManyAsync(ADeclineOfMany(chosen), CancellationToken.None)
+                .ConfigureAwait(true);
+
+        var entry = Assert.Single(Decided(many));
+        var result = Assert.IsAssignableFrom<ObjectResult>(single.Result);
+
+        if (result.Value is RequestFailure refused)
+        {
+            var failure = Assert.IsType<RequestFailure>(entry.Failure);
+            Assert.Equal(refused.Code, failure.Code);
+            Assert.Equal(refused.Message, failure.Message, StringComparer.Ordinal);
+            Assert.Equal(refused.Current?.State, failure.Current?.State);
+        }
+        else
+        {
+            var moved = Assert.IsType<QueuedRequest>(result.Value);
+            var row = Assert.IsType<QueuedRequest>(entry.Request);
+            Assert.Equal(moved.State, row.State);
+            Assert.Equal(moved.Revision, row.Revision);
+        }
+
+        // The stores are what the endpoints left behind, and they have to agree too: an answer that
+        // matched while the writes differed would be the interesting failure.
+        var here = await Held(alone, one.Request.Id).ConfigureAwait(true);
+        var there = await Held(together, other.Request.Id).ConfigureAwait(true);
+
+        Assert.Equal(here.Request.State, there.Request.State);
+        Assert.Equal(here.Revision, there.Revision);
+        Assert.Equal(here.Request.History.Count, there.Request.History.Count);
+    }
+
+    /// <summary>
+    /// An action carrying no requests is refused. Answered rather than refused, it would report that
+    /// it had decided everything it was asked to, which is true and is what a surface draws as done.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AnActionOnNothingIsRefusedRatherThanAnsweredAsDone()
+    {
+        var store = new InMemoryRequestStore();
+
+        Assert.Equal(
+            nameof(ApproveManyBody.Requests),
+            Field(await ControllerFor(store, Operator)
+                .ApproveManyAsync(new ApproveManyBody { Requests = [] }, CancellationToken.None)
+                .ConfigureAwait(true)));
+
+        Assert.Equal(
+            nameof(ApproveManyBody.Requests),
+            Field(await ControllerFor(store, Operator)
+                .ApproveManyAsync(new ApproveManyBody(), CancellationToken.None)
+                .ConfigureAwait(true)));
+    }
+
+    /// <summary>
+    /// An entry with no request in it, or none with a revision, is refused before anything is
+    /// written, and the message says which position of the body is wrong.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AnEntryThatNamesNoRequestOrNoRevisionIsRefusedBeforeAnythingIsWritten()
+    {
+        var store = new InMemoryRequestStore();
+        var open = await ThreeOpenRequestsAsync(store).ConfigureAwait(true);
+
+        var nameless = Choosing(open).ToArray();
+        nameless[2] = new RequestToDecide { Revision = 1 };
+
+        var refusal = Refusal(await ControllerFor(store, Operator)
+            .ApproveManyAsync(new ApproveManyBody { Requests = nameless }, CancellationToken.None)
+            .ConfigureAwait(true));
+
+        Assert.Equal(RequestFailureCode.InvalidBody, refusal.Code);
+        Assert.Contains("position 3", refusal.Message, StringComparison.Ordinal);
+
+        var revisionless = Choosing(open).ToArray();
+        revisionless[0] = new RequestToDecide { Id = open[0].Request.Id };
+
+        Assert.Contains(
+            "position 1",
+            Refusal(await ControllerFor(store, Operator)
+                .ApproveManyAsync(new ApproveManyBody { Requests = revisionless }, CancellationToken.None)
+                .ConfigureAwait(true)).Message,
+            StringComparison.Ordinal);
+
+        // Nothing in the body was acted on, which is what "before anything is written" means.
+        foreach (var one in open)
+        {
+            Assert.Equal(RequestState.Open, (await Held(store, one.Request.Id).ConfigureAwait(true)).Request.State);
+        }
+    }
+
+    /// <summary>
+    /// The same request twice in one action is refused rather than answered with a conflict the
+    /// action created itself. The second entry would report that the request had moved since it was
+    /// read, against a move made one line earlier by the same call.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task TheSameRequestTwiceInOneActionIsRefusedBeforeAnythingIsWritten()
+    {
+        var store = new InMemoryRequestStore();
+        var open = await ThreeOpenRequestsAsync(store).ConfigureAwait(true);
+
+        var twice = Choosing(open).Append(Choosing(open)[1]).ToArray();
+
+        var refusal = Refusal(await ControllerFor(store, Operator)
+            .ApproveManyAsync(new ApproveManyBody { Requests = twice }, CancellationToken.None)
+            .ConfigureAwait(true));
+
+        Assert.Equal(RequestFailureCode.InvalidBody, refusal.Code);
+        Assert.Contains("position 2 and position 4", refusal.Message, StringComparison.Ordinal);
+
+        foreach (var one in open)
+        {
+            Assert.Equal(RequestState.Open, (await Held(store, one.Request.Id).ConfigureAwait(true)).Request.State);
+        }
+    }
+
+    /// <summary>
+    /// An action carrying more requests than a page holds is refused rather than acted on as far as
+    /// the cap. A caller given the first two hundred and not told has just decided the rest were
+    /// done.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task MoreRequestsThanAPageHoldsIsRefusedRatherThanPartlyDone()
+    {
+        var store = new InMemoryRequestStore();
+        var open = await ThreeOpenRequestsAsync(store).ConfigureAwait(true);
+
+        var overflowing = Enumerable
+            .Range(0, RequestsController.MaximumPageSize + 1)
+            .Select(index => new RequestToDecide
+            {
+                // Identifiers a test made up rather than minted, so the same body is sent every
+                // run: what is under test is the count, and none of these is ever looked up.
+                Id = index < open.Count
+                    ? open[index].Request.Id
+                    : new Guid(string.Format(CultureInfo.InvariantCulture, "b6000000-0000-0000-0000-{0:D12}", index)),
+                Revision = 1
+            })
+            .ToArray();
+
+        var refusal = Refusal(await ControllerFor(store, Operator)
+            .ApproveManyAsync(new ApproveManyBody { Requests = overflowing }, CancellationToken.None)
+            .ConfigureAwait(true));
+
+        Assert.Equal(RequestFailureCode.InvalidBody, refusal.Code);
+        Assert.Contains(
+            RequestsController.MaximumPageSize.ToString(CultureInfo.InvariantCulture),
+            refusal.Message,
+            StringComparison.Ordinal);
+
+        foreach (var one in open)
+        {
+            Assert.Equal(RequestState.Open, (await Held(store, one.Request.Id).ConfigureAwait(true)).Request.State);
+        }
+    }
+
+    /// <summary>
+    /// A decline of several is held to the same rule about a reason as a decline of one, and the
+    /// refusal arrives before any of the requests is touched.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ADeclineOfSeveralWithNoReasonIsRefusedBeforeAnythingIsWritten()
+    {
+        var store = new InMemoryRequestStore();
+        var open = await ThreeOpenRequestsAsync(store).ConfigureAwait(true);
+
+        Assert.Equal(
+            nameof(DeclineManyBody.Reason),
+            Field(await ControllerFor(store, Operator)
+                .DeclineManyAsync(
+                    new DeclineManyBody { Requests = Choosing(open) },
+                    CancellationToken.None)
+                .ConfigureAwait(true)));
+
+        Assert.Equal(
+            nameof(DeclineManyBody.Note),
+            Field(await ControllerFor(store, Operator)
+                .DeclineManyAsync(
+                    new DeclineManyBody { Requests = Choosing(open), Reason = DeclineReason.Other },
+                    CancellationToken.None)
+                .ConfigureAwait(true)));
+
+        foreach (var one in open)
+        {
+            Assert.Equal(RequestState.Open, (await Held(store, one.Request.Id).ConfigureAwait(true)).Request.State);
+        }
+    }
+
+    /// <summary>
+    /// A call that authenticates and names nobody decides nothing at all, rather than deciding the
+    /// action and recording an empty identifier as having made it.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ACallThatNamesNobodyDecidesNothing()
+    {
+        var store = new InMemoryRequestStore();
+        var open = await ThreeOpenRequestsAsync(store).ConfigureAwait(true);
+
+        var refusal = Refusal(await ControllerFor(store, caller: null)
+            .ApproveManyAsync(new ApproveManyBody { Requests = Choosing(open) }, CancellationToken.None)
+            .ConfigureAwait(true));
+
+        Assert.Equal(RequestFailureCode.NoUserOnTheCall, refusal.Code);
+
+        foreach (var one in open)
+        {
+            Assert.Equal(RequestState.Open, (await Held(store, one.Request.Id).ConfigureAwait(true)).Request.State);
+        }
+    }
+
+    /// <summary>
+    /// Both decline bodies spell the reason and the note the same way.
+    /// <para>
+    /// One refusal names a field for both endpoints, and it names it from the single body. A rename
+    /// on one side only would leave a caller of the other told that a field it does not have is
+    /// wrong, which reads as a client bug rather than as this.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void BothDeclineBodiesSpellTheReasonAndTheNoteTheSameWay()
+    {
+        Assert.Equal(
+            Named<DeclineRequestBody>([nameof(DeclineRequestBody.Reason), nameof(DeclineRequestBody.Note)]),
+            Named<DeclineManyBody>([nameof(DeclineManyBody.Reason), nameof(DeclineManyBody.Note)]));
+    }
+
+    /// <summary>
+    /// The properties one shape carries under the names asked for, so a rename on one side of a
+    /// pair shows as a difference rather than as a test that stopped looking.
+    /// </summary>
+    /// <typeparam name="TBody">The body.</typeparam>
+    /// <param name="names">The property names to look for.</param>
+    /// <returns>The names that are there, with the type of each.</returns>
+    private static string[] Named<TBody>(string[] names)
+        => names
+            .Select(name => typeof(TBody).GetProperty(name, BindingFlags.Public | BindingFlags.Instance))
+            .Where(property => property is not null)
+            .Select(property => property!.Name + ":" + property.PropertyType.Name)
+            .OrderBy(line => line, StringComparer.Ordinal)
+            .ToArray();
+
+    /// <summary>
+    /// Three open requests in the store, each named by a provider so every move is available on it.
+    /// </summary>
+    /// <param name="store">Where they go.</param>
+    /// <returns>The requests and the revisions the store holds them at.</returns>
+    private async Task<IReadOnlyList<StoredRequest>> ThreeOpenRequestsAsync(InMemoryRequestStore store)
+    {
+        var titles = new[] { ("The Conversation", 1974, "603"), ("Stalker", 1979, "1398"), ("Solaris", 1972, "593") };
+        var open = new List<StoredRequest>(titles.Length);
+
+        foreach (var (title, year, provider) in titles)
+        {
+            open.Add(await store.AddAsync(
+                new MediaRequest
+                {
+                    Id = _identifiers.NewId(),
+                    RequestedByUserId = Asker,
+                    RequestedAt = Started,
+                    StateChangedAt = Started,
+                    Kind = RequestedItemKind.Movie,
+                    DisplayTitle = title,
+                    DisplayYear = year,
+                    ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tmdb"] = provider }
+                },
+                CancellationToken.None).ConfigureAwait(true));
+        }
+
+        return open;
+    }
+
+    /// <summary>
+    /// One request in the store, in the state asked for.
+    /// <para>
+    /// The moves that get it there are the model's own, and the ones into an observed state are made
+    /// as the plugin rather than as a person, because that is who the table admits for them.
+    /// </para>
+    /// </summary>
+    /// <param name="store">Where it goes.</param>
+    /// <param name="state">The state it has to be in.</param>
+    /// <returns>The request and the revision the store holds it at.</returns>
+    private async Task<StoredRequest> InStateAsync(InMemoryRequestStore store, RequestState state)
+    {
+        var open = (await ThreeOpenRequestsAsync(store).ConfigureAwait(true))[0];
+
+        if (state == RequestState.Open)
+        {
+            return open;
+        }
+
+        var operator_ = RequestCaller.Administrator(Watcher);
+
+        var moved = state switch
+        {
+            RequestState.Approved => await store.ReplaceAsync(
+                RequestLifecycle.Move(open.Request, RequestState.Approved, Started, operator_),
+                open.Revision,
+                CancellationToken.None).ConfigureAwait(true),
+            RequestState.Declined => await store.ReplaceAsync(
+                RequestLifecycle.Decline(open.Request, DeclineReason.NotWanted, "Not this one.", Started, operator_),
+                open.Revision,
+                CancellationToken.None).ConfigureAwait(true),
+            RequestState.Fulfilled => await store.ReplaceAsync(
+                RequestLifecycle.Move(open.Request, RequestState.Fulfilled, Started, RequestCaller.Plugin),
+                open.Revision,
+                CancellationToken.None).ConfigureAwait(true),
+            _ => await FailedAsync(store, open, operator_).ConfigureAwait(true)
+        };
+
+        return moved;
+    }
+
+    /// <summary>
+    /// A request that was approved and then did not arrive, which is the only route into the failed
+    /// state the table has.
+    /// </summary>
+    /// <param name="store">Where it is.</param>
+    /// <param name="open">The request as the store holds it.</param>
+    /// <param name="operator_">Who approves it.</param>
+    /// <returns>The request and the revision the store holds it at.</returns>
+    private static async Task<StoredRequest> FailedAsync(
+        InMemoryRequestStore store,
+        StoredRequest open,
+        RequestCaller operator_)
+    {
+        var approved = await store.ReplaceAsync(
+            RequestLifecycle.Move(open.Request, RequestState.Approved, Started, operator_),
+            open.Revision,
+            CancellationToken.None).ConfigureAwait(true);
+
+        return await store.ReplaceAsync(
+            RequestLifecycle.Move(approved.Request, RequestState.Failed, Started, RequestCaller.Plugin),
+            approved.Revision,
+            CancellationToken.None).ConfigureAwait(true);
+    }
+
+    /// <summary>
+    /// The requests as a caller would choose them off a page of the queue.
+    /// </summary>
+    /// <param name="stored">What the store holds.</param>
+    /// <returns>The selection.</returns>
+    private static RequestToDecide[] Choosing(IReadOnlyList<StoredRequest> stored)
+        => stored
+            .Select(one => new RequestToDecide { Id = one.Request.Id, Revision = one.Revision })
+            .ToArray();
+
+    /// <summary>
+    /// A decline of one request, carrying the reason and the note the many-decline uses.
+    /// </summary>
+    /// <param name="revision">The revision it was read at.</param>
+    /// <returns>The body.</returns>
+    private static DeclineRequestBody ADecline(long revision)
+        => new DeclineRequestBody
+        {
+            Revision = revision,
+            Reason = DeclineReason.NotWanted,
+            Note = "This one is not going on the disk."
+        };
+
+    /// <summary>
+    /// A decline of several, carrying the same reason and note as the single one above, so the two
+    /// paths differ in nothing but the shape of the call.
+    /// </summary>
+    /// <param name="chosen">The requests.</param>
+    /// <returns>The body.</returns>
+    private static DeclineManyBody ADeclineOfMany(IReadOnlyList<RequestToDecide> chosen)
+        => new DeclineManyBody
+        {
+            Requests = chosen,
+            Reason = DeclineReason.NotWanted,
+            Note = "This one is not going on the disk."
+        };
+
+    /// <summary>
+    /// What the store holds for one request, which is what a leg asserts against rather than the
+    /// answer the endpoint returned.
+    /// </summary>
+    /// <param name="store">The store.</param>
+    /// <param name="id">The request.</param>
+    /// <returns>The request and its revision.</returns>
+    private static async Task<StoredRequest> Held(InMemoryRequestStore store, Guid id)
+    {
+        var stored = await store.GetAsync(id, CancellationToken.None).ConfigureAwait(true);
+
+        return Assert.NotNull(stored);
+    }
+
+    /// <summary>
+    /// A controller wired to one store and one identity, with a clock and an identifier source the
+    /// test controls.
+    /// </summary>
+    /// <param name="store">Where requests are kept.</param>
+    /// <param name="caller">Who the server says is calling.</param>
+    /// <returns>The controller under test.</returns>
+    private RequestsController ControllerFor(IRequestStore store, Guid? caller)
+        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller));
+
+    /// <summary>
+    /// The entries an action came back with, with the status code checked.
+    /// </summary>
+    /// <param name="answered">What the action returned.</param>
+    /// <returns>The entries.</returns>
+    private static IReadOnlyList<DecidedRequest> Decided(ActionResult<DecidedRequests> answered)
+    {
+        var result = Assert.IsAssignableFrom<ObjectResult>(answered.Result);
+        Assert.Equal(200, result.StatusCode);
+        return Assert.IsType<DecidedRequests>(result.Value).Requests;
+    }
+
+    /// <summary>
+    /// The refusal a whole action came back with, under the status code its class is reported with.
+    /// </summary>
+    /// <param name="answered">What the action returned.</param>
+    /// <returns>The refusal.</returns>
+    private static RequestFailure Refusal(ActionResult<DecidedRequests> answered)
+    {
+        var result = Assert.IsAssignableFrom<ObjectResult>(answered.Result);
+        var failure = Assert.IsType<RequestFailure>(result.Value);
+        Assert.Equal(RequestFailure.StatusFor(failure.Code), result.StatusCode);
+        return failure;
+    }
+
+    /// <summary>
+    /// The field a refused body named.
+    /// </summary>
+    /// <param name="answered">What the action returned.</param>
+    /// <returns>The field.</returns>
+    private static string? Field(ActionResult<DecidedRequests> answered)
+    {
+        var failure = Refusal(answered);
+        Assert.Equal(RequestFailureCode.InvalidBody, failure.Code);
+        Assert.NotEmpty(failure.Message);
+        return failure.Field;
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/Api/EndpointPolicyTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/EndpointPolicyTests.cs
@@ -60,6 +60,11 @@ public sealed class EndpointPolicyTests
         // such call in the model, which is a permission decided in two places.
         "RequestsController.ApproveAsync POST Requests/{id}/Approve -> RequiresElevation",
 
+        // Saying yes to several at once. The same policy as saying yes to one, because it is the
+        // same decision made more times: an action reachable by a signed-in user would be refused
+        // once per request in the model, which is a permission decided in two places.
+        "RequestsController.ApproveManyAsync POST Requests/Approve -> RequiresElevation",
+
         // Asking for something. An authenticated user, because a request has to be attributable to
         // somebody and a caller with no session names nobody.
         "RequestsController.CreateAsync POST Requests -> DefaultAuthorization",
@@ -67,6 +72,9 @@ public sealed class EndpointPolicyTests
         // Saying no. The same policy as an approval, and the decline reason is something a user
         // reads rather than writes.
         "RequestsController.DeclineAsync POST Requests/{id}/Decline -> RequiresElevation",
+
+        // Saying no to several at once, for one reason.
+        "RequestsController.DeclineManyAsync POST Requests/Decline -> RequiresElevation",
 
         // One person's own requests. The same policy as asking, and the narrowing is the read
         // rather than the policy: this endpoint has nothing wider than the caller's own requests to

--- a/Jellyfin.Plugin.Requests.Tests/Api/ErrorSurfaceTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/ErrorSurfaceTests.cs
@@ -287,6 +287,57 @@ public sealed class ErrorSurfaceTests
                     CancellationToken.None)
                 .ConfigureAwait(true)));
 
+        // The actions on several requests, and only the refusals that are the call's own. A refusal
+        // about one request inside such an action is built by the same code that builds it for the
+        // single decision, in RequestsController.DecideAsync, so its message is one of the ones
+        // already walked above; what is new here is the refusals of a body carrying a selection.
+        Add("POST Requests/Approve with an empty selection", elevated: true, Of(
+            await ControllerFor(store, Operator)
+                .ApproveManyAsync(new ApproveManyBody(), CancellationToken.None)
+                .ConfigureAwait(true)));
+
+        Add("POST Requests/Approve with an entry naming no request", elevated: true, Of(
+            await ControllerFor(store, Operator)
+                .ApproveManyAsync(
+                    new ApproveManyBody { Requests = [new RequestToDecide { Revision = open.Revision }] },
+                    CancellationToken.None)
+                .ConfigureAwait(true)));
+
+        Add("POST Requests/Approve with an entry carrying no revision", elevated: true, Of(
+            await ControllerFor(store, Operator)
+                .ApproveManyAsync(
+                    new ApproveManyBody { Requests = [new RequestToDecide { Id = open.Request.Id }] },
+                    CancellationToken.None)
+                .ConfigureAwait(true)));
+
+        Add("POST Requests/Approve naming one request twice", elevated: true, Of(
+            await ControllerFor(store, Operator)
+                .ApproveManyAsync(
+                    new ApproveManyBody
+                    {
+                        Requests =
+                        [
+                            new RequestToDecide { Id = open.Request.Id, Revision = open.Revision },
+                            new RequestToDecide { Id = open.Request.Id, Revision = open.Revision }
+                        ]
+                    },
+                    CancellationToken.None)
+                .ConfigureAwait(true)));
+
+        Add("POST Requests/Approve from a call naming no person", elevated: true, Of(
+            await ControllerFor(store, caller: null)
+                .ApproveManyAsync(
+                    new ApproveManyBody { Requests = [new RequestToDecide { Id = open.Request.Id, Revision = open.Revision }] },
+                    CancellationToken.None)
+                .ConfigureAwait(true)));
+
+        Add("POST Requests/Decline with no reason", elevated: true, Of(
+            await ControllerFor(store, Operator)
+                .DeclineManyAsync(
+                    new DeclineManyBody { Requests = [new RequestToDecide { Id = open.Request.Id, Revision = open.Revision }] },
+                    CancellationToken.None)
+                .ConfigureAwait(true)));
+
         return refusals;
 
         void Add(string what, bool elevated, (int Status, RequestFailure Failure) answered)

--- a/Jellyfin.Plugin.Requests.Tests/Api/PublishedApiDocumentTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/PublishedApiDocumentTests.cs
@@ -97,6 +97,20 @@ public sealed class PublishedApiDocumentTests
             + " (body@Body:CreateRequestBody)"
             + " -> 200:CreatedRequest, 201:CreatedRequest, 400:RequestFailure, 403:RequestFailure, 503:RequestFailure",
 
+        // Saying yes to several at once. Three codes where the single decision publishes six, and
+        // the three that are missing are the point: a request that is not there, one that moved and
+        // a store that could not be read are answers about one request, and they come back inside
+        // the entry for that request rather than as the status of a call that may already have
+        // written some of the others.
+        "POST MediaRequests/v1/Requests/Approve"
+            + " (body@Body:ApproveManyBody)"
+            + " -> 200:DecidedRequests, 400:RequestFailure, 403:RequestFailure",
+
+        // Saying no to several at once, for one reason.
+        "POST MediaRequests/v1/Requests/Decline"
+            + " (body@Body:DeclineManyBody)"
+            + " -> 200:DecidedRequests, 400:RequestFailure, 403:RequestFailure",
+
         // Saying yes.
         "POST MediaRequests/v1/Requests/{id}/Approve"
             + " (body@Body:ApproveRequestBody, id@Path:Guid)"
@@ -249,6 +263,8 @@ public sealed class PublishedApiDocumentTests
         const string Queue = "GET MediaRequests/v1/Requests/Queue";
         const string Approve = "POST MediaRequests/v1/Requests/{id}/Approve";
         const string Decline = "POST MediaRequests/v1/Requests/{id}/Decline";
+        const string ApproveMany = "POST MediaRequests/v1/Requests/Approve";
+        const string DeclineMany = "POST MediaRequests/v1/Requests/Decline";
 
         // What this install allows. One call and one status: it reads no store, refuses nothing and
         // has no failure to walk, which is why it publishes one code where every other endpoint
@@ -293,6 +309,23 @@ public sealed class PublishedApiDocumentTests
         Saw(Decline, await ControllerFor(store, Operator).DeclineAsync(absent, new DeclineRequestBody { Revision = 1, Reason = DeclineReason.NotWanted }, CancellationToken.None).ConfigureAwait(true));
         Saw(Decline, await ControllerFor(store, Operator).DeclineAsync(toApprove.Request.Id, new DeclineRequestBody { Revision = toApprove.Revision + 7, Reason = DeclineReason.NotWanted }, CancellationToken.None).ConfigureAwait(true));
         Saw(Decline, await ControllerFor(unreadable, Operator).DeclineAsync(toApprove.Request.Id, new DeclineRequestBody { Revision = 1, Reason = DeclineReason.NotWanted }, CancellationToken.None).ConfigureAwait(true));
+
+        // The two actions on several requests. Three statuses each and no more, and the third call
+        // in each pair is the one worth reading: a store that cannot be read answers 200 here,
+        // because by the time one request is refused another may already be written and a status
+        // saying the call failed would be saying nothing happened while something had.
+        var toApproveTogether = await store.AddAsync(AnAsk(), CancellationToken.None).ConfigureAwait(true);
+        var toDeclineTogether = await store.AddAsync(AnAsk(), CancellationToken.None).ConfigureAwait(true);
+
+        Saw(ApproveMany, await ControllerFor(store, Operator).ApproveManyAsync(new ApproveManyBody { Requests = [Choosing(toApproveTogether)] }, CancellationToken.None).ConfigureAwait(true));
+        Saw(ApproveMany, await ControllerFor(store, Operator).ApproveManyAsync(new ApproveManyBody(), CancellationToken.None).ConfigureAwait(true));
+        Saw(ApproveMany, await ControllerFor(store, caller: null).ApproveManyAsync(new ApproveManyBody { Requests = [Choosing(toApproveTogether)] }, CancellationToken.None).ConfigureAwait(true));
+        Saw(ApproveMany, await ControllerFor(unreadable, Operator).ApproveManyAsync(new ApproveManyBody { Requests = [Choosing(toApproveTogether)] }, CancellationToken.None).ConfigureAwait(true));
+
+        Saw(DeclineMany, await ControllerFor(store, Operator).DeclineManyAsync(new DeclineManyBody { Requests = [Choosing(toDeclineTogether)], Reason = DeclineReason.NotWanted }, CancellationToken.None).ConfigureAwait(true));
+        Saw(DeclineMany, await ControllerFor(store, Operator).DeclineManyAsync(new DeclineManyBody { Requests = [Choosing(toDeclineTogether)] }, CancellationToken.None).ConfigureAwait(true));
+        Saw(DeclineMany, await ControllerFor(store, caller: null).DeclineManyAsync(new DeclineManyBody { Requests = [Choosing(toDeclineTogether)], Reason = DeclineReason.NotWanted }, CancellationToken.None).ConfigureAwait(true));
+        Saw(DeclineMany, await ControllerFor(unreadable, Operator).DeclineManyAsync(new DeclineManyBody { Requests = [Choosing(toDeclineTogether)], Reason = DeclineReason.NotWanted }, CancellationToken.None).ConfigureAwait(true));
 
         return answered;
 
@@ -468,6 +501,15 @@ public sealed class PublishedApiDocumentTests
         DisplayYear = 1974,
         ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tmdb"] = "603" }
     };
+
+    /// <summary>
+    /// One request as a caller chooses it off a page of the queue, for the actions that carry
+    /// several.
+    /// </summary>
+    /// <param name="stored">What the store holds.</param>
+    /// <returns>The entry.</returns>
+    private static RequestToDecide Choosing(StoredRequest stored)
+        => new RequestToDecide { Id = stored.Request.Id, Revision = stored.Revision };
 
     /// <summary>
     /// A body asking for a film.

--- a/Jellyfin.Plugin.Requests/Api/ApproveManyBody.cs
+++ b/Jellyfin.Plugin.Requests/Api/ApproveManyBody.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.Requests.Api;
+
+/// <summary>
+/// What an approval of several requests carries: the requests, each with the revision it was read
+/// at.
+/// <para>
+/// A separate shape from <see cref="ApproveRequestBody"/> rather than the same one repeated, for the
+/// reason there are two endpoints at all: what a caller sends is what it may send, and a body that
+/// meant one request or many depending on which field was filled in is a body whose rule is read in
+/// prose.
+/// </para>
+/// </summary>
+public sealed record ApproveManyBody
+{
+    /// <summary>
+    /// Gets the requests being approved, in the order the caller chose them.
+    /// <para>
+    /// Nullable so that a body with no list at all is refused as a body that is wrong rather than
+    /// read as an action on nothing, which would answer that it decided everything it was asked to.
+    /// </para>
+    /// </summary>
+    public IReadOnlyList<RequestToDecide>? Requests { get; init; }
+}

--- a/Jellyfin.Plugin.Requests/Api/DecidedRequest.cs
+++ b/Jellyfin.Plugin.Requests/Api/DecidedRequest.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace Jellyfin.Plugin.Requests.Api;
+
+/// <summary>
+/// What one request in an action on several came to: the row as the queue now holds it, or the
+/// refusal that request got.
+/// <para>
+/// Exactly one of the two is present, and which one is what a caller reads to tell a request that
+/// moved from one that did not. The identifier is on the entry either way, so a client matches the
+/// answer to what it sent by name rather than by counting positions.
+/// </para>
+/// <para>
+/// <b>There is no status code on an entry.</b> A status code is an answer to a call, and this is not
+/// a call: several of these come back under one status. The failure carries the code a client
+/// branches on, which <c>docs/api.md</c> pairs with a status once and in one place, and putting that
+/// status here too would be a second copy of a pairing whose whole value is that there is one.
+/// </para>
+/// </summary>
+public sealed record DecidedRequest
+{
+    /// <summary>
+    /// Gets the request this entry is about, as the caller named it.
+    /// </summary>
+    public required Guid Id { get; init; }
+
+    /// <summary>
+    /// Gets the request at its new revision, where the move was made. Absent where it was refused.
+    /// </summary>
+    public QueuedRequest? Request { get; init; }
+
+    /// <summary>
+    /// Gets why this one was refused, in the shape every failure of this API comes back in. Absent
+    /// where the move was made.
+    /// </summary>
+    public RequestFailure? Failure { get; init; }
+}

--- a/Jellyfin.Plugin.Requests/Api/DecidedRequests.cs
+++ b/Jellyfin.Plugin.Requests/Api/DecidedRequests.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.Requests.Api;
+
+/// <summary>
+/// What an action on several requests did, one entry per request, in the order the caller sent them.
+/// <para>
+/// <b>The answer is per request because the outcome is.</b> Some of an action succeeds and some of
+/// it is refused, and a single verdict over the whole thing would have to be either "done", which is
+/// false the moment one row moved underneath the operator, or "failed", which throws away the ones
+/// that were decided and cannot be undecided. A surface that reports this as done when part of it
+/// was refused is the failure this shape exists against.
+/// </para>
+/// <para>
+/// There is no count of what succeeded and none of what failed. Both are read off the entries, and a
+/// number beside a list it is derived from is a number that disagrees with the list the first time
+/// one of them is built wrong.
+/// </para>
+/// </summary>
+public sealed record DecidedRequests
+{
+    /// <summary>
+    /// Gets one entry per request the action carried, in the order it carried them. Every request
+    /// the caller sent has an entry: there is no entry missing for a request nothing happened to,
+    /// because "nothing happened to it" is something a caller has to be told rather than left to
+    /// infer from an absence.
+    /// </summary>
+    public required IReadOnlyList<DecidedRequest> Requests { get; init; }
+}

--- a/Jellyfin.Plugin.Requests/Api/DeclineManyBody.cs
+++ b/Jellyfin.Plugin.Requests/Api/DeclineManyBody.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using Jellyfin.Plugin.Requests.Model;
+
+namespace Jellyfin.Plugin.Requests.Api;
+
+/// <summary>
+/// What a decline of several requests carries: the requests, and the one reason the whole action is
+/// made for.
+/// <para>
+/// <b>One reason for the action rather than one per request.</b> The gesture this exists for is an
+/// operator who has come back to forty requests and is answering a batch of them the same way. A
+/// reason per row would be a form rather than a batch, and the operator who wants to say something
+/// different about one request makes that one decision on its own, where the single endpoint already
+/// carries a reason and a note of its own.
+/// </para>
+/// <para>
+/// The consequence is worth stating rather than discovering: every person whose request is in this
+/// action is told the same thing. An operator declining twenty requests for one reason is saying one
+/// thing twenty times, which is what they meant, and an operator who wanted to say twenty things
+/// makes twenty decisions.
+/// </para>
+/// </summary>
+public sealed record DeclineManyBody
+{
+    /// <summary>
+    /// Gets the requests being declined, in the order the caller chose them. Nullable for the reason
+    /// it is on an approval of several: a body with no list is refused rather than read as an action
+    /// on nothing.
+    /// </summary>
+    public IReadOnlyList<RequestToDecide>? Requests { get; init; }
+
+    /// <summary>
+    /// Gets why the requests are being declined. Required, and the same rule as on the single
+    /// decline: a decline with no reason reads as arbitrary to the person who asked, and what they
+    /// do next is ask for the same title again.
+    /// </summary>
+    public DeclineReason? Reason { get; init; }
+
+    /// <summary>
+    /// Gets what the operator wants to say about it, which every request in the action carries.
+    /// Required beside <see cref="DeclineReason.Other"/> and optional beside every other reason,
+    /// again as on the single decline.
+    /// </summary>
+    public string? Note { get; init; }
+}

--- a/Jellyfin.Plugin.Requests/Api/RequestToDecide.cs
+++ b/Jellyfin.Plugin.Requests/Api/RequestToDecide.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace Jellyfin.Plugin.Requests.Api;
+
+/// <summary>
+/// One request inside an action on several: which request, and the revision the operator was
+/// looking at when they chose it.
+/// <para>
+/// The revision is per request rather than per action, because the rows on an operator's screen were
+/// read at whatever revision each one was at and one of them can move while the others do not. An
+/// action carrying a single revision would either refuse everything because one row is stale, or
+/// carry no revision at all, which is the silent overwrite the single decision refuses.
+/// </para>
+/// </summary>
+public sealed record RequestToDecide
+{
+    /// <summary>
+    /// Gets the request being decided.
+    /// <para>
+    /// Nullable so that an entry which left it out is refused rather than read as the empty
+    /// identifier, which is a value no request has and which would come back as one that does not
+    /// exist rather than as a body that is wrong.
+    /// </para>
+    /// </summary>
+    public Guid? Id { get; init; }
+
+    /// <summary>
+    /// Gets the revision the caller read that request at, from <see cref="QueuedRequest.Revision"/>.
+    /// Nullable for the reason it is on the single decision: a body that left it out is refused
+    /// rather than read as a revision nobody sent.
+    /// </summary>
+    public long? Revision { get; init; }
+}

--- a/Jellyfin.Plugin.Requests/Api/RequestsController.cs
+++ b/Jellyfin.Plugin.Requests/Api/RequestsController.cs
@@ -77,6 +77,22 @@ public sealed class RequestsController : RequestsControllerBase
     /// </summary>
     private const int JoinAttempts = 3;
 
+    /// <summary>
+    /// The store failure, written once because it is answered from a call and from inside one
+    /// request of an action on several.
+    /// <para>
+    /// The sentence says nothing about the rest of the call on purpose. It was true of a single
+    /// decision that nothing at all had been changed, and it is not true of the fourth request in an
+    /// action whose first three were written; what holds in both places is that this request was not
+    /// decided and nothing about it moved.
+    /// </para>
+    /// </summary>
+    private static readonly RequestFailure StoreCouldNotBeRead = new RequestFailure
+    {
+        Code = RequestFailureCode.TheStoreCouldNotBeRead,
+        Message = "The queue could not be read, so this was not decided and nothing about it was changed. This is a fault on the server rather than anything wrong with the call, and the server log says which file and why."
+    };
+
     private readonly IRequestStore _store;
     private readonly IClock _clock;
     private readonly IIdentifierSource _identifiers;
@@ -406,30 +422,140 @@ public sealed class RequestsController : RequestsControllerBase
                 "A decision carries the revision it was made against. Without one this would be a write against whatever the store holds by the time it arrives, which is how two operators deciding one request end with one decision silently lost.");
         }
 
-        if (body.Reason is not DeclineReason reason || !Enum.IsDefined(reason))
+        if (!Declining(body.Reason, body.Note, out var refusal))
         {
-            return Invalid(
-                nameof(DeclineRequestBody.Reason),
-                "A decline carries a reason. Without one the person who asked is told no and nothing else, and what they do next is ask for the same title again.");
+            return Invalid(refusal.Field, refusal.Reason);
         }
 
-        if (reason == DeclineReason.Other && string.IsNullOrWhiteSpace(body.Note))
-        {
-            return Invalid(
-                nameof(DeclineRequestBody.Note),
-                "A decline for a reason that is not on the list has to say what the reason was. Other with nothing beside it is a decline with no reason, which is the thing a required reason exists to prevent.");
-        }
-
-        if (body.Note is not null && body.Note.Length > MediaRequest.NoteMaximumLength)
-        {
-            return Invalid(nameof(DeclineRequestBody.Note), Longer(nameof(DeclineRequestBody.Note), body.Note.Length));
-        }
+        var reason = body.Reason!.Value;
 
         return await MoveAsync(
             id,
             revision,
             (request, at, by) => RequestLifecycle.Decline(request, reason, body.Note, at, by),
             cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Approves several requests in one action.
+    /// <para>
+    /// The gesture is an operator who has been away and is answering a batch. What it is not is a
+    /// faster way to make one decision: every request in it goes through the same code as the single
+    /// endpoint, one at a time, so no rule of the transition table is reachable here that is not
+    /// reachable there.
+    /// </para>
+    /// </summary>
+    /// <param name="body">The requests, each with the revision the operator was looking at.</param>
+    /// <param name="cancellationToken">Cancels the call.</param>
+    /// <returns>One entry per request, in the order they were sent.</returns>
+    [HttpPost("Requests/Approve")]
+    [Authorize(Policy = AdministratorPolicy)]
+    [ProducesResponseType<DecidedRequests>(StatusCodes.Status200OK)]
+    [ProducesResponseType<RequestFailure>(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType<RequestFailure>(StatusCodes.Status403Forbidden)]
+    public async Task<ActionResult<DecidedRequests>> ApproveManyAsync(
+        [FromBody] ApproveManyBody body,
+        CancellationToken cancellationToken)
+    {
+        if (body is null)
+        {
+            return Invalid(
+                "body",
+                "There is no body on this call, and the requests being decided are in it.");
+        }
+
+        if (!Chosen(body.Requests, out var chosen, out var refusal))
+        {
+            return Invalid(refusal.Field, refusal.Reason);
+        }
+
+        return await DecideEachAsync(
+            chosen,
+            static (request, at, by) => RequestLifecycle.Move(request, RequestState.Approved, at, by),
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Declines several requests in one action, for one reason.
+    /// </summary>
+    /// <param name="body">The requests, the reason they are all declined for, and the note.</param>
+    /// <param name="cancellationToken">Cancels the call.</param>
+    /// <returns>One entry per request, in the order they were sent.</returns>
+    [HttpPost("Requests/Decline")]
+    [Authorize(Policy = AdministratorPolicy)]
+    [ProducesResponseType<DecidedRequests>(StatusCodes.Status200OK)]
+    [ProducesResponseType<RequestFailure>(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType<RequestFailure>(StatusCodes.Status403Forbidden)]
+    public async Task<ActionResult<DecidedRequests>> DeclineManyAsync(
+        [FromBody] DeclineManyBody body,
+        CancellationToken cancellationToken)
+    {
+        if (body is null)
+        {
+            return Invalid(
+                "body",
+                "There is no body on this call, and the requests being decided are in it.");
+        }
+
+        if (!Chosen(body.Requests, out var chosen, out var refusal)
+            || !Declining(body.Reason, body.Note, out refusal))
+        {
+            return Invalid(refusal.Field, refusal.Reason);
+        }
+
+        var reason = body.Reason!.Value;
+
+        return await DecideEachAsync(
+            chosen,
+            (request, at, by) => RequestLifecycle.Decline(request, reason, body.Note, at, by),
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Makes one move on each of several requests, in the order they were sent.
+    /// <para>
+    /// <b>One at a time, and each one through <see cref="DecideAsync"/>.</b> That is the whole of
+    /// what makes this path the same path as the single decision: the read, the revision check, the
+    /// call into the model and the write against the revision are one piece of code with one caller
+    /// more, rather than a second implementation that has to be kept in step with the first.
+    /// </para>
+    /// <para>
+    /// Sequential rather than at once. A decision is a read followed by a write against the revision
+    /// that was read, so running them together would have the writes of one action contend with each
+    /// other and refuse each other for a conflict this call created itself.
+    /// </para>
+    /// <para>
+    /// <b>A refusal that is about one request is in that request's entry, not in the status of the
+    /// call.</b> By the time one of them is refused another may already be written, and a call that
+    /// answered with a failure would be saying nothing happened while something had. What stays a
+    /// refusal of the call is what is decided before anything is written: a body that cannot be
+    /// read, and a caller that names nobody.
+    /// </para>
+    /// </summary>
+    /// <param name="chosen">The requests and the revisions they were read at.</param>
+    /// <param name="move">The move, as the model makes it.</param>
+    /// <param name="cancellationToken">Cancels the call.</param>
+    /// <returns>One entry per request.</returns>
+    private async Task<ActionResult<DecidedRequests>> DecideEachAsync(
+        IReadOnlyList<(Guid Id, long Revision)> chosen,
+        Func<MediaRequest, DateTimeOffset, RequestCaller, MediaRequest> move,
+        CancellationToken cancellationToken)
+    {
+        var caller = await _callers.UserIdAsync(HttpContext).ConfigureAwait(false);
+
+        if (caller is not Guid administrator)
+        {
+            return NoUser("This call is authenticated but names no user, so there is nobody to record as having decided.");
+        }
+
+        var decided = new List<DecidedRequest>(chosen.Count);
+
+        foreach (var one in chosen)
+        {
+            decided.Add(await DecideAsync(one.Id, one.Revision, administrator, move, cancellationToken).ConfigureAwait(false));
+        }
+
+        return Ok(new DecidedRequests { Requests = decided });
     }
 
     /// <summary>
@@ -471,6 +597,41 @@ public sealed class RequestsController : RequestsControllerBase
             return NoUser("This call is authenticated but names no user, so there is nobody to record as having decided.");
         }
 
+        var decided = await DecideAsync(id, revision, administrator, move, cancellationToken).ConfigureAwait(false);
+
+        // One request, so the entry's refusal becomes the status of the call. On the endpoints that
+        // carry several, the same entry stays in the answer beside the others, which is the only
+        // difference between the two paths.
+        return decided.Failure is RequestFailure refusal ? Answer(refusal) : Ok(decided.Request);
+    }
+
+    /// <summary>
+    /// The decision itself: read the request, check it is where the caller thinks it is, ask the
+    /// model to move it, and write it back against the revision that was read.
+    /// <para>
+    /// It answers with an entry rather than with a status code, which is what lets one request and
+    /// forty go through it. A status code is an answer to a call, and an action on several requests
+    /// is one call with several answers in it.
+    /// </para>
+    /// <para>
+    /// <b>Who is calling is decided above this and passed in.</b> An action on forty requests asks
+    /// the server once who is calling rather than forty times, and the answer cannot change halfway
+    /// through an action.
+    /// </para>
+    /// </summary>
+    /// <param name="id">The request being moved.</param>
+    /// <param name="revision">The revision the caller read it at.</param>
+    /// <param name="administrator">Who is deciding, recorded on the move.</param>
+    /// <param name="move">The move, as the model makes it.</param>
+    /// <param name="cancellationToken">Cancels the call.</param>
+    /// <returns>The request at its new revision, or why it was refused.</returns>
+    private async Task<DecidedRequest> DecideAsync(
+        Guid id,
+        long revision,
+        Guid administrator,
+        Func<MediaRequest, DateTimeOffset, RequestCaller, MediaRequest> move,
+        CancellationToken cancellationToken)
+    {
         StoredRequest? stored;
 
         try
@@ -479,22 +640,26 @@ public sealed class RequestsController : RequestsControllerBase
         }
         catch (RequestStoreLoadException)
         {
-            return TheStoreCouldNotBeRead();
+            return NotMoved(id, StoreCouldNotBeRead);
         }
 
         if (stored is not StoredRequest held)
         {
-            return Failed(
-                RequestFailureCode.NoSuchRequest,
-                "There is no request with that identifier. It may have been removed and it may never have existed, and this answer is the same either way.");
+            return NotMoved(
+                id,
+                Refusal(
+                    RequestFailureCode.NoSuchRequest,
+                    "There is no request with that identifier. It may have been removed and it may never have existed, and this answer is the same either way."));
         }
 
         if (held.Revision != revision)
         {
-            return Failed(
-                RequestFailureCode.MovedSinceItWasRead,
-                "This request has moved since it was read, so the decision was made against something that is no longer there. What the queue holds now is beside this.",
-                current: Queued(held));
+            return NotMoved(
+                id,
+                Refusal(
+                    RequestFailureCode.MovedSinceItWasRead,
+                    "This request has moved since it was read, so the decision was made against something that is no longer there. What the queue holds now is beside this.",
+                    current: Queued(held)));
         }
 
         MediaRequest moved;
@@ -508,42 +673,45 @@ public sealed class RequestsController : RequestsControllerBase
         }
         catch (IllegalRequestTransitionException refused)
         {
-            return Failed(RequestFailureCode.TheTableRefusesTheMove, refused.Message, current: Queued(held));
+            return NotMoved(id, Refusal(RequestFailureCode.TheTableRefusesTheMove, refused.Message, current: Queued(held)));
         }
         catch (RequestNotIdentifiedException refused)
         {
-            return Failed(RequestFailureCode.TheRequestNamesNothing, refused.Message, current: Queued(held));
+            return NotMoved(id, Refusal(RequestFailureCode.TheRequestNamesNothing, refused.Message, current: Queued(held)));
         }
         catch (RequestMoveNotPermittedException refused)
         {
             // No call that reaches here can produce this today, and the reason is measured rather
-            // than assumed: both endpoints require elevation, so the caller is built as an
-            // administrator, and every legal cell into Approved or Declined is a decision cell that
-            // admits one. TheOnlyCallerTheseEndpointsBuildIsAdmittedByEveryMoveTheyCanMake holds
-            // that, and it reds the day a cell in the table stops admitting an administrator. This
-            // arm is what that day answers with instead of a stack trace.
-            return Failed(RequestFailureCode.TheCallerMayNotMakeThisMove, refused.Message, current: Queued(held));
+            // than assumed: every endpoint that reaches this requires elevation, so the caller is
+            // built as an administrator, and every legal cell into Approved or Declined is a
+            // decision cell that admits one.
+            // TheOnlyCallerTheseEndpointsBuildIsAdmittedByEveryMoveTheyCanMake holds that, and it
+            // reds the day a cell in the table stops admitting an administrator. This arm is what
+            // that day answers with instead of a stack trace.
+            return NotMoved(id, Refusal(RequestFailureCode.TheCallerMayNotMakeThisMove, refused.Message, current: Queued(held)));
         }
 
         try
         {
             var written = await _store.ReplaceAsync(moved, revision, cancellationToken).ConfigureAwait(false);
 
-            return Ok(Queued(written));
+            return new DecidedRequest { Id = id, Request = Queued(written) };
         }
         catch (RequestConcurrencyException lost)
         {
             // The window between the read above and this write. It is small and it is real: two
             // administrators clicking within it both pass the revision check and exactly one of
             // them is accepted here.
-            return Failed(
-                RequestFailureCode.MovedSinceItWasRead,
-                "This request moved while the decision was being written, so it was refused rather than applied over the decision that got there first.",
-                current: lost.Current is StoredRequest now ? Queued(now) : null);
+            return NotMoved(
+                id,
+                Refusal(
+                    RequestFailureCode.MovedSinceItWasRead,
+                    "This request moved while the decision was being written, so it was refused rather than applied over the decision that got there first.",
+                    current: lost.Current is StoredRequest now ? Queued(now) : null));
         }
         catch (RequestStoreLoadException)
         {
-            return TheStoreCouldNotBeRead();
+            return NotMoved(id, StoreCouldNotBeRead);
         }
     }
 
@@ -659,9 +827,44 @@ public sealed class RequestsController : RequestsControllerBase
         string message,
         string? field = null,
         QueuedRequest? current = null)
-        => StatusCode(
-            RequestFailure.StatusFor(code),
-            new RequestFailure { Code = code, Message = message, Field = field, Current = current });
+        => Answer(Refusal(code, message, field, current));
+
+    /// <summary>
+    /// One failure, under the status code its class is reported with.
+    /// <para>
+    /// The pairing is <see cref="RequestFailure.StatusFor"/>'s and is read here rather than chosen,
+    /// which is what lets a refusal built inside a decision come back from the single endpoint under
+    /// the same status code it would have had if the endpoint had built it.
+    /// </para>
+    /// </summary>
+    /// <param name="failure">What went wrong.</param>
+    /// <returns>The failure, under its status code.</returns>
+    private ObjectResult Answer(RequestFailure failure)
+        => StatusCode(RequestFailure.StatusFor(failure.Code), failure);
+
+    /// <summary>
+    /// One failure, as the shape every failure of this API comes back in.
+    /// </summary>
+    /// <param name="code">What went wrong.</param>
+    /// <param name="message">The sentence for the person reading it.</param>
+    /// <param name="field">The field that is wrong, where there is one.</param>
+    /// <param name="current">What the store holds now, where the caller may see it.</param>
+    /// <returns>The failure.</returns>
+    private static RequestFailure Refusal(
+        RequestFailureCode code,
+        string message,
+        string? field = null,
+        QueuedRequest? current = null)
+        => new RequestFailure { Code = code, Message = message, Field = field, Current = current };
+
+    /// <summary>
+    /// One request an action did not move, and why.
+    /// </summary>
+    /// <param name="id">The request, as the caller named it.</param>
+    /// <param name="failure">Why it was refused.</param>
+    /// <returns>The entry.</returns>
+    private static DecidedRequest NotMoved(Guid id, RequestFailure failure)
+        => new DecidedRequest { Id = id, Failure = failure };
 
     /// <summary>
     /// A body that cannot be acted on, naming the field that is wrong.
@@ -696,9 +899,7 @@ public sealed class RequestsController : RequestsControllerBase
     /// </summary>
     /// <returns>The failure.</returns>
     private ObjectResult TheStoreCouldNotBeRead()
-        => Failed(
-            RequestFailureCode.TheStoreCouldNotBeRead,
-            "The queue could not be read, so this call was not answered rather than answered with part of it. Nothing was changed. This is a fault on the server rather than anything wrong with the call, and the server log says which file and why.");
+        => Answer(StoreCouldNotBeRead);
 
     /// <summary>
     /// One request as the person waiting for it sees it.
@@ -853,6 +1054,146 @@ public sealed class RequestsController : RequestsControllerBase
         refusal = default;
         return true;
     }
+
+    /// <summary>
+    /// Refuses a decline that carries no usable reason, naming the field that is wrong.
+    /// <para>
+    /// One rule for the decline of one request and the decline of forty. The reason and the note are
+    /// the model's rules and are refused there by throwing; they are checked here as well, ahead of
+    /// the model, so the caller is told which field was wrong. Written once because a second copy is
+    /// the endpoint that ends up one rule behind, and both bodies spell these two fields the same,
+    /// which <c>BothDeclineBodiesSpellTheReasonAndTheNoteTheSameWay</c> holds.
+    /// </para>
+    /// </summary>
+    /// <param name="reason">The reason the caller sent.</param>
+    /// <param name="note">What the caller wants to say about it.</param>
+    /// <param name="refusal">The field and the reason, where the answer is no.</param>
+    /// <returns><see langword="true"/> where the decline can be made.</returns>
+    private static bool Declining(DeclineReason? reason, string? note, out (string Field, string Reason) refusal)
+    {
+        if (reason is not DeclineReason chosen || !Enum.IsDefined(chosen))
+        {
+            refusal = Refused(
+                nameof(DeclineRequestBody.Reason),
+                "A decline carries a reason. Without one the person who asked is told no and nothing else, and what they do next is ask for the same title again.");
+            return false;
+        }
+
+        if (chosen == DeclineReason.Other && string.IsNullOrWhiteSpace(note))
+        {
+            refusal = Refused(
+                nameof(DeclineRequestBody.Note),
+                "A decline for a reason that is not on the list has to say what the reason was. Other with nothing beside it is a decline with no reason, which is the thing a required reason exists to prevent.");
+            return false;
+        }
+
+        if (note is not null && note.Length > MediaRequest.NoteMaximumLength)
+        {
+            refusal = Refused(nameof(DeclineRequestBody.Note), Longer(nameof(DeclineRequestBody.Note), note.Length));
+            return false;
+        }
+
+        refusal = default;
+        return true;
+    }
+
+    /// <summary>
+    /// Refuses a selection that cannot be acted on, and hands back the requests where it can.
+    /// <para>
+    /// <b>The whole selection is refused rather than the part of it that is readable.</b> Every
+    /// check here is about the body rather than about the queue, so it is answered before anything
+    /// is written; acting on the readable half of a body somebody built wrong would leave an
+    /// operator with some of an action done and no way to tell which part was even attempted.
+    /// </para>
+    /// <para>
+    /// A position is named rather than an index, because the message is read by a person looking at
+    /// a body they sent, and the field is the list rather than one entry: an entry of a list is not
+    /// something the body names.
+    /// </para>
+    /// </summary>
+    /// <param name="requests">What the body carried.</param>
+    /// <param name="chosen">The requests and their revisions, where the selection can be acted on.</param>
+    /// <param name="refusal">The field and the reason, where it cannot.</param>
+    /// <returns><see langword="true"/> where the selection can be acted on.</returns>
+    private static bool Chosen(
+        IReadOnlyList<RequestToDecide>? requests,
+        out IReadOnlyList<(Guid Id, long Revision)> chosen,
+        out (string Field, string Reason) refusal)
+    {
+        chosen = [];
+
+        if (requests is null || requests.Count == 0)
+        {
+            refusal = Refused(
+                nameof(ApproveManyBody.Requests),
+                "An action carries the requests it is an action on. An empty one would be answered as having decided everything it was asked to, which is true and says nothing.");
+            return false;
+        }
+
+        if (requests.Count > MaximumPageSize)
+        {
+            refusal = Refused(
+                nameof(ApproveManyBody.Requests),
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    "An action carries at most {0} requests, which is the page an operator selects them from. It is refused rather than acted on as far as the cap, because a caller told nothing would read a partly done action as a whole one.",
+                    MaximumPageSize));
+            return false;
+        }
+
+        var picked = new List<(Guid Id, long Revision)>(requests.Count);
+        var seen = new Dictionary<Guid, int>();
+
+        for (var position = 0; position < requests.Count; position++)
+        {
+            var one = requests[position];
+
+            if (one?.Id is not Guid id || id == Guid.Empty)
+            {
+                refusal = Refused(
+                    nameof(ApproveManyBody.Requests),
+                    At(position, "names no request, so there is nothing for this action to decide there."));
+                return false;
+            }
+
+            if (one.Revision is not long revision)
+            {
+                refusal = Refused(
+                    nameof(ApproveManyBody.Requests),
+                    At(position, "carries no revision. A decision made against whatever the store holds by the time it arrives is how two operators deciding one request end with one decision silently lost."));
+                return false;
+            }
+
+            if (seen.TryGetValue(id, out var first))
+            {
+                refusal = Refused(
+                    nameof(ApproveManyBody.Requests),
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        "The same request is in position {0} and position {1}. The second would be refused as having moved since it was read, against a move this same action had just made, so the action is refused instead of answering with a conflict it created itself.",
+                        first + 1,
+                        position + 1));
+                return false;
+            }
+
+            seen.Add(id, position);
+            picked.Add((id, revision));
+        }
+
+        chosen = picked;
+        refusal = default;
+        return true;
+    }
+
+    /// <summary>
+    /// One sentence about the request in one position of a selection, counted the way somebody
+    /// reading their own body counts.
+    /// </summary>
+    /// <param name="position">Where it is in the list, counted from zero.</param>
+    /// <param name="wrong">What is wrong with it.</param>
+    /// <returns>The sentence.</returns>
+    private static string At(int position, string wrong)
+        => string.Format(CultureInfo.InvariantCulture, "The request in position {0} {1}", position + 1, wrong);
 
     /// <summary>
     /// The message for a field that is longer than a request keeps.

--- a/docs/api.md
+++ b/docs/api.md
@@ -295,6 +295,59 @@ rather than `TheTableRefusesTheMove`. Both are refusals and they tell an operato
 one says somebody else got there first and here is what they did, the other says this request can
 never be approved. The second would be false.
 
+## Deciding on several
+
+    POST MediaRequests/v1/Requests/Approve
+    POST MediaRequests/v1/Requests/Decline
+
+The same two operations over a selection rather than over one request. An operator who has been away
+comes back to forty requests, and one call per request is why people stop working a queue.
+
+Each entry carries its own revision, because the rows were read at whatever revision each one was at
+and one of them can move while the others do not. A decline carries one reason and one note for the
+whole action: the gesture is answering a batch the same way, and an operator who wants to say
+something different about one request makes that one decision on its own.
+
+An action carries at most 200 requests, which is the page they are selected from. More is **refused**
+rather than acted on as far as the cap, for the reason a large `take` is refused rather than
+answered with fewer.
+
+### What comes back
+
+`200`, with one entry per request, in the order they were sent. Every request that was sent has an
+entry. Each entry carries the row at its new revision, or the failure that request got, and never
+both.
+
+    {
+      "requests": [
+        { "id": "...", "request": { "state": "Approved", "revision": 4 } },
+        { "id": "...", "failure": { "code": "MovedSinceItWasRead", "current": { ... } } }
+      ]
+    }
+
+**A refusal about one request is in that request's entry rather than in the status of the call.** By
+the time one of them is refused another may already be written, so a call answering with a failure
+would be saying nothing happened while something had. The successful ones stay done and are not
+rolled back: a decision an operator made is not something this API takes away because the next row
+in the list had moved.
+
+So a client cannot read the status code alone. `200` here means the action was carried out, not that
+every request in it moved, and a surface that draws it as done without reading the entries is the
+failure this shape exists against.
+
+What stays a refusal of the whole call is what is decided before anything is written: a body that
+cannot be read, and a call that names no person. Both answer exactly as they do on a single
+decision, and neither leaves anything written.
+
+A body is refused whole rather than in part. An entry naming no request, an entry with no revision,
+an empty selection and the same request twice are all `InvalidBody` with the position named, and
+nothing in the action is attempted. The last of those would otherwise report that a request had
+moved since it was read, against a move the same call had just made.
+
+There is no status code on an entry. A status code is an answer to a call and several entries come
+back under one; the failure carries the code, and the table below is where a code and a status are
+paired, once.
+
 ## When a call fails
 
 Every failure of this API comes back in one shape, whichever endpoint it came from:
@@ -385,8 +438,10 @@ on the day it is added, and a class attribute is edited by somebody who is not r
 | `GET Requests/Queue`         | `RequiresElevation`    | an administrator     |
 | `POST Requests/{id}/Approve` | `RequiresElevation`    | an administrator     |
 | `POST Requests/{id}/Decline` | `RequiresElevation`    | an administrator     |
+| `POST Requests/Approve`      | `RequiresElevation`    | an administrator     |
+| `POST Requests/Decline`      | `RequiresElevation`    | an administrator     |
 
-The two decisions carry the same policy as the queue, and that is the endpoint agreeing with the
+The four decisions carry the same policy as the queue, and that is the endpoint agreeing with the
 model rather than deciding anything: every cell of the table these two can reach admits an
 administrator and nobody else, so an endpoint open to any signed-in person would refuse each such
 call one layer down. A permission answered in two places is a permission that comes to be answered
@@ -420,5 +475,6 @@ asked for, which is a weaker disclosure than a row and still a disclosure, is op
 
 - Whether a user may ever be told that a title has already been asked for is open between #51 and #71.
 - The capability endpoint is #55.
-- Deciding on several requests in one call is #62. Nothing here does it, and a client that wants it
-  today makes one call per request.
+- Which of these a page calls, and what an operator sees while an action on several is running, is
+  the administrator surface rather than this document. The endpoints promise what is written above
+  and nothing about a screen.


### PR DESCRIPTION
Closes #62.

An operator who has been away comes back to forty requests, and one call per
request is why people stop working a queue. This adds the two endpoints that
take a selection:

    POST MediaRequests/v1/Requests/Approve
    POST MediaRequests/v1/Requests/Decline

**The answer is per request, because the outcome is.** Some of an action
succeeds and some of it is refused because a row moved underneath the operator.
A single verdict over the whole thing would be either done, which is false the
moment one row moved, or failed, which throws away decisions already written
that cannot be undecided. Each entry carries the row at its new revision or the
refusal that request got, never both, and every request sent has an entry.

**A refusal about one request is inside that request's entry rather than in the
status of the call.** By the time one is refused another may already be written,
so a call answering with a failure would be saying nothing happened while
something had. What stays a refusal of the whole call is what is decided before
anything is written: a body that cannot be read, and a call naming no person.
Both answer exactly as they do on a single decision and neither leaves anything
written.

**There is one piece of code and not two.** The read, the revision check, the
call into the model and the write against the revision moved into `DecideAsync`,
and the single decision now unwraps one of its entries into a status code. That
is what makes the third condition of the issue a fact about the code rather than
a promise.

## Against the done-when

**Several requests can be approved or declined in one action.**
`ApprovingSeveralMovesEachOneAndReportsItsNewRow` and
`DecliningSeveralCarriesOneReasonOntoEveryOneOfThem` move three requests each and
then ask the store what it holds rather than believing the answer.

**A partial failure names the requests that failed and why, and leaves the
successful ones done.** `OneRefusalLeavesTheOthersDecidedAndSaysWhichAndWhy`
sends four: one that a second operator decided between the read and the call, one
that is not in the store, and two ordinary ones. The two are approved, the stale
one comes back with what the store holds now beside the refusal, and the absent
one comes back as no such request.

**The bulk path makes the same model calls as the single path, so no transition
rule is bypassed.** `TheActionAndTheSingleDecisionAgreeOnEveryStateARequestCanBeIn`
runs both paths over identical stores for every state a request can be in and for
both moves, and compares the answers and what each store holds afterwards.

## The runs

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release
    Bestanden!: Fehler: 0, erfolgreich: 453, gesamt: 453 (net9.0)
    Bestanden!: Fehler: 0, erfolgreich: 453, gesamt: 453 (net10.0)

Three deletions, each made on its own with the rest of the file unchanged, and
each watched turning the suite red before this was pushed.

The action stops at the first refusal instead of carrying on:

    ActOnManyRequestsTests.OneRefusalLeavesTheOthersDecidedAndSaysWhichAndWhy [FAIL]
    Fehler: 1, erfolgreich: 19, gesamt: 20

The action writes the state itself instead of asking the model:

    TheActionAndTheSingleDecisionAgreeOnEveryStateARequestCanBeIn(from: Approved, approving: True) [FAIL]
    TheActionAndTheSingleDecisionAgreeOnEveryStateARequestCanBeIn(from: Declined, approving: True) [FAIL]
    TheActionAndTheSingleDecisionAgreeOnEveryStateARequestCanBeIn(from: Failed, approving: True) [FAIL]
    TheActionAndTheSingleDecisionAgreeOnEveryStateARequestCanBeIn(from: Open, approving: True) [FAIL]
    TheActionAndTheSingleDecisionAgreeOnEveryStateARequestCanBeIn(from: Fulfilled, approving: True) [FAIL]
    ActOnManyRequestsTests.ApprovingSeveralMovesEachOneAndReportsItsNewRow [FAIL]
    Fehler: 6, erfolgreich: 14, gesamt: 20

The same request named twice is let through:

    ActOnManyRequestsTests.TheSameRequestTwiceInOneActionIsRefusedBeforeAnythingIsWritten [FAIL]
    Fehler: 1, erfolgreich: 19, gesamt: 20

The two written-down registries were red until they were told, which is what they
are for. `EndpointPolicyTests` and `PublishedApiDocumentTests` both fail on an
endpoint nobody added a line for, and the lines added carry the reason for the
policy and for the three status codes.

The formatter was run on the document rather than assumed:

    npx --yes prettier@3.6.2 --check "docs/api.md"
    All matched files use Prettier code style!

## What is in here beyond the issue's scope line, and why

`docs/api.md` is not in the scope the issue names. It said in as many words that
deciding on several requests in one call is #62 and that nothing here does it, so
landing the endpoints and leaving that sentence would put a false statement in
the document a caller is told to read. The section added is what the endpoints
promise; nothing about a screen is promised there.

## What this does not do

The page half of the issue's scope is not in here. The queue page draws no rows
yet, so there is nothing on it to select, and the rows with their filter, sort and
paging are #60. Nothing in this change touches the web assets.

No second person has read this. What stands in its place is above: the commands,
the runs, and the three deletions watched turning the suite red.
