### PR TITLE
Name what an operator has to see before a request can be answered

### DIFF
--- a/docs/queue.md
+++ b/docs/queue.md
@@ -1,0 +1,168 @@
+# What the queue must show for a decision to be possible
+
+This plugin exists so that answering a request does not need a second system. That is a claim about
+one page, and this document is what the claim means: the things an operator has to be able to read
+before approving or declining, each with the reason a decision is worse without it.
+
+It is written before the rows are built, so the page is measured against a list somebody argued for
+rather than against whatever fitted in the width. The rows themselves are #60, acting on them is #61
+and #62, and the health panel beside them is #63. None of those decide what is on this list.
+
+## What earns a place
+
+An item is here because a decision is wrong or arbitrary without it, not because it is available. A
+queue that shows everything the store holds is as unusable as one that shows a title and a name, and
+the failure is the same in both directions: the operator goes somewhere else to find the answer.
+
+Each item below says what it is, why the decision needs it, and where it comes from in this tree
+today. The last part is what makes the list checkable rather than aspirational. An item nothing here
+can answer is work that has to be named, and two of the six are exactly that.
+
+The measurements are read at `e667f895b81f6fc62b7778de601fde607068fb17`, which is `master`.
+
+## Who asked, and when
+
+An operator does not decide a request, they decide a request from a person. The same title asked for
+by somebody who asks once a month and by somebody who asked for four other things yesterday is two
+different decisions, and the date is what separates a request that has been waiting from one that
+arrived while the page was open.
+
+The queue answer carries the identifier and both timestamps:
+
+    git grep -n "RequestedByUserId\|RequestedAt\|StateChangedAt" -- Jellyfin.Plugin.Requests/Api/QueuedRequest.cs
+    Jellyfin.Plugin.Requests/Api/QueuedRequest.cs:45:    public required Guid RequestedByUserId { get; init; }
+    Jellyfin.Plugin.Requests/Api/QueuedRequest.cs:85:    public required DateTimeOffset RequestedAt { get; init; }
+    Jellyfin.Plugin.Requests/Api/QueuedRequest.cs:90:    public required DateTimeOffset StateChangedAt { get; init; }
+
+What it carries is an identifier and not a name. Turning one into the other is the server's own user
+list, which the dashboard page reaches without leaving the server, so the name is a rendering
+question rather than a second system. This plugin holds no copy of anybody's name and nothing here
+asks it to start.
+
+The page is administrators only, which is where a name belongs and stops. What a user may learn
+about another user's request is `docs/api.md`, and it is nothing.
+
+## What was asked for, including which seasons
+
+Approving a series without knowing whether it is one season or nine is approving an unknown quantity
+of somebody's disk. The kind, the title, the year and the seasons are the request, and the note the
+requester wrote is the only place they get to say why.
+
+    git grep -n "Kind\|DisplayTitle\|DisplayYear\|Seasons\|RequesterNote" -- Jellyfin.Plugin.Requests/Api/QueuedRequest.cs
+    Jellyfin.Plugin.Requests/Api/QueuedRequest.cs:55:    public required RequestedItemKind Kind { get; init; }
+    Jellyfin.Plugin.Requests/Api/QueuedRequest.cs:60:    public required string DisplayTitle { get; init; }
+    Jellyfin.Plugin.Requests/Api/QueuedRequest.cs:65:    public int? DisplayYear { get; init; }
+    Jellyfin.Plugin.Requests/Api/QueuedRequest.cs:75:    public IReadOnlyList<int> Seasons { get; init; } = [];
+    Jellyfin.Plugin.Requests/Api/QueuedRequest.cs:100:    public string? RequesterNote { get; init; }
+
+The year is what stops two films with one title being one decision. The provider identifiers are on
+the same answer and are not for the operator to read: they are what the fulfilment check matches on,
+and a page that printed them would be showing plumbing.
+
+There is no poster, no synopsis and no rating here, and there will not be. This plugin makes no call
+to a metadata source, decided in #92, so what the page can show about a title is the snapshot the
+request carried when it was made. An operator who wants more than that is looking something up, and
+this document is not going to pretend otherwise by leaving the limit out.
+
+## Whether the server already holds it, in whole or in part
+
+The commonest correct answer to a request is that the thing is already on the server and the person
+did not find it. A queue that does not say so sends the operator into their own library to look,
+which is the trip this plugin is meant to remove, and the answer is worth more for a series than for
+a film because half of one is a real state.
+
+    git grep -n "Availability" -- Jellyfin.Plugin.Requests/Api/QueuedRequest.cs
+    Jellyfin.Plugin.Requests/Api/QueuedRequest.cs:115:    public required LibraryAvailability Availability { get; init; }
+    Jellyfin.Plugin.Requests/Api/QueuedRequest.cs:120:    public DateTimeOffset? AvailabilityCheckedAt { get; init; }
+
+`LibraryAvailability` has four values and `Partial` is the one this item exists for. `Unknown` is a
+fourth answer rather than a missing one, and the page has to show it as what it is: nothing has
+looked yet. The time of the check is on the answer for the same reason, because an availability read
+a week ago and one read a minute ago are different facts and a page that renders them identically is
+telling the operator something it does not know.
+
+## Whether the same title has been asked for before, and what was decided
+
+This is the item an operator most notices the absence of, and it is the first of two on this list
+that the queue answer cannot carry today.
+
+A title that was declined once and is asked for again is the case where the first decision matters
+most. Without it in front of them the operator either declines from memory, which fails the first
+time it is somebody else's memory, or approves something that was refused for a reason that has not
+changed. The reason is in the store: a decline carries one, and a finished request is kept.
+
+    git grep -n "FinishedRequestRetentionDays" -- Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs
+    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:99:    public int FinishedRequestRetentionDays { get; set; } = 365;
+
+Nothing on the queue path reads it. `JoinedByUserIds` on the queue answer is not this: it is the
+several people standing behind one request that is still open, decided in #38, and it says nothing
+about a request that was finished before this one was made.
+Enforcing the retention period is #49 and is not built, so today the records are all still there.
+
+So this item is work on the answer rather than on the page, and naming it here is the point of
+writing the list before the rows.
+
+## Whether this person is asking for a lot
+
+Requests are approved one at a time and a disk fills up all at once. An operator looking at a single
+row cannot see that it is the eleventh from the same person this week, and the ceiling that exists
+is a number in the configuration rather than something the queue shows:
+
+    git grep -n "OpenRequestsPerUser" -- Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs
+    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:67:    public int OpenRequestsPerUser { get; set; } = 10;
+
+The store can count a person's requests, in `IRequestStore.FindForUserAsync`, so the fact is
+available and is not on the queue answer. This is the second of the two items that need the answer
+widened, and it is the cheaper of them.
+
+Enforcing the ceiling at the moment a request is created is #114 and is a different thing from
+showing it here. A quota that refuses silently and a queue that shows the operator who is near it
+answer different questions, and the second is the one that lets an operator decide before the
+refusal rather than explain it afterwards.
+
+## What approving will do next
+
+Approving means one of two things and the operator has to know which. On a server with no external
+service behind this plugin, approval is a state and the fetching is somebody's own business.
+With a bridge configured, approval hands the request to something that will start downloading. An
+operator who does not know which install they are in cannot know whether they are finishing their
+work or starting somebody else's.
+
+This is one answer per install rather than one per row, so it belongs beside the queue and not in it:
+
+    git grep -n "BridgeConfigured" -- Jellyfin.Plugin.Requests/Api/InstallCapabilities.cs
+    Jellyfin.Plugin.Requests/Api/InstallCapabilities.cs:59:    public required bool BridgeConfigured { get; init; }
+
+Whether the configured service is answering right now is `BackendReachability`, which separates
+`NotConfigured` from `Unreachable`, and showing that is #63 rather than this list. The distinction
+matters here because approving into a service that has stopped answering is a decision an operator
+would take differently, and a page that shows only "a bridge exists" hides it.
+
+## Nothing on this list needs a second system
+
+That is the third thing this issue asks for, and it is a property of the list rather than of the
+page. Five of the six items are answered from this plugin's own store and configuration. The sixth,
+the requester as a name rather than an identifier, is answered from the server this plugin is
+running inside.
+
+None of the six asks the operator to open a metadata site, a chat log, or the external service's own
+queue.
+
+One question is deliberately not on the list because it would need one: whether the external service
+can actually fetch the title. That answer lives on the other side of the bridge, it changes without
+anybody here being told, and an operator who wants it is looking at the other system by definition.
+What this plugin owes instead is that a submission which fails is visible as a failure rather than as
+a request sitting in approved forever, which is the `Failed` state and is #82 and #86.
+
+## What the page shows today
+
+The page is a shell. It says so about itself:
+
+    git grep -n "The queue view is not built yet" -- Jellyfin.Plugin.Requests/Web/queue.html
+    Jellyfin.Plugin.Requests/Web/queue.html:29:                    <p>The queue view is not built yet.</p>
+
+So the second condition of #59 is unmet in full and is #60's to meet. Of the six items, four can be
+rendered from the answer the queue endpoint already gives, and two cannot be rendered at all until
+that answer carries them: whether the same title was asked for before and what was decided, and how
+much this person is asking for. Those two are work on the endpoint, and a page built without them
+would meet the list only by dropping the two hardest items from it.


### PR DESCRIPTION
Part of #59. This lands the first and third conditions of that issue and leaves the second, which is #60's.

The plugin's claim is that answering a request needs no second system, and that is a claim about one page. Nothing in the tree said what it means. `docs/queue.md` is the list: six things an operator has to be able to read before approving or declining, each with the reason a decision is worse without it, and each with where it comes from in this tree today.

The order matters. Written after the rows, a list is a description of what fitted; written before them, it is something the page can be measured against. Two of the six turn out not to be renderable at all from the answer the queue endpoint gives, and both are the ones a page built list-last would drop quietly.

**Whether the same title was asked for before, and what was decided.** The store keeps a finished request and a decline carries its reason, but nothing on the queue path reads either. `JoinedByUserIds` is not this: it is the several people behind one request that is still open, decided in #38.

**Whether the person in front of the operator is asking for a lot.** The ceiling exists as `PluginConfiguration.OpenRequestsPerUser`, and `IRequestStore.FindForUserAsync` can count, and the queue answer carries neither.

Both are work on the endpoint rather than on the page. Naming them here is what stops them being discovered by an operator who has to go and look.

### What was measured

Read at `e667f895b81f6fc62b7778de601fde607068fb17`, which is `master`. Every quotation in the document carries the command that produced it. The one that decides the second condition of #59:

    git grep -n "The queue view is not built yet" -- Jellyfin.Plugin.Requests/Web/queue.html
    Jellyfin.Plugin.Requests/Web/queue.html:29:                    <p>The queue view is not built yet.</p>

The page is a shell, so it shows none of the six today.

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!: Fehler: 0, erfolgreich: 502, gesamt: 502 (net9.0)
    Bestanden!: Fehler: 0, erfolgreich: 502, gesamt: 502 (net10.0)

    npx --yes prettier@3.6.2 --check "docs/queue.md"
    All matched files use Prettier code style!

### What this does not claim

No guard is added and none is claimed to bite. This is a document, the suite is unchanged, and 502 tests passing on each line says the tree is where it was rather than that anything new refuses anything.

No server ran. What the page shows was read from the file and not from a running dashboard.

The list is an argument and not a measurement. That an operator needs each of the six is my reasoning from what a decision requires, and the only parts of it a command settles are where each item comes from and whether the answer carries it.

Nobody else has read this change.