### PR TITLE
Take a policy name from the server instead of writing one it does not register

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Api/EndpointPolicyTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/EndpointPolicyTests.cs
@@ -15,9 +15,19 @@ namespace Jellyfin.Plugin.Requests.Tests.Api;
 /// Who may reach each endpoint, held against the built assembly.
 /// <para>
 /// The invariant lint holds two rules over the source text, and they are not this check. They refuse
-/// the two ways a policy is taken away: an anonymous endpoint, and an <c>[Authorize]</c> that names
-/// no policy. Neither can see an endpoint that simply never carried an attribute, because a rule
-/// about text cannot refuse the absence of a line. That is what this reads the assembly for.
+/// an anonymous endpoint, and a policy written as a string rather than taken from the constant the
+/// server holds it in. Neither can see an endpoint that simply never carried an attribute, because a
+/// rule about text cannot refuse the absence of a line. That is what this reads the assembly for.
+/// </para>
+/// <para>
+/// <b>An endpoint open to any signed-in caller names no policy, and the empty cell below is that
+/// rather than an omission.</b> The server registers no name for "any signed-in person" and builds
+/// the requirement into its unnamed default policy, so what an endpoint can carry is the default or
+/// a name the server registers. This plugin named <c>DefaultAuthorization</c> for it, which the
+/// server registers on neither claimed line, and every endpoint answered 500 to every caller;
+/// <c>docs/api.md</c> carries the measurement and the repair. So the leg below asks that the
+/// attribute be there and that the policy be the one written down, where the default is written down
+/// as itself.
 /// </para>
 /// <para>
 /// What no test here can say is what the server does with a policy. The server evaluates it and
@@ -53,7 +63,7 @@ public sealed class EndpointPolicyTests
         // What this install is and what it allows. A signed-in person, because nothing this plugin
         // answers is safe to hand a caller the server has not authenticated, and because the kinds
         // an install accepts is a fact about somebody's server rather than about this version.
-        "CapabilitiesController.CapabilitiesAsync GET Capabilities -> DefaultAuthorization",
+        "CapabilitiesController.CapabilitiesAsync GET Capabilities -> (the server's default)",
 
         // Saying yes. A decision is an administrator's, in the transition table and here, and the
         // two answers have to agree: an endpoint reachable by a signed-in user would refuse every
@@ -67,7 +77,7 @@ public sealed class EndpointPolicyTests
 
         // Asking for something. An authenticated user, because a request has to be attributable to
         // somebody and a caller with no session names nobody.
-        "RequestsController.CreateAsync POST Requests -> DefaultAuthorization",
+        "RequestsController.CreateAsync POST Requests -> (the server's default)",
 
         // Saying no. The same policy as an approval, and the decline reason is something a user
         // reads rather than writes.
@@ -79,7 +89,7 @@ public sealed class EndpointPolicyTests
         // One person's own requests. The same policy as asking, and the narrowing is the read
         // rather than the policy: this endpoint has nothing wider than the caller's own requests to
         // return.
-        "RequestsController.MineAsync GET Requests -> DefaultAuthorization",
+        "RequestsController.MineAsync GET Requests -> (the server's default)",
 
         // The whole queue, which is every person's requests and who asked for each. An
         // administrator, and it is the only read here that needs one.
@@ -87,8 +97,7 @@ public sealed class EndpointPolicyTests
     ];
 
     /// <summary>
-    /// Every endpoint carries a policy of its own, named, and the set is exactly the one written
-    /// above.
+    /// Every endpoint carries a policy of its own and the set is exactly the one written above.
     /// </summary>
     [Fact]
     public void EveryEndpointCarriesThePolicyWrittenDownForIt()
@@ -105,18 +114,23 @@ public sealed class EndpointPolicyTests
     /// <summary>
     /// No endpoint relies on the attribute the controller carries.
     /// <para>
-    /// An endpoint with no policy of its own is reachable under whatever its class happens to
+    /// An endpoint with no attribute of its own is reachable under whatever its class happens to
     /// declare on the day it is added, and a class attribute is edited by somebody who is not
     /// reading the endpoint. This is the leg that catches the endpoint added with no attribute at
     /// all, which is what neither the lint nor a per-endpoint refusal test can see.
+    /// </para>
+    /// <para>
+    /// It asks for the attribute rather than for a policy name on it, and that is narrower than it
+    /// was: an endpoint open to any signed-in caller carries the server's default policy, which is
+    /// spelled by naming none. Which policy each one carries is the leg above, against the list, so
+    /// nothing moved from being checked to being assumed.
     /// </para>
     /// </summary>
     [Fact]
     public void NoEndpointInheritsItsPolicyFromTheControllerItSitsOn()
     {
         var inherited = Actions()
-            .Where(action => !action.Method.GetCustomAttributes<AuthorizeAttribute>(inherit: false)
-                .Any(attribute => !string.IsNullOrWhiteSpace(attribute.Policy)))
+            .Where(action => !action.Method.GetCustomAttributes<AuthorizeAttribute>(inherit: false).Any())
             .Select(action => Named(action.Type, action.Method))
             .OrderBy(name => name, StringComparer.Ordinal)
             .ToArray();
@@ -143,16 +157,15 @@ public sealed class EndpointPolicyTests
     }
 
     /// <summary>
-    /// The controller carries a policy too, so the floor under every endpoint is a signed-in caller
-    /// rather than whatever the framework defaults to. The endpoints do not rely on it, which is the
-    /// leg above; this is that it is there.
+    /// The controller carries the attribute too, so the floor under every endpoint is a signed-in
+    /// caller rather than an open route. The endpoints do not rely on it, which is the leg above;
+    /// this is that it is there.
     /// </summary>
     [Fact]
     public void TheControllerItselfCarriesAPolicy()
     {
         var controllers = Controllers()
-            .Where(type => !type.GetCustomAttributes<AuthorizeAttribute>(inherit: true)
-                .Any(attribute => !string.IsNullOrWhiteSpace(attribute.Policy)))
+            .Where(type => !type.GetCustomAttributes<AuthorizeAttribute>(inherit: true).Any())
             .Select(type => type.FullName ?? type.Name)
             .OrderBy(name => name, StringComparer.Ordinal)
             .ToArray();
@@ -196,7 +209,7 @@ public sealed class EndpointPolicyTests
                 string.Join(
                     "+",
                     action.Method.GetCustomAttributes<AuthorizeAttribute>(inherit: false)
-                        .Select(attribute => attribute.Policy ?? "(none)")
+                        .Select(attribute => attribute.Policy ?? "(the server's default)")
                         .OrderBy(policy => policy, StringComparer.Ordinal))))
             .OrderBy(line => line, StringComparer.Ordinal)];
 

--- a/Jellyfin.Plugin.Requests.Tests/Api/ListRequestsTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/ListRequestsTests.cs
@@ -437,14 +437,19 @@ public sealed class ListRequestsTests
             ["RequiresElevation"],
             queue.GetCustomAttributes<AuthorizeAttribute>(inherit: false).Select(attribute => attribute.Policy));
 
+        // No policy on the endpoint a user reaches, which is the server's default policy rather than
+        // a missing one: the server registers no name for "any signed-in person", so naming one is
+        // how this plugin came to answer 500 to every caller. The attribute is there, which is the
+        // difference between the default and nothing at all, and EndpointPolicyTests holds that for
+        // every endpoint rather than for these two.
         Assert.Equal(
-            ["DefaultAuthorization"],
+            new string?[] { null },
             mine.GetCustomAttributes<AuthorizeAttribute>(inherit: false).Select(attribute => attribute.Policy));
 
-        // The controller's own policy is the floor under both, so an endpoint that ever lost its own
-        // attribute would still need a signed-in caller rather than being open.
+        // The controller's own attribute is the floor under both, so an endpoint that ever lost its
+        // own would still need a signed-in caller rather than being open.
         Assert.Equal(
-            ["DefaultAuthorization"],
+            new string?[] { null },
             typeof(RequestsController).GetCustomAttributes<AuthorizeAttribute>(inherit: false).Select(attribute => attribute.Policy));
     }
 

--- a/Jellyfin.Plugin.Requests/Api/CapabilitiesController.cs
+++ b/Jellyfin.Plugin.Requests/Api/CapabilitiesController.cs
@@ -30,7 +30,7 @@ namespace Jellyfin.Plugin.Requests.Api;
 /// dependencies and every store test a capability to carry.
 /// </para>
 /// </summary>
-[Authorize(Policy = AuthenticatedUserPolicy)]
+[Authorize]
 public sealed class CapabilitiesController : RequestsControllerBase
 {
     private readonly IInstallSettings _settings;
@@ -61,7 +61,7 @@ public sealed class CapabilitiesController : RequestsControllerBase
     /// those has an answer before anybody has configured anything.
     /// </returns>
     [HttpGet("Capabilities")]
-    [Authorize(Policy = AuthenticatedUserPolicy)]
+    [Authorize]
     [ProducesResponseType(StatusCodes.Status200OK)]
     public async Task<ActionResult<InstallCapabilities>> CapabilitiesAsync(CancellationToken cancellationToken)
     {

--- a/Jellyfin.Plugin.Requests/Api/RequestsController.cs
+++ b/Jellyfin.Plugin.Requests/Api/RequestsController.cs
@@ -9,6 +9,7 @@ using Jellyfin.Plugin.Requests.Intake;
 using Jellyfin.Plugin.Requests.Model;
 using Jellyfin.Plugin.Requests.Storage;
 using Jellyfin.Plugin.Requests.Time;
+using MediaBrowser.Common.Api;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -44,16 +45,20 @@ namespace Jellyfin.Plugin.Requests.Api;
 /// endpoint that carried none would be reachable by whatever the class happens to declare on the day
 /// it is added, and a class attribute is edited by somebody who is not reading the endpoint. Which
 /// policy each one carries, and what a caller may see under it, is <c>docs/api.md</c>; that the
-/// attribute is there at all is refused by <c>EndpointPolicyTests</c> over the built assembly and by
-/// two rules in the invariant lint over the source.
+/// attribute is there at all is refused by <c>EndpointPolicyTests</c> over the built assembly, which
+/// is the only place it can be: the two rules in the invariant lint refuse the two ways one is taken
+/// away, and a rule about text cannot see a line nobody wrote.
 /// </para>
 /// <para>
 /// Two policies are used here and no endpoint is anonymous. Creating a request and reading one's own
 /// need an authenticated user, because a request has to be attributable to somebody to exist at all
-/// and a caller with no session has no "own". Reading the whole queue needs an administrator.
+/// and a caller with no session has no "own"; the server registers no name for that and builds it
+/// into its default policy, so those endpoints carry <c>[Authorize]</c> with nothing after it.
+/// Reading the whole queue and every decision need an administrator, which the server does name, so
+/// those carry its own constant.
 /// </para>
 /// </summary>
-[Authorize(Policy = AuthenticatedUserPolicy)]
+[Authorize]
 public sealed class RequestsController : RequestsControllerBase
 {
     /// <summary>
@@ -129,7 +134,7 @@ public sealed class RequestsController : RequestsControllerBase
     /// here is the smallest thing that names the field that was wrong.
     /// </returns>
     [HttpPost("Requests")]
-    [Authorize(Policy = AuthenticatedUserPolicy)]
+    [Authorize]
     [ProducesResponseType<CreatedRequest>(StatusCodes.Status201Created)]
     [ProducesResponseType<CreatedRequest>(StatusCodes.Status200OK)]
     [ProducesResponseType<RequestFailure>(StatusCodes.Status400BadRequest)]
@@ -218,7 +223,7 @@ public sealed class RequestsController : RequestsControllerBase
     /// <param name="cancellationToken">Cancels the call.</param>
     /// <returns>The page, and how many of the caller's requests matched.</returns>
     [HttpGet("Requests")]
-    [Authorize(Policy = AuthenticatedUserPolicy)]
+    [Authorize]
     [ProducesResponseType<RequestsPage<MyRequest>>(StatusCodes.Status200OK)]
     [ProducesResponseType<RequestFailure>(StatusCodes.Status400BadRequest)]
     [ProducesResponseType<RequestFailure>(StatusCodes.Status403Forbidden)]
@@ -293,7 +298,7 @@ public sealed class RequestsController : RequestsControllerBase
     /// <param name="cancellationToken">Cancels the call.</param>
     /// <returns>The page, and how many requests matched.</returns>
     [HttpGet("Requests/Queue")]
-    [Authorize(Policy = AdministratorPolicy)]
+    [Authorize(Policy = Policies.RequiresElevation)]
     [ProducesResponseType<RequestsPage<QueuedRequest>>(StatusCodes.Status200OK)]
     [ProducesResponseType<RequestFailure>(StatusCodes.Status400BadRequest)]
     [ProducesResponseType<RequestFailure>(StatusCodes.Status503ServiceUnavailable)]
@@ -348,7 +353,7 @@ public sealed class RequestsController : RequestsControllerBase
     /// <see cref="RequestFailure"/> rather than obeyed.
     /// </returns>
     [HttpPost("Requests/{id}/Approve")]
-    [Authorize(Policy = AdministratorPolicy)]
+    [Authorize(Policy = Policies.RequiresElevation)]
     [ProducesResponseType<QueuedRequest>(StatusCodes.Status200OK)]
     [ProducesResponseType<RequestFailure>(StatusCodes.Status400BadRequest)]
     [ProducesResponseType<RequestFailure>(StatusCodes.Status403Forbidden)]
@@ -396,7 +401,7 @@ public sealed class RequestsController : RequestsControllerBase
     /// The request as the queue now holds it, at its new revision, or the refusal.
     /// </returns>
     [HttpPost("Requests/{id}/Decline")]
-    [Authorize(Policy = AdministratorPolicy)]
+    [Authorize(Policy = Policies.RequiresElevation)]
     [ProducesResponseType<QueuedRequest>(StatusCodes.Status200OK)]
     [ProducesResponseType<RequestFailure>(StatusCodes.Status400BadRequest)]
     [ProducesResponseType<RequestFailure>(StatusCodes.Status403Forbidden)]
@@ -449,7 +454,7 @@ public sealed class RequestsController : RequestsControllerBase
     /// <param name="cancellationToken">Cancels the call.</param>
     /// <returns>One entry per request, in the order they were sent.</returns>
     [HttpPost("Requests/Approve")]
-    [Authorize(Policy = AdministratorPolicy)]
+    [Authorize(Policy = Policies.RequiresElevation)]
     [ProducesResponseType<DecidedRequests>(StatusCodes.Status200OK)]
     [ProducesResponseType<RequestFailure>(StatusCodes.Status400BadRequest)]
     [ProducesResponseType<RequestFailure>(StatusCodes.Status403Forbidden)]
@@ -482,7 +487,7 @@ public sealed class RequestsController : RequestsControllerBase
     /// <param name="cancellationToken">Cancels the call.</param>
     /// <returns>One entry per request, in the order they were sent.</returns>
     [HttpPost("Requests/Decline")]
-    [Authorize(Policy = AdministratorPolicy)]
+    [Authorize(Policy = Policies.RequiresElevation)]
     [ProducesResponseType<DecidedRequests>(StatusCodes.Status200OK)]
     [ProducesResponseType<RequestFailure>(StatusCodes.Status400BadRequest)]
     [ProducesResponseType<RequestFailure>(StatusCodes.Status403Forbidden)]

--- a/Jellyfin.Plugin.Requests/Api/RequestsControllerBase.cs
+++ b/Jellyfin.Plugin.Requests/Api/RequestsControllerBase.cs
@@ -19,6 +19,18 @@ namespace Jellyfin.Plugin.Requests.Api;
 /// in the invariant lint: a second route attribute anywhere else, and a method template beginning
 /// with a slash, which silently replaces the controller's route rather than extending it.
 /// </para>
+/// <para>
+/// <b>A policy is either one the server registers a name for, taken from the server's own constant,
+/// or it is the server's default.</b> The names it registers are <c>Policies</c> in
+/// <c>MediaBrowser.Common</c>, an assembly this plugin already references, so an endpoint naming one
+/// of them cannot name a policy that does not exist. There is no registered name for "any signed-in
+/// person": the server builds that requirement into the unnamed default policy, so an endpoint open
+/// to any signed-in caller carries <c>[Authorize]</c> with nothing after it, which is what the
+/// server's own controllers carry for the same thing. A policy written here as a string is refused
+/// by <c>policy-is-named-by-the-servers-own-constant</c> in the invariant lint: a name the server
+/// does not register does not make an endpoint narrower, it makes the endpoint answer 500 to
+/// everybody, which is what this plugin shipped until <c>docs/api.md</c> recorded the repair.
+/// </para>
 /// </summary>
 [ApiController]
 [Route(RoutePrefix)]
@@ -49,23 +61,4 @@ public abstract class RequestsControllerBase : ControllerBase
     /// </para>
     /// </summary>
     public const string RoutePrefix = "MediaRequests/" + VersionSegment;
-
-    /// <summary>
-    /// The server's policy for a call that has to come from a signed-in user. Named as a literal
-    /// because the constant that holds it lives in the server's own web assembly, which a plugin
-    /// does not reference; the string is the contract either way.
-    /// <para>
-    /// It is here rather than on one controller because there is more than one, and a second copy of
-    /// the literal beside the second controller would be a second spelling of a contract this
-    /// repository does not own.
-    /// </para>
-    /// </summary>
-    protected const string AuthenticatedUserPolicy = "DefaultAuthorization";
-
-    /// <summary>
-    /// The server's policy for a call that has to come from an administrator, named as a literal for
-    /// the same reason as the one above. It is what the server's own dashboard endpoints carry, so an
-    /// endpoint under it is reachable by exactly the people who can already administer the server.
-    /// </summary>
-    protected const string AdministratorPolicy = "RequiresElevation";
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -426,20 +426,21 @@ and would otherwise match nothing, and an empty page reads exactly like an empty
 
 ## Who may reach what
 
-Every endpoint carries a policy of its own, and the controller carries one as the floor under all of
-them. An endpoint with no policy of its own is reachable under whatever its class happens to declare
-on the day it is added, and a class attribute is edited by somebody who is not reading the endpoint.
+Every endpoint carries an authorisation attribute of its own, and the controller carries one as the
+floor under all of them. An endpoint with none of its own is reachable under whatever its class
+happens to declare on the day it is added, and a class attribute is edited by somebody who is not
+reading the endpoint.
 
-| Endpoint                     | Policy                 | Who that is          |
-| ---------------------------- | ---------------------- | -------------------- |
-| `GET Capabilities`           | `DefaultAuthorization` | any signed-in person |
-| `POST Requests`              | `DefaultAuthorization` | any signed-in person |
-| `GET Requests`               | `DefaultAuthorization` | any signed-in person |
-| `GET Requests/Queue`         | `RequiresElevation`    | an administrator     |
-| `POST Requests/{id}/Approve` | `RequiresElevation`    | an administrator     |
-| `POST Requests/{id}/Decline` | `RequiresElevation`    | an administrator     |
-| `POST Requests/Approve`      | `RequiresElevation`    | an administrator     |
-| `POST Requests/Decline`      | `RequiresElevation`    | an administrator     |
+| Endpoint                     | Policy                       | Who that is          |
+| ---------------------------- | ---------------------------- | -------------------- |
+| `GET Capabilities`           | the server's default         | any signed-in person |
+| `POST Requests`              | the server's default         | any signed-in person |
+| `GET Requests`               | the server's default         | any signed-in person |
+| `GET Requests/Queue`         | `Policies.RequiresElevation` | an administrator     |
+| `POST Requests/{id}/Approve` | `Policies.RequiresElevation` | an administrator     |
+| `POST Requests/{id}/Decline` | `Policies.RequiresElevation` | an administrator     |
+| `POST Requests/Approve`      | `Policies.RequiresElevation` | an administrator     |
+| `POST Requests/Decline`      | `Policies.RequiresElevation` | an administrator     |
 
 The four decisions carry the same policy as the queue, and that is the endpoint agreeing with the
 model rather than deciding anything: every cell of the table these two can reach admits an
@@ -452,18 +453,54 @@ reds if the table stops agreeing.
 queue is a list of who asked for what, so there is no answer this plugin gives that is safe to hand a
 caller the server has not authenticated.
 
-The policies are the server's own, named as literals because the constants that hold them live in the
-server's web assembly and a plugin does not reference it. The string is the contract either way.
+### The name in the middle column, and the defect it is the repair for
+
+The policies are the server's own and the name comes from the server's own constant, `Policies` in
+`MediaBrowser.Common`, which this plugin already references. There is no registered name for "any
+signed-in person": the server builds that requirement into its unnamed default policy, so the three
+endpoints open to anybody with a session carry `[Authorize]` with nothing after it, which is what the
+server's own controllers carry for the same thing.
+
+This table said `DefaultAuthorization` in those three rows and the controllers carried it as a
+string, and **every endpoint this plugin serves answered 500 to every caller, on both claimed
+lines**. A policy name the server does not register does not admit fewer people; it throws inside the
+authorisation middleware before the endpoint is reached. The run that measured it is in the pull
+request for #58, on `jellyfin/jellyfin:10.11.11` and on `jellyfin/jellyfin:12.0-rc4`:
+
+    [ERR] Jellyfin.Api.Middleware.ExceptionMiddleware: Error processing request. URL GET /MediaRequests/v1/Requests/Queue.
+    System.InvalidOperationException: The AuthorizationPolicy named: 'DefaultAuthorization' was not found.
+
+That the name is absent from the server assembly of each line is readable without a server, from the
+package each target compiles against:
+
+    tr -d '\000' < ~/.nuget/packages/jellyfin.common/10.11.11/lib/net9.0/MediaBrowser.Common.dll \
+        | grep -oE 'DefaultAuthorization|RequiresElevation' | sort | uniq -c
+          3 RequiresElevation
+    tr -d '\000' < ~/.nuget/packages/jellyfin.common/12.0.0-rc4/lib/net10.0/MediaBrowser.Common.dll \
+        | grep -oE 'DefaultAuthorization|RequiresElevation' | sort | uniq -c
+          3 RequiresElevation
+
+So the string is where the defect lived, rather than the particular name that was in it: a name
+written here is a name nothing checks, and one taken from the constant is a compile error the day it
+stops existing.
 
 What holds this. `EndpointPolicyTests` reads the built assembly and refuses an endpoint whose policy
-is not the one written down for it, an endpoint carrying no policy of its own, and an anonymous one.
-The invariant lint refuses the two source shapes that take a policy away: `no-anonymous-endpoint` and
-`authorize-names-a-policy`, the second of which is about a bare `[Authorize]`, which reads as though
-it decided something and admits every signed-in person on the server.
+is not the one written down for it, an endpoint carrying no attribute of its own, and an anonymous
+one. The invariant lint refuses the two source shapes that take a policy away:
+`no-anonymous-endpoint`, and `policy-is-named-by-the-servers-own-constant`, which is about a policy
+written as a string.
+
+What is weaker than before, said rather than left to be discovered: an endpoint carrying the default
+policy and an endpoint whose author meant to name one and did not are the same bytes, so no check
+here tells them apart. What is checked is that the attribute is there and that the policy is the one
+this table names, the default included.
 
 What none of that holds is the server turning a caller away, which is the server's own evaluation of
 the policy and needs a running one. `docs/testing.md` carries that as a refused test with what
-replaces it.
+replaces it. **That applies to the repair above as well: no run on a server records these endpoints
+answering anything other than 500.** What is measured is that the name they used exists on neither
+line and that the name they use now exists on both. The first-load procedure in `docs/testing.md` is
+where a run against a server would go, and it has not been made since this changed.
 
 The rule underneath the table is narrower than the table. **A user sees their own requests in full
 and learns nothing at all about anybody else's**, which is what `GET Requests` returns and why its

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -94,8 +94,10 @@ and it is the same refusal as installing into a real server above rather than a 
 
 What replaces it is two things, on two sides of the endpoint. `EndpointPolicyTests` reads the built
 assembly and refuses an endpoint whose policy is not the one written down for it, an endpoint with
-no policy of its own, and an anonymous one; `no-anonymous-endpoint` and `authorize-names-a-policy`
-refuse the two source shapes that take a policy away. That is the half about which policy an
+no attribute of its own, and an anonymous one; `no-anonymous-endpoint` and
+`policy-is-named-by-the-servers-own-constant` refuse the two source shapes that take a policy away,
+which are an endpoint reachable with no session and a policy written here as a string rather than
+taken from the constant the server registers it under. That is the half about which policy an
 endpoint is under. The other half is that the endpoint a caller without elevation can reach has
 nothing wider than that caller's own requests to return, which `ListRequestsTests` asks under every
 combination of filter, order and page. Neither is the server turning somebody away, and neither

--- a/tools/opengrep/fixtures/policy/ReachableWithoutASession.cs
+++ b/tools/opengrep/fixtures/policy/ReachableWithoutASession.cs
@@ -1,26 +1,31 @@
-// Fixture for no-anonymous-endpoint and authorize-names-a-policy. This file is in
-// no project and is never compiled; it exists so both rules can be watched
-// refusing the mistakes they name.
+// Fixture for no-anonymous-endpoint and policy-is-named-by-the-servers-own-constant.
+// This file is in no project and is never compiled; it exists so both rules can
+// be watched refusing the mistakes they name.
 //
 // Both near-misses are one keystroke away from correct code and neither is a
 // build failure. The first is what somebody writes while testing an endpoint by
-// hand and then does not take out again. The second reads as though it says
-// "this needs authorisation", and it does: it says only that the caller is
-// authenticated, which on a family server is everybody, and it says nothing
-// about which of them.
+// hand and then does not take out again.
+//
+// The second is the one that shipped. A policy written out as a string reads as
+// the narrowest thing on the page and is the only line here that cannot be
+// checked by anything: the name below is the one this plugin carried, the server
+// registers it on neither claimed line, and an endpoint under a policy nothing
+// registers answers 500 to every caller rather than admitting fewer of them.
 
 namespace Jellyfin.Plugin.Requests.Fixtures;
 
 public sealed class ReachableWithoutASession : RequestsControllerBase
 {
     // Legal neighbours, left here on purpose: this is how an endpoint is written
-    // and neither rule may fire on either of them.
+    // and neither rule may fire on either of them. The first carries the server's
+    // default policy, which is spelled by naming none; the second carries a name
+    // the server registers, taken from the constant it registers it under.
     [HttpGet("Requests")]
-    [Authorize(Policy = "DefaultAuthorization")]
+    [Authorize]
     public IActionResult Mine() => Ok();
 
     [HttpGet("Requests/Queue")]
-    [Authorize(Policy = "RequiresElevation")]
+    [Authorize(Policy = Policies.RequiresElevation)]
     public IActionResult Queue() => Ok();
 
     // The regression: an endpoint anybody can reach with no session at all.
@@ -28,9 +33,9 @@ public sealed class ReachableWithoutASession : RequestsControllerBase
     [AllowAnonymous]
     public IActionResult Anything() => Ok();
 
-    // And the one that looks like it decided something. Every signed-in person on
-    // the server passes it, which is the whole server's household.
+    // And the name nothing checks, which is how every endpoint here came to
+    // answer 500 on both server lines.
     [HttpGet("Requests/Everybody")]
-    [Authorize]
+    [Authorize(Policy = "DefaultAuthorization")]
     public IActionResult Everybody() => Ok();
 }

--- a/tools/opengrep/rules.yaml
+++ b/tools/opengrep/rules.yaml
@@ -375,23 +375,39 @@ rules:
         - "Jellyfin.Plugin.Requests/**/*.cs"
         - "tools/opengrep/fixtures/policy/**/*.cs"
 
-  # Invariant (api, #51): a policy is named rather than left to the default.
-  # Decided in docs/api.md. A bare `[Authorize]` reads as though it decided
-  # something and decides almost nothing: it admits every signed-in person, which
-  # on a family server is the whole household, and it says nothing about which of
-  # them may read a queue. The named policies are the server's own, so an
-  # endpoint under one is reachable by exactly the people the server already
-  # says may do that thing. The attribute with a policy is a longer token
-  # sequence and is not matched by this.
-  - id: authorize-names-a-policy
+  # Invariant (api, #51): a policy this plugin names is one the server registers,
+  # and the way that is held is that the name comes from the server's own
+  # constant rather than from a string here. Decided in docs/api.md.
+  #
+  # This rule replaced one that said the opposite, and the reason is measured
+  # rather than argued. The rule here refused a bare `[Authorize]` and asked for
+  # a named policy instead, on the reading that a name is always narrower than
+  # the default. That is false for the one case it mattered in: the server
+  # registers no name for "any signed-in person" and builds the requirement into
+  # its unnamed default policy, so the name written here for it,
+  # `DefaultAuthorization`, was a name nothing registers. An endpoint under an
+  # unregistered policy does not admit fewer people, it throws inside the
+  # authorisation middleware, and every endpoint this plugin serves answered 500
+  # to every caller on both claimed lines. docs/api.md carries the run.
+  #
+  # So the shape refused is the string, in either direction: a name that is
+  # correct today is still a name nothing checks, and the constants are in
+  # MediaBrowser.Common, which this plugin already references. Taking the name
+  # from there makes a policy the server does not register a compile error. An
+  # endpoint open to any signed-in caller carries `[Authorize]` with nothing
+  # after it, which is what the server's own controllers carry for the same
+  # thing, and no-anonymous-endpoint is what keeps that from sliding to open.
+  - id: policy-is-named-by-the-servers-own-constant
     languages: [generic]
     severity: ERROR
     message: >-
-      Name the policy. A bare [Authorize] admits every signed-in caller and says
-      nothing about which of them may reach this endpoint (#51). Write
-      [Authorize(Policy = ...)] with one of the server's named policies.
+      Do not write a policy name as a string. Take it from Policies in
+      MediaBrowser.Common, so a name the server does not register is a compile
+      error rather than an endpoint that answers 500 to everybody (#51). An
+      endpoint open to any signed-in person carries [Authorize] and no policy,
+      which is the server's default.
     patterns:
-      - pattern: '[Authorize]'
+      - pattern: '[Authorize(Policy = "...")]'
     paths:
       include:
         - "Jellyfin.Plugin.Requests/**/*.cs"


### PR DESCRIPTION
Part of #51.

## What was wrong

Every endpoint this plugin serves answered 500 to every caller, on a server of both claimed lines.
The controllers named `DefaultAuthorization` as the policy for a signed-in person and the server
registers no policy under that name. An endpoint under a name nothing registers does not admit fewer
people; the authorisation middleware throws before the endpoint is reached.

It was found by the first-load run in #206, which fetched the queue endpoint on a server of each line
and read the exception out of the server's own log:

    [ERR] Jellyfin.Api.Middleware.ExceptionMiddleware: Error processing request. URL GET /MediaRequests/v1/Requests/Queue.
    System.InvalidOperationException: The AuthorizationPolicy named: 'DefaultAuthorization' was not found.

That the name is absent is readable without a server, from the package each target compiles against:

    tr -d '\000' < ~/.nuget/packages/jellyfin.common/10.11.11/lib/net9.0/MediaBrowser.Common.dll | grep -oE 'DefaultAuthorization|RequiresElevation' | sort | uniq -c
          3 RequiresElevation
    tr -d '\000' < ~/.nuget/packages/jellyfin.common/12.0.0-rc4/lib/net10.0/MediaBrowser.Common.dll | grep -oE 'DefaultAuthorization|RequiresElevation' | sort | uniq -c
          3 RequiresElevation

`RequiresElevation` is there on both and `DefaultAuthorization` is on neither.

## The means

C# and the existing lint set, because the repair is a change to attributes the compiler already reads
and to a rule file the gate already scans. Nothing is added: `MediaBrowser.Common` is on the
reference list already, so taking the constant from it costs no package and no target.

## What changed

`RequiresElevation` now comes from `Policies` in `MediaBrowser.Common` rather than from a string, so
a name that stops existing is a compile error. There is no registered name for "any signed-in person"
at all, because the server builds that requirement into its unnamed default policy, so the three
endpoints open to anybody with a session carry `[Authorize]` with nothing after it, which is what the
server's own controllers carry for the same thing. The two constants on `RequestsControllerBase` are
gone; a symbol shared with the server is not a second spelling the way a copied literal was.

The lint rule that stood here said the opposite and is replaced rather than edited.
`authorize-names-a-policy` refused a bare `[Authorize]` and asked for a name instead, on the reading
that a name is always narrower than the default, which is the reading that put the unregistered name
in. `policy-is-named-by-the-servers-own-constant` refuses the shape that allowed it, a policy written
as a string, and the fixture carries the exact line that shipped.

## The runs

At `a1fc4f0`, before this change, and with it, on both claimed lines:

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Der Buildvorgang wurde erfolgreich ausgefuehrt.
    0 Warnung(en)
    0 Fehler

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!: Fehler: 0, erfolgreich: 502, uebersprungen: 0, gesamt: 502 (net9.0)
    Bestanden!: Fehler: 0, erfolgreich: 502, uebersprungen: 0, gesamt: 502 (net10.0)

    npx --yes prettier@3.6.2 --check "docs/api.md" "docs/testing.md"
    All matched files use Prettier code style!

## That the guards bite

Three near-misses, each made at the source on its own, run with
`dotnet test Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj -f net9.0 --configuration Release`, and put back afterwards.

The queue endpoint losing its elevation, which is the one-line mistake in this change's own shape:

    [HttpGet("Requests/Queue")]
    [Authorize]
    EndpointPolicyTests.EveryEndpointCarriesThePolicyWrittenDownForIt [FAIL]
    ListRequestsTests.TheQueueEndpointCarriesTheElevationPolicyAndTheOwnRequestsEndpointDoesNot [FAIL]

An endpoint left with no attribute of its own, falling back to the controller's. This is the leg this
change weakened, so it is the one worth watching:

    // [Authorize] removed from MineAsync
    EndpointPolicyTests.NoEndpointInheritsItsPolicyFromTheControllerItSitsOn [FAIL]
    EndpointPolicyTests.EveryEndpointCarriesThePolicyWrittenDownForIt [FAIL]
    ListRequestsTests.TheQueueEndpointCarriesTheElevationPolicyAndTheOwnRequestsEndpointDoesNot [FAIL]

The controller losing the floor under all of them:

    // [Authorize] removed from the RequestsController class
    EndpointPolicyTests.TheControllerItselfCarriesAPolicy [FAIL]
    ListRequestsTests.TheQueueEndpointCarriesTheElevationPolicyAndTheOwnRequestsEndpointDoesNot [FAIL]

The tree was left as it was found after each:

    git status --porcelain

## What is not covered

**No server ran.** Nothing here shows these endpoints answering anything other than 500. What is
measured is that the name they used exists in the server assembly of neither line and the name they
use now exists in both. Docker is not available on the machine this was made on, so the first-load
procedure in `docs/testing.md`, which is what produced the failing run in #206, was not repeated.
`docs/api.md` says this in those words rather than leaving it to be assumed.

**The new lint rule was not watched firing here.** Opengrep publishes a Linux binary and this was
made on Windows, so `tools/opengrep/prove-rules-fire.sh` was not run locally. `Repo Invariant Lint`
runs both of its steps on this pull request and is the verdict on the pattern: the second step fails
unless every declared rule fired on a fixture, so a pattern that matches nothing reds rather than
passing.

**The assembly check is narrower than it was**, and this is a disclosure rather than a repair. An
endpoint carrying the default policy and an endpoint whose author meant to name one and did not are
the same bytes, so nothing tells them apart. What is still checked is that the attribute is on the
endpoint itself rather than inherited, and that the policy is the one the table in `docs/api.md`
names, the default included.

**A sentence in `Jellyfin.Plugin.Requests/Web/queue.html` is now false.** It says every endpoint
answers 500 on a real server today and that the repair belongs to #51. The first half stops being
true with this change and the second half is this change. That file is where the queue rows are
drawn, which is #60 and #64, and it is not touched here.

**#51 stays open.** Its first condition asks for the policy to be enforced by a rule in the
invariant lint, and what enforces the presence of an attribute is still the assembly check; the
wording that settles whether that satisfies the condition is not mine to take, and the comment
already on the issue sets out which of its three conditions hold.

One correction to this body. The sentence above first said this does not close the issue, in a spelling GitHub reads as an instruction rather than as prose, and merging shut #51 on that reading alone. The issue is open again and this wording is the repair.

## Reading

Nobody but me has read this change. There is no second reader on it, and the runs above stand in
place of one rather than beside one.

