### PR TITLE
Recognise the same want handed over again instead of acquiring it twice

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Doubles/InMemoryRequestStore.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/InMemoryRequestStore.cs
@@ -82,6 +82,25 @@ internal sealed class InMemoryRequestStore : IRequestStore
     }
 
     /// <inheritdoc />
+    public Task<StoredRequest?> FindByWantAsync(Guid wantId, CancellationToken cancellationToken)
+    {
+        if (wantId == Guid.Empty)
+        {
+            throw new ArgumentException(
+                "A want identifier that names nothing cannot be looked up, because it is not one any request can have absorbed.",
+                nameof(wantId));
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_gate)
+        {
+            return Task.FromResult<StoredRequest?>(
+                _held.Values.Cast<StoredRequest?>().FirstOrDefault(stored => stored!.Value.Request.WantIds.Contains(wantId)));
+        }
+    }
+
+    /// <inheritdoc />
     public Task<RequestPage> PageAsync(RequestQuery query, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(query);

--- a/Jellyfin.Plugin.Requests.Tests/Doubles/StoreThatCannotBeRead.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/StoreThatCannotBeRead.cs
@@ -48,6 +48,9 @@ internal sealed class StoreThatCannotBeRead : IRequestStore
         => throw Unreadable();
 
     /// <inheritdoc />
+    public Task<StoredRequest?> FindByWantAsync(Guid wantId, CancellationToken cancellationToken) => throw Unreadable();
+
+    /// <inheritdoc />
     public Task<RequestPage> PageAsync(RequestQuery query, CancellationToken cancellationToken) => throw Unreadable();
 
     /// <inheritdoc />

--- a/Jellyfin.Plugin.Requests.Tests/Doubles/StoreThatMovesARequestUnderTheWrite.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/StoreThatMovesARequestUnderTheWrite.cs
@@ -63,6 +63,10 @@ internal sealed class StoreThatMovesARequestUnderTheWrite : IRequestStore
         => _inner.FindByProviderIdentifierAsync(kind, provider, value, cancellationToken);
 
     /// <inheritdoc />
+    public Task<StoredRequest?> FindByWantAsync(Guid wantId, CancellationToken cancellationToken)
+        => _inner.FindByWantAsync(wantId, cancellationToken);
+
+    /// <inheritdoc />
     public Task<RequestPage> PageAsync(RequestQuery query, CancellationToken cancellationToken)
         => _inner.PageAsync(query, cancellationToken);
 

--- a/Jellyfin.Plugin.Requests.Tests/Doubles/StoreThatRefusesTheFirstLookup.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/StoreThatRefusesTheFirstLookup.cs
@@ -60,6 +60,10 @@ internal sealed class StoreThatRefusesTheFirstLookup : IRequestStore
     }
 
     /// <inheritdoc />
+    public Task<StoredRequest?> FindByWantAsync(Guid wantId, CancellationToken cancellationToken)
+        => _inner.FindByWantAsync(wantId, cancellationToken);
+
+    /// <inheritdoc />
     public Task<RequestPage> PageAsync(RequestQuery query, CancellationToken cancellationToken)
         => _inner.PageAsync(query, cancellationToken);
 

--- a/Jellyfin.Plugin.Requests.Tests/Model/MediaRequestTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Model/MediaRequestTests.cs
@@ -39,7 +39,8 @@ public class MediaRequestTests
         "Seasons",
         "State",
         "StateChangedAt",
-        "StateChangedByUserId"
+        "StateChangedByUserId",
+        "WantIds"
     ];
 
     /// <summary>
@@ -123,6 +124,30 @@ public class MediaRequestTests
         Assert.Null(request.AvailabilityCheckedAt);
         Assert.Null(request.StateChangedByUserId);
         Assert.Empty(request.ProviderIds);
+    }
+
+    /// <summary>
+    /// A want named twice on one request is refused. These are the key a repeat of the same want is
+    /// recognised by, and a request that recorded one want as two facts is a record that cannot be
+    /// counted or reasoned about afterwards.
+    /// </summary>
+    [Fact]
+    public void AWantNamedTwiceOnOneRequestIsRefused()
+    {
+        var want = Guid.NewGuid();
+
+        Assert.Throws<ArgumentException>(() => ARequest() with { WantIds = [want, want] });
+    }
+
+    /// <summary>
+    /// A want identifier that names nothing is refused rather than stored. It would match nothing on
+    /// the way back in, so keeping it would be a request claiming to have absorbed a want that no
+    /// lookup can ever find.
+    /// </summary>
+    [Fact]
+    public void AWantIdentifierThatNamesNothingIsRefused()
+    {
+        Assert.Throws<ArgumentException>(() => ARequest() with { WantIds = [Guid.Empty] });
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Requests.Tests/Seam/WantHandoverTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Seam/WantHandoverTests.cs
@@ -271,12 +271,148 @@ public class WantHandoverTests
     }
 
     /// <summary>
+    /// The same want handed over three times is one request. That is the sequence the other side
+    /// actually produces: a refresh recreated the item, the server restarted, the user undid the
+    /// gesture and did it again, and each of those hands the same identifier across.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task TheSameWantHandedOverThreeTimesIsOneRequest()
+    {
+        var store = new InMemoryRequestStore();
+        var handover = Seam(store);
+        var want = Want();
+
+        Assert.True(await handover.AcceptAsync(want, CancellationToken.None));
+        Assert.True(await handover.AcceptAsync(want, CancellationToken.None));
+        Assert.True(await handover.AcceptAsync(want, CancellationToken.None));
+
+        var made = Assert.Single(await store.GetAllAsync(CancellationToken.None));
+
+        Assert.Equal([want.WantId], made.Request.WantIds);
+        Assert.Equal(1, made.Revision);
+    }
+
+    /// <summary>
+    /// A repeat is recognised by the want alone, with nothing else to go on. A want carrying no
+    /// provider identifiers has no identity for the identity rule to compare, so this is the case
+    /// where the two rules are visibly different things rather than one written twice.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ARepeatIsCaughtEvenWhereThereAreNoIdentifiersToCompare()
+    {
+        var store = new InMemoryRequestStore();
+        var handover = Seam(store);
+        var want = Want() with { ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) };
+
+        Assert.True(await handover.AcceptAsync(want, CancellationToken.None));
+        Assert.True(await handover.AcceptAsync(want, CancellationToken.None));
+
+        Assert.Single(await store.GetAllAsync(CancellationToken.None));
+    }
+
+    /// <summary>
+    /// A want whose request was already answered is still a want that has been taken. Letting a
+    /// declined request be the one thing that lets a repeat through would make a refusal the way to
+    /// acquire something twice.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AWantWhoseRequestWasDeclinedDoesNotComeBackAsANewOne()
+    {
+        var store = new InMemoryRequestStore();
+        var handover = Seam(store);
+        var want = Want();
+
+        Assert.True(await handover.AcceptAsync(want, CancellationToken.None));
+
+        var made = Assert.Single(await store.GetAllAsync(CancellationToken.None));
+
+        await store.ReplaceAsync(
+            made.Request with { State = RequestState.Declined },
+            made.Revision,
+            CancellationToken.None);
+
+        Assert.True(await handover.AcceptAsync(want, CancellationToken.None));
+
+        var held = Assert.Single(await store.GetAllAsync(CancellationToken.None));
+
+        Assert.Equal(RequestState.Declined, held.Request.State);
+    }
+
+    /// <summary>
+    /// One request absorbs the wants of everybody who asked. Two people wanting the same film are
+    /// two wants on the other side, and each of them has to be recognisable afterwards or the second
+    /// person's repeat creates the request the first person is already waiting for.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ARequestKeepsEveryWantItAbsorbed()
+    {
+        var store = new InMemoryRequestStore();
+        var handover = Seam(store);
+
+        var first = Want();
+        var second = Want() with
+        {
+            WantId = new Guid("44444444-4444-4444-4444-444444444444"),
+            RequestedByUserId = SecondAsker
+        };
+
+        Assert.True(await handover.AcceptAsync(first, CancellationToken.None));
+        Assert.True(await handover.AcceptAsync(second, CancellationToken.None));
+        Assert.True(await handover.AcceptAsync(second, CancellationToken.None));
+
+        var made = Assert.Single(await store.GetAllAsync(CancellationToken.None));
+
+        Assert.Equal([first.WantId, second.WantId], made.Request.WantIds);
+        Assert.Equal([SecondAsker], made.Request.JoinedByUserIds);
+    }
+
+    /// <summary>
+    /// The check survives a restart, because what it reads is on the disk rather than in memory. The
+    /// store is closed and a second one is opened over the same directory, which is what a server
+    /// stopping and starting does to it.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task TheSameWantAfterARestartIsStillTheSameWant()
+    {
+        var directory = TestRunDirectory.CreateSubdirectory();
+        var want = Want();
+
+        try
+        {
+            using (var before = new FileRequestStore(directory, new RecordingLogger()))
+            {
+                Assert.True(await Seam(before).AcceptAsync(want, CancellationToken.None));
+                Assert.Single(await before.GetAllAsync(CancellationToken.None));
+            }
+
+            using var after = new FileRequestStore(directory, new RecordingLogger());
+
+            Assert.True(await Seam(after).AcceptAsync(want, CancellationToken.None));
+
+            var held = Assert.Single(await after.GetAllAsync(CancellationToken.None));
+
+            Assert.Equal([want.WantId], held.Request.WantIds);
+            Assert.Equal(1, held.Revision);
+        }
+        finally
+        {
+            TestRunDirectory.Remove(directory);
+        }
+    }
+
+    /// <summary>
     /// The field sets that cannot become a request, each with the refusal that names what is wrong.
     /// </summary>
     /// <returns>One case per way of being wrong.</returns>
     public static TheoryData<HandedOverWant, HandoverRefusal> FieldSetsThatCannotBecomeARequest()
         => new TheoryData<HandedOverWant, HandoverRefusal>
         {
+            { Want() with { WantId = Guid.Empty }, HandoverRefusal.NoWantNamed },
             { Want() with { RequestedByUserId = Guid.Empty }, HandoverRefusal.NoUserNamed },
             { Want() with { Title = "   " }, HandoverRefusal.NoTitle },
             { Want() with { Kind = (RequestedItemKind)9 }, HandoverRefusal.KindNotRecognised }

--- a/Jellyfin.Plugin.Requests.Tests/Storage/RequestStoreContract.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Storage/RequestStoreContract.cs
@@ -721,6 +721,84 @@ public abstract class RequestStoreContract
     }
 
     /// <summary>
+    /// A want the sibling handed over is found again by its own identifier. This is the lookup that
+    /// makes a repeat recognisable as one, and without it every refresh that recreated an item on the
+    /// browsing side is another acquisition here.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ARequestIsFoundByAWantItAbsorbed()
+    {
+        var store = NewStore();
+        var want = Guid.NewGuid();
+        var request = ARequest() with { WantIds = [Guid.NewGuid(), want] };
+
+        var added = await store.AddAsync(request, CancellationToken.None).ConfigureAwait(true);
+        var found = await store.FindByWantAsync(want, CancellationToken.None).ConfigureAwait(true);
+
+        Assert.NotNull(found);
+        Assert.Equal(added, found.Value);
+    }
+
+    /// <summary>
+    /// A want nothing has absorbed is an answer rather than a failure, in the same way an unknown
+    /// request identifier is. The seam asks this of every handover, and most of them are the first
+    /// time that want has been seen.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AWantNobodyHasHandedOverIsAnsweredWithNothing()
+    {
+        var store = NewStore();
+
+        await store.AddAsync(ARequest() with { WantIds = [Guid.NewGuid()] }, CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Null(await store.FindByWantAsync(Guid.NewGuid(), CancellationToken.None).ConfigureAwait(true));
+    }
+
+    /// <summary>
+    /// The lookup answers whatever state the request is in. A want whose request was declined has
+    /// still been taken, and a store that answered only for the open ones would make a refusal the
+    /// one thing that lets a repeat through.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AWantIsStillFoundAfterItsRequestWasAnswered()
+    {
+        var store = NewStore();
+        var want = Guid.NewGuid();
+
+        var added = await store
+            .AddAsync(ARequest() with { WantIds = [want] }, CancellationToken.None)
+            .ConfigureAwait(true);
+
+        await store
+            .ReplaceAsync(added.Request with { State = RequestState.Declined }, added.Revision, CancellationToken.None)
+            .ConfigureAwait(true);
+
+        var found = await store.FindByWantAsync(want, CancellationToken.None).ConfigureAwait(true);
+
+        Assert.NotNull(found);
+        Assert.Equal(RequestState.Declined, found.Value.Request.State);
+    }
+
+    /// <summary>
+    /// A want identifier that names nothing is refused rather than answered. It is not an identifier
+    /// any request can have absorbed, so an answer of nothing found would read as a fact about the
+    /// store instead of as a caller's mistake.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AWantIdentifierThatNamesNothingIsRefused()
+    {
+        var store = NewStore();
+
+        await Assert
+            .ThrowsAsync<ArgumentException>(() => store.FindByWantAsync(Guid.Empty, CancellationToken.None))
+            .ConfigureAwait(true);
+    }
+
+    /// <summary>
     /// A request with only the fields that have no default, and its own identifier each time so a
     /// test can add two without arranging anything.
     /// </summary>

--- a/Jellyfin.Plugin.Requests/Intake/RequestIntake.cs
+++ b/Jellyfin.Plugin.Requests/Intake/RequestIntake.cs
@@ -103,14 +103,29 @@ public sealed class RequestIntake
                 return new IntakeResult(added, IntakeOutcome.Created);
             }
 
-            if (existing.Request.WasAskedForBy(ask.RequestedByUserId))
+            var alreadyWaiting = existing.Request.WasAskedForBy(ask.RequestedByUserId);
+
+            // Wants the existing request has not absorbed yet. Empty for every ask that arrived over
+            // the HTTP endpoint, because a person typing a title carries none, so nothing below this
+            // changes what that endpoint does.
+            var unabsorbed = ask.WantIds
+                .Where(wantId => !existing.Request.WantIds.Contains(wantId))
+                .ToArray();
+
+            if (alreadyWaiting && unabsorbed.Length == 0)
             {
                 return new IntakeResult(existing, IntakeOutcome.AlreadyWaiting);
             }
 
+            // A want is written even where the person is already waiting, because the want is what a
+            // repeat is recognised by and one that was never recorded is one that arrives again as
+            // something new. That is the only case where this writes without adding anybody.
             var joined = existing.Request with
             {
-                JoinedByUserIds = [.. existing.Request.JoinedByUserIds, ask.RequestedByUserId]
+                JoinedByUserIds = alreadyWaiting
+                    ? existing.Request.JoinedByUserIds
+                    : [.. existing.Request.JoinedByUserIds, ask.RequestedByUserId],
+                WantIds = [.. existing.Request.WantIds, .. unabsorbed]
             };
 
             try
@@ -119,7 +134,7 @@ public sealed class RequestIntake
                     .ReplaceAsync(joined, existing.Revision, cancellationToken)
                     .ConfigureAwait(false);
 
-                return new IntakeResult(written, IntakeOutcome.Joined);
+                return new IntakeResult(written, alreadyWaiting ? IntakeOutcome.AlreadyWaiting : IntakeOutcome.Joined);
             }
             catch (RequestConcurrencyException) when (attempt < JoinAttempts)
             {

--- a/Jellyfin.Plugin.Requests/Model/MediaRequest.cs
+++ b/Jellyfin.Plugin.Requests/Model/MediaRequest.cs
@@ -50,6 +50,7 @@ public sealed record MediaRequest
     private readonly string? _requesterNote;
     private readonly string? _declineNote;
     private readonly IReadOnlyList<int> _seasons = [];
+    private readonly IReadOnlyList<Guid> _wantIds = [];
 
     /// <summary>
     /// Gets this request's own identifier, which is not the identifier of anything it refers to.
@@ -141,6 +142,31 @@ public sealed record MediaRequest
     /// </para>
     /// </summary>
     public IReadOnlyList<Guid> JoinedByUserIds { get; init; } = [];
+
+    /// <summary>
+    /// Gets the sibling discover plugin's own identifiers for the wants this request absorbed,
+    /// oldest first. Empty on a request nobody handed over, which is every request a person typed.
+    /// <para>
+    /// <b>This is an idempotency key and not a second identity.</b> Whether two asks are the same
+    /// thing is <see cref="RequestIdentity"/>'s answer, over the provider identifiers and the
+    /// seasons. This answers a narrower question: has this exact want already been taken. The other
+    /// side derives one identifier per title and user and hands it over again after a refresh that
+    /// recreated the item, after a restart, and after a user undid and redid the gesture, so
+    /// without it each of those is another acquisition of something somebody is already waiting for.
+    /// </para>
+    /// <para>
+    /// A list rather than one value, because one request absorbs several wants: two people wanting
+    /// the same film are two wants on the other side and one request here, in #38.
+    /// </para>
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Where a want is named twice, or where one of them names nothing.
+    /// </exception>
+    public IReadOnlyList<Guid> WantIds
+    {
+        get => _wantIds;
+        init => _wantIds = WantSet(value);
+    }
 
     /// <summary>
     /// Gets where the request stands. Defaults to <see cref="RequestState.Open"/>, because a
@@ -260,6 +286,42 @@ public sealed record MediaRequest
     /// <returns><see langword="true"/> where that person asked for this.</returns>
     public bool WasAskedForBy(Guid userId)
         => RequestedByUserId == userId || JoinedByUserIds.Contains(userId);
+
+    /// <summary>
+    /// Refuses a want list that is not a set of wants. A want named twice is a caller's mistake
+    /// being stored as a fact, and an empty identifier names nothing, so both are refused rather
+    /// than tidied: the whole point of these is that they are the key a repeat is recognised by,
+    /// and a key quietly cleaned up is one nobody can rely on.
+    /// <para>
+    /// The order is the order the wants were absorbed and is kept, so the first is the want the
+    /// request was made for.
+    /// </para>
+    /// </summary>
+    /// <param name="wantIds">The wants as they arrived.</param>
+    /// <returns>The same wants.</returns>
+    private static IReadOnlyList<Guid> WantSet(IReadOnlyList<Guid>? wantIds)
+    {
+        if (wantIds is null || wantIds.Count == 0)
+        {
+            return [];
+        }
+
+        if (wantIds.Any(wantId => wantId == Guid.Empty))
+        {
+            throw new ArgumentException(
+                "A want identifier that names nothing is refused, because these are what a repeat of the same want is recognised by.",
+                nameof(wantIds));
+        }
+
+        if (wantIds.Distinct().Count() != wantIds.Count)
+        {
+            throw new ArgumentException(
+                "The same want is named twice, and a want absorbed twice is one fact recorded as two.",
+                nameof(wantIds));
+        }
+
+        return [.. wantIds];
+    }
 
     /// <summary>
     /// Refuses a season list that is not a set of seasons. A repeat is a caller's mistake being

--- a/Jellyfin.Plugin.Requests/Seam/HandedOverWant.cs
+++ b/Jellyfin.Plugin.Requests/Seam/HandedOverWant.cs
@@ -46,10 +46,10 @@ public sealed record HandedOverWant
     /// Gets the sibling's own identifier for this want, which is stable across a refresh that
     /// recreated the item and across a restart.
     /// <para>
-    /// It is carried through to the log line a refusal leaves, so an operator asked about a want by
-    /// the other side's identifier can find what this side did with it. Storing it, so that the same
-    /// want arriving again is recognised as the same want whatever else changed, is #116 and is not
-    /// done here.
+    /// It is stored on the request it becomes, which is what makes a repeat recognisable as one
+    /// whatever else changed and across a restart, and it is carried through to the log line a
+    /// refusal leaves, so an operator asked about a want by the other side's identifier can find
+    /// what this side did with it.
     /// </para>
     /// </summary>
     public required Guid WantId { get; init; }

--- a/Jellyfin.Plugin.Requests/Seam/HandoverRefusal.cs
+++ b/Jellyfin.Plugin.Requests/Seam/HandoverRefusal.cs
@@ -27,6 +27,12 @@ public enum HandoverRefusal
     NoUserNamed = 1,
 
     /// <summary>
+    /// The field set carried no identifier for the want itself, so a repeat of it could never be
+    /// recognised as one and every arrival would be a new request.
+    /// </summary>
+    NoWantNamed = 7,
+
+    /// <summary>
     /// The want named no title, and a request carries the title as it read when it was asked for.
     /// </summary>
     NoTitle = 2,

--- a/Jellyfin.Plugin.Requests/Seam/WantHandover.cs
+++ b/Jellyfin.Plugin.Requests/Seam/WantHandover.cs
@@ -32,9 +32,15 @@ namespace Jellyfin.Plugin.Requests.Seam;
 /// <b>Whether an ask joins an existing request is not decided here.</b> It is
 /// <see cref="RequestIntake"/>'s, which is the same object the HTTP endpoint asks, so two users
 /// wanting the same film produce one request with both of them recorded however each of them asked.
-/// The one thing this seam does not yet do is recognise the same want arriving twice by the
-/// sibling's own identifier for it, which is #116: today a repeat is caught by the identity rule
-/// over the provider identifiers, and a want carrying none has no identity to be caught by.
+/// </para>
+/// <para>
+/// <b>The same want twice is one request, and that is a separate rule from the one above.</b> The
+/// want identifier is an idempotency key: the other side derives it from the title and the user and
+/// hands it over again after a refresh that recreated the item, after a restart, and after a gesture
+/// undone and redone. It is looked up before anything is built, over everything the store holds and
+/// in every state, so a want whose request was declined is still a want that has been taken. The
+/// identity rule cannot stand in for this, because it compares provider identifiers and a want
+/// carrying none is different from every other want including another copy of itself.
 /// </para>
 /// </summary>
 public sealed class WantHandover : IWantHandover
@@ -51,6 +57,7 @@ public sealed class WantHandover : IWantHandover
     /// </summary>
     public const int KnownContractVersion = 1;
 
+    private readonly IRequestStore _store;
     private readonly RequestIntake _intake;
     private readonly IClock _clock;
     private readonly IIdentifierSource _identifiers;
@@ -79,6 +86,7 @@ public sealed class WantHandover : IWantHandover
         ArgumentNullException.ThrowIfNull(settings);
         ArgumentNullException.ThrowIfNull(logger);
 
+        _store = store;
         _intake = new RequestIntake(store);
         _clock = clock;
         _identifiers = identifiers;
@@ -100,6 +108,11 @@ public sealed class WantHandover : IWantHandover
         if (want.ContractVersion != KnownContractVersion)
         {
             return Refused(want, HandoverRefusal.ContractVersionNotKnown);
+        }
+
+        if (want.WantId == Guid.Empty)
+        {
+            return Refused(want, HandoverRefusal.NoWantNamed);
         }
 
         if (want.RequestedByUserId == Guid.Empty)
@@ -133,6 +146,35 @@ public sealed class WantHandover : IWantHandover
             return Refused(want, HandoverRefusal.KindNotAccepted);
         }
 
+        StoredRequest? absorbed;
+
+        try
+        {
+            absorbed = await _store.FindByWantAsync(want.WantId, cancellationToken).ConfigureAwait(false);
+        }
+        catch (RequestStoreLoadException)
+        {
+            return Refused(want, HandoverRefusal.TheStoreCouldNotBeReached);
+        }
+
+        if (absorbed is StoredRequest already)
+        {
+            // The same want again, which is the ordinary case rather than a defect: the other side
+            // hands one over after a refresh that recreated the item, after a restart, and after a
+            // gesture undone and redone. It is accepted, because a request for it exists, and
+            // nothing is written, because it is already recorded. Whatever state that request is in
+            // counts, including declined: a want that was answered has still been taken.
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug(
+                    "The want {WantId} was handed over again and is already request {RequestId}, so nothing was made.",
+                    want.WantId,
+                    already.Request.Id);
+            }
+
+            return true;
+        }
+
         var asked = _clock.UtcNow;
 
         var incoming = new MediaRequest
@@ -144,7 +186,8 @@ public sealed class WantHandover : IWantHandover
             Kind = want.Kind,
             DisplayTitle = want.Title,
             DisplayYear = want.Year,
-            ProviderIds = want.ProviderIds
+            ProviderIds = want.ProviderIds,
+            WantIds = [want.WantId]
         };
 
         IntakeResult intake;

--- a/Jellyfin.Plugin.Requests/Storage/FileRequestStore.cs
+++ b/Jellyfin.Plugin.Requests/Storage/FileRequestStore.cs
@@ -199,6 +199,23 @@ public sealed class FileRequestStore : IRequestStore, IDisposable
     }
 
     /// <inheritdoc />
+    public async Task<StoredRequest?> FindByWantAsync(Guid wantId, CancellationToken cancellationToken)
+    {
+        if (wantId == Guid.Empty)
+        {
+            throw new ArgumentException(
+                "A want identifier that names nothing cannot be looked up, because it is not one any request can have absorbed.",
+                nameof(wantId));
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var held = await HeldAsync(cancellationToken).ConfigureAwait(false);
+
+        return held.ByWant.TryGetValue(wantId, out var carrying) ? carrying : null;
+    }
+
+    /// <inheritdoc />
     public async Task<RequestPage> PageAsync(RequestQuery query, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(query);
@@ -595,7 +612,7 @@ public sealed class FileRequestStore : IRequestStore, IDisposable
     private readonly record struct ProviderKey(RequestedItemKind Kind, string Provider, string Value);
 
     /// <summary>
-    /// What the store holds, and the two lookups the surfaces read it through.
+    /// What the store holds, and the lookups the surfaces read it through.
     /// <para>
     /// Both lookups are built once, here, out of the set that is about to be published, and neither
     /// is edited afterwards. That is what makes them safe to hand out: a reader that took this
@@ -622,6 +639,7 @@ public sealed class FileRequestStore : IRequestStore, IDisposable
 
             var byUser = new Dictionary<Guid, List<StoredRequest>>();
             var byProviderIdentifier = new Dictionary<ProviderKey, List<StoredRequest>>(ProviderKeyComparer.Instance);
+            var byWant = new Dictionary<Guid, StoredRequest>();
 
             foreach (var stored in held.Values)
             {
@@ -642,8 +660,19 @@ public sealed class FileRequestStore : IRequestStore, IDisposable
                 {
                     Under(byProviderIdentifier, identifier).Add(stored);
                 }
+
+                // One request per want and not a list. A want is absorbed once, so two requests
+                // claiming one would be a defect rather than a case to serve, and the last writer
+                // winning here would hide it. The set on the record refuses a repeat inside one
+                // request; nothing refuses two records claiming the same want, and this is where
+                // that would show as a wrong answer rather than as a crash.
+                foreach (var want in stored.Request.WantIds)
+                {
+                    byWant[want] = stored;
+                }
             }
 
+            ByWant = byWant;
             ByUser = byUser.ToDictionary(entry => entry.Key, entry => entry.Value.ToArray());
             ByProviderIdentifier = byProviderIdentifier.ToDictionary(
                 entry => entry.Key,
@@ -665,6 +694,11 @@ public sealed class FileRequestStore : IRequestStore, IDisposable
         /// Gets the requests carrying each external identifier.
         /// </summary>
         public Dictionary<ProviderKey, StoredRequest[]> ByProviderIdentifier { get; }
+
+        /// <summary>
+        /// Gets the request that absorbed each want the sibling handed over.
+        /// </summary>
+        public Dictionary<Guid, StoredRequest> ByWant { get; }
 
         /// <summary>
         /// The list under a key, made if it is the first one.

--- a/Jellyfin.Plugin.Requests/Storage/IRequestStore.cs
+++ b/Jellyfin.Plugin.Requests/Storage/IRequestStore.cs
@@ -133,6 +133,32 @@ public interface IRequestStore
         CancellationToken cancellationToken);
 
     /// <summary>
+    /// The request that already absorbed one want from the sibling discover plugin, if any.
+    /// <para>
+    /// This is the question the seam asks before it does anything else, and it is a different
+    /// question from the one above. The identifier lookup asks whether anything names the same
+    /// title; this asks whether this exact want has already been taken. The other side derives its
+    /// identifier from the title and the user and hands it over again after a refresh, a restart, or
+    /// a gesture undone and redone, so an answer here is what stops each of those becoming another
+    /// acquisition.
+    /// </para>
+    /// <para>
+    /// Answered over everything held, whatever state the request is in. A want whose request was
+    /// declined has still been taken, and answering only for the open ones would make a refusal the
+    /// one thing that lets a repeat through.
+    /// </para>
+    /// </summary>
+    /// <param name="wantId">The sibling's own identifier for the want.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>
+    /// The request carrying that want, at the revision the store holds it at, or
+    /// <see langword="null"/> where no request has absorbed it. At most one request can, because a
+    /// want is absorbed once.
+    /// </returns>
+    /// <exception cref="ArgumentException">Where the want identifier names nothing.</exception>
+    Task<StoredRequest?> FindByWantAsync(Guid wantId, CancellationToken cancellationToken);
+
+    /// <summary>
     /// One page of the queue an operator reads, filtered, ordered and counted from a single
     /// snapshot.
     /// <para>

--- a/docs/seam.md
+++ b/docs/seam.md
@@ -102,8 +102,17 @@ The contract is one way. A handover carries a want across and nothing is learned
 was accepted. A query in the other direction would make each side hold a piece of the other's state,
 which is the arrangement both boards are avoiding and the reason the contract is shaped this way at
 all. So this side offers the seam no way to read request state, and the duplicate case is answered
-where the handover happens instead: the same want arriving twice produces one request, which is
-#116, and the sibling's own repeat handling does the rest on its side.
+where the handover happens instead: the same want arriving twice produces one request, and the
+sibling's own repeat handling does the rest on its side.
+
+That is a rule of its own and not the identity rule wearing another name. The want identifier is an
+idempotency key, looked up before anything is built, over every request the store holds and in every
+state, so a want whose request was declined is still a want that has been taken. The identity rule
+answers a different question, whether two asks are the same thing, and it answers it against the
+provider identifiers, so a want carrying none is different from every other want including another
+copy of itself. Each rule catches what the other cannot:
+
+    git grep -n 'Task<StoredRequest?> FindByWantAsync' -- Jellyfin.Plugin.Requests/Storage/IRequestStore.cs
 
 The user's answer to what happened to their request comes from this plugin's own surface, decided in
 [`docs/surface.md`](surface.md) and reaching the same clients: the channel for a client that renders


### PR DESCRIPTION
Closes #116.

The seam took every handover as a new ask. The other side derives one identifier
per title and user and hands it across again after a refresh that recreated the
item, after a restart, and after a gesture undone and redone, so each of those was
another row on the queue and, once approved, another acquisition of something
somebody was already waiting for.

## The three conditions

**The same want identifier arriving twice produces one request.**
`TheSameWantHandedOverThreeTimesIsOneRequest` hands the same field set over three
times and asserts one request at revision 1. Two more make the rule visible where
the identity rule cannot stand in for it:
`ARepeatIsCaughtEvenWhereThereAreNoIdentifiersToCompare`, because a want carrying
no provider identifiers is different from every other want including another copy
of itself, and `AWantWhoseRequestWasDeclinedDoesNotComeBackAsANewOne`, because a
want that was answered has still been taken and a refusal must not be the one
thing that lets a repeat through.

**Two users wanting the same title are one request with both requesters
recorded.** That was already true and is now also true of their wants:
`ARequestKeepsEveryWantItAbsorbed` asserts both identifiers on the one request
alongside both people, which is what stops the second person's repeat creating
what the first is waiting for.

**The want identifier is stored and the check survives a restart.**
`TheSameWantAfterARestartIsStillTheSameWant` accepts a want through a
`FileRequestStore`, closes it, opens a second store over the same directory, and
hands the same want over again. One request, still at revision 1.

## Why this is a second rule and not the identity rule again

They answer different questions and each catches what the other cannot. The
identity rule asks whether two asks are the same thing and answers against the
provider identifiers and the seasons. This asks whether this exact want has
already been taken, and answers it whatever else changed and in whatever state the
request is now in. `docs/seam.md` carries the distinction where a reader of the
seam will meet it.

## What this moved outside the issue's scope

The issue names the seam code, the model code and the test project.
`IRequestStore` gained `FindByWantAsync` and both implementations answer it, which
is the storage code. There was no way to keep it inside: a repeat has to be found
whatever state its request is in, and the lookups the store already offers are by
person and by external identifier, neither of which answers that. The file store
builds the index in the same pass as the other two, so a write costs one more walk
of a set it has just serialised and a read costs nothing.

`RequestStoreContract` gained four cases, so any store this plugin ever ships is
judged on the same promise rather than only the one under test today.

## Run at this branch's head

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Der Buildvorgang wurde erfolgreich ausgeführt.
        0 Warnung(en)

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!: Fehler: 0, erfolgreich: 483, gesamt: 483 (net9.0)
    Bestanden!: Fehler: 0, erfolgreich: 483, gesamt: 483 (net10.0)

Four hundred and sixty-seven of those were there before this change.

## Every guard, watched failing

Each mutation was made, the affected tests were run on `net9.0`, and the change
was reverted afterwards.

The seam stops asking whether the want was already taken:

    ARepeatIsCaughtEvenWhereThereAreNoIdentifiersToCompare [FAIL]
    AWantWhoseRequestWasDeclinedDoesNotComeBackAsANewOne [FAIL]
    Fehler: 2, erfolgreich: 18, gesamt: 20

Two of the five reddened and not all five, and that is the measurement rather
than a weakness in it. `TheSameWantHandedOverThreeTimesIsOneRequest` stays green
under this mutation because the identity rule catches that particular repeat
through the provider identifiers, so it is not on its own proof of the lookup.
The two that redden are the cases the identity rule cannot reach.

The want is not written onto the request it becomes:

    ARequestKeepsEveryWantItAbsorbed [FAIL]
    TheSameWantAfterARestartIsStillTheSameWant [FAIL]
    ARepeatIsCaughtEvenWhereThereAreNoIdentifiersToCompare [FAIL]
    TheSameWantHandedOverThreeTimesIsOneRequest [FAIL]
    AWantWhoseRequestWasDeclinedDoesNotComeBackAsANewOne [FAIL]
    Fehler: 5, erfolgreich: 15, gesamt: 20

The file store's want index left unbuilt:

    FileRequestStoreTests.AWantIsStillFoundAfterItsRequestWasAnswered [FAIL]
    FileRequestStoreTests.ARequestIsFoundByAWantItAbsorbed [FAIL]
    Fehler: 2, erfolgreich: 45, gesamt: 47

The intake stops absorbing a want onto a request that joins:

    ARequestKeepsEveryWantItAbsorbed [FAIL]
    Fehler: 1, erfolgreich: 19, gesamt: 20

The record accepts a want named twice:

    MediaRequestTests.AWantNamedTwiceOnOneRequestIsRefused [FAIL]
    Fehler: 1, erfolgreich: 8, gesamt: 9

## What is claimed rather than measured

**Nothing was run on a Jellyfin server, and no plugin handed anything over.** The
suite drives the seam directly. Whether another plugin in one process can name
these types is #117 and is unmeasured.

**Nothing refuses two records claiming one want.** The record refuses a repeat
inside one request, and the store's index keeps one request per want, so a second
record claiming a want already absorbed would be answered with one of the two and
no error. The seam cannot produce that state, because it looks the want up before
it writes; a caller building requests some other way could.

**A request written by an older version carries no wants**, which is correct and
needs no migration: nothing had handed one over. It also means a want handed over
before this change is not recognised as a repeat now, because there was nowhere to
record it at the time.

**No second reader has looked at this.** The runs above and the mutations stand in
place of one.
