### PR TITLE
State that an undone gesture does not cross the seam, and what would change that

### DIFF
--- a/docs/seam.md
+++ b/docs/seam.md
@@ -188,6 +188,37 @@ which is neither a leak that has been shown nor a safety anybody has earned. The
 that a caller reads their own requests and never another person's, is enforced at the endpoints in
 `docs/api.md` and not by the store beneath them.
 
+## An undone gesture does not cross the seam
+
+A gesture that expresses a want can be taken back. Somebody unmarks a favourite, or marks one by
+accident and unmarks it a second later. Nothing about that reaches this side.
+
+The contract carries one message and it is the handover:
+
+    git grep -n 'Task<bool> AcceptAsync' -- Jellyfin.Plugin.Requests/Seam/IWantHandover.cs
+    Jellyfin.Plugin.Requests/Seam/IWantHandover.cs:44:    Task<bool> AcceptAsync(HandedOverWant want, CancellationToken cancellationToken);
+
+There is no second call and no field on the want that says one was withdrawn, so a request made from
+a handover stays exactly as it was when the gesture behind it is undone. That is a statement about
+the contract rather than about either implementation: this side could not act on an undone gesture
+today even if it wanted to, because nothing tells it one happened.
+
+What would have to change for it to cross is a message on the contract, and that is the sibling
+board's to add rather than this one's. This side would implement it when the contract carries it,
+and inventing the field here instead would be half an agreement, which is the same argument
+[the trust section](#what-this-side-trusts-and-what-it-checks-anyway) makes about a caller identity
+nobody agreed. Adding it would also be an argument rather than a field: a want undone a second after
+it was expressed and one undone a week after an operator has already acted on it are not the same
+event, and the second is not something a gesture on a browsing surface can decide alone.
+
+Taking back an ask on this side's own surfaces is a separate thing and is not covered by this
+document. It is #68, it needs a state a request can be withdrawn into, and the model records that
+there is none:
+
+    git grep -n 'Cancelled' -- Jellyfin.Plugin.Requests/Model/
+    Jellyfin.Plugin.Requests/Model/RequestActor.cs:43:    /// is no state for a user withdrawing, refused with the <c>Cancelled</c> state on #113. The
+    Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs:69:/// user withdrawing has no state to move to because <c>Cancelled</c> was refused on #113. An
+
 ## What happens to the wants recorded before this plugin was installed
 
 The sibling records every want locally whether or not anything accepted it, so a server that ran it
@@ -303,5 +334,6 @@ the closing condition of the issue beside it.
 - What a request records about having arrived over the seam, and which caller handed it over. The
   contract carries no field naming the caller, so the second half of that is a question for the
   contract rather than for this side. #118.
-- What an undone gesture does, which today is nothing, because the contract carries no message for
-  it. #68.
+- What a person taking back their own ask does on this side's own surfaces. That an undone gesture
+  does not cross the seam is above; what this document still does not hold is the other half, which
+  needs a state a request can be withdrawn into and has none. #68.


### PR DESCRIPTION
Part of #68. This is the third condition of that issue and nothing else in it.

## What was missing

A gesture that expresses a want can be taken back. Somebody unmarks a favourite, or marks one by accident and unmarks it a second later. A reader of `docs/seam.md` had no way to find out what that does, beyond one clause in the list of what the document does not hold, measured at `origin/master`, `730af80`:

    git grep -n 'undone gesture' origin/master -- docs/seam.md
    origin/master:docs/seam.md:306:- What an undone gesture does, which today is nothing, because the contract carries no message for

That is enough to know something is missing and not enough to act on, and it sat in the list of absences while the fact itself is settled rather than open.

## What it now says

The contract carries one message and there is no second call:

    git grep -n 'Task<bool> AcceptAsync' origin/master -- Jellyfin.Plugin.Requests/Seam/IWantHandover.cs
    origin/master:Jellyfin.Plugin.Requests/Seam/IWantHandover.cs:44:    Task<bool> AcceptAsync(HandedOverWant want, CancellationToken cancellationToken);

So a request made from a handover stays as it was when the gesture behind it is undone, and this side could not act on an undone gesture today even if it wanted to, because nothing tells it one happened. What would have to change is a message on the contract, which is the other board's to add and this side's to implement once it carries one.

The list of absences keeps a bullet, narrowed to the half that is still absent: taking back an ask on this side's own surfaces, which needs a state a request can be withdrawn into and has none.

    git grep -n 'Cancelled' origin/master -- Jellyfin.Plugin.Requests/Model/
    origin/master:Jellyfin.Plugin.Requests/Model/RequestActor.cs:43:    /// is no state for a user withdrawing, refused with the <c>Cancelled</c> state on #113. The
    origin/master:Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs:69:/// user withdrawing has no state to move to because <c>Cancelled</c> was refused on #113. An

## The runs

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!: Fehler: 0, erfolgreich: 500, gesamt: 500 (net9.0)
    Bestanden!: Fehler: 0, erfolgreich: 500, gesamt: 500 (net10.0)

    npx --yes prettier@3.6.2 --check --end-of-line auto docs/seam.md
    All matched files use Prettier code style!

The suite is unmoved by this change and that is the point of quoting it: nothing here is a claim the suite could check, and this is a document rather than a guard.

## What this does not do

#68 stays open on this, and the wording matters: the sentence that stood here said the same thing with a word GitHub reads as an instruction rather than as prose, and merging this shut the issue on that reading alone. It is open again. The first two conditions there ask for cancellation defined per state in the model, and the state a withdrawal would move into is the one refused on #113, so taking either would settle a decision rather than implement one. The fourth condition is met and was met before this change: nothing in this repository decides which gesture the other side uses.

## Reading

Nobody but me has read this change. There is no second reader on it, and the commands above stand in place of one rather than beside one.
