### PR TITLE
Take a want from the browsing sibling and make a request of it

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Doubles/InstallSettingsThatCannotBeRead.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/InstallSettingsThatCannotBeRead.cs
@@ -1,0 +1,26 @@
+using Jellyfin.Plugin.Requests.Configuration;
+
+namespace Jellyfin.Plugin.Requests.Tests.Doubles;
+
+/// <summary>
+/// An install whose stored settings are something the plugin cannot run on.
+/// <para>
+/// The real one refuses on the read rather than correcting what it found, so every caller meets the
+/// refusal instead of acting on a value nobody chose. This is that refusal without a configuration
+/// file, so a caller can be watched answering for it.
+/// </para>
+/// </summary>
+internal sealed class InstallSettingsThatCannotBeRead : IInstallSettings
+{
+    /// <inheritdoc />
+    /// <exception cref="InvalidConfigurationException">Always.</exception>
+    public PluginConfiguration Current
+        => throw new InvalidConfigurationException(
+            [
+                new ConfigurationProblem
+                {
+                    Setting = nameof(PluginConfiguration.AcceptsMovies),
+                    Why = "Neither kind is accepted, so there is nothing anybody can ask for."
+                }
+            ]);
+}

--- a/Jellyfin.Plugin.Requests.Tests/Seam/WantHandoverTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Seam/WantHandoverTests.cs
@@ -1,0 +1,318 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Configuration;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Seam;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Seam;
+
+/// <summary>
+/// The call the sibling discover plugin makes into this one.
+/// <para>
+/// The failures these exist against are the three the issue asks to be decided rather than
+/// discovered: a title this side has never seen treated as an error, a field set carrying a version
+/// this side does not know read for the fields it recognises, and a refusal that reaches nobody
+/// because the contract has no field for one.
+/// </para>
+/// </summary>
+public class WantHandoverTests
+{
+    private static readonly DateTimeOffset Noon = new DateTimeOffset(2026, 3, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private static readonly Guid Asker = new Guid("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid SecondAsker = new Guid("22222222-2222-2222-2222-222222222222");
+
+    /// <summary>
+    /// A want naming something no request has ever named creates a request. There is no pre-agreed
+    /// catalogue on this side, so this is the ordinary case rather than the exception, and the store
+    /// it is answered against is empty.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AWantForATitleNothingHasEverAskedForBecomesARequest()
+    {
+        var store = new InMemoryRequestStore();
+        var handover = Seam(store);
+
+        Assert.Empty(await store.GetAllAsync(CancellationToken.None));
+
+        var accepted = await handover.AcceptAsync(Want(), CancellationToken.None);
+
+        var held = await store.GetAllAsync(CancellationToken.None);
+        var made = Assert.Single(held).Request;
+
+        Assert.True(accepted);
+        Assert.Equal(Asker, made.RequestedByUserId);
+        Assert.Equal(RequestedItemKind.Movie, made.Kind);
+        Assert.Equal(RequestState.Open, made.State);
+        Assert.Equal(Noon, made.RequestedAt);
+    }
+
+    /// <summary>
+    /// The queue renders from the title and the year that crossed, and nothing refreshes either.
+    /// <para>
+    /// The row is read the way the administrator queue reads it, through the store's own query, so
+    /// what is asserted is what an operator would see. That nothing could have been fetched to build
+    /// it is the assembly's reference list in <c>SiblingIndependenceTests</c> and the dependency
+    /// count in <c>CatalogueSplitTests</c>; what is added here is the count for this seam, below.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task TheQueueRendersFromTheTitleAndYearThatCrossed()
+    {
+        var store = new InMemoryRequestStore();
+
+        Assert.True(await Seam(store).AcceptAsync(
+            Want() with { Title = "Der Himmel über Berlin", Year = 1987 },
+            CancellationToken.None));
+
+        var page = await store.PageAsync(new RequestQuery { Take = 10 }, CancellationToken.None);
+        var row = Assert.Single(page.Requests).Request;
+
+        Assert.Equal("Der Himmel über Berlin", row.DisplayTitle);
+        Assert.Equal(1987, row.DisplayYear);
+    }
+
+    /// <summary>
+    /// This seam is built from the store, the clock, the identifier source, the settings and a
+    /// logger, and from nothing else. A metadata source would arrive as a dependency, and the
+    /// sentence about the queue rendering with nothing outbound reachable is only true while there
+    /// is nothing here that could fetch.
+    /// </summary>
+    [Fact]
+    public void TheSeamIsBuiltFromNothingThatCouldFetchATitle()
+    {
+        var taken = typeof(WantHandover)
+            .GetConstructors(BindingFlags.Public | BindingFlags.Instance)
+            .Single()
+            .GetParameters()
+            .Select(parameter => parameter.ParameterType.Name)
+            .ToArray();
+
+        Assert.Equal(
+            ["IRequestStore", "IClock", "IIdentifierSource", "IInstallSettings", "ILogger"],
+            taken);
+    }
+
+    /// <summary>
+    /// Two people wanting the same film are one request with both of them recorded. The rule is the
+    /// identity rule and it is applied by the same intake the HTTP endpoint asks, which is what stops
+    /// a want arriving over the seam being acquired a second time.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task TwoPeopleWantingTheSameFilmAreOneRequest()
+    {
+        var store = new InMemoryRequestStore();
+        var handover = Seam(store);
+
+        Assert.True(await handover.AcceptAsync(Want(), CancellationToken.None));
+        Assert.True(await handover.AcceptAsync(
+            Want() with { RequestedByUserId = SecondAsker, WantId = Guid.NewGuid() },
+            CancellationToken.None));
+
+        var held = await store.GetAllAsync(CancellationToken.None);
+        var made = Assert.Single(held).Request;
+
+        Assert.Equal(Asker, made.RequestedByUserId);
+        Assert.Equal([SecondAsker], made.JoinedByUserIds);
+    }
+
+    /// <summary>
+    /// A field set built against a version this plugin does not know is refused whole. Nothing is
+    /// read out of it, which is the half that matters: a version that changed the meaning of a field
+    /// and one that added a field are indistinguishable to a reader that takes what it recognises,
+    /// and the first of those files a want against the wrong thing.
+    /// </summary>
+    /// <param name="version">A contract version that is not the one this plugin implements.</param>
+    /// <returns>A task that completes when the case has been checked.</returns>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(2)]
+    [InlineData(97)]
+    public async Task AWantBuiltAgainstAVersionThisPluginDoesNotKnowIsRefusedWhole(int version)
+    {
+        var store = new InMemoryRequestStore();
+        var log = new RecordingLogger();
+
+        var accepted = await Seam(store, log: log).AcceptAsync(
+            Want() with { ContractVersion = version },
+            CancellationToken.None);
+
+        Assert.False(accepted);
+        Assert.Empty(await store.GetAllAsync(CancellationToken.None));
+        Assert.Contains(
+            nameof(HandoverRefusal.ContractVersionNotKnown),
+            Assert.Single(log.At(LogLevel.Warning)).Message,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A kind this install is set not to accept is refused, and the refusal names itself in the log.
+    /// The setting is read on every handover rather than held, so an operator turning a kind off
+    /// means the next want of that kind.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AKindThisInstallDoesNotAcceptIsRefusedAndSaysSo()
+    {
+        var store = new InMemoryRequestStore();
+        var log = new RecordingLogger();
+        var settings = new FakeInstallSettings(new PluginConfiguration { AcceptsSeries = false });
+
+        var accepted = await Seam(store, settings, log).AcceptAsync(
+            Want() with { Kind = RequestedItemKind.Series },
+            CancellationToken.None);
+
+        Assert.False(accepted);
+        Assert.Empty(await store.GetAllAsync(CancellationToken.None));
+        Assert.Contains(
+            nameof(HandoverRefusal.KindNotAccepted),
+            Assert.Single(log.At(LogLevel.Warning)).Message,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The field set has to carry a user and a title for a request to exist at all, and a kind has to
+    /// be one of the kinds this plugin knows. Each is refused with its own reason rather than with one
+    /// that covers all three, because the reason is the only thing an operator gets.
+    /// </summary>
+    /// <param name="broken">The want, broken in one way.</param>
+    /// <param name="expected">The refusal that names what is wrong with it.</param>
+    /// <returns>A task that completes when the case has been checked.</returns>
+    [Theory]
+    [MemberData(nameof(FieldSetsThatCannotBecomeARequest))]
+    public async Task AFieldSetThatCannotBecomeARequestIsRefusedWithItsOwnReason(
+        HandedOverWant broken,
+        HandoverRefusal expected)
+    {
+        var store = new InMemoryRequestStore();
+        var log = new RecordingLogger();
+
+        Assert.False(await Seam(store, log: log).AcceptAsync(broken, CancellationToken.None));
+        Assert.Empty(await store.GetAllAsync(CancellationToken.None));
+        Assert.Contains(
+            expected.ToString(),
+            Assert.Single(log.At(LogLevel.Warning)).Message,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A store that cannot be read refuses the handover rather than throwing across the seam. An
+    /// exception leaving this call is a fault in the calling plugin's own path for something that is
+    /// an ordinary answer here.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AStoreThatCannotBeReadRefusesRatherThanThrowingAtTheCaller()
+    {
+        var log = new RecordingLogger();
+
+        var accepted = await Seam(new StoreThatCannotBeRead(), log: log)
+            .AcceptAsync(Want(), CancellationToken.None);
+
+        Assert.False(accepted);
+        Assert.Contains(
+            nameof(HandoverRefusal.TheStoreCouldNotBeReached),
+            Assert.Single(log.At(LogLevel.Warning)).Message,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Settings the plugin cannot run on refuse the handover in the same way, and say that it is this
+    /// server rather than the field set that is wrong.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task SettingsThisPluginCannotRunOnRefuseTheHandoverRatherThanThrowing()
+    {
+        var store = new InMemoryRequestStore();
+        var log = new RecordingLogger();
+
+        var accepted = await Seam(store, new InstallSettingsThatCannotBeRead(), log)
+            .AcceptAsync(Want(), CancellationToken.None);
+
+        Assert.False(accepted);
+        Assert.Empty(await store.GetAllAsync(CancellationToken.None));
+        Assert.Contains(
+            nameof(HandoverRefusal.ThisInstallCannotRun),
+            Assert.Single(log.At(LogLevel.Warning)).Message,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// No line a refusal writes carries the title or the person. A log is pasted into issue trackers,
+    /// and what somebody asked for is the thing in this plugin worth being careful with; the want
+    /// identifier is what an operator needs to find it and it names nobody.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ARefusalNamesTheWantAndNeitherTheTitleNorThePerson()
+    {
+        var log = new RecordingLogger();
+        var want = Want() with { ContractVersion = 4, Title = "Nosferatu" };
+
+        Assert.False(await Seam(new InMemoryRequestStore(), log: log).AcceptAsync(want, CancellationToken.None));
+
+        var line = Assert.Single(log.At(LogLevel.Warning)).Message;
+
+        Assert.Contains(want.WantId.ToString(), line, StringComparison.Ordinal);
+        Assert.DoesNotContain("Nosferatu", line, StringComparison.Ordinal);
+        Assert.DoesNotContain(Asker.ToString(), line, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The field sets that cannot become a request, each with the refusal that names what is wrong.
+    /// </summary>
+    /// <returns>One case per way of being wrong.</returns>
+    public static TheoryData<HandedOverWant, HandoverRefusal> FieldSetsThatCannotBecomeARequest()
+        => new TheoryData<HandedOverWant, HandoverRefusal>
+        {
+            { Want() with { RequestedByUserId = Guid.Empty }, HandoverRefusal.NoUserNamed },
+            { Want() with { Title = "   " }, HandoverRefusal.NoTitle },
+            { Want() with { Kind = (RequestedItemKind)9 }, HandoverRefusal.KindNotRecognised }
+        };
+
+    /// <summary>
+    /// A want as the contract carries one, which every case here starts from and breaks in one way.
+    /// </summary>
+    /// <returns>A field set this plugin accepts.</returns>
+    private static HandedOverWant Want()
+        => new HandedOverWant
+        {
+            ContractVersion = WantHandover.KnownContractVersion,
+            WantId = new Guid("33333333-3333-3333-3333-333333333333"),
+            RequestedByUserId = Asker,
+            Kind = RequestedItemKind.Movie,
+            Title = "Stalker",
+            Year = 1979,
+            ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tmdb"] = "1398" }
+        };
+
+    /// <summary>
+    /// The seam over a store, with a clock that does not move and identifiers that count.
+    /// </summary>
+    /// <param name="store">Where requests are kept.</param>
+    /// <param name="settings">What the install is set to, or a fresh install where not given.</param>
+    /// <param name="log">Where refusals are written, or a discarded one where not given.</param>
+    /// <returns>The seam under test.</returns>
+    private static WantHandover Seam(
+        IRequestStore store,
+        IInstallSettings? settings = null,
+        RecordingLogger? log = null)
+        => new WantHandover(
+            store,
+            new TestClock(Noon),
+            new SequentialIdentifierSource(),
+            settings ?? new FakeInstallSettings(),
+            log ?? new RecordingLogger());
+}

--- a/Jellyfin.Plugin.Requests/Api/RequestsController.cs
+++ b/Jellyfin.Plugin.Requests/Api/RequestsController.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.Requests.Identity;
+using Jellyfin.Plugin.Requests.Intake;
 using Jellyfin.Plugin.Requests.Model;
 using Jellyfin.Plugin.Requests.Storage;
 using Jellyfin.Plugin.Requests.Time;
@@ -70,14 +71,6 @@ public sealed class RequestsController : RequestsControllerBase
     public const int MaximumPageSize = 200;
 
     /// <summary>
-    /// How many times a join is attempted before giving up. A join is a read followed by a write
-    /// against the revision that was read, so two people joining one request in the same moment
-    /// means one of them is refused and re-decides. Three is enough for that and small enough that
-    /// a genuinely contended request fails visibly instead of spinning.
-    /// </summary>
-    private const int JoinAttempts = 3;
-
-    /// <summary>
     /// The store failure, written once because it is answered from a call and from inside one
     /// request of an action on several.
     /// <para>
@@ -97,6 +90,7 @@ public sealed class RequestsController : RequestsControllerBase
     private readonly IClock _clock;
     private readonly IIdentifierSource _identifiers;
     private readonly ICallerIdentity _callers;
+    private readonly RequestIntake _intake;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RequestsController"/> class.
@@ -115,6 +109,12 @@ public sealed class RequestsController : RequestsControllerBase
         _clock = clock;
         _identifiers = identifiers;
         _callers = callers;
+
+        // Built here rather than injected, because it is this controller's use of the store rather
+        // than a fifth thing the server has to supply. CatalogueSplitTests counts what this
+        // controller is constructed from, and a request intake that arrived as a dependency would
+        // read as one.
+        _intake = new RequestIntake(store);
     }
 
     /// <summary>
@@ -961,22 +961,6 @@ public sealed class RequestsController : RequestsControllerBase
         };
 
     /// <summary>
-    /// Whether a request already in the queue is one a new ask may join.
-    /// <para>
-    /// Only a request that is still waiting for an answer or waiting to arrive. A declined request
-    /// is an answer somebody gave and joining it would make a new asker inherit a refusal they never
-    /// saw; a fulfilled one is finished, and a person asking for something the server already holds
-    /// is asking a question the queue is the wrong place to answer; a failed one has been given up
-    /// on. In every one of those a new ask is a new request, which is also what puts it back in front
-    /// of an operator.
-    /// </para>
-    /// </summary>
-    /// <param name="request">A request the store holds.</param>
-    /// <returns><see langword="true"/> where a new ask may join it.</returns>
-    private static bool StillOpenToJoiners(MediaRequest request)
-        => request.State is RequestState.Open or RequestState.Approved;
-
-    /// <summary>
     /// Refuses a body that cannot become a request, naming the field that is wrong.
     /// <para>
     /// The cap on the note and the shape of a season list are the record's own rules and are refused
@@ -1210,20 +1194,14 @@ public sealed class RequestsController : RequestsControllerBase
             MediaRequest.NoteMaximumLength);
 
     /// <summary>
-    /// Puts the ask against what is already in the queue, and either joins one of them or creates it.
+    /// Puts the ask against what is already in the queue, and answers in the shape this endpoint
+    /// returns.
     /// <para>
-    /// The candidates are read out of the store by identifier rather than by walking it, which is
-    /// what makes this cheap on a queue of any size. A request carrying no identifier reaches nobody
-    /// and is joined by nobody, which is <see cref="RequestIdentity"/>'s answer and not this
-    /// method's: such a request has no identity, so it is different from everything including
-    /// another copy of itself.
-    /// </para>
-    /// <para>
-    /// The seasons narrow as the walk goes on. Where an existing request covers some of what is
-    /// being asked for, what is left to ask for is what the next candidate is compared against, so a
-    /// series whose seasons are spread over two existing requests is joined to the second rather
-    /// than duplicated. If the narrowing ever leaves nothing, the candidate that took the last
-    /// season compares as the same request and is joined.
+    /// Whether an ask joins something or becomes something is <see cref="RequestIntake"/>'s, and it
+    /// is there rather than here because the seam to the sibling discover plugin asks the same
+    /// question over the same store. What is left here is the translation into
+    /// <see cref="RequestOutcome"/>, which is the wire shape this endpoint publishes and is not the
+    /// vocabulary the seam answers in.
     /// </para>
     /// </summary>
     /// <param name="incoming">The ask, as a request that does not exist yet.</param>
@@ -1231,110 +1209,37 @@ public sealed class RequestsController : RequestsControllerBase
     /// <returns>What the caller is now waiting for and what asking did.</returns>
     private async Task<CreatedRequest> AskAsync(MediaRequest incoming, CancellationToken cancellationToken)
     {
-        for (var attempt = 1; ; attempt++)
+        var intake = await _intake.AskAsync(incoming, cancellationToken).ConfigureAwait(false);
+
+        return new CreatedRequest
         {
-            var ask = incoming;
-            var candidates = await CandidatesAsync(ask, cancellationToken).ConfigureAwait(false);
-            StoredRequest? joining = null;
-
-            foreach (var candidate in candidates)
-            {
-                var match = RequestIdentity.Compare(candidate.Request, ask);
-
-                if (match == RequestMatch.Same)
-                {
-                    joining = candidate;
-                    break;
-                }
-
-                if (match == RequestMatch.Overlapping)
-                {
-                    ask = ask with
-                    {
-                        Seasons = RequestIdentity.SeasonsNotAlreadyAskedFor(candidate.Request, ask, [])
-                    };
-                }
-            }
-
-            if (joining is not StoredRequest existing)
-            {
-                var added = await _store.AddAsync(ask, cancellationToken).ConfigureAwait(false);
-
-                return new CreatedRequest
-                {
-                    Id = added.Request.Id,
-                    State = added.Request.State,
-                    Outcome = RequestOutcome.Created
-                };
-            }
-
-            if (existing.Request.WasAskedForBy(ask.RequestedByUserId))
-            {
-                return new CreatedRequest
-                {
-                    Id = existing.Request.Id,
-                    State = existing.Request.State,
-                    Outcome = RequestOutcome.AlreadyWaiting
-                };
-            }
-
-            var joined = existing.Request with
-            {
-                JoinedByUserIds = [.. existing.Request.JoinedByUserIds, ask.RequestedByUserId]
-            };
-
-            try
-            {
-                var written = await _store
-                    .ReplaceAsync(joined, existing.Revision, cancellationToken)
-                    .ConfigureAwait(false);
-
-                return new CreatedRequest
-                {
-                    Id = written.Request.Id,
-                    State = written.Request.State,
-                    Outcome = RequestOutcome.Joined
-                };
-            }
-            catch (RequestConcurrencyException) when (attempt < JoinAttempts)
-            {
-                // Somebody moved that request between the read and the write, which on this endpoint
-                // is usually a second person joining it in the same moment. Deciding again against
-                // what the store holds now is exactly what the store contract asks a refused caller
-                // to do, and the decision may come out differently: an operator who declined it
-                // meanwhile makes it no longer joinable, and the next pass creates instead.
-            }
-        }
+            Id = intake.Request.Request.Id,
+            State = intake.Request.Request.State,
+            Outcome = Reported(intake.Outcome)
+        };
     }
 
     /// <summary>
-    /// The requests already in the queue that could be the same thing as this ask.
+    /// One intake outcome as this endpoint publishes it.
+    /// <para>
+    /// Written as a switch with no default arm on purpose. A value added to
+    /// <see cref="IntakeOutcome"/> and not answered here fails the build rather than being reported
+    /// as whichever arm happened to be written last.
+    /// </para>
     /// </summary>
-    /// <param name="ask">The ask.</param>
-    /// <param name="cancellationToken">Cancels the reads.</param>
-    /// <returns>Every joinable request naming at least one of the ask's identifiers, each once.</returns>
-    private async Task<IReadOnlyList<StoredRequest>> CandidatesAsync(
-        MediaRequest ask,
-        CancellationToken cancellationToken)
-    {
-        var found = new Dictionary<Guid, StoredRequest>();
-
-        foreach (var identifier in ask.ProviderIds)
+    /// <param name="outcome">What asking did.</param>
+    /// <returns>The same thing in the vocabulary this endpoint answers in.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Where the outcome is a value nothing here reports.
+    /// </exception>
+    private static RequestOutcome Reported(IntakeOutcome outcome)
+        => outcome switch
         {
-            var carrying = await _store
-                .FindByProviderIdentifierAsync(ask.Kind, identifier.Key, identifier.Value, cancellationToken)
-                .ConfigureAwait(false);
+            IntakeOutcome.Created => RequestOutcome.Created,
+            IntakeOutcome.Joined => RequestOutcome.Joined,
+            IntakeOutcome.AlreadyWaiting => RequestOutcome.AlreadyWaiting,
 
-            foreach (var candidate in carrying.Where(candidate => StillOpenToJoiners(candidate.Request)))
-            {
-                // Keyed by identifier, because one existing request can carry two of the identifiers
-                // the caller sent and would otherwise be compared and joined twice.
-                found[candidate.Request.Id] = candidate;
-            }
-        }
-
-        // Oldest first, so the request people have been waiting on longest is the one a new asker
-        // joins, and so the answer does not depend on which order the store happened to return them.
-        return [.. found.Values.OrderBy(candidate => candidate.Request.RequestedAt).ThenBy(candidate => candidate.Request.Id)];
-    }
+            _ => throw new InvalidOperationException(FormattableString.Invariant(
+                $"There is no answer this endpoint reports for the intake outcome {outcome}."))
+        };
 }

--- a/Jellyfin.Plugin.Requests/Intake/IntakeOutcome.cs
+++ b/Jellyfin.Plugin.Requests/Intake/IntakeOutcome.cs
@@ -1,0 +1,27 @@
+namespace Jellyfin.Plugin.Requests.Intake;
+
+/// <summary>
+/// What asking for something did to the queue.
+/// <para>
+/// It is here rather than beside either caller because both of them ask the same question. The HTTP
+/// endpoint reports it to a signed-in person and the seam reports nothing at all to the plugin that
+/// handed a want over, and neither of those is a reason for a second vocabulary of what happened.
+/// </para>
+/// </summary>
+public enum IntakeOutcome
+{
+    /// <summary>
+    /// Nothing in the queue was the same thing, so a request was made.
+    /// </summary>
+    Created = 0,
+
+    /// <summary>
+    /// Somebody was already waiting for it and the asker was added to them.
+    /// </summary>
+    Joined = 1,
+
+    /// <summary>
+    /// The asker was already waiting for it, so nothing moved.
+    /// </summary>
+    AlreadyWaiting = 2
+}

--- a/Jellyfin.Plugin.Requests/Intake/IntakeResult.cs
+++ b/Jellyfin.Plugin.Requests/Intake/IntakeResult.cs
@@ -1,0 +1,10 @@
+using Jellyfin.Plugin.Requests.Storage;
+
+namespace Jellyfin.Plugin.Requests.Intake;
+
+/// <summary>
+/// The request somebody is waiting for after asking, and what asking did to get there.
+/// </summary>
+/// <param name="Request">The request as the store now holds it, at its current revision.</param>
+/// <param name="Outcome">Whether that request was made, joined, or already the asker's own.</param>
+public readonly record struct IntakeResult(StoredRequest Request, IntakeOutcome Outcome);

--- a/Jellyfin.Plugin.Requests/Intake/RequestIntake.cs
+++ b/Jellyfin.Plugin.Requests/Intake/RequestIntake.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+
+namespace Jellyfin.Plugin.Requests.Intake;
+
+/// <summary>
+/// One ask turned into a request, against everything the store already holds.
+/// <para>
+/// <b>Two surfaces ask, and this is the one that answers.</b> A person asks over the HTTP endpoint
+/// and the sibling discover plugin hands a want across the seam, and both of them mean the same
+/// thing: somebody wants this title. The identity rule that decides whether that is a new request or
+/// a second person on an existing one is <see cref="RequestIdentity"/>, and it is applied here so
+/// there is one place that applies it rather than one per surface. The failure this prevents is the
+/// cheap one to write and the expensive one to undo: a second acquisition of a film somebody is
+/// already waiting for, because the surface it arrived on did not know the other surface's rule.
+/// </para>
+/// <para>
+/// It takes the store and nothing else. What a request says about who asked, when, and what the
+/// title read as is decided by whoever built the record; this decides only whether that record joins
+/// something or becomes something.
+/// </para>
+/// </summary>
+public sealed class RequestIntake
+{
+    /// <summary>
+    /// How many times a join is attempted before giving up. A join is a read followed by a write
+    /// against the revision that was read, so two people joining one request in the same moment
+    /// means one of them is refused and re-decides. Three is enough for that and small enough that
+    /// a genuinely contended request fails visibly instead of spinning.
+    /// </summary>
+    public const int JoinAttempts = 3;
+
+    private readonly IRequestStore _store;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequestIntake"/> class.
+    /// </summary>
+    /// <param name="store">Where requests are kept.</param>
+    /// <exception cref="ArgumentNullException">Where there is no store to ask.</exception>
+    public RequestIntake(IRequestStore store)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+
+        _store = store;
+    }
+
+    /// <summary>
+    /// Asks for something, joining whatever is already waiting for the same thing.
+    /// <para>
+    /// The seasons are narrowed as candidates are compared, so a caller asking for two seasons where
+    /// one is already on an open request ends up asking for the other. That narrowing is the
+    /// identity rule's, not this method's.
+    /// </para>
+    /// </summary>
+    /// <param name="incoming">The request as the surface built it.</param>
+    /// <param name="cancellationToken">Cancels the call.</param>
+    /// <returns>The request the asker is now waiting for, and what asking did.</returns>
+    /// <exception cref="ArgumentNullException">Where there is no request to ask with.</exception>
+    /// <exception cref="RequestStoreLoadException">Where the store cannot be read.</exception>
+    /// <exception cref="RequestConcurrencyException">
+    /// Where a join was refused <see cref="JoinAttempts"/> times because the request kept moving
+    /// underneath the write. That is a contended request rather than a fault, and it is raised
+    /// rather than retried forever so the caller answers instead of spinning.
+    /// </exception>
+    public async Task<IntakeResult> AskAsync(MediaRequest incoming, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(incoming);
+
+        for (var attempt = 1; ; attempt++)
+        {
+            var ask = incoming;
+            var candidates = await CandidatesAsync(ask, cancellationToken).ConfigureAwait(false);
+            StoredRequest? joining = null;
+
+            foreach (var candidate in candidates)
+            {
+                var match = RequestIdentity.Compare(candidate.Request, ask);
+
+                if (match == RequestMatch.Same)
+                {
+                    joining = candidate;
+                    break;
+                }
+
+                if (match == RequestMatch.Overlapping)
+                {
+                    ask = ask with
+                    {
+                        Seasons = RequestIdentity.SeasonsNotAlreadyAskedFor(candidate.Request, ask, [])
+                    };
+                }
+            }
+
+            if (joining is not StoredRequest existing)
+            {
+                var added = await _store.AddAsync(ask, cancellationToken).ConfigureAwait(false);
+
+                return new IntakeResult(added, IntakeOutcome.Created);
+            }
+
+            if (existing.Request.WasAskedForBy(ask.RequestedByUserId))
+            {
+                return new IntakeResult(existing, IntakeOutcome.AlreadyWaiting);
+            }
+
+            var joined = existing.Request with
+            {
+                JoinedByUserIds = [.. existing.Request.JoinedByUserIds, ask.RequestedByUserId]
+            };
+
+            try
+            {
+                var written = await _store
+                    .ReplaceAsync(joined, existing.Revision, cancellationToken)
+                    .ConfigureAwait(false);
+
+                return new IntakeResult(written, IntakeOutcome.Joined);
+            }
+            catch (RequestConcurrencyException) when (attempt < JoinAttempts)
+            {
+                // Somebody moved that request between the read and the write, which here is usually
+                // a second person joining it in the same moment. Deciding again against what the
+                // store holds now is exactly what the store contract asks a refused caller to do,
+                // and the decision may come out differently: an operator who declined it meanwhile
+                // makes it no longer joinable, and the next pass creates instead.
+            }
+        }
+    }
+
+    /// <summary>
+    /// Whether a request is one a later asker can be added to. A declined or fulfilled request is
+    /// not: joining it would leave somebody waiting on an answer that has already been given.
+    /// </summary>
+    /// <param name="request">The request being judged.</param>
+    /// <returns><see langword="true"/> where somebody else can still join it.</returns>
+    private static bool StillOpenToJoiners(MediaRequest request)
+        => request.State is RequestState.Open or RequestState.Approved;
+
+    /// <summary>
+    /// Everything already in the queue that could be the same thing as what is being asked for,
+    /// oldest first.
+    /// </summary>
+    /// <param name="ask">What is being asked for.</param>
+    /// <param name="cancellationToken">Cancels the call.</param>
+    /// <returns>The requests worth comparing against.</returns>
+    private async Task<IReadOnlyList<StoredRequest>> CandidatesAsync(
+        MediaRequest ask,
+        CancellationToken cancellationToken)
+    {
+        var found = new Dictionary<Guid, StoredRequest>();
+
+        foreach (var identifier in ask.ProviderIds)
+        {
+            var carrying = await _store
+                .FindByProviderIdentifierAsync(ask.Kind, identifier.Key, identifier.Value, cancellationToken)
+                .ConfigureAwait(false);
+
+            foreach (var candidate in carrying.Where(candidate => StillOpenToJoiners(candidate.Request)))
+            {
+                // Keyed by identifier, because one existing request can carry two of the identifiers
+                // the caller sent and would otherwise be compared and joined twice.
+                found[candidate.Request.Id] = candidate;
+            }
+        }
+
+        // Oldest first, so the request people have been waiting on longest is the one a new asker
+        // joins, and so the answer does not depend on which order the store happened to return them.
+        return [.. found.Values.OrderBy(candidate => candidate.Request.RequestedAt).ThenBy(candidate => candidate.Request.Id)];
+    }
+}

--- a/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
@@ -4,6 +4,7 @@ using Jellyfin.Plugin.Requests.Bridge;
 using Jellyfin.Plugin.Requests.Configuration;
 using Jellyfin.Plugin.Requests.Fulfilment;
 using Jellyfin.Plugin.Requests.Identity;
+using Jellyfin.Plugin.Requests.Seam;
 using Jellyfin.Plugin.Requests.Storage;
 using Jellyfin.Plugin.Requests.Time;
 using MediaBrowser.Controller;
@@ -72,6 +73,16 @@ public sealed class PluginServiceRegistrator : IPluginServiceRegistrator
         // service exists before deciding what to do. An adapter, when there is one, replaces this
         // registration and nothing else.
         serviceCollection.AddSingleton<IRequestBackend, NoRequestBackend>();
+
+        // The seam the sibling discover plugin hands a want across. Registered into the server's own
+        // collection because that is where a second plugin in this process would resolve it from;
+        // whether one can name the type at all is #117 and is not decided by registering it.
+        serviceCollection.AddSingleton<IWantHandover>(provider => new WantHandover(
+            provider.GetRequiredService<IRequestStore>(),
+            provider.GetRequiredService<IClock>(),
+            provider.GetRequiredService<IIdentifierSource>(),
+            provider.GetRequiredService<IInstallSettings>(),
+            provider.GetRequiredService<ILogger<WantHandover>>()));
 
         // The server's library, as the two questions this plugin asks of it. One per server, because
         // the instance subscribes to the library's own events and a second subscription would look

--- a/Jellyfin.Plugin.Requests/Seam/HandedOverWant.cs
+++ b/Jellyfin.Plugin.Requests/Seam/HandedOverWant.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Jellyfin.Plugin.Requests.Model;
+
+namespace Jellyfin.Plugin.Requests.Seam;
+
+/// <summary>
+/// One want, as it arrives from the sibling discover plugin.
+/// <para>
+/// <b>The field set is the contract's and this type is not a second copy of it.</b> What crosses is
+/// fixed on the sibling's board, in the contract issue <c>docs/seam.md</c> points at, and this is
+/// that field set expressed in the only way an in-process call can express one. Nothing is added
+/// here that the contract does not carry: a field this side invented would be a field the other side
+/// never fills, and it would read to somebody implementing against this type as part of the
+/// agreement.
+/// </para>
+/// <para>
+/// <b>It is not a request.</b> A want is what somebody expressed on a browsing surface this plugin
+/// does not own; a request is what this plugin makes of it, with an identifier of its own, a state,
+/// a history, and a place in a queue. Keeping the two types apart is what stops the contract's shape
+/// leaking into the model, and it is why the fields here are named the way the contract names them
+/// rather than the way <see cref="MediaRequest"/> does.
+/// </para>
+/// <para>
+/// <b>Nothing here is stored as it stands.</b> The title and the year become the display snapshot
+/// this plugin keeps and never refreshes, which is what lets the queue render with no metadata
+/// source reachable. No image crosses and none is fetched.
+/// </para>
+/// </summary>
+public sealed record HandedOverWant
+{
+    private readonly IReadOnlyDictionary<string, string> _providerIds = ReadOnlyDictionary<string, string>.Empty;
+
+    /// <summary>
+    /// Gets which version of the contract this field set was built against.
+    /// <para>
+    /// Required, and read before anything else in the record. What happens where this side does not
+    /// know the version is <see cref="WantHandover.KnownContractVersion"/> and the rule is in
+    /// <c>docs/seam.md</c>.
+    /// </para>
+    /// </summary>
+    public required int ContractVersion { get; init; }
+
+    /// <summary>
+    /// Gets the sibling's own identifier for this want, which is stable across a refresh that
+    /// recreated the item and across a restart.
+    /// <para>
+    /// It is carried through to the log line a refusal leaves, so an operator asked about a want by
+    /// the other side's identifier can find what this side did with it. Storing it, so that the same
+    /// want arriving again is recognised as the same want whatever else changed, is #116 and is not
+    /// done here.
+    /// </para>
+    /// </summary>
+    public required Guid WantId { get; init; }
+
+    /// <summary>
+    /// Gets the user the sibling says asked for this.
+    /// <para>
+    /// This side cannot verify it. There is no session on a call from another plugin in the same
+    /// process, so what stands behind this field is the sibling's own permission check; what that
+    /// means and what this side checks anyway is #118.
+    /// </para>
+    /// </summary>
+    public required Guid RequestedByUserId { get; init; }
+
+    /// <summary>
+    /// Gets what sort of thing was wanted.
+    /// </summary>
+    public required RequestedItemKind Kind { get; init; }
+
+    /// <summary>
+    /// Gets the title as it read on the browsing surface at the moment somebody asked.
+    /// </summary>
+    public required string Title { get; init; }
+
+    /// <summary>
+    /// Gets the release year, where the sibling had one.
+    /// </summary>
+    public int? Year { get; init; }
+
+    /// <summary>
+    /// Gets the external identifiers naming the thing that was wanted.
+    /// <para>
+    /// These are what the identity rule compares, so a want carrying none reaches no existing
+    /// request and is joined by none: it has no identity, which makes it different from everything
+    /// including another copy of itself. That is <see cref="RequestIdentity"/>'s answer rather than
+    /// anything this seam decides.
+    /// </para>
+    /// </summary>
+    public IReadOnlyDictionary<string, string> ProviderIds
+    {
+        get => _providerIds;
+        init => _providerIds = value ?? ReadOnlyDictionary<string, string>.Empty;
+    }
+}

--- a/Jellyfin.Plugin.Requests/Seam/HandoverRefusal.cs
+++ b/Jellyfin.Plugin.Requests/Seam/HandoverRefusal.cs
@@ -1,0 +1,54 @@
+namespace Jellyfin.Plugin.Requests.Seam;
+
+/// <summary>
+/// Why a handover was not turned into a request.
+/// <para>
+/// The contract allows this side to answer one thing, which is whether the handover was accepted, so
+/// none of this reaches the plugin that called. It exists because the reason has to reach somebody:
+/// an operator whose users report that nothing happens when they ask for a film needs to be able to
+/// find out that this install does not accept series, rather than to discover it by reading the
+/// source.
+/// </para>
+/// <para>
+/// Where the operator reads it is the server's log, which is the honest limit of this today. A page
+/// that says what this install is refusing and why is the diagnostics view in #63.
+/// </para>
+/// </summary>
+public enum HandoverRefusal
+{
+    /// <summary>
+    /// The field set was built against a version of the contract this plugin does not know.
+    /// </summary>
+    ContractVersionNotKnown = 0,
+
+    /// <summary>
+    /// The want named no user, so there would be nobody to record as having asked.
+    /// </summary>
+    NoUserNamed = 1,
+
+    /// <summary>
+    /// The want named no title, and a request carries the title as it read when it was asked for.
+    /// </summary>
+    NoTitle = 2,
+
+    /// <summary>
+    /// The want named something that is not a kind of thing this plugin knows.
+    /// </summary>
+    KindNotRecognised = 3,
+
+    /// <summary>
+    /// The want named a kind this install is set not to accept.
+    /// </summary>
+    KindNotAccepted = 4,
+
+    /// <summary>
+    /// The queue could not be read or written, so nothing could be decided about this want.
+    /// </summary>
+    TheStoreCouldNotBeReached = 5,
+
+    /// <summary>
+    /// What this install is set to is something the plugin cannot run on, so no want can be judged
+    /// against it. That is a fault on this server rather than anything the other side sent.
+    /// </summary>
+    ThisInstallCannotRun = 6
+}

--- a/Jellyfin.Plugin.Requests/Seam/IWantHandover.cs
+++ b/Jellyfin.Plugin.Requests/Seam/IWantHandover.cs
@@ -1,0 +1,36 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jellyfin.Plugin.Requests.Seam;
+
+/// <summary>
+/// The one call the sibling discover plugin makes into this one.
+/// <para>
+/// <b>One way, one moment, one answer.</b> A user expressed a want on a browsing surface this plugin
+/// does not own, and the other side says what was wanted and who wanted it. Nothing is learned back
+/// except whether the handover was accepted, which is the whole of what the contract allows this
+/// side to say, and there is no call in the other direction: <c>docs/seam.md</c> argues why a read
+/// back is refused rather than missing.
+/// </para>
+/// <para>
+/// <b>Whether the other plugin can reach this at all is not settled here.</b> Naming a type means
+/// having the type, and whether a second plugin in one server process can name this one is the
+/// assembly-loading question in #117. This interface is what it would name; that it is registered
+/// into the server's container is not a measurement that anything can resolve it.
+/// </para>
+/// </summary>
+public interface IWantHandover
+{
+    /// <summary>
+    /// Takes one want and makes this plugin's answer to it.
+    /// </summary>
+    /// <param name="want">The field set the contract fixes.</param>
+    /// <param name="cancellationToken">Cancels the handover.</param>
+    /// <returns>
+    /// <see langword="true"/> where a request for this want now exists, whether it was made by this
+    /// call or was already there with somebody else waiting on it. <see langword="false"/> where the
+    /// handover was refused, and the reason for that is on this side's log rather than in this
+    /// answer, because the contract carries no field for one.
+    /// </returns>
+    Task<bool> AcceptAsync(HandedOverWant want, CancellationToken cancellationToken);
+}

--- a/Jellyfin.Plugin.Requests/Seam/WantHandover.cs
+++ b/Jellyfin.Plugin.Requests/Seam/WantHandover.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Configuration;
+using Jellyfin.Plugin.Requests.Identity;
+using Jellyfin.Plugin.Requests.Intake;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Time;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.Requests.Seam;
+
+/// <summary>
+/// The call that does the work of the seam: one want from the sibling discover plugin, turned into a
+/// request in this plugin's queue.
+/// <para>
+/// <b>A title this plugin has never seen is the ordinary case.</b> There is no pre-agreed catalogue
+/// on this side and nothing here fetches one, so a want naming something absent from every request
+/// ever made is a request being made for the first time and not an error. The title and the year are
+/// stored as they arrived and are never refreshed, which is what lets the queue render on a server
+/// where nothing outbound resolves.
+/// </para>
+/// <para>
+/// <b>A refusal is a decision and reaches the caller as one bit.</b> The contract carries no field
+/// for a reason, so what the other side learns is that the handover was not accepted, and the reason
+/// is written to this server's log where an operator can find it. Answering <see langword="false"/>
+/// rather than throwing is deliberate: an exception crossing a plugin boundary is a fault in the
+/// caller's own code path for something that is an ordinary answer here.
+/// </para>
+/// <para>
+/// <b>Whether an ask joins an existing request is not decided here.</b> It is
+/// <see cref="RequestIntake"/>'s, which is the same object the HTTP endpoint asks, so two users
+/// wanting the same film produce one request with both of them recorded however each of them asked.
+/// The one thing this seam does not yet do is recognise the same want arriving twice by the
+/// sibling's own identifier for it, which is #116: today a repeat is caught by the identity rule
+/// over the provider identifiers, and a want carrying none has no identity to be caught by.
+/// </para>
+/// </summary>
+public sealed class WantHandover : IWantHandover
+{
+    /// <summary>
+    /// The contract version this plugin implements.
+    /// <para>
+    /// One number rather than a range, and the rule around it is in <c>docs/seam.md</c>. The
+    /// sibling's board has not minted a version rule yet, so what this constant records is which
+    /// version this side believes it implements rather than a number read off the contract. That is
+    /// cheap to correct because this seam is an in-process call: it serialises nothing, nothing on
+    /// disk carries it, and no caller outside this process can be pinned to it.
+    /// </para>
+    /// </summary>
+    public const int KnownContractVersion = 1;
+
+    private readonly RequestIntake _intake;
+    private readonly IClock _clock;
+    private readonly IIdentifierSource _identifiers;
+    private readonly IInstallSettings _settings;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WantHandover"/> class.
+    /// </summary>
+    /// <param name="store">Where requests are kept.</param>
+    /// <param name="clock">The injected clock, so a request's times are testable.</param>
+    /// <param name="identifiers">Where a new request's identifier comes from.</param>
+    /// <param name="settings">What this install is set to.</param>
+    /// <param name="logger">Where a refusal is written.</param>
+    /// <exception cref="ArgumentNullException">Where anything it needs is missing.</exception>
+    public WantHandover(
+        IRequestStore store,
+        IClock clock,
+        IIdentifierSource identifiers,
+        IInstallSettings settings,
+        ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(clock);
+        ArgumentNullException.ThrowIfNull(identifiers);
+        ArgumentNullException.ThrowIfNull(settings);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _intake = new RequestIntake(store);
+        _clock = clock;
+        _identifiers = identifiers;
+        _settings = settings;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    /// <exception cref="ArgumentNullException">Where there is no want to accept.</exception>
+    public async Task<bool> AcceptAsync(HandedOverWant want, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(want);
+
+        // The version is read before any other field. A field set whose version this side does not
+        // know is refused whole rather than read for the fields it recognises: reading what is
+        // recognised and ignoring the rest makes a version that changed the meaning of a field
+        // indistinguishable from one that added a field, and the first of those is a want filed
+        // against the wrong thing rather than a want dropped.
+        if (want.ContractVersion != KnownContractVersion)
+        {
+            return Refused(want, HandoverRefusal.ContractVersionNotKnown);
+        }
+
+        if (want.RequestedByUserId == Guid.Empty)
+        {
+            return Refused(want, HandoverRefusal.NoUserNamed);
+        }
+
+        if (string.IsNullOrWhiteSpace(want.Title))
+        {
+            return Refused(want, HandoverRefusal.NoTitle);
+        }
+
+        if (!Enum.IsDefined(want.Kind))
+        {
+            return Refused(want, HandoverRefusal.KindNotRecognised);
+        }
+
+        bool accepted;
+
+        try
+        {
+            accepted = Accepts(want.Kind);
+        }
+        catch (InvalidConfigurationException)
+        {
+            return Refused(want, HandoverRefusal.ThisInstallCannotRun);
+        }
+
+        if (!accepted)
+        {
+            return Refused(want, HandoverRefusal.KindNotAccepted);
+        }
+
+        var asked = _clock.UtcNow;
+
+        var incoming = new MediaRequest
+        {
+            Id = _identifiers.NewId(),
+            RequestedByUserId = want.RequestedByUserId,
+            RequestedAt = asked,
+            StateChangedAt = asked,
+            Kind = want.Kind,
+            DisplayTitle = want.Title,
+            DisplayYear = want.Year,
+            ProviderIds = want.ProviderIds
+        };
+
+        IntakeResult intake;
+
+        try
+        {
+            intake = await _intake.AskAsync(incoming, cancellationToken).ConfigureAwait(false);
+        }
+        catch (RequestStoreLoadException)
+        {
+            // The store says which file and why in its own log line. What is added here is which
+            // want was lost because of it, so the two can be put together.
+            return Refused(want, HandoverRefusal.TheStoreCouldNotBeReached);
+        }
+        catch (RequestConcurrencyException)
+        {
+            // The request kept moving underneath the join for as many attempts as the intake makes.
+            // That is a contended request rather than a fault, and the contract has no way to ask
+            // the caller to try again, so it is refused and the other side's own repeat handling is
+            // what brings the want back.
+            return Refused(want, HandoverRefusal.TheStoreCouldNotBeReached);
+        }
+
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug(
+                "The want {WantId} handed over the seam is request {RequestId}, which the handover {Outcome}.",
+                want.WantId,
+                intake.Request.Request.Id,
+                intake.Outcome);
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Whether this install accepts that kind of thing at all.
+    /// <para>
+    /// Asked of the settings on every handover rather than held, because an operator turning a kind
+    /// off means the next want of that kind, not the next restart.
+    /// </para>
+    /// </summary>
+    /// <param name="kind">What was wanted.</param>
+    /// <returns><see langword="true"/> where this install takes requests for it.</returns>
+    /// <exception cref="InvalidConfigurationException">
+    /// Where what is stored is something this plugin cannot run on.
+    /// </exception>
+    private bool Accepts(RequestedItemKind kind)
+    {
+        var current = _settings.Current;
+
+        return kind switch
+        {
+            RequestedItemKind.Movie => current.AcceptsMovies,
+            RequestedItemKind.Series => current.AcceptsSeries,
+
+            _ => false
+        };
+    }
+
+    /// <summary>
+    /// Writes down why a want was not turned into a request, and answers the caller.
+    /// <para>
+    /// The line carries the sibling's own identifier for the want, the reason, and the version that
+    /// arrived, which is what an operator asked about a want by the other side's identifier needs to
+    /// find it. It carries no title and no user, because a log is pasted into issue trackers and
+    /// what somebody asked for is the thing in this plugin worth being careful with.
+    /// </para>
+    /// </summary>
+    /// <param name="want">What arrived.</param>
+    /// <param name="refusal">Why it is not becoming a request.</param>
+    /// <returns>Always <see langword="false"/>, which is what the contract lets this side say.</returns>
+    private bool Refused(HandedOverWant want, HandoverRefusal refusal)
+    {
+        _logger.LogWarning(
+            "A want handed over the seam was not made into a request: {Refusal}. The other side calls it {WantId} and built it against contract version {ContractVersion}.",
+            refusal,
+            want.WantId,
+            want.ContractVersion);
+
+        return false;
+    }
+}

--- a/docs/seam.md
+++ b/docs/seam.md
@@ -131,12 +131,57 @@ which is neither a leak that has been shown nor a safety anybody has earned. The
 that a caller reads their own requests and never another person's, is enforced at the endpoints in
 `docs/api.md` and not by the store beneath them.
 
+## A field set this side does not understand is refused whole
+
+The contract carries a version. What this side does with one it does not know is a stated rule
+rather than whatever the code happens to do, because the two plausible behaviours differ in a way
+nobody notices until it has already gone wrong.
+
+**The rule.** This plugin implements exactly the contract versions in its known set, which today is
+one version and is `WantHandover.KnownContractVersion`. A field set carrying anything else is
+refused whole. Not one field is read out of it, and no request is made from it.
+
+    git grep -n 'public const int KnownContractVersion' -- Jellyfin.Plugin.Requests/Seam/WantHandover.cs
+
+**Why not read the fields it recognises.** Because that behaviour cannot tell the two kinds of
+version change apart. A version that added a field and a version that changed what an existing field
+means look identical to a reader that takes what it knows and ignores the rest, and the second one
+turns into a want filed against the wrong title, the wrong person or the wrong kind. A refusal is a
+want that did not arrive, which the other side can see; a misread is a request in somebody's queue
+that nobody can trace back.
+
+**What the number is, today.** It is what this side believes it implements rather than a number read
+off the contract, because the contract's own version rule is still open on the sibling's board. That
+is cheap to correct: the seam is an in-process call, it serialises nothing, nothing on disk carries
+the number, and no caller outside this process can be pinned to it. When the contract mints its
+rule, the constant moves to match it and the behaviour above does not change.
+
+## What a refusal looks like from each side
+
+The contract lets this side answer one thing, which is whether the handover was accepted. So a
+refusal reaches the sibling as exactly that and carries no reason, and this is the shape rather than
+an omission: a reason travelling back would be a second thing the contract has to define and keep in
+step.
+
+The reason is written on this side instead, to the server's log, with the sibling's own identifier
+for the want so an operator asked about a want by that identifier can find what happened to it. The
+line names the refusal and the version that arrived. It carries neither the title nor the person,
+because a log is pasted into issue trackers and what somebody asked for is the thing in this plugin
+worth being careful with.
+
+The refusals that exist are in `HandoverRefusal`, and reading them from there rather than from a
+list here is deliberate:
+
+    git grep -n '^    [A-Z][A-Za-z]* = [0-9]' -- Jellyfin.Plugin.Requests/Seam/HandoverRefusal.cs
+
+Where an operator reads it is the server's log and nowhere else today. A page that says what this
+install is refusing and why is the diagnostics view in #63.
+
 ## What this document does not yet hold
 
 Named here so the absence is read as absence rather than as a decision nobody wrote down. Each is
 the closing condition of the issue beside it.
 
-- What happens to a field set carrying a contract version this plugin does not know. #90.
 - The trust position of an in-process handover, and what this side checks before it believes a user
   identifier it cannot verify. #118.
 - How each side finds the other. #89.


### PR DESCRIPTION
Closes #90.

The seam had a document and no call. This is the call: a want expressed on a
browsing surface this plugin does not own arrives here, and this side makes a
request of it or refuses it for a reason an operator can find.

## What is here

`IWantHandover` is the one call, and `WantHandover` answers it. What arrives is
`HandedOverWant`, which is the contract's field set expressed as an in-process
type and nothing more: no field is added here that the contract does not carry,
because a field this side invented is one the other side never fills and would
read to somebody implementing against this type as part of the agreement.

Whether an ask joins something already in the queue moves out of the controller
into `RequestIntake`, which both surfaces now ask. That was the alternative to
writing the identity rule a second time behind the seam, and a second copy of it
is a second chance for one surface to acquire a film somebody is already waiting
for. The controller keeps the four dependencies it had and builds the intake from
its own store, so the count `CatalogueSplitTests` reads does not move.

## The four conditions

**A handover for an unknown title creates a request.** There is no pre-agreed
catalogue on this side, so this is the ordinary case rather than an error.
`AWantForATitleNothingHasEverAskedForBecomesARequest` asserts the store is empty
first and holds exactly one request afterwards.

**The queue renders from the stored title and year.**
`TheQueueRendersFromTheTitleAndYearThatCrossed` reads the row back through the
store query the administrator queue uses. That nothing could have been fetched to
build it is the assembly's reference list in `SiblingIndependenceTests`; what this
change adds is `TheSeamIsBuiltFromNothingThatCouldFetchATitle`, which reads this
seam's constructor and fails on a sixth dependency, because a metadata source
would arrive as one.

**A refusal uses the one channel the contract allows.** The answer is `false` and
carries no reason, because the contract has no field for one. The reason goes to
the server's log with the sibling's own identifier for the want, so an operator
asked about a want by that identifier can find what happened to it. That the log
is the only place today is stated in `docs/seam.md` and in `HandoverRefusal`
itself, and a page that says what an install is refusing is #63.

**An unknown contract version follows a stated rule, and the rule is in
`docs/seam.md`.** The field set is refused whole and not one field is read out of
it. The document says why the alternative is worse: reading what is recognised
and ignoring the rest cannot tell a version that added a field from one that
changed what a field means, and the second files a want against the wrong thing.

## Run at this branch's head

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Der Buildvorgang wurde erfolgreich ausgeführt.
        0 Warnung(en)

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!: Fehler: 0, erfolgreich: 467, gesamt: 467 (net9.0)
    Bestanden!: Fehler: 0, erfolgreich: 467, gesamt: 467 (net10.0)

Four hundred and fifty-three of those were there before this change.

## Every guard, watched failing

Each mutation was made in `Jellyfin.Plugin.Requests/Seam/WantHandover.cs`, the
seam's own tests were run on `net9.0`, and the change was reverted afterwards.

The contract version check deleted:

    AWantBuiltAgainstAVersionThisPluginDoesNotKnowIsRefusedWhole(version: 0) [FAIL]
    AWantBuiltAgainstAVersionThisPluginDoesNotKnowIsRefusedWhole(version: 2) [FAIL]
    AWantBuiltAgainstAVersionThisPluginDoesNotKnowIsRefusedWhole(version: 97) [FAIL]
    ARefusalNamesTheWantAndNeitherTheTitleNorThePerson [FAIL]
    Fehler: 4, erfolgreich: 10, gesamt: 14

The accepted-kind check deleted:

    AKindThisInstallDoesNotAcceptIsRefusedAndSaysSo [FAIL]
    Fehler: 1, erfolgreich: 13, gesamt: 14

The refusal line given the title back:

    ARefusalNamesTheWantAndNeitherTheTitleNorThePerson [FAIL]
    Fehler: 1, erfolgreich: 13, gesamt: 14

The store failure let out of the call:

    AStoreThatCannotBeReadRefusesRatherThanThrowingAtTheCaller [FAIL]
    Fehler: 1, erfolgreich: 13, gesamt: 14

The configuration refusal let out of the call:

    SettingsThisPluginCannotRunOnRefuseTheHandoverRatherThanThrowing [FAIL]
    Fehler: 1, erfolgreich: 13, gesamt: 14

The three field checks deleted:

    AFieldSetThatCannotBecomeARequestIsRefusedWithItsOwnReason(expected: NoUserNamed) [FAIL]
    AFieldSetThatCannotBecomeARequestIsRefusedWithItsOwnReason(expected: NoTitle) [FAIL]
    AFieldSetThatCannotBecomeARequestIsRefusedWithItsOwnReason(expected: KindNotRecognised) [FAIL]
    Fehler: 3, erfolgreich: 11, gesamt: 14

## What this does not do, and what is claimed rather than measured

**The contract version number is this side's belief and not a reading of the
contract.** The sibling's version rule is still open on that board, so
`KnownContractVersion` records which version this plugin thinks it implements. The
behaviour around it does not depend on the number being right, and correcting the
number is cheap because the seam serialises nothing: no disk format carries it and
no caller outside this process can be pinned to it.

**The want identifier is carried and not stored.** It reaches the log line, and
nothing yet recognises the same want arriving again by it. That is #116, and until
it lands a repeat is caught only by the identity rule over the provider
identifiers, so a want carrying none has no identity to be caught by.

**Nothing here checks that the named user exists, and nothing records that a
request arrived through the seam.** Both are #118, together with the trust
position this side takes on a user identifier it cannot verify.

**Nothing was run on a Jellyfin server.** The suite drives this call directly, and
whether another plugin in one server process can name these types at all is #117
and is unmeasured. Registering the interface into the server's container is not a
measurement that anything can resolve it.

**No second reader has looked at this.** The runs above and the mutations stand in
place of one.
