### PR TITLE
Refuse a handover naming somebody this server does not have

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Doubles/FakeKnownUsers.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/FakeKnownUsers.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Jellyfin.Plugin.Requests.Seam;
+
+namespace Jellyfin.Plugin.Requests.Tests.Doubles;
+
+/// <summary>
+/// The users a server has, decided by the test.
+/// <para>
+/// The real one asks the server's user manager, which a test would have to build a server to reach.
+/// This holds a list, and a test that wants a handover refused for naming nobody leaves the list
+/// without them.
+/// </para>
+/// </summary>
+internal sealed class FakeKnownUsers : IKnownUsers
+{
+    private readonly HashSet<Guid> _users;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FakeKnownUsers"/> class over the people this
+    /// server has.
+    /// </summary>
+    /// <param name="users">Everybody the server knows.</param>
+    public FakeKnownUsers(params Guid[] users) => _users = [.. users ?? []];
+
+    /// <summary>
+    /// A server that has nobody at all, which is what a handover naming anybody meets.
+    /// </summary>
+    /// <returns>A server with no users.</returns>
+    public static FakeKnownUsers Nobody() => new FakeKnownUsers();
+
+    /// <inheritdoc />
+    public bool Has(Guid userId) => _users.Contains(userId);
+}

--- a/Jellyfin.Plugin.Requests.Tests/Seam/WantHandoverTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Seam/WantHandoverTests.cs
@@ -99,7 +99,7 @@ public class WantHandoverTests
             .ToArray();
 
         Assert.Equal(
-            ["IRequestStore", "IClock", "IIdentifierSource", "IInstallSettings", "ILogger"],
+            ["IRequestStore", "IClock", "IIdentifierSource", "IInstallSettings", "IKnownUsers", "ILogger"],
             taken);
     }
 
@@ -406,6 +406,49 @@ public class WantHandoverTests
     }
 
     /// <summary>
+    /// A handover naming somebody this server does not have is refused. The identifier cannot be
+    /// verified as the person who actually asked, and nothing here pretends otherwise; what it can
+    /// be checked against is the server's own users, and a request stored against a user nobody has
+    /// is one no surface can ever show to anybody.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AHandoverNamingAUserTheServerDoesNotHaveIsRefused()
+    {
+        var store = new InMemoryRequestStore();
+        var log = new RecordingLogger();
+
+        var accepted = await Seam(store, log: log, users: FakeKnownUsers.Nobody())
+            .AcceptAsync(Want(), CancellationToken.None);
+
+        Assert.False(accepted);
+        Assert.Empty(await store.GetAllAsync(CancellationToken.None));
+        Assert.Contains(
+            nameof(HandoverRefusal.UserNotOnThisServer),
+            Assert.Single(log.At(LogLevel.Warning)).Message,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The server is asked about the user the want names and not about anybody else. A check that
+    /// passed for the wrong person would be worse than none, because it reads afterwards as a check
+    /// that was made.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task TheUserAskedAboutIsTheOneTheWantNames()
+    {
+        var store = new InMemoryRequestStore();
+
+        var accepted = await Seam(store, users: new FakeKnownUsers(SecondAsker))
+            .AcceptAsync(Want(), CancellationToken.None);
+
+        Assert.False(accepted);
+        Assert.True(await Seam(store, users: new FakeKnownUsers(SecondAsker))
+            .AcceptAsync(Want() with { RequestedByUserId = SecondAsker }, CancellationToken.None));
+    }
+
+    /// <summary>
     /// The field sets that cannot become a request, each with the refusal that names what is wrong.
     /// </summary>
     /// <returns>One case per way of being wrong.</returns>
@@ -440,15 +483,18 @@ public class WantHandoverTests
     /// <param name="store">Where requests are kept.</param>
     /// <param name="settings">What the install is set to, or a fresh install where not given.</param>
     /// <param name="log">Where refusals are written, or a discarded one where not given.</param>
+    /// <param name="users">Who the server has, or both people these tests use where not given.</param>
     /// <returns>The seam under test.</returns>
     private static WantHandover Seam(
         IRequestStore store,
         IInstallSettings? settings = null,
-        RecordingLogger? log = null)
+        RecordingLogger? log = null,
+        IKnownUsers? users = null)
         => new WantHandover(
             store,
             new TestClock(Noon),
             new SequentialIdentifierSource(),
             settings ?? new FakeInstallSettings(),
+            users ?? new FakeKnownUsers(Asker, SecondAsker),
             log ?? new RecordingLogger());
 }

--- a/Jellyfin.Plugin.Requests.Tests/SiblingIndependenceTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/SiblingIndependenceTests.cs
@@ -39,6 +39,13 @@ public class SiblingIndependenceTests
         // that enumeration lives here rather than beside the library interface it is passed to. It
         // arrives with the server's own libraries and is excluded from the install with them.
         "Jellyfin.Data",
+
+        // The seam refuses a handover naming somebody this server does not have, in #118, and the
+        // only member of the server's user manager that answers on both claimed lines hands back the
+        // user record. Nothing here reads that record: the answer is thrown away and its presence is
+        // the whole result. The reference is the price of asking, it arrives with the server's own
+        // libraries, and it is excluded from the install with them.
+        "Jellyfin.Database.Implementations",
         "MediaBrowser.Common",
         "MediaBrowser.Controller",
         "MediaBrowser.Model",

--- a/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
@@ -77,11 +77,14 @@ public sealed class PluginServiceRegistrator : IPluginServiceRegistrator
         // The seam the sibling discover plugin hands a want across. Registered into the server's own
         // collection because that is where a second plugin in this process would resolve it from;
         // whether one can name the type at all is #117 and is not decided by registering it.
+        serviceCollection.AddSingleton<IKnownUsers, ServerKnownUsers>();
+
         serviceCollection.AddSingleton<IWantHandover>(provider => new WantHandover(
             provider.GetRequiredService<IRequestStore>(),
             provider.GetRequiredService<IClock>(),
             provider.GetRequiredService<IIdentifierSource>(),
             provider.GetRequiredService<IInstallSettings>(),
+            provider.GetRequiredService<IKnownUsers>(),
             provider.GetRequiredService<ILogger<WantHandover>>()));
 
         // The server's library, as the two questions this plugin asks of it. One per server, because

--- a/Jellyfin.Plugin.Requests/Seam/HandoverRefusal.cs
+++ b/Jellyfin.Plugin.Requests/Seam/HandoverRefusal.cs
@@ -27,6 +27,13 @@ public enum HandoverRefusal
     NoUserNamed = 1,
 
     /// <summary>
+    /// The user the want named is not a user this server has. The identifier could not be verified
+    /// as belonging to the person who asked, which is the trust position <c>docs/seam.md</c> states,
+    /// but it can be checked against the server's own users and this one is not among them.
+    /// </summary>
+    UserNotOnThisServer = 8,
+
+    /// <summary>
     /// The field set carried no identifier for the want itself, so a repeat of it could never be
     /// recognised as one and every arrival would be a new request.
     /// </summary>

--- a/Jellyfin.Plugin.Requests/Seam/IKnownUsers.cs
+++ b/Jellyfin.Plugin.Requests/Seam/IKnownUsers.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace Jellyfin.Plugin.Requests.Seam;
+
+/// <summary>
+/// Whether the server has a user, asked of the server rather than assumed.
+/// <para>
+/// One question and no more. A handover names a user this plugin cannot verify, and what is owed
+/// against that is not a permission check, which this side is in no position to make; it is that the
+/// identifier names somebody. A seam that could answer more would be a seam somebody later uses to
+/// answer more.
+/// </para>
+/// <para>
+/// It is an interface for the reason the clock and the install settings are: the real one reaches
+/// into the server, and a test that had to build a server to run is a test nobody runs.
+/// </para>
+/// </summary>
+public interface IKnownUsers
+{
+    /// <summary>
+    /// Whether this server has that user.
+    /// </summary>
+    /// <param name="userId">The identifier a caller handed over.</param>
+    /// <returns><see langword="true"/> where the server knows somebody by it.</returns>
+    bool Has(Guid userId);
+}

--- a/Jellyfin.Plugin.Requests/Seam/ServerKnownUsers.cs
+++ b/Jellyfin.Plugin.Requests/Seam/ServerKnownUsers.cs
@@ -1,0 +1,37 @@
+using System;
+using MediaBrowser.Controller.Library;
+
+namespace Jellyfin.Plugin.Requests.Seam;
+
+/// <summary>
+/// The server's own answer to whether it has a user.
+/// <para>
+/// This is the one place that asks the server's user manager, so the reach exists once and
+/// everything above it takes <see cref="IKnownUsers"/> instead.
+/// </para>
+/// </summary>
+public sealed class ServerKnownUsers : IKnownUsers
+{
+    private readonly IUserManager _users;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ServerKnownUsers"/> class.
+    /// </summary>
+    /// <param name="users">The server's users.</param>
+    /// <exception cref="ArgumentNullException">Where there is nothing to ask.</exception>
+    public ServerKnownUsers(IUserManager users)
+    {
+        ArgumentNullException.ThrowIfNull(users);
+
+        _users = users;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// The answer is thrown away and only its presence is read. <c>GetUserById</c> is the one member
+    /// on both claimed lines that answers this question, and it hands back the server's own user
+    /// record, so asking it costs this plugin a reference to the assembly that record lives in.
+    /// <c>SiblingIndependenceTests</c> is where that cost is written down rather than absorbed.
+    /// </remarks>
+    public bool Has(Guid userId) => userId != Guid.Empty && _users.GetUserById(userId) is not null;
+}

--- a/Jellyfin.Plugin.Requests/Seam/WantHandover.cs
+++ b/Jellyfin.Plugin.Requests/Seam/WantHandover.cs
@@ -62,6 +62,7 @@ public sealed class WantHandover : IWantHandover
     private readonly IClock _clock;
     private readonly IIdentifierSource _identifiers;
     private readonly IInstallSettings _settings;
+    private readonly IKnownUsers _users;
     private readonly ILogger _logger;
 
     /// <summary>
@@ -71,6 +72,7 @@ public sealed class WantHandover : IWantHandover
     /// <param name="clock">The injected clock, so a request's times are testable.</param>
     /// <param name="identifiers">Where a new request's identifier comes from.</param>
     /// <param name="settings">What this install is set to.</param>
+    /// <param name="users">The server's answer to whether it has the user a want names.</param>
     /// <param name="logger">Where a refusal is written.</param>
     /// <exception cref="ArgumentNullException">Where anything it needs is missing.</exception>
     public WantHandover(
@@ -78,12 +80,14 @@ public sealed class WantHandover : IWantHandover
         IClock clock,
         IIdentifierSource identifiers,
         IInstallSettings settings,
+        IKnownUsers users,
         ILogger logger)
     {
         ArgumentNullException.ThrowIfNull(store);
         ArgumentNullException.ThrowIfNull(clock);
         ArgumentNullException.ThrowIfNull(identifiers);
         ArgumentNullException.ThrowIfNull(settings);
+        ArgumentNullException.ThrowIfNull(users);
         ArgumentNullException.ThrowIfNull(logger);
 
         _store = store;
@@ -91,6 +95,7 @@ public sealed class WantHandover : IWantHandover
         _clock = clock;
         _identifiers = identifiers;
         _settings = settings;
+        _users = users;
         _logger = logger;
     }
 
@@ -118,6 +123,15 @@ public sealed class WantHandover : IWantHandover
         if (want.RequestedByUserId == Guid.Empty)
         {
             return Refused(want, HandoverRefusal.NoUserNamed);
+        }
+
+        // The identifier cannot be verified as the person who actually asked, and this side is in no
+        // position to check that: there is no session on a call from another plugin. What it can
+        // check is that the identifier names somebody, which is the difference between trusting the
+        // caller's permission check and storing a request against a user nobody has.
+        if (!_users.Has(want.RequestedByUserId))
+        {
+            return Refused(want, HandoverRefusal.UserNotOnThisServer);
         }
 
         if (string.IsNullOrWhiteSpace(want.Title))

--- a/docs/seam.md
+++ b/docs/seam.md
@@ -140,6 +140,35 @@ which is neither a leak that has been shown nor a safety anybody has earned. The
 that a caller reads their own requests and never another person's, is enforced at the endpoints in
 `docs/api.md` and not by the store beneath them.
 
+## What this side trusts, and what it checks anyway
+
+The HTTP API takes the requester from the authenticated session and refuses a body that names
+somebody else, so filing a request as another person is not something it declines to do, it is
+something the call has no way to express. The seam is the opposite shape: it carries a user
+identifier, there is no session behind it, and this plugin cannot verify that the person named is
+the person who asked.
+
+**That is a boundary rather than a hole, and the reason is worth stating plainly.** The caller is
+another plugin running inside the same server process. Anything in that process can already read
+this plugin's store, write its files, and do a great deal more than file a request in somebody's
+name. A check here would therefore protect against nothing that is not already possible, and it
+would read afterwards as a check that was made.
+
+**So the sibling's own permission check is the only check on that path, and this side is trusting
+it.** Whoever is evaluating this plugin should read that sentence as it stands: a want that arrives
+over the seam is attributed to whoever the caller says asked for it.
+
+**What this side checks anyway is that the identifier names somebody this server has.** That is a
+different question from whether they asked, and it is the one this side can answer. A handover
+naming a user the server does not have is refused and nothing is stored, because a request against
+a user nobody has is a row no surface can ever show to anyone and a person nothing can ever notify.
+
+    git grep -n 'UserNotOnThisServer' -- Jellyfin.Plugin.Requests/Seam/
+
+The check costs one reference, which is written down in `SiblingIndependenceTests` with the reason:
+the server's user manager answers this question with the user record, and this plugin reads nothing
+out of that record.
+
 ## A field set this side does not understand is refused whole
 
 The contract carries a version. What this side does with one it does not know is a stated rule
@@ -191,8 +220,9 @@ install is refusing and why is the diagnostics view in #63.
 Named here so the absence is read as absence rather than as a decision nobody wrote down. Each is
 the closing condition of the issue beside it.
 
-- The trust position of an in-process handover, and what this side checks before it believes a user
-  identifier it cannot verify. #118.
+- What a request records about having arrived over the seam, and which caller handed it over. The
+  contract carries no field naming the caller, so the second half of that is a question for the
+  contract rather than for this side. #118.
 - How each side finds the other. #89.
 - What an undone gesture does, which today is nothing, because the contract carries no message for
   it. #68.


### PR DESCRIPTION
Part of #118. Two of its three conditions; the third is measured below and is a
question for the contract rather than for this side.

## The trust position, written down

`docs/seam.md` now says it rather than leaving it to be inferred from the absence
of a check. The seam carries a user identifier, there is no session behind it, and
this plugin cannot verify that the person named is the person who asked. Anything
running in the server process can already read this plugin's store and do a great
deal more than file a request in somebody's name, so a check that pretended to
verify the requester would protect against nothing and would read afterwards as a
check that was made. The sibling's own permission check is the only check on that
path, and this side is trusting it.

## What is checked anyway

That the identifier names somebody this server has. It is a different question
from whether they asked, and it is the one this side can answer.
`AHandoverNamingAUserTheServerDoesNotHaveIsRefused` asserts the refusal, the empty
store and the reason in the log; `TheUserAskedAboutIsTheOneTheWantNames` asserts
the same server answers no for one person and yes for another, because a check
that passed for the wrong user would be worse than none.

## The reference this costs

`Jellyfin.Database.Implementations` is now on the plugin's reference list.
`IUserManager.GetUserById` is the only member that answers this on both claimed
lines, and it hands back the server's user record. Nothing here reads that record:
the answer is thrown away and its presence is the whole result.

`UsersIds` would have avoided it and does not exist on the SDKs this tree compiles
against, which is a compiler refusal rather than a reading:

    error CS1061: "IUserManager" enthält keine Definition für "UsersIds"

`SiblingIndependenceTests` caught the addition before it was noticed, which is what
that list is for, and the entry carries its reason.

## Run at this branch's head

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Der Buildvorgang wurde erfolgreich ausgeführt.
        0 Warnung(en)

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!: Fehler: 0, erfolgreich: 485, gesamt: 485 (net9.0)
    Bestanden!: Fehler: 0, erfolgreich: 485, gesamt: 485 (net10.0)

Four hundred and eighty-three of those were there before this change.

## The guard, watched failing

The check deleted from the seam, tests run on `net9.0`, reverted afterwards:

    TheUserAskedAboutIsTheOneTheWantNames [FAIL]
    AHandoverNamingAUserTheServerDoesNotHaveIsRefused [FAIL]
    Fehler: 2, erfolgreich: 20, gesamt: 22

## Why this does not close the issue

The second condition asks that the history of a request show it arrived through
the seam and name the caller. The contract fixes what crosses, and no field on it
names the caller:

    gh issue view 94 --repo Flowfin/jellyfin-plugin-discover --json body \
      --jq '.body' | grep -n 'What crosses'

```
What crosses is small on purpose: the title's provider identifiers, its kind, its
title and year for display, the identifier of the user who asked, this plugin's
own identifier for the want, and a contract version.
```

Six fields and a version, and none of them says who called. So "names the caller"
cannot be filled from a handover as the contract stands: this side can record that
a request arrived over the seam, which is a fact it knows, and it cannot record
which caller unless the contract grows a field, which is the sibling board's
decision rather than one to take here. Recording the arrival is also a history
entry at creation, and a request has no history entry today, so it is a model and
storage change rather than a line in this one. Both are left for #118 to settle
with an answer to the caller question.

The third condition's second half asks that the security documentation from #104
repeat the conclusion. #104 is open and that document does not exist.

## What is claimed rather than measured

**Nothing was run on a Jellyfin server.** The suite hands its own answer to
whether a user exists; whether `IUserManager` answers the same way on a real
server of each line is unmeasured here, and the floor builds are what say the call
exists at the claimed ABI.

**No second reader has looked at this.** The runs above and the mutation stand in
place of one.
