### PR TITLE
Be the sink the sibling looks for, and let nothing out of it but the answer

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Doubles/ALayerThatFails.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/ALayerThatFails.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Configuration;
+using Jellyfin.Plugin.Requests.Identity;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Seam;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Time;
+
+namespace Jellyfin.Plugin.Requests.Tests.Doubles;
+
+/// <summary>
+/// Any one of the layers beneath the seam, failing in a way nothing above it foresaw.
+/// <para>
+/// It is one type standing for five because the property under test is about the boundary rather
+/// than about any layer: a test drops this into whichever slot it is examining and leaves the rest
+/// as they are, so the same double proves the store, the clock, the identifier source, the settings
+/// and the server's users are each caught. Five doubles that each throw would be five files saying
+/// one thing.
+/// </para>
+/// <para>
+/// What it raises is deliberately a plain <see cref="InvalidOperationException"/> and never one of
+/// this plugin's own. The refusals the seam names by hand are proven elsewhere with the exceptions
+/// that carry them; this is the case where something arrived that nobody wrote a name for, which is
+/// the only case a catch-all can be the answer to.
+/// </para>
+/// </summary>
+internal sealed class ALayerThatFails : IRequestStore, IClock, IIdentifierSource, IInstallSettings, IKnownUsers
+{
+    /// <summary>
+    /// What every member raises. A test asserts this never reaches the caller, so it has to be
+    /// something a test can recognise if it does.
+    /// </summary>
+    public const string Detail = "The layer beneath the seam failed in a way nothing above it names.";
+
+    /// <inheritdoc />
+    public DateTimeOffset UtcNow => throw Failed();
+
+    /// <inheritdoc />
+    public PluginConfiguration Current => throw Failed();
+
+    /// <inheritdoc />
+    public Guid NewId() => throw Failed();
+
+    /// <inheritdoc />
+    public bool Has(Guid userId) => throw Failed();
+
+    /// <inheritdoc />
+    public Task<StoredRequest?> GetAsync(Guid id, CancellationToken cancellationToken) => throw Failed();
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<StoredRequest>> GetAllAsync(CancellationToken cancellationToken) => throw Failed();
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<StoredRequest>> FindForUserAsync(Guid userId, CancellationToken cancellationToken)
+        => throw Failed();
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<StoredRequest>> FindByProviderIdentifierAsync(
+        RequestedItemKind kind,
+        string provider,
+        string value,
+        CancellationToken cancellationToken)
+        => throw Failed();
+
+    /// <inheritdoc />
+    public Task<StoredRequest?> FindByWantAsync(Guid wantId, CancellationToken cancellationToken) => throw Failed();
+
+    /// <inheritdoc />
+    public Task<RequestPage> PageAsync(RequestQuery query, CancellationToken cancellationToken) => throw Failed();
+
+    /// <inheritdoc />
+    public Task<StoredRequest> AddAsync(MediaRequest request, CancellationToken cancellationToken) => throw Failed();
+
+    /// <inheritdoc />
+    public Task<StoredRequest> ReplaceAsync(
+        MediaRequest request,
+        long expectedRevision,
+        CancellationToken cancellationToken)
+        => throw Failed();
+
+    /// <inheritdoc />
+    public Task<bool> RemoveAsync(Guid id, long expectedRevision, CancellationToken cancellationToken)
+        => throw Failed();
+
+    private static InvalidOperationException Failed() => new InvalidOperationException(Detail);
+}

--- a/Jellyfin.Plugin.Requests.Tests/Doubles/StoreThatNeverAnswers.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/StoreThatNeverAnswers.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+
+namespace Jellyfin.Plugin.Requests.Tests.Doubles;
+
+/// <summary>
+/// A store that takes every call and answers none of them, ever.
+/// <para>
+/// This is the case a cancellation token cannot reach and the one worth having a double for. A store
+/// that throws is refused by name; a store that is slow finishes eventually; a store holding a lock
+/// nothing will release, or sitting on a disk that has stopped answering, leaves a task that never
+/// completes however politely it is asked to stop. A caller that only awaits it waits for as long as
+/// the process lives.
+/// </para>
+/// <para>
+/// It never completes rather than waiting a measured amount, so no test built on it spends real
+/// time or depends on how busy the machine is. What is asserted against it is that a caller answered
+/// at all.
+/// </para>
+/// </summary>
+internal sealed class StoreThatNeverAnswers : IRequestStore
+{
+    /// <inheritdoc />
+    public Task<StoredRequest?> GetAsync(Guid id, CancellationToken cancellationToken) => Never<StoredRequest?>();
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<StoredRequest>> GetAllAsync(CancellationToken cancellationToken)
+        => Never<IReadOnlyList<StoredRequest>>();
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<StoredRequest>> FindForUserAsync(Guid userId, CancellationToken cancellationToken)
+        => Never<IReadOnlyList<StoredRequest>>();
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<StoredRequest>> FindByProviderIdentifierAsync(
+        RequestedItemKind kind,
+        string provider,
+        string value,
+        CancellationToken cancellationToken)
+        => Never<IReadOnlyList<StoredRequest>>();
+
+    /// <inheritdoc />
+    public Task<StoredRequest?> FindByWantAsync(Guid wantId, CancellationToken cancellationToken)
+        => Never<StoredRequest?>();
+
+    /// <inheritdoc />
+    public Task<RequestPage> PageAsync(RequestQuery query, CancellationToken cancellationToken) => Never<RequestPage>();
+
+    /// <inheritdoc />
+    public Task<StoredRequest> AddAsync(MediaRequest request, CancellationToken cancellationToken)
+        => Never<StoredRequest>();
+
+    /// <inheritdoc />
+    public Task<StoredRequest> ReplaceAsync(
+        MediaRequest request,
+        long expectedRevision,
+        CancellationToken cancellationToken)
+        => Never<StoredRequest>();
+
+    /// <inheritdoc />
+    public Task<bool> RemoveAsync(Guid id, long expectedRevision, CancellationToken cancellationToken)
+        => Never<bool>();
+
+    private static Task<T> Never<T>() => new TaskCompletionSource<T>().Task;
+}

--- a/Jellyfin.Plugin.Requests.Tests/PluginServiceRegistrationTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/PluginServiceRegistrationTests.cs
@@ -1,7 +1,14 @@
+using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
 using Jellyfin.Plugin.Requests.Bridge;
 using Jellyfin.Plugin.Requests.Configuration;
 using Jellyfin.Plugin.Requests.Identity;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Seam;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
 using Jellyfin.Plugin.Requests.Time;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -20,6 +27,8 @@ namespace Jellyfin.Plugin.Requests.Tests;
     Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
 public class PluginServiceRegistrationTests
 {
+    private static readonly Guid Asker = new Guid("11111111-1111-1111-1111-111111111111");
+
     /// <summary>
     /// A server asking for the clock gets the machine's clock, and a server asking for the
     /// identifier source gets the framework's generator. Those are the defaults nothing should have
@@ -78,6 +87,72 @@ public class PluginServiceRegistrationTests
             provider.GetRequiredService<IIdentifierSource>());
     }
 
+    /// <summary>
+    /// A server holds the seam the sibling discover plugin would resolve, and it is this plugin's
+    /// implementation rather than something the container built by accident.
+    /// <para>
+    /// This is the registration half of being a sink. Whether a second plugin in one process can
+    /// name the type at all is the assembly-loading question in #117 and is not answered by
+    /// resolving it from inside this assembly, which is why the sentence above says what it says.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void ServerGetsTheSeamTheSiblingWouldResolve()
+    {
+        using var provider = RegisteredWithTheServerStoodInFor(new InMemoryRequestStore());
+
+        Assert.IsType<WantHandover>(provider.GetRequiredService<IWantHandover>());
+    }
+
+    /// <summary>
+    /// One sink and no more. The sibling has to define what several implementations of its contract
+    /// mean, and this plugin should not be the reason it has to: a second registration here would
+    /// hand it two sinks that both believe they own the queue.
+    /// </summary>
+    [Fact]
+    public void ExactlyOneSinkIsRegistered()
+    {
+        var services = new ServiceCollection();
+
+        new PluginServiceRegistrator().RegisterServices(services, null!);
+
+        Assert.Single(services, service => service.ServiceType == typeof(IWantHandover));
+    }
+
+    /// <summary>
+    /// Registering the sink is harmless on the ordinary server, which is one with no sibling
+    /// installed. Nothing here reaches for the other plugin, nothing starts, and a handover that
+    /// never arrives costs the server the object and nothing else.
+    /// <para>
+    /// That no sibling assembly is loaded while this runs is asserted in
+    /// <c>SiblingIndependenceTests</c>, so what is added here is that the registration produces a
+    /// working sink in that state rather than one waiting for something absent.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task TheSinkWorksOnAServerWithNoSiblingInstalled()
+    {
+        var store = new InMemoryRequestStore();
+
+        using var provider = RegisteredWithTheServerStoodInFor(store);
+
+        var accepted = await provider.GetRequiredService<IWantHandover>().AcceptAsync(
+            new HandedOverWant
+            {
+                ContractVersion = WantHandover.KnownContractVersion,
+                WantId = new Guid("44444444-4444-4444-4444-444444444444"),
+                RequestedByUserId = Asker,
+                Kind = RequestedItemKind.Movie,
+                Title = "Solaris",
+                Year = 1972
+            },
+            CancellationToken.None);
+
+        Assert.True(accepted);
+        Assert.Single(await store.GetAllAsync(CancellationToken.None));
+    }
+
     private static ServiceProvider Registered()
     {
         var services = new ServiceCollection();
@@ -86,6 +161,35 @@ public class PluginServiceRegistrationTests
         // so the suite has nothing to build here. If a registration ever needs it, this line stops
         // compiling or throws, which is the signal to give the suite a host double.
         new PluginServiceRegistrator().RegisterServices(services, null!);
+
+        return services.BuildServiceProvider();
+    }
+
+    /// <summary>
+    /// The registration as it ships, with the four things behind it that only a running server has.
+    /// <para>
+    /// Each of the four is stood in for because reaching the real one from a test would read
+    /// something other than the registration. The logger factory and the user manager come from the
+    /// server's own container and are not in this collection at all. The store and the settings both
+    /// reach the plugin instance, which is a static the host sets while loading and which any test
+    /// running beside this one replaces, so a test resolving them would fail for a reason nobody
+    /// caused; <c>ServerInstallSettings</c> says so about itself where it takes its second
+    /// constructor. What is left over the four is the seam's own registration, which is what these
+    /// tests are about.
+    /// </para>
+    /// </summary>
+    /// <param name="store">The queue the sink writes into.</param>
+    /// <returns>A provider the sink can be resolved from.</returns>
+    private static ServiceProvider RegisteredWithTheServerStoodInFor(IRequestStore store)
+    {
+        var services = new ServiceCollection();
+
+        new PluginServiceRegistrator().RegisterServices(services, null!);
+
+        services.AddLogging();
+        services.AddSingleton(store);
+        services.AddSingleton<IInstallSettings>(new FakeInstallSettings());
+        services.AddSingleton<IKnownUsers>(new FakeKnownUsers(Asker));
 
         return services.BuildServiceProvider();
     }

--- a/Jellyfin.Plugin.Requests.Tests/Seam/WantHandoverTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Seam/WantHandoverTests.cs
@@ -99,7 +99,7 @@ public class WantHandoverTests
             .ToArray();
 
         Assert.Equal(
-            ["IRequestStore", "IClock", "IIdentifierSource", "IInstallSettings", "IKnownUsers", "ILogger"],
+            ["IRequestStore", "IClock", "IIdentifierSource", "IInstallSettings", "IKnownUsers", "ILogger", "TimeSpan"],
             taken);
     }
 
@@ -449,6 +449,133 @@ public class WantHandoverTests
     }
 
     /// <summary>
+    /// Every layer beneath the seam, failing one at a time in a way nothing above it names, and no
+    /// exception reaching the caller from any of them.
+    /// <para>
+    /// The refusals the seam decides on by name are proven case by case above, with the exceptions
+    /// that carry them. This is the other half: what arrives that nobody wrote a name for. The
+    /// caller is another plugin serving a user's gesture on a surface this one does not own, so a
+    /// defect here becoming an exception there fails that gesture for a reason nobody on that side
+    /// can act on.
+    /// </para>
+    /// </summary>
+    /// <param name="layer">Which layer beneath the seam fails.</param>
+    /// <returns>A task that completes when the case has been checked.</returns>
+    [Theory]
+    [InlineData("the queue")]
+    [InlineData("the clock")]
+    [InlineData("the identifier source")]
+    [InlineData("the settings")]
+    [InlineData("the server's users")]
+    public async Task NothingLeavesTheSeamWhenALayerBeneathItFails(string layer)
+    {
+        var log = new RecordingLogger();
+
+        var accepted = await SeamOver(layer, log).AcceptAsync(Want(), CancellationToken.None);
+
+        Assert.False(accepted);
+        Assert.Contains(
+            nameof(HandoverRefusal.SomethingBeneathThisSeamFailed),
+            Assert.Single(log.At(LogLevel.Warning)).Message,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// What failed is on the log at error level with the fault itself, so an operator has the thing
+    /// the caller was not told. A refusal the other side cannot read a reason out of is only
+    /// acceptable while the reason reaches somebody.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task WhatFailedBeneathTheSeamReachesTheOperatorEvenThoughTheCallerIsNotTold()
+    {
+        var log = new RecordingLogger();
+
+        Assert.False(await SeamOver("the queue", log).AcceptAsync(Want(), CancellationToken.None));
+
+        var reported = Assert.Single(log.At(LogLevel.Error));
+
+        Assert.Equal(ALayerThatFails.Detail, Assert.IsType<InvalidOperationException>(reported.Exception).Message);
+    }
+
+    /// <summary>
+    /// A call carrying no field set at all is answered rather than raised. It is a defect in the
+    /// caller rather than a want that could not be taken, and it is still answered the same way,
+    /// because the boundary is what it is regardless of who was wrong.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AHandoverCarryingNoFieldSetIsAnsweredRatherThanRaised()
+    {
+        var log = new RecordingLogger();
+
+        Assert.False(await Seam(new InMemoryRequestStore(), log: log).AcceptAsync(null!, CancellationToken.None));
+        Assert.Contains(
+            nameof(HandoverRefusal.NothingWasHandedOver),
+            Assert.Single(log.At(LogLevel.Warning)).Message,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A store that will never answer is given up on rather than waited out, so the handover returns
+    /// whatever the queue is doing.
+    /// <para>
+    /// This is the case a cancellation token does not reach. A token is a request the callee honours
+    /// and the case worth bounding is the one where it cannot: a write holding a lock nothing will
+    /// release leaves a task that never completes however politely it is asked to stop.
+    /// </para>
+    /// <para>
+    /// The bound is passed as nothing here, so the test spends no real time and does not depend on
+    /// how busy the machine is. What it proves is that the seam races the queue rather than awaiting
+    /// it; what the number is on a server is <see cref="WantHandover.DefaultAnswerWithin"/>, and it
+    /// is what the registrator hands over.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AQueueThatNeverAnswersIsRefusedRatherThanWaitedOut()
+    {
+        var log = new RecordingLogger();
+
+        var accepted = await Seam(new StoreThatNeverAnswers(), log: log, answerWithin: TimeSpan.Zero)
+            .AcceptAsync(Want(), CancellationToken.None);
+
+        Assert.False(accepted);
+        Assert.Contains(
+            nameof(HandoverRefusal.TheStoreDidNotAnswerInTime),
+            Assert.Single(log.At(LogLevel.Warning)).Message,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A handover the caller cancelled is answered rather than raised, for the same reason as
+    /// everything else here. No request was made, which is what the one bit says.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ACancelledHandoverIsAnsweredRatherThanRaised()
+    {
+        using var gone = new CancellationTokenSource();
+
+        await gone.CancelAsync();
+
+        var store = new InMemoryRequestStore();
+
+        Assert.False(await Seam(store).AcceptAsync(Want(), gone.Token));
+        Assert.Empty(await store.GetAllAsync(CancellationToken.None));
+    }
+
+    /// <summary>
+    /// A server hands the seam the bound this plugin ships with, and it is a real one rather than
+    /// none. A bound of nothing would refuse every handover a store did not answer synchronously.
+    /// </summary>
+    [Fact]
+    public void TheBoundAServerGetsIsARealOne()
+    {
+        Assert.True(WantHandover.DefaultAnswerWithin > TimeSpan.Zero);
+    }
+
+    /// <summary>
     /// The field sets that cannot become a request, each with the refusal that names what is wrong.
     /// </summary>
     /// <returns>One case per way of being wrong.</returns>
@@ -484,17 +611,82 @@ public class WantHandoverTests
     /// <param name="settings">What the install is set to, or a fresh install where not given.</param>
     /// <param name="log">Where refusals are written, or a discarded one where not given.</param>
     /// <param name="users">Who the server has, or both people these tests use where not given.</param>
+    /// <param name="answerWithin">
+    /// How long to wait for the queue, or the shipping bound where not given. A test that is not
+    /// about waiting takes the shipping one, so nothing here passes for the wrong reason.
+    /// </param>
     /// <returns>The seam under test.</returns>
     private static WantHandover Seam(
         IRequestStore store,
         IInstallSettings? settings = null,
         RecordingLogger? log = null,
-        IKnownUsers? users = null)
+        IKnownUsers? users = null,
+        TimeSpan? answerWithin = null)
         => new WantHandover(
             store,
             new TestClock(Noon),
             new SequentialIdentifierSource(),
             settings ?? new FakeInstallSettings(),
             users ?? new FakeKnownUsers(Asker, SecondAsker),
-            log ?? new RecordingLogger());
+            log ?? new RecordingLogger(),
+            answerWithin ?? WantHandover.DefaultAnswerWithin);
+
+    /// <summary>
+    /// The seam with one layer beneath it failing and every other layer as it is elsewhere here.
+    /// </summary>
+    /// <param name="layer">Which layer fails.</param>
+    /// <param name="log">Where the refusal is written.</param>
+    /// <returns>The seam under test.</returns>
+    private static WantHandover SeamOver(string layer, RecordingLogger log)
+    {
+        var failing = new ALayerThatFails();
+
+        // An unrecognised name is a case nobody wrote, and it fails here rather than passing as a
+        // handover over five working layers.
+        return layer switch
+        {
+            "the queue" => new WantHandover(
+                failing,
+                new TestClock(Noon),
+                new SequentialIdentifierSource(),
+                new FakeInstallSettings(),
+                new FakeKnownUsers(Asker, SecondAsker),
+                log,
+                WantHandover.DefaultAnswerWithin),
+            "the clock" => new WantHandover(
+                new InMemoryRequestStore(),
+                failing,
+                new SequentialIdentifierSource(),
+                new FakeInstallSettings(),
+                new FakeKnownUsers(Asker, SecondAsker),
+                log,
+                WantHandover.DefaultAnswerWithin),
+            "the identifier source" => new WantHandover(
+                new InMemoryRequestStore(),
+                new TestClock(Noon),
+                failing,
+                new FakeInstallSettings(),
+                new FakeKnownUsers(Asker, SecondAsker),
+                log,
+                WantHandover.DefaultAnswerWithin),
+            "the settings" => new WantHandover(
+                new InMemoryRequestStore(),
+                new TestClock(Noon),
+                new SequentialIdentifierSource(),
+                failing,
+                new FakeKnownUsers(Asker, SecondAsker),
+                log,
+                WantHandover.DefaultAnswerWithin),
+            "the server's users" => new WantHandover(
+                new InMemoryRequestStore(),
+                new TestClock(Noon),
+                new SequentialIdentifierSource(),
+                new FakeInstallSettings(),
+                failing,
+                log,
+                WantHandover.DefaultAnswerWithin),
+
+            _ => throw new ArgumentOutOfRangeException(nameof(layer), layer, "That is not a layer beneath the seam.")
+        };
+    }
 }

--- a/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
@@ -85,7 +85,8 @@ public sealed class PluginServiceRegistrator : IPluginServiceRegistrator
             provider.GetRequiredService<IIdentifierSource>(),
             provider.GetRequiredService<IInstallSettings>(),
             provider.GetRequiredService<IKnownUsers>(),
-            provider.GetRequiredService<ILogger<WantHandover>>()));
+            provider.GetRequiredService<ILogger<WantHandover>>(),
+            WantHandover.DefaultAnswerWithin));
 
         // The server's library, as the two questions this plugin asks of it. One per server, because
         // the instance subscribes to the library's own events and a second subscription would look

--- a/Jellyfin.Plugin.Requests/Seam/HandoverRefusal.cs
+++ b/Jellyfin.Plugin.Requests/Seam/HandoverRefusal.cs
@@ -63,5 +63,26 @@ public enum HandoverRefusal
     /// What this install is set to is something the plugin cannot run on, so no want can be judged
     /// against it. That is a fault on this server rather than anything the other side sent.
     /// </summary>
-    ThisInstallCannotRun = 6
+    ThisInstallCannotRun = 6,
+
+    /// <summary>
+    /// Nothing arrived to make a request of. The call carried no field set at all, which is a defect
+    /// in the caller rather than a want that could not be taken, and it is answered the same way
+    /// because the alternative is an exception crossing a plugin boundary.
+    /// </summary>
+    NothingWasHandedOver = 9,
+
+    /// <summary>
+    /// The queue was still deciding when this side ran out of the time it gives itself. The want is
+    /// not lost by it: the other side hands the same identifier over again and the repeat is
+    /// recognised, which is the whole reason this side is allowed to stop waiting.
+    /// </summary>
+    TheStoreDidNotAnswerInTime = 10,
+
+    /// <summary>
+    /// Something under this seam failed in a way nothing here expected. It is a refusal rather than
+    /// an exception for the same reason every other entry is, and what actually went wrong is on
+    /// this server's log at error level with the fault itself.
+    /// </summary>
+    SomethingBeneathThisSeamFailed = 11
 }

--- a/Jellyfin.Plugin.Requests/Seam/IWantHandover.cs
+++ b/Jellyfin.Plugin.Requests/Seam/IWantHandover.cs
@@ -13,6 +13,14 @@ namespace Jellyfin.Plugin.Requests.Seam;
 /// back is refused rather than missing.
 /// </para>
 /// <para>
+/// <b>Nothing leaves this call except the answer, and it leaves promptly.</b> No exception crosses
+/// the boundary, including one raised by nothing this side foresaw, because the caller is serving a
+/// user's gesture on a surface this plugin does not own and a fault of this plugin's would fail that
+/// gesture for a reason nobody there can act on. Nor does the call wait on this side's queue for
+/// longer than it gives itself: a store that has stopped answering is refused rather than waited
+/// out, and the want comes back on the next handover because it carries an identifier.
+/// </para>
+/// <para>
 /// <b>Whether the other plugin can reach this at all is not settled here.</b> Naming a type means
 /// having the type, and whether a second plugin in one server process can name this one is the
 /// assembly-loading question in #117. This interface is what it would name; that it is registered
@@ -30,7 +38,8 @@ public interface IWantHandover
     /// <see langword="true"/> where a request for this want now exists, whether it was made by this
     /// call or was already there with somebody else waiting on it. <see langword="false"/> where the
     /// handover was refused, and the reason for that is on this side's log rather than in this
-    /// answer, because the contract carries no field for one.
+    /// answer, because the contract carries no field for one. A cancelled call and one nothing here
+    /// foresaw both answer <see langword="false"/> rather than raising, which is the promise above.
     /// </returns>
     Task<bool> AcceptAsync(HandedOverWant want, CancellationToken cancellationToken);
 }

--- a/Jellyfin.Plugin.Requests/Seam/WantHandover.cs
+++ b/Jellyfin.Plugin.Requests/Seam/WantHandover.cs
@@ -29,6 +29,15 @@ namespace Jellyfin.Plugin.Requests.Seam;
 /// caller's own code path for something that is an ordinary answer here.
 /// </para>
 /// <para>
+/// <b>That holds for what nothing here foresaw as well, and for waiting.</b> The refusals below are
+/// the ones this side can name; the boundary catches everything else and answers the same one bit,
+/// so a defect in this plugin cannot become an exception on a surface it does not own. Waiting is
+/// the other half of the same promise: a call into the queue is raced against
+/// <see cref="DefaultAnswerWithin"/> and refused where the queue has not answered by then, because a
+/// sink that hangs stalls the gesture behind it just as surely as one that throws. Both are safe to
+/// do because a want carries an identifier and the other side hands it over again.
+/// </para>
+/// <para>
 /// <b>Whether an ask joins an existing request is not decided here.</b> It is
 /// <see cref="RequestIntake"/>'s, which is the same object the HTTP endpoint asks, so two users
 /// wanting the same film produce one request with both of them recorded however each of them asked.
@@ -57,6 +66,18 @@ public sealed class WantHandover : IWantHandover
     /// </summary>
     public const int KnownContractVersion = 1;
 
+    /// <summary>
+    /// How long this side waits for the queue before it answers without it.
+    /// <para>
+    /// The number is deliberately larger than any write this store makes and far smaller than a
+    /// person's patience on the surface the other plugin draws. What it is really bounding is the
+    /// case no timeout on the store itself can bound, which is a store that has stopped answering
+    /// rather than one that is slow, and the cost of being wrong about it is one want handed over
+    /// again rather than one want lost.
+    /// </para>
+    /// </summary>
+    public static readonly TimeSpan DefaultAnswerWithin = TimeSpan.FromSeconds(5);
+
     private readonly IRequestStore _store;
     private readonly RequestIntake _intake;
     private readonly IClock _clock;
@@ -64,6 +85,7 @@ public sealed class WantHandover : IWantHandover
     private readonly IInstallSettings _settings;
     private readonly IKnownUsers _users;
     private readonly ILogger _logger;
+    private readonly TimeSpan _answerWithin;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="WantHandover"/> class.
@@ -74,14 +96,21 @@ public sealed class WantHandover : IWantHandover
     /// <param name="settings">What this install is set to.</param>
     /// <param name="users">The server's answer to whether it has the user a want names.</param>
     /// <param name="logger">Where a refusal is written.</param>
+    /// <param name="answerWithin">
+    /// How long to wait for the queue before answering without it. A server passes
+    /// <see cref="DefaultAnswerWithin"/>; it is a parameter so the bound can be proven rather than
+    /// waited out.
+    /// </param>
     /// <exception cref="ArgumentNullException">Where anything it needs is missing.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Where the bound is negative.</exception>
     public WantHandover(
         IRequestStore store,
         IClock clock,
         IIdentifierSource identifiers,
         IInstallSettings settings,
         IKnownUsers users,
-        ILogger logger)
+        ILogger logger,
+        TimeSpan answerWithin)
     {
         ArgumentNullException.ThrowIfNull(store);
         ArgumentNullException.ThrowIfNull(clock);
@@ -89,6 +118,7 @@ public sealed class WantHandover : IWantHandover
         ArgumentNullException.ThrowIfNull(settings);
         ArgumentNullException.ThrowIfNull(users);
         ArgumentNullException.ThrowIfNull(logger);
+        ArgumentOutOfRangeException.ThrowIfLessThan(answerWithin, TimeSpan.Zero);
 
         _store = store;
         _intake = new RequestIntake(store);
@@ -97,14 +127,57 @@ public sealed class WantHandover : IWantHandover
         _settings = settings;
         _users = users;
         _logger = logger;
+        _answerWithin = answerWithin;
     }
 
     /// <inheritdoc />
-    /// <exception cref="ArgumentNullException">Where there is no want to accept.</exception>
     public async Task<bool> AcceptAsync(HandedOverWant want, CancellationToken cancellationToken)
     {
-        ArgumentNullException.ThrowIfNull(want);
+        if (want is null)
+        {
+            _logger.LogWarning(
+                "A handover crossed the seam carrying no field set at all, so there was nothing to make a request of: {Refusal}.",
+                HandoverRefusal.NothingWasHandedOver);
 
+            return false;
+        }
+
+        try
+        {
+            return await TakeAsync(want, cancellationToken).ConfigureAwait(false);
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+        catch (Exception reason)
+#pragma warning restore CA1031
+        {
+            // Nothing at all leaves this call. The caller is another plugin, and the thing it is
+            // serving is a user's gesture on a surface this plugin does not own, so a fault of this
+            // plugin's arriving there is that user's gesture failing for a reason nobody on that
+            // side can act on. Every ordinary outcome is refused by name above; this catches what
+            // nothing here foresaw, including a cancellation, which is one more way of saying no
+            // request was made.
+            _logger.LogError(
+                reason,
+                "A want handed over the seam ran into something nothing here expected, so it was refused. The other side calls it {WantId}.",
+                want.WantId);
+
+            return Refused(want, HandoverRefusal.SomethingBeneathThisSeamFailed);
+        }
+    }
+
+    /// <summary>
+    /// The handover itself, with every refusal it can decide on by name.
+    /// <para>
+    /// It is separate from <see cref="AcceptAsync"/> so that the boundary is one place rather than a
+    /// promise made again at every return. What leaves here may throw; what leaves the method above
+    /// may not.
+    /// </para>
+    /// </summary>
+    /// <param name="want">The field set the contract fixes.</param>
+    /// <param name="cancellationToken">Cancels the handover.</param>
+    /// <returns>Whether a request for this want now exists.</returns>
+    private async Task<bool> TakeAsync(HandedOverWant want, CancellationToken cancellationToken)
+    {
         // The version is read before any other field. A field set whose version this side does not
         // know is refused whole rather than read for the fields it recognises: reading what is
         // recognised and ignoring the rest makes a version that changed the meaning of a field
@@ -160,18 +233,24 @@ public sealed class WantHandover : IWantHandover
             return Refused(want, HandoverRefusal.KindNotAccepted);
         }
 
-        StoredRequest? absorbed;
+        Answer<StoredRequest?> lookup;
 
         try
         {
-            absorbed = await _store.FindByWantAsync(want.WantId, cancellationToken).ConfigureAwait(false);
+            lookup = await WithinTheBoundAsync(
+                _store.FindByWantAsync(want.WantId, cancellationToken)).ConfigureAwait(false);
         }
         catch (RequestStoreLoadException)
         {
             return Refused(want, HandoverRefusal.TheStoreCouldNotBeReached);
         }
 
-        if (absorbed is StoredRequest already)
+        if (!lookup.InTime)
+        {
+            return Refused(want, HandoverRefusal.TheStoreDidNotAnswerInTime);
+        }
+
+        if (lookup.Value is StoredRequest already)
         {
             // The same want again, which is the ordinary case rather than a defect: the other side
             // hands one over after a refresh that recreated the item, after a restart, and after a
@@ -204,11 +283,12 @@ public sealed class WantHandover : IWantHandover
             WantIds = [want.WantId]
         };
 
-        IntakeResult intake;
+        Answer<IntakeResult> intake;
 
         try
         {
-            intake = await _intake.AskAsync(incoming, cancellationToken).ConfigureAwait(false);
+            intake = await WithinTheBoundAsync(
+                _intake.AskAsync(incoming, cancellationToken)).ConfigureAwait(false);
         }
         catch (RequestStoreLoadException)
         {
@@ -225,16 +305,63 @@ public sealed class WantHandover : IWantHandover
             return Refused(want, HandoverRefusal.TheStoreCouldNotBeReached);
         }
 
+        if (!intake.InTime)
+        {
+            return Refused(want, HandoverRefusal.TheStoreDidNotAnswerInTime);
+        }
+
         if (_logger.IsEnabled(LogLevel.Debug))
         {
             _logger.LogDebug(
                 "The want {WantId} handed over the seam is request {RequestId}, which the handover {Outcome}.",
                 want.WantId,
-                intake.Request.Request.Id,
-                intake.Outcome);
+                intake.Value.Request.Request.Id,
+                intake.Value.Outcome);
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Waits for one call into the queue and gives up on it after <see cref="_answerWithin"/>.
+    /// <para>
+    /// <b>Why this is not a cancellation token handed down.</b> A token is a request the callee
+    /// honours, and the case worth bounding is the one where it does not: a write holding a lock
+    /// nothing releases, or a disk that has stopped answering, leaves a task that never completes
+    /// however politely it is asked to. Racing the call is the only shape that returns whatever the
+    /// thing underneath is doing, which is what this side promised the surface it does not own.
+    /// </para>
+    /// <para>
+    /// <b>The abandoned call is left running and its fault is swallowed.</b> Stopping it is not
+    /// available, and a fault nobody reads would otherwise arrive later as an unobserved exception
+    /// on an unrelated thread. What it might still write is safe to have written: a want carries an
+    /// identifier, the other side hands the same one over again, and a request made by the
+    /// abandoned call is recognised as the repeat it is rather than made twice.
+    /// </para>
+    /// </summary>
+    /// <typeparam name="T">What the call answers with.</typeparam>
+    /// <param name="work">The call already started.</param>
+    /// <returns>The answer, or a note that none arrived in time.</returns>
+    private async Task<Answer<T>> WithinTheBoundAsync<T>(Task<T> work)
+    {
+        using var finished = new CancellationTokenSource();
+
+        var bound = Task.Delay(_answerWithin, finished.Token);
+
+        if (!ReferenceEquals(await Task.WhenAny(work, bound).ConfigureAwait(false), work))
+        {
+            _ = work.ContinueWith(
+                static abandoned => _ = abandoned.Exception,
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted,
+                TaskScheduler.Default);
+
+            return new Answer<T>(false, default!);
+        }
+
+        await finished.CancelAsync().ConfigureAwait(false);
+
+        return new Answer<T>(true, await work.ConfigureAwait(false));
     }
 
     /// <summary>
@@ -284,4 +411,12 @@ public sealed class WantHandover : IWantHandover
 
         return false;
     }
+
+    /// <summary>
+    /// What one bounded call into the queue came back with.
+    /// </summary>
+    /// <typeparam name="T">What the call answers with.</typeparam>
+    /// <param name="InTime">Whether it answered before this side stopped waiting.</param>
+    /// <param name="Value">What it answered, where it did.</param>
+    private readonly record struct Answer<T>(bool InTime, T Value);
 }

--- a/docs/seam.md
+++ b/docs/seam.md
@@ -40,6 +40,54 @@ So a change to `docs/api.md` is not a change to the seam, and a change to the co
 change to the API. Somebody who conflates them will either look for a route that does not exist or
 apply the API's rules to a call that has none of them.
 
+## How each side finds the other
+
+Neither side goes looking. The sibling declares the contract, asks the server's container for every
+implementation of it, and treats none at all as a complete and supported state rather than an error.
+This side's whole job is to be one of those implementations, put there when this plugin loads:
+
+    git grep -n 'AddSingleton<IWantHandover>' -- Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
+
+That is the registration Jellyfin gives a plugin for exactly this, so there is no discovery
+mechanism here, no probe, and nothing on either side that has to be told the other exists.
+
+**Exactly one implementation is registered, and that is a rule rather than an accident.** Several
+would be a thing the sibling has to define the meaning of, and this plugin should not be what forces
+that question. `ExactlyOneSinkIsRegistered` refuses a second one.
+
+**Registering costs a server with no sibling installed nothing.** That is the ordinary server and
+the one most people run. Nothing here reaches for the other plugin, nothing starts, and a handover
+that never arrives leaves an object nobody asks. `TheSinkWorksOnAServerWithNoSiblingInstalled` is
+that state, asserted while `SiblingIndependenceTests` holds that no sibling assembly is loaded at
+all.
+
+**Being reachable is a different claim and is not made here.** Naming a type means having the type,
+and whether a second plugin in one server process can name this one is #117, which nobody has
+measured on either claimed line. Resolving the sink from inside this assembly, which is what the
+suite does, says the registration is there and says nothing about who else can ask for it.
+
+### Two obligations that come with being a sink
+
+Both are about the caller rather than about this plugin, because the thing on the other end of the
+call is a user's gesture on a surface this plugin does not own.
+
+**Nothing leaves the call except the answer.** No exception crosses the boundary, including one
+raised by something nothing here foresaw, because a defect in this plugin arriving there fails that
+gesture for a reason nobody on that side can act on. The refusals this side can name are in
+`HandoverRefusal`; everything else is caught at the boundary, written to this server's log at error
+level with the fault itself, and answered as the same one bit. A cancelled call answers the same
+way, because no request was made.
+
+**The call does not wait on this side's queue for longer than it gives itself.** A sink that hangs
+stalls the gesture behind it just as surely as one that throws. The bound is
+`WantHandover.DefaultAnswerWithin` and it is raced against the call rather than handed down as a
+cancellation token, because the case worth bounding is the one a token cannot reach: a write holding
+a lock nothing will release leaves a task that never completes however politely it is asked to stop.
+
+Giving up is safe here for the same reason a repeat is safe. The want carries an identifier, the
+other side hands it over again, and a request the abandoned call still managed to write is
+recognised as the repeat it is rather than made twice.
+
 ## Both sides watch the library, and neither tells the other
 
 This plugin decides that a request is fulfilled by watching the server's library for the thing
@@ -223,6 +271,5 @@ the closing condition of the issue beside it.
 - What a request records about having arrived over the seam, and which caller handed it over. The
   contract carries no field naming the caller, so the second half of that is a question for the
   contract rather than for this side. #118.
-- How each side finds the other. #89.
 - What an undone gesture does, which today is nothing, because the contract carries no message for
   it. #68.


### PR DESCRIPTION
Closes #89.

The sibling declares the contract, asks the server's container for every implementation of it, and treats none at all as a complete and supported state. This side's whole job is to be one of those implementations. The registration arrived with the handover in #215 and nothing held it to what being a sink costs, which is three obligations the issue names and which are cheap now and cannot be added afterwards.

## The four conditions

**The implementation is registered through the server's plugin service registration.** It was already, and nothing asserted it. `ServerGetsTheSeamTheSiblingWouldResolve` resolves `IWantHandover` out of the collection the registrator fills and gets this plugin's implementation, and `ExactlyOneSinkIsRegistered` refuses a second one, because several would be a thing the sibling has to define the meaning of and this plugin should not be what forces that question. Both run on both claimed lines, which is what the suite's two target frameworks are.

What the condition also says is "present on both claimed server lines", and no server was started for this. The suite is the evidence and it is the weaker half; the reason a stronger one was not produced is under "What is claimed rather than measured" below.

**The handover never throws, with every layer beneath it failing.** It did throw. The refusals this side can name were caught one at a time, and anything else was not:

    git grep -n 'catch (RequestStoreLoadException)\|catch (RequestConcurrencyException)' origin/master -- Jellyfin.Plugin.Requests/Seam/WantHandover.cs

The caller is another plugin serving a user's gesture on a surface this one does not own, so a defect here arriving there fails that gesture for a reason nobody on that side can act on. There is now one boundary: what leaves `TakeAsync` may throw, what leaves `AcceptAsync` may not. The fault is written to this server's log at error level with the exception itself, so the operator has the thing the caller was not told, and the caller gets the one bit the contract allows.

`NothingLeavesTheSeamWhenALayerBeneathItFails` is a case per layer, with the store, the clock, the identifier source, the settings and the server's users each failing in turn and the other four left as they are. A call carrying no field set and a call the caller cancelled answer the same way rather than raising.

**The handover returns promptly whatever the store is doing.** It did not. Every call into the queue was awaited, and a cancellation token does not reach the case worth bounding: a token is a request the callee honours, and a write holding a lock nothing will release leaves a task that never completes however politely it is asked to stop. The call is now raced against `WantHandover.DefaultAnswerWithin` and refused where the queue has not answered by then.

Giving up is safe for the same reason a repeat is safe. The want carries an identifier, the other side hands it over again, and a request the abandoned call still managed to write is recognised as the repeat it is rather than made twice. The abandoned task's fault is swallowed deliberately, because one nobody reads arrives later as an unobserved exception on an unrelated thread.

`AQueueThatNeverAnswersIsRefusedRatherThanWaitedOut` passes nothing as the bound, so the test spends no real time and does not depend on how busy the machine is. What a server gets is a real number and `TheBoundAServerGetsIsARealOne` refuses a bound of nothing.

**Registration is harmless on a server with no sibling installed.** `TheSinkWorksOnAServerWithNoSiblingInstalled` hands a want to the sink resolved out of the registration and reads the request back, in a suite where `SiblingIndependenceTests.NoSiblingPluginIsLoadedWhileTheSuiteRuns` holds that no sibling assembly is loaded at all.

## The suite

```
dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
Bestanden!   : Fehler:     0, erfolgreich:   498, übersprungen:     0, gesamt:   498 - Jellyfin.Plugin.Requests.Tests.dll (net9.0)
Bestanden!   : Fehler:     0, erfolgreich:   498, übersprungen:     0, gesamt:   498 - Jellyfin.Plugin.Requests.Tests.dll (net10.0)
```

Four hundred and eighty-five before this, so thirteen are new.

## Each guard watched failing

**The boundary.** Removing it and calling `TakeAsync` directly:

```
Fehler!      : Fehler:     7, erfolgreich:   491, gesamt:   498 (net9.0)
Fehler!      : Fehler:     7, erfolgreich:   491, gesamt:   498 (net10.0)
```

The seven are the five layers, the fault reaching the operator, and the cancelled call.

**The answer to a call carrying no field set.** Removing the early return, so the field set is read as it was before:

```
Fehler!      : Fehler:     1, erfolgreich:   497, gesamt:   498 (net9.0)
Fehler!      : Fehler:     1, erfolgreich:   497, gesamt:   498 (net10.0)
```

**The bound.** This one does not go red, and that is the failure it exists against rather than a gap in the proof: with the race removed and the call awaited, the run never finishes. It was watched under a hang timeout instead:

```
dotnet test ... --filter "FullyQualifiedName~AQueueThatNeverAnswersIsRefusedRatherThanWaitedOut" --blame-hang --blame-hang-timeout 90s
Der aktive Testlauf wurde abgebrochen. Grund: Der Testhostprozess ist abgestürzt.
Datensammler "Blame" - Meldung: Die angegebene Inaktivitätszeit von 90 Sekunden ist abgelaufen.
Beim Absturz ausgeführter Test:
Jellyfin.Plugin.Requests.Tests.Seam.WantHandoverTests.AQueueThatNeverAnswersIsRefusedRatherThanWaitedOut
runner exit=1
```

The tree was restored between each of the three and the suite re-run green.

## One test that was written and taken back

The first version of `TheSinkWorksOnAServerWithNoSiblingInstalled` resolved the store and the settings from the registration as they ship, over a plugin instance built by the suite's host double. It failed on one target framework and passed on the other. Both reach `Plugin.Instance`, which is a static the host sets while loading and which any test running beside it replaces, so the test failed for a reason nobody caused. `ServerInstallSettings` says exactly that about itself where it takes its second constructor, and the four things a running server supplies are now stood in for, with the reason written at the helper that does it.

## What is claimed rather than measured

**Nothing was run on a Jellyfin server.** No container engine is reachable here:

```
docker version --format '{{.Server.Version}}'
failed to connect to the docker API at npipe:////./pipe/dockerDesktopLinuxEngine
```

so "present on both claimed server lines" rests on the suite running on both target frameworks and not on a server of either line.

**Whether another plugin can name this type at all is not claimed.** Resolving the sink from inside this assembly says the registration is there and says nothing about who else can ask for it. That is #117, which nobody has measured on either line, and `docs/seam.md` says it in those words rather than softer ones.

**No second reader has looked at this.** The runs above stand in place of one.
