### PR TITLE
Prove a replay of the sibling's whole history is safe, and safe to run again

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Seam/WantHandoverTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Seam/WantHandoverTests.cs
@@ -371,6 +371,109 @@ public class WantHandoverTests
     }
 
     /// <summary>
+    /// The whole set the sibling recorded before this plugin was installed, replayed twice, is the
+    /// queue it produced the first time and no second copy of it.
+    /// <para>
+    /// On a server that ran the browsing plugin first there is a list of people who already asked for
+    /// things, and installing this plugin has to mean something for them or they ask again. The
+    /// contract is one way and this side cannot pull that list, so the replay is the sibling's to
+    /// initiate and it uses the same call a live handover uses. What this side owes against it is
+    /// that a replay is safe to run, and that a replay that was interrupted is safe to run again.
+    /// </para>
+    /// <para>
+    /// A whole set replayed is a stronger statement than one want handed over twice, which is what
+    /// the tests above make. The set carries the shapes that go wrong together rather than alone:
+    /// two people wanting one film, a want with no provider identifiers for the identity rule to
+    /// compare, and a second kind. Revisions are asserted rather than counts, because a second pass
+    /// that rewrote every request in place would leave the count unmoved.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task TheWholeSetReplayedTwiceIsTheQueueItMadeTheFirstTime()
+    {
+        var store = new InMemoryRequestStore();
+        var handover = Seam(store);
+        var recorded = WhatTheSiblingRecordedBefore();
+
+        foreach (var want in recorded)
+        {
+            Assert.True(await handover.AcceptAsync(want, CancellationToken.None));
+        }
+
+        var afterTheFirstPass = await store.GetAllAsync(CancellationToken.None);
+
+        foreach (var want in recorded)
+        {
+            Assert.True(await handover.AcceptAsync(want, CancellationToken.None));
+        }
+
+        var afterTheSecond = await store.GetAllAsync(CancellationToken.None);
+
+        Assert.Equal(
+            afterTheFirstPass.Select(held => (held.Request.Id, held.Revision)),
+            afterTheSecond.Select(held => (held.Request.Id, held.Revision)));
+
+        // The set is four wants and three of them name one film between two people, so what a
+        // correct first pass produces is three requests. Asserting it here means the comparison
+        // above cannot pass by both passes having produced nothing.
+        Assert.Equal(3, afterTheFirstPass.Count);
+        Assert.Equal(
+            [.. recorded.Select(want => want.WantId).Order()],
+            [.. afterTheSecond.SelectMany(held => held.Request.WantIds).Order()]);
+    }
+
+    /// <summary>
+    /// A replay that stopped halfway and was run again from the start finishes the set, and the part
+    /// that had already landed is not made a second time.
+    /// <para>
+    /// That is the ordinary way a replay of somebody's whole history ends: the server was restarted,
+    /// the other side gave up on a refusal, or somebody closed a browser. A replay that can only be
+    /// run once is one nobody can safely start.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AReplayThatStoppedHalfwayIsSafeToRunAgainFromTheStart()
+    {
+        var store = new InMemoryRequestStore();
+        var handover = Seam(store);
+        var recorded = WhatTheSiblingRecordedBefore();
+
+        foreach (var want in recorded.Take(2))
+        {
+            Assert.True(await handover.AcceptAsync(want, CancellationToken.None));
+        }
+
+        var whatLandedBeforeItStopped = await store.GetAllAsync(CancellationToken.None);
+
+        foreach (var want in recorded)
+        {
+            Assert.True(await handover.AcceptAsync(want, CancellationToken.None));
+        }
+
+        var held = await store.GetAllAsync(CancellationToken.None);
+
+        // What the interrupted pass had already made is still the same request rather than a second
+        // one beside it. The prefix carries the want with no provider identifiers on purpose: that
+        // is the one the identity rule cannot answer, so it is the one whose second arrival becomes
+        // a second request where nothing recognises the want itself.
+        //
+        // Revisions are not asserted here and are asserted in the whole-set case. A completing pass
+        // is allowed to write to a request that already existed, because the wants it carries that
+        // had not landed yet include one that joins it.
+        foreach (var landed in whatLandedBeforeItStopped)
+        {
+            Assert.Single(held, request => request.Request.Id == landed.Request.Id);
+        }
+
+        Assert.Equal(3, held.Count);
+        Assert.Equal(
+            [.. recorded.Select(want => want.WantId).Order()],
+            [.. held.SelectMany(request => request.Request.WantIds).Order()]);
+    }
+
+    /// <summary>
     /// The check survives a restart, because what it reads is on the disk rather than in memory. The
     /// store is closed and a second one is opened over the same directory, which is what a server
     /// stopping and starting does to it.
@@ -587,6 +690,43 @@ public class WantHandoverTests
             { Want() with { Title = "   " }, HandoverRefusal.NoTitle },
             { Want() with { Kind = (RequestedItemKind)9 }, HandoverRefusal.KindNotRecognised }
         };
+
+    /// <summary>
+    /// What the sibling had already recorded on a server that ran it before this plugin arrived.
+    /// <para>
+    /// Four wants, chosen for the shapes that go wrong together. Two people want one film, so the
+    /// identity rule joins the second onto the first and a replay has two chances to make it twice.
+    /// One want carries no provider identifiers, which is the case the identity rule cannot answer
+    /// and the want identifier has to. One is a series rather than a film.
+    /// </para>
+    /// </summary>
+    /// <returns>The set, in the order the other side would replay it.</returns>
+    private static HandedOverWant[] WhatTheSiblingRecordedBefore()
+        =>
+        [
+            Want(),
+            Want() with
+            {
+                WantId = new Guid("55555555-5555-5555-5555-555555555555"),
+                Title = "Le Samouraï",
+                Year = 1967,
+                ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal)
+            },
+            Want() with
+            {
+                WantId = new Guid("44444444-4444-4444-4444-444444444444"),
+                RequestedByUserId = SecondAsker
+            },
+            Want() with
+            {
+                WantId = new Guid("66666666-6666-6666-6666-666666666666"),
+                RequestedByUserId = SecondAsker,
+                Kind = RequestedItemKind.Series,
+                Title = "Das Boot",
+                Year = 1985,
+                ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tvdb"] = "78804" }
+            }
+        ];
 
     /// <summary>
     /// A want as the contract carries one, which every case here starts from and breaks in one way.

--- a/docs/seam.md
+++ b/docs/seam.md
@@ -188,6 +188,38 @@ which is neither a leak that has been shown nor a safety anybody has earned. The
 that a caller reads their own requests and never another person's, is enforced at the endpoints in
 `docs/api.md` and not by the store beneath them.
 
+## What happens to the wants recorded before this plugin was installed
+
+The sibling records every want locally whether or not anything accepted it, so a server that ran it
+first already has a list of people who asked for things. Installing this plugin has to mean
+something for them, or they ask again, or worse, they believe they already have.
+
+**The replay is the sibling's to initiate and this side needs no new message for it.** That follows
+from the contract rather than from a preference: it is one way, so this side cannot pull that list
+and cannot even ask whether one exists. What the other side does is hand each recorded want over
+with the same call a live one arrives on, which is why nothing here is added for it and why nothing
+here can tell a replay from a first arrival at the moment it happens.
+
+**What this side owes against that is that a replay is safe to run, and safe to run again.** Both
+are the want identifier doing its job under another name. Replaying a want that already became a
+request creates nothing, and a replay that stopped halfway and was started again from the beginning
+finishes the set without making the part that landed a second time. The second is the one worth
+naming: a replay of somebody's whole history ends halfway often, because a server restarted or
+somebody closed a browser, and a replay that can only be run once is one nobody can safely start.
+
+    git grep -n 'TheWholeSetReplayedTwiceIsTheQueueItMadeTheFirstTime\|AReplayThatStoppedHalfwayIsSafeToRunAgainFromTheStart' -- Jellyfin.Plugin.Requests.Tests/Seam/WantHandoverTests.cs
+
+**What is not answered, and it is the rest of #93.** An adopted request is not distinguishable from
+one that arrived live. A request carries no history entry when it is made, and
+`RequestHistoryEntry` has no field that could say how the ask reached this side:
+
+    git grep -n 'public required RequestState From\|public Guid? ByUserId' -- Jellyfin.Plugin.Requests/Model/RequestHistoryEntry.cs
+
+So an operator who finds a sudden queue cannot see where it came from. What a request records about
+having arrived over the seam is the entry below that belongs to #118, and it has to be settled there
+rather than added afterwards, because the history is append-only and entries written without it
+cannot be corrected.
+
 ## What this side trusts, and what it checks anyway
 
 The HTTP API takes the requester from the authenticated session and refuses a body that names


### PR DESCRIPTION
Part of #93. It does not close it, and what is left is set out at the bottom.

A server that ran the browsing plugin first already holds a list of people who asked for things, and installing this plugin has to mean something for them or they ask again. The contract is one way, so this side cannot pull that list: the other side replays it through the same call a live handover arrives on. What this side owes against that is that running a replay is safe.

## The first condition, and why the tests that were here did not already meet it

The suite asserted a want handed over three times, a want with no provider identifiers handed over twice, and a want whose request had been declined coming back. All of those are one want. The condition asks for the whole set replayed twice, and a set is where the failures that need two wants live: a second person joining a film the identity rule already matched, and a want carrying no identifiers beside one that carries them.

`TheWholeSetReplayedTwiceIsTheQueueItMadeTheFirstTime` replays four wants, then replays the same four, and asserts the store holds the same requests at the same revisions. Revisions rather than a count, because a second pass that rewrote every request in place would leave the count where it was.

`AReplayThatStoppedHalfwayIsSafeToRunAgainFromTheStart` is the case the issue does not name and that a replay of somebody's whole history actually meets: it ends halfway because a server restarted or somebody closed a browser. The prefix that lands first carries the want with no provider identifiers on purpose, so the case the identity rule cannot answer is inside the part that has to survive being sent again.

## Watched failing

Removing the branch that recognises a want already taken:

```
Fehler!      : Fehler:     4, erfolgreich:    30, gesamt:    34 (net9.0)
Fehler!      : Fehler:     4, erfolgreich:    30, gesamt:    34 (net10.0)
```

Four, of which two are these and two are the want-identifier tests that were already here. The tree was restored and the suite re-run:

```
dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
Bestanden!   : Fehler:     0, erfolgreich:   500, übersprungen:     0, gesamt:   500 (net9.0)
Bestanden!   : Fehler:     0, erfolgreich:   500, übersprungen:     0, gesamt:   500 (net10.0)
```

## Two earlier versions of the interrupted case, and what they were

Recorded because both looked correct and neither was.

The first asserted a count and the want identifiers. It passed with the guard removed, because with the no-identifier want outside the interrupted prefix the identity rule caught everything the want identifier would have. A test that could not have failed proves nothing, and the repair was to move that want into the prefix rather than to keep the assertion.

The second asserted that every request the interrupted pass had made kept its revision. That is wrong about the behaviour rather than about the guard: a completing pass carries wants that had not landed yet, one of which joins a request that already existed, and writing to it is correct. It went red on the unmodified tree, which is how it was found.

## The third condition

`docs/seam.md` now says the replay is the sibling's to initiate and that nothing is added here for it, with the reason it follows from the contract rather than from a preference.

## What is left, and why it is not here

**The second condition is unmet: an adopted request is not distinguishable in its history from one that arrived live.** A request carries no history entry when it is made, and the entry type has no field that could say how the ask reached this side:

```
git grep -n 'public required RequestState From\|public Guid? ByUserId' -- Jellyfin.Plugin.Requests/Model/RequestHistoryEntry.cs
Jellyfin.Plugin.Requests/Model/RequestHistoryEntry.cs:27:    public required RequestState From { get; init; }
Jellyfin.Plugin.Requests/Model/RequestHistoryEntry.cs:44:    public Guid? ByUserId { get; init; }
```

So an operator who finds a sudden queue cannot see where it came from. What a request records about having arrived over the seam is already the first entry under "What this document does not yet hold" and belongs to #118, which is open. It has to be settled there rather than added afterwards, because the history is append-only and entries written without it cannot be corrected. `docs/seam.md` now says that in the replay section as well, where somebody reading about a replay will meet it.

**No second reader has looked at this.** The runs above stand in place of one.
