### PR TITLE
Draw the queue and leave the narrowing to the server

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Web/QueueViewTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Web/QueueViewTests.cs
@@ -1,0 +1,366 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Api;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+using PluginUnderTest = global::Jellyfin.Plugin.Requests.Plugin;
+
+namespace Jellyfin.Plugin.Requests.Tests.Web;
+
+/// <summary>
+/// What the queue page asks the server for, read out of the page the assembly carries and then
+/// asked of the endpoint itself.
+/// <para>
+/// The failure these exist against is a page that narrows a queue in the browser. It looks right on
+/// a store with forty requests and is unusable on one with ten thousand, because the browser is
+/// being handed the whole queue in order to show fifty rows of it, and nothing earlier says so: the
+/// build is clean, the formatter is happy, and the page renders.
+/// </para>
+/// <para>
+/// The page is read as the assembly carries it rather than as the working tree holds it, for the
+/// reason <see cref="PageRulesTests"/> gives: what a server serves is the embedded copy.
+/// </para>
+/// <para>
+/// The bound is worth stating. These read the page's source and drive the endpoint; they do not run
+/// the page. Whether a browser draws what the answer holds is behaviour, and driving a browser to
+/// ask is what <c>docs/testing.md</c> refuses.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class QueueViewTests
+{
+    /// <summary>
+    /// How many requests the queue is asked to hold for the size leg. Ten thousand is the number
+    /// the store's own cost bounds are stated at, so both sides of this plugin are measured against
+    /// one size rather than against two nobody compared.
+    /// </summary>
+    private const int Records = 10_000;
+
+    /// <summary>
+    /// The view an operator gets before touching anything, as the four controls select it.
+    /// <para>
+    /// The kind opens on an empty value, which is the filter the page leaves out of the question
+    /// rather than sends, and the endpoint reads an absent parameter as the queue not narrowed on
+    /// that field.
+    /// </para>
+    /// </summary>
+    private static readonly (string Control, string Value)[] Opening =
+    [
+        ("RequestsQueueState", "Open"),
+        ("RequestsQueueKind", string.Empty),
+        ("RequestsQueueOrder", "RequestedAt"),
+        ("RequestsQueueDescending", "false")
+    ];
+
+    /// <summary>
+    /// The ways a page does for itself what it asked the server to do. Each is written as it is
+    /// called on an array, so the words in the prose around them are not what is being read.
+    /// </summary>
+    private static readonly string[] TheServersWork =
+    [
+        ".sort(",
+        ".filter(",
+        ".slice(",
+        ".splice(",
+        ".reverse("
+    ];
+
+    /// <summary>
+    /// The two parts of the question the pager moves rather than an operator. They have no control
+    /// on the page, and naming them is what stops the leg that looks for controls from passing on a
+    /// page that lost one.
+    /// </summary>
+    private static readonly string[] ThePagersOwn = ["skip", "take"];
+
+    private readonly SequentialIdentifierSource _identifiers = new SequentialIdentifierSource();
+
+    /// <summary>
+    /// The queue opens on open requests, oldest first.
+    /// <para>
+    /// Read off the options the page marks as selected, because that is what a browser starts the
+    /// controls on and therefore what the first question is built from. The one-character mistake
+    /// this is aimed at is <c>selected</c> moving one line, which turns the queue an operator opens
+    /// every day into a list of things already dealt with and breaks nothing else.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void TheQueueOpensOnOpenRequestsOldestFirst()
+    {
+        var body = QueuePage();
+
+        foreach (var (control, value) in Opening)
+        {
+            Assert.Equal(value, SelectedValueOf(body, control));
+        }
+
+        Assert.Equal(0, BoundOf(body, "skip"));
+    }
+
+    /// <summary>
+    /// Every part of the question the page asks is a parameter the endpoint declares.
+    /// <para>
+    /// The endpoint's side is reflected rather than restated, so this is a comparison between the
+    /// page and the API rather than between the page and a list somebody kept up to date. A control
+    /// the endpoint cannot answer is a control whose only possible implementation is work done in
+    /// the browser, and that is the shape this refuses before it is written.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void EveryPartOfTheQuestionTheQueueAsksIsAParameterTheEndpointDeclares()
+    {
+        var declared = typeof(RequestsController)
+            .GetMethod(nameof(RequestsController.QueueAsync))!
+            .GetParameters()
+            .Select(parameter => parameter.Name!)
+            .Where(name => !string.Equals(name, "cancellationToken", StringComparison.Ordinal))
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        var page = AskedBy(QueuePage()).Order(StringComparer.Ordinal).ToArray();
+
+        Assert.NotEmpty(declared);
+        Assert.Equal(declared, page, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Each narrowing the page offers is read from a control on the page.
+    /// <para>
+    /// Without this the leg above passes on a page that names the endpoint's parameters and sends a
+    /// value it decided itself, which is a filter an operator cannot see and cannot change.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void EveryNarrowingTheQueueOffersIsReadFromAControlOnThePage()
+    {
+        var body = QueuePage();
+
+        var withoutAControl = AskedBy(body)
+            .Where(name => !body.Contains(IdOf(name), StringComparison.Ordinal))
+            .ToArray();
+
+        // The two the pager moves are the page's own and have no control: they are asserted here so
+        // that a control disappearing does not leave this leg looking at a shorter list.
+        Assert.Equal(ThePagersOwn, withoutAControl, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// The page does none of the work it asked the server for.
+    /// <para>
+    /// Every one of these is how a queue gets narrowed, ordered or paged in a browser, and each is
+    /// available on an array of rows the page has already been handed. What makes them refusable is
+    /// that the page has no honest use for any of them: what it draws is the answer, in the order
+    /// the answer came in.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void TheQueuePageDoesNoneOfTheWorkItAskedTheServerFor()
+    {
+        var body = QueuePage();
+
+        var doneHere = TheServersWork
+            .Where(work => body.Contains(work, StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.NotEmpty(body);
+        Assert.Empty(doneHere);
+    }
+
+    /// <summary>
+    /// A queue of ten thousand requests is one page of rows to whoever is reading it.
+    /// <para>
+    /// The question is the page's own, parsed out of it rather than written here, so this measures
+    /// what a browser opening the queue actually receives. What comes back is the page size and the
+    /// count of everything that matched, which is what a pager is drawn from: the browser is told
+    /// how many there are without being sent them.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AQueueOfTenThousandIsOnePageOfRowsToTheBrowser()
+    {
+        var body = QueuePage();
+        var store = new InMemoryRequestStore();
+
+        var asked = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        for (var made = 0; made < Records; made++)
+        {
+            await store.AddAsync(
+                new MediaRequest
+                {
+                    Id = _identifiers.NewId(),
+                    RequestedByUserId = new Guid("c1000000-0000-0000-0000-000000000001"),
+                    RequestedAt = asked.AddMinutes(made),
+                    StateChangedAt = asked.AddMinutes(made),
+                    Kind = RequestedItemKind.Movie,
+                    DisplayTitle = made.ToString(CultureInfo.InvariantCulture),
+                    ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal)
+                    {
+                        ["Tmdb"] = made.ToString(CultureInfo.InvariantCulture)
+                    }
+                },
+                CancellationToken.None).ConfigureAwait(true);
+        }
+
+        var take = BoundOf(body, "take");
+
+        var controller = new RequestsController(
+            store,
+            new TestClock(asked),
+            _identifiers,
+            new FakeCallerIdentity(new Guid("c1000000-0000-0000-0000-0000000000ad")));
+
+        var answered = await controller.QueueAsync(
+            [Enum.Parse<RequestState>(SelectedValueOf(body, "RequestsQueueState"), false)],
+            null,
+            Enum.Parse<RequestQueryOrder>(SelectedValueOf(body, "RequestsQueueOrder"), false),
+            bool.Parse(SelectedValueOf(body, "RequestsQueueDescending")),
+            BoundOf(body, "skip"),
+            take,
+            CancellationToken.None).ConfigureAwait(true);
+
+        var result = Assert.IsType<OkObjectResult>(answered.Result);
+        var answer = Assert.IsType<RequestsPage<QueuedRequest>>(result.Value);
+
+        Assert.Equal(take, answer.Requests.Count);
+        Assert.Equal(Records, answer.MatchCount);
+        Assert.Equal(take, answer.Take);
+
+        // Oldest first, which is the half of the opening view no reading of the markup can show.
+        Assert.Equal(asked.AddMinutes(0), answer.Requests[0].RequestedAt);
+        Assert.Equal(asked.AddMinutes(take - 1), answer.Requests[take - 1].RequestedAt);
+        Assert.All(answer.Requests, row => Assert.Equal(RequestState.Open, row.State));
+    }
+
+    /// <summary>
+    /// The identifier the page gives the control that answers one part of the question.
+    /// </summary>
+    /// <param name="asked">The endpoint parameter's name.</param>
+    /// <returns>The element identifier the page uses for it.</returns>
+    private static string IdOf(string asked)
+        => "RequestsQueue" + char.ToUpperInvariant(asked[0]) + asked[1..];
+
+    /// <summary>
+    /// The value of the option a select starts on.
+    /// </summary>
+    /// <param name="body">The page as it is embedded.</param>
+    /// <param name="id">The select's identifier.</param>
+    /// <returns>The value the browser would send before anybody touches it.</returns>
+    private static string SelectedValueOf(string body, string id)
+    {
+        var at = body.IndexOf("id=\"" + id + "\"", StringComparison.Ordinal);
+        Assert.True(at >= 0, "The page carries no control with the identifier " + id + ".");
+
+        var end = body.IndexOf("</select>", at, StringComparison.Ordinal);
+        Assert.True(end >= 0, "The control " + id + " is not a select the page closes.");
+
+        var options = body[at..end].Split("<option ", StringSplitOptions.RemoveEmptyEntries);
+
+        var selected = options
+            .Where(option => option.Contains("selected", StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.Single(selected);
+
+        return ValueOf(selected[0]);
+    }
+
+    /// <summary>
+    /// What one option carries as its value.
+    /// </summary>
+    /// <param name="option">The option, from its attributes onwards.</param>
+    /// <returns>The value, which is empty for the option that narrows nothing.</returns>
+    private static string ValueOf(string option)
+    {
+        const string Marker = "value=\"";
+
+        var at = option.IndexOf(Marker, StringComparison.Ordinal);
+        Assert.True(at >= 0, "An option the page marks as selected carries no value.");
+
+        var start = at + Marker.Length;
+
+        return option[start..option.IndexOf('"', start)];
+    }
+
+    /// <summary>
+    /// Every part of the question the page sends, read out of the page's own list of them.
+    /// </summary>
+    /// <param name="body">The page as it is embedded.</param>
+    /// <returns>The parameter names, in the order the page writes them.</returns>
+    private static IEnumerable<string> AskedBy(string body)
+    {
+        const string Marker = "var asked = [";
+
+        var at = body.IndexOf(Marker, StringComparison.Ordinal);
+        Assert.True(at >= 0, "The page does not say what it asks for.");
+
+        var start = at + Marker.Length;
+        var list = body[start..body.IndexOf(']', start)];
+
+        return list
+            .Split(',', StringSplitOptions.RemoveEmptyEntries)
+            .Select(name => name.Trim().Trim('"'))
+            .Where(name => name.Length > 0);
+    }
+
+    /// <summary>
+    /// One of the two numbers the pager moves, read out of the page.
+    /// </summary>
+    /// <param name="body">The page as it is embedded.</param>
+    /// <param name="name">Which of them.</param>
+    /// <returns>What the page opens on.</returns>
+    private static int BoundOf(string body, string name)
+    {
+        const string Marker = "var bounds = {";
+
+        var at = body.IndexOf(Marker, StringComparison.Ordinal);
+        Assert.True(at >= 0, "The page does not say where its first page starts or how big it is.");
+
+        var start = at + Marker.Length;
+        var written = body[start..body.IndexOf('}', start)];
+
+        var named = written.IndexOf(name + ":", StringComparison.Ordinal);
+        Assert.True(named >= 0, "The page's bounds do not name " + name + ".");
+
+        var digits = written[(named + name.Length + 1)..]
+            .TrimStart()
+            .TakeWhile(char.IsAsciiDigit)
+            .ToArray();
+
+        return int.Parse(new string(digits), CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// The queue page as the built assembly carries it.
+    /// </summary>
+    /// <returns>The page, inline script and all.</returns>
+    private static string QueuePage()
+    {
+        var assembly = typeof(PluginUnderTest).Assembly;
+
+        var resource = assembly
+            .GetManifestResourceNames()
+            .Single(name => name.EndsWith("Web.queue.html", StringComparison.Ordinal));
+
+        using var stream = assembly.GetManifestResourceStream(resource)
+            ?? throw new InvalidOperationException($"The assembly carries no resource named {resource}.");
+
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+
+        return reader.ReadToEnd();
+    }
+}

--- a/Jellyfin.Plugin.Requests/Web/queue.html
+++ b/Jellyfin.Plugin.Requests/Web/queue.html
@@ -5,7 +5,7 @@
         <title>Requests</title>
     </head>
     <body>
-        <div id="RequestsQueuePage" data-role="page" class="page type-interior pluginConfigurationPage" data-require="emby-button">
+        <div id="RequestsQueuePage" data-role="page" class="page type-interior pluginConfigurationPage" data-require="emby-button,emby-select">
             <div data-role="content">
                 <div class="content-primary">
                     <div class="requestsShell"></div>
@@ -15,24 +15,132 @@
                     <p class="requestsMessage" role="status"></p>
 
                     <!--
-                        The rows an operator works through, with the filter, the sort and the paging
-                        that make a long queue usable, are #60, and acting on them is #61 and #62.
-                        This page is the shell those are built into.
+                        Every narrowing here is a parameter of the queue endpoint and none of it is
+                        done in this page. The server holds the whole queue, so it is the only side
+                        that can filter, order and slice one read; a page that fetched everything and
+                        did the same work again would be asking a household server to send a decade
+                        of requests so that a browser could throw away all but fifty of them.
 
-                        Nothing here reads the queue yet, and that is not only because the rows are
-                        somebody else's issue. Every endpoint this plugin serves answers 500 on a
-                        real server today, because the policy the controller names is not one the
-                        server registers; the run that measured it is in this change's pull request
-                        and the repair is #51's. A page shipped now with a call in it would show an
-                        operator an error every time they opened it.
+                        What the rows show is the list in docs/queue.md, less the two items that
+                        document names as absent from the answer this endpoint gives. Acting on a row
+                        is #61 and #62, and the panel beside the queue is #63.
                     -->
-                    <p>The queue view is not built yet.</p>
+                    <div class="requestsQueueControls">
+                        <label class="requestsQueueControl" for="RequestsQueueState">
+                            <span>State</span>
+                            <select is="emby-select" id="RequestsQueueState">
+                                <option value="Open" selected>Open</option>
+                                <option value="Approved">Approved</option>
+                                <option value="Declined">Declined</option>
+                                <option value="Fulfilled">Fulfilled</option>
+                                <option value="Failed">Failed</option>
+                                <option value="">Every state</option>
+                            </select>
+                        </label>
+
+                        <label class="requestsQueueControl" for="RequestsQueueKind">
+                            <span>Kind</span>
+                            <select is="emby-select" id="RequestsQueueKind">
+                                <option value="" selected>Every kind</option>
+                                <option value="Movie">Film</option>
+                                <option value="Series">Series</option>
+                            </select>
+                        </label>
+
+                        <label class="requestsQueueControl" for="RequestsQueueOrder">
+                            <span>Ordered by</span>
+                            <select is="emby-select" id="RequestsQueueOrder">
+                                <option value="RequestedAt" selected>When it was asked for</option>
+                                <option value="StateChangedAt">When it last moved</option>
+                                <option value="DisplayTitle">Title</option>
+                            </select>
+                        </label>
+
+                        <label class="requestsQueueControl" for="RequestsQueueDescending">
+                            <span>Direction</span>
+                            <!--
+                                Ascending and descending rather than oldest and newest, because the
+                                same control also runs the title order and "oldest title" is not a
+                                thing. Ascending on the order above it is the oldest first, which is
+                                what this page opens on.
+                            -->
+                            <select is="emby-select" id="RequestsQueueDescending">
+                                <option value="false" selected>Ascending</option>
+                                <option value="true">Descending</option>
+                            </select>
+                        </label>
+                    </div>
+
+                    <table class="requestsQueueTable">
+                        <caption class="requestsQueueSummary" aria-live="polite"></caption>
+                        <thead>
+                            <tr>
+                                <th scope="col">Title</th>
+                                <th scope="col">Kind</th>
+                                <th scope="col">State</th>
+                                <th scope="col">Asked for</th>
+                                <th scope="col">Last moved</th>
+                                <th scope="col">Requester</th>
+                                <th scope="col">In the library</th>
+                                <th scope="col">Note</th>
+                            </tr>
+                        </thead>
+                        <tbody class="requestsQueueRows"></tbody>
+                    </table>
+
+                    <div class="requestsQueuePager">
+                        <button is="emby-button" type="button" class="raised" id="RequestsQueuePrevious">Previous page</button>
+                        <button is="emby-button" type="button" class="raised" id="RequestsQueueNext">Next page</button>
+                    </div>
                 </div>
             </div>
 
             <script type="text/javascript">
                 (function () {
                     var page = document.querySelector("#RequestsQueuePage");
+
+                    /*
+                     * Every part of the question this page asks, named exactly as the queue endpoint
+                     * names it. The four with a control are read from that control; the two without
+                     * are the bounds below. Anything the endpoint does not declare cannot be added
+                     * here without the suite naming it, which is what keeps a control that quietly
+                     * does its own work out of this page.
+                     */
+                    var asked = ["state", "kind", "order", "descending", "skip", "take"];
+
+                    /*
+                     * Where the page starts and how many rows it holds. Fifty is the endpoint's own
+                     * page size, so the browser is handed one screen of a queue whatever the queue
+                     * holds, and the pager moves this rather than growing it.
+                     */
+                    var bounds = { skip: 0, take: 50 };
+
+                    var rows = page.querySelector(".requestsQueueRows");
+                    var summary = page.querySelector(".requestsQueueSummary");
+                    var previous = page.querySelector("#RequestsQueuePrevious");
+                    var next = page.querySelector("#RequestsQueueNext");
+
+                    var states = {
+                        Open: "Open",
+                        Approved: "Approved",
+                        Declined: "Declined",
+                        Fulfilled: "Fulfilled",
+                        Failed: "Failed",
+                    };
+
+                    var kinds = { Movie: "Film", Series: "Series" };
+
+                    /*
+                     * What the library holds of what was asked for. `Unknown` is a fourth answer
+                     * rather than a missing one, so it says that nothing has looked rather than
+                     * leaving the cell blank for an operator to read as "no".
+                     */
+                    var availability = {
+                        Unknown: "Not checked",
+                        Absent: "No",
+                        Partial: "In part",
+                        Present: "Yes",
+                    };
 
                     // Loaded through the same endpoint the dashboard fetches this page from, because
                     // an embedded resource is reachable only under a name the plugin registered.
@@ -52,6 +160,145 @@
                         });
                     }
 
+                    /*
+                     * The control that answers one part of the question, or nothing where that part
+                     * is the page bounds rather than something an operator chose.
+                     */
+                    function control(name) {
+                        return page.querySelector("#RequestsQueue" + name.charAt(0).toUpperCase() + name.substring(1));
+                    }
+
+                    /*
+                     * The question, as the endpoint's own parameters. An empty control is left out
+                     * rather than sent empty, because a filter naming no value is the queue not
+                     * narrowed and the endpoint reads an absent parameter as exactly that.
+                     */
+                    function question() {
+                        var sent = {};
+
+                        asked.forEach(function (name) {
+                            var from = control(name);
+                            var value = from ? from.value : String(bounds[name]);
+
+                            if (value !== "") {
+                                sent[name] = value;
+                            }
+                        });
+
+                        return sent;
+                    }
+
+                    /*
+                     * One cell. `textContent` rather than any of the ways of writing markup: a title
+                     * and a note are things a person typed, and a dashboard that renders them as
+                     * markup is a scripting hole reachable by anybody who can file a request.
+                     */
+                    function cell(row, text) {
+                        var target = document.createElement("td");
+                        target.textContent = text;
+                        row.appendChild(target);
+                        return target;
+                    }
+
+                    function moment(value) {
+                        return value ? new Date(value).toLocaleString() : "";
+                    }
+
+                    function title(request) {
+                        var written = request.DisplayTitle;
+
+                        if (request.DisplayYear) {
+                            written = written + " (" + request.DisplayYear + ")";
+                        }
+
+                        if (request.Seasons && request.Seasons.length) {
+                            written = written + ", seasons " + request.Seasons.join(", ");
+                        }
+
+                        return written;
+                    }
+
+                    function held(request) {
+                        var answer = availability[request.Availability] || request.Availability;
+
+                        return request.AvailabilityCheckedAt ? answer + ", checked " + moment(request.AvailabilityCheckedAt) : answer;
+                    }
+
+                    function draw(answer) {
+                        var drawn = document.createDocumentFragment();
+
+                        answer.Requests.forEach(function (request) {
+                            var row = document.createElement("tr");
+
+                            cell(row, title(request));
+                            cell(row, kinds[request.Kind] || request.Kind);
+                            cell(row, states[request.State] || request.State);
+                            cell(row, moment(request.RequestedAt));
+                            cell(row, moment(request.StateChangedAt));
+                            cell(row, request.RequestedByUserId);
+                            cell(row, held(request));
+                            cell(row, request.RequesterNote || "");
+
+                            drawn.appendChild(row);
+                        });
+
+                        rows.replaceChildren(drawn);
+
+                        var first = answer.MatchCount === 0 ? 0 : answer.Skip + 1;
+                        var last = answer.Skip + answer.Requests.length;
+
+                        summary.textContent = first + " to " + last + " of " + answer.MatchCount;
+
+                        previous.disabled = answer.Skip <= 0;
+                        next.disabled = last >= answer.MatchCount;
+                    }
+
+                    function read() {
+                        Dashboard.showLoadingMsg();
+                        RequestsShell.say(page, "");
+
+                        return RequestsShell.get("Requests/Queue", question())
+                            .then(function (answer) {
+                                draw(answer);
+                                Dashboard.hideLoadingMsg();
+                            })
+                            .catch(function () {
+                                RequestsShell.say(page, "The queue could not be read. The server said nothing this page can act on.");
+                                Dashboard.hideLoadingMsg();
+                            });
+                    }
+
+                    /*
+                     * A narrowing starts the queue again from the top. Keeping the offset across a
+                     * change of filter is how an operator lands on an empty page and reads it as an
+                     * empty queue.
+                     */
+                    function narrowed() {
+                        bounds.skip = 0;
+                        read();
+                    }
+
+                    function step(by) {
+                        bounds.skip = Math.max(0, bounds.skip + by * bounds.take);
+                        read();
+                    }
+
+                    asked.forEach(function (name) {
+                        var from = control(name);
+
+                        if (from) {
+                            from.addEventListener("change", narrowed);
+                        }
+                    });
+
+                    previous.addEventListener("click", function () {
+                        step(-1);
+                    });
+
+                    next.addEventListener("click", function () {
+                        step(1);
+                    });
+
                     page.addEventListener("pageshow", function () {
                         Dashboard.showLoadingMsg();
 
@@ -59,6 +306,7 @@
                             .then(function () {
                                 RequestsShell.attach(page, "RequestsQueue");
                                 Dashboard.hideLoadingMsg();
+                                read();
                             })
                             .catch(function () {
                                 Dashboard.hideLoadingMsg();

--- a/Jellyfin.Plugin.Requests/Web/shell.css
+++ b/Jellyfin.Plugin.Requests/Web/shell.css
@@ -50,3 +50,49 @@
 .requestsMessage:empty {
     display: none;
 }
+
+/*
+ * The narrowings, laid out in a row that wraps rather than in a fixed grid. An operator on a narrow
+ * screen gets the same controls in one column instead of a row that scrolls sideways.
+ */
+.requestsQueueControls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1em;
+    align-items: flex-end;
+    margin-bottom: 1em;
+}
+
+.requestsQueueControl {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2em;
+}
+
+.requestsQueueTable {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+/*
+ * The count sits above the rows and is read out when it changes, so somebody who moved a page hears
+ * where they are rather than having to go looking for the number.
+ */
+.requestsQueueSummary {
+    text-align: left;
+    padding-bottom: 0.5em;
+}
+
+.requestsQueueTable th,
+.requestsQueueTable td {
+    text-align: left;
+    padding: 0.4em 0.6em;
+    border-bottom: 1px solid rgba(127, 127, 127, 0.4);
+    vertical-align: top;
+}
+
+.requestsQueuePager {
+    display: flex;
+    gap: 0.5em;
+    margin-top: 1em;
+}

--- a/Jellyfin.Plugin.Requests/Web/shell.js
+++ b/Jellyfin.Plugin.Requests/Web/shell.js
@@ -100,15 +100,14 @@ var RequestsShell = {
      * reachable without a session: the client is what holds the token and adds the header, and a bare
      * fetch would be a second place that has to know how this server authenticates.
      *
-     * No page calls this yet. Every endpoint answers 500 on a real server today, because the policy
-     * the controller names is not one the server registers; that is #51's and it is measured rather
-     * than supposed. This is here so the pages that read the queue are written against one helper
-     * rather than each growing its own.
+     * The question goes in `asked` and is turned into a query string by the client rather than by
+     * the caller. A page that built its own would be a second place that has to know how a value is
+     * escaped, and the queue's filters carry text somebody typed.
      */
-    get: function (path) {
+    get: function (path, asked) {
         return ApiClient.ajax({
             type: "GET",
-            url: ApiClient.getUrl(RequestsShell.apiBase + "/" + path),
+            url: ApiClient.getUrl(RequestsShell.apiBase + "/" + path, asked),
             dataType: "json",
         });
     },


### PR DESCRIPTION
Part of #60.

The queue page was a shell that said so about itself. It now reads the queue
endpoint and draws a row per request, with the state, the kind, the order, the
direction and the paging sent as that endpoint's own parameters.

## What the three conditions look like now

**The default view is open requests, oldest first.** The four controls open on
`state=Open`, no kind, `order=RequestedAt` and `descending=false`, read off the
options the page marks as selected, which is what a browser starts them on.

**Filter, sort and paging go through the API.** Every part of the question the
page sends is a parameter of `QueueAsync`, compared against it by reflection
rather than against a list in a test. What is not here is the requester filter
the body of #60 asks for, for the reason already recorded on that issue on
12 August, which is why this says `Part of` rather than closing it.

**Ten thousand requests are one page to the browser.** Measured against the
endpoint rather than argued: a store holding ten thousand, asked the page's own
question, answers fifty rows and a count of ten thousand.

## The runs

Both frameworks, at `dd93902`:

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    0 Fehler

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!: Fehler: 0, erfolgreich: 507, gesamt: 507 (net9.0)
    Bestanden!: Fehler: 0, erfolgreich: 507, gesamt: 507 (net10.0)

    npx --yes prettier@3.6.2 --check --end-of-line auto "Jellyfin.Plugin.Requests/Web/*.{html,css,js}"
    All matched files use Prettier code style!

Every new leg was watched failing before this was pushed, each for the mistake
it names, on `net9.0`. The page was edited, the suite run, and the edit reverted.

The direction moved one option, which is the whole of "oldest first":

    <option value="false">Ascending</option>
    <option value="true" selected>Descending</option>
    QueueViewTests.TheQueueOpensOnOpenRequestsOldestFirst [FAIL]
    QueueViewTests.AQueueOfTenThousandIsOnePageOfRowsToTheBrowser [FAIL]
    Fehler: 2, erfolgreich: 505, gesamt: 507

A filter the endpoint has no parameter for:

    var asked = ["state", "kind", "order", "descending", "requester", "skip", "take"];
    QueueViewTests.EveryPartOfTheQuestionTheQueueAsksIsAParameterTheEndpointDeclares [FAIL]
    QueueViewTests.EveryNarrowingTheQueueOffersIsReadFromAControlOnThePage [FAIL]
    Fehler: 2, erfolgreich: 505, gesamt: 507

The page taking a slice of what it was handed:

    answer.Requests.slice(0).forEach(function (request) {
    QueueViewTests.TheQueuePageDoesNoneOfTheWorkItAskedTheServerFor [FAIL]
    Fehler: 1, erfolgreich: 506, gesamt: 507

The page asking for the whole queue instead of a page of it:

    var bounds = { skip: 0, take: 10000 };
    QueueViewTests.AQueueOfTenThousandIsOnePageOfRowsToTheBrowser [FAIL]
    Fehler: 1, erfolgreich: 506, gesamt: 507

The last one is the endpoint refusing a page above its maximum, which is what a
browser asking for everything runs into.

## What this does not do, and one thing it breaks

Nothing here runs the page. These legs read the page as the assembly carries it
and drive the endpoint; whether a browser draws what the answer holds is
behaviour, and `docs/testing.md` refuses driving one.

**`docs/queue.md` now quotes a line this change removes.** Its last section
runs

    git grep -n "The queue view is not built yet" -- Jellyfin.Plugin.Requests/Web/queue.html

and that sentence is gone, because it was the page saying it was not built. That
document is #59's and is not in #60's declared scope, so it is named here rather
than edited: two changes to one file from two directions is the collision that
rule exists against.

#60 declares its scope as the plugin's web assets, and this adds a test file as
well. A change to behaviour without a guard is the alternative, and this
repository's own contributing document asks for the guard.

No second person has read this. The evidence above stands in place of one.
