### PR TITLE
Hold the queue's rows to the rules the rest of the tree keeps

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Web/PageControlsTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Web/PageControlsTests.cs
@@ -1,0 +1,244 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+using PluginUnderTest = global::Jellyfin.Plugin.Requests.Plugin;
+
+namespace Jellyfin.Plugin.Requests.Tests.Web;
+
+/// <summary>
+/// What an operator working the queue without a mouse meets.
+/// <para>
+/// Two things decide it and both are readable off the page. A control with no label is a control a
+/// screen reader announces as its own type and nothing else, so an operator hears "combo box" four
+/// times and has to guess which is the state. And a control that is a styled element with a click
+/// handler on it is one the keyboard never reaches at all: focus does not stop there, the space bar
+/// does nothing, and the page looks identical to one that works.
+/// </para>
+/// <para>
+/// The bound is worth stating plainly. This reads the page rather than driving a browser through
+/// it, so what it holds is that every control is a real control and that each carries a name. That
+/// somebody can complete the work with a keyboard is a claim about behaviour, and running a browser
+/// to make it a measurement is what <c>docs/testing.md</c> refuses.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class PageControlsTests
+{
+    /// <summary>
+    /// The element the dashboard hands the script, which carries an identifier for that reason
+    /// rather than because anybody operates it.
+    /// </summary>
+    private const string ThePageItself = "RequestsQueuePage";
+
+    /// <summary>
+    /// The elements a browser gives keyboard behaviour to without being asked. Anything else the
+    /// page attaches behaviour to is a control only a pointer can work.
+    /// </summary>
+    private static readonly string[] RealControls = ["select", "button", "input", "textarea"];
+
+    /// <summary>
+    /// Every control the queue carries has a name something can read out.
+    /// <para>
+    /// A select is named by the label that points at it, and a button by the words between its
+    /// tags. Both sides are read off the page rather than listed here, so a control added without
+    /// either is named by this the first time the suite runs.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void EveryControlOnTheQueueCarriesANameSomethingCanReadOut()
+    {
+        var body = Queue();
+
+        var unlabelled = IdentifiersOf(body, "<select ")
+            .Where(id => !body.Contains("for=\"" + id + "\"", StringComparison.Ordinal))
+            .ToArray();
+
+        var silent = Buttons(body)
+            .Where(button => button.Words.Length == 0)
+            .Select(button => button.Id)
+            .ToArray();
+
+        Assert.NotEmpty(IdentifiersOf(body, "<select "));
+        Assert.NotEmpty(Buttons(body));
+        Assert.Empty(unlabelled);
+        Assert.Empty(silent);
+    }
+
+    /// <summary>
+    /// Everything the queue reaches for by name is a control the keyboard already reaches.
+    /// <para>
+    /// An identifier on this page exists so the script can find an element and give it something to
+    /// do, so every one of them is required to sit on an element a browser makes focusable on its
+    /// own. The mistake this refuses is the cheap one: drawing a pager out of two styled elements
+    /// with click handlers, which looks right, reads right, and is unusable without a pointer.
+    /// </para>
+    /// <para>
+    /// The page's own element is the one exception, and it is named rather than filtered by shape.
+    /// It is not a control: it is what the dashboard hands the script, and the event on it is the
+    /// dashboard's own rather than anything an operator does.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void EverythingTheQueueReachesForByNameIsAControlAKeyboardReaches()
+    {
+        var body = Queue();
+
+        var named = Identifiers(body)
+            .Where(id => !string.Equals(id, ThePageItself, StringComparison.Ordinal))
+            .ToArray();
+
+        var unreachable = named
+            .Where(id => !RealControls.Contains(ElementCarrying(body, id), StringComparer.Ordinal))
+            .ToArray();
+
+        Assert.NotEmpty(named);
+        Assert.Empty(unreachable);
+
+        // A page that orders focus by hand is a page whose order stops matching what is drawn the
+        // first time a control moves, so the order is the document's own or it is nobody's.
+        Assert.DoesNotContain("tabindex", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Which element carries an identifier.
+    /// </summary>
+    /// <param name="body">The page.</param>
+    /// <param name="id">The identifier.</param>
+    /// <returns>The element's name, in lower case as the page writes it.</returns>
+    private static string ElementCarrying(string body, string id)
+    {
+        var at = body.IndexOf("id=\"" + id + "\"", StringComparison.Ordinal);
+        Assert.True(at >= 0, "The script reaches for #" + id + " and the page declares nothing under it.");
+
+        var opens = body.LastIndexOf('<', at);
+        Assert.True(opens >= 0, "The identifier " + id + " sits inside no element.");
+
+        var name = body[(opens + 1)..];
+
+        return new string([.. name.TakeWhile(char.IsAsciiLetter)]);
+    }
+
+    /// <summary>
+    /// The identifiers carried by one kind of element.
+    /// </summary>
+    /// <param name="body">The page.</param>
+    /// <param name="element">The element, as it is opened.</param>
+    /// <returns>Each identifier, in the order the page declares them.</returns>
+    private static IEnumerable<string> IdentifiersOf(string body, string element)
+    {
+        var at = body.IndexOf(element, StringComparison.Ordinal);
+
+        while (at >= 0)
+        {
+            var opens = body.IndexOf('>', at);
+
+            if (opens < 0)
+            {
+                yield break;
+            }
+
+            var declared = body[at..opens];
+            const string Marker = "id=\"";
+            var named = declared.IndexOf(Marker, StringComparison.Ordinal);
+
+            if (named >= 0)
+            {
+                var start = named + Marker.Length;
+                yield return declared[start..declared.IndexOf('"', start)];
+            }
+
+            at = body.IndexOf(element, opens, StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>
+    /// Every identifier the page declares, whatever carries it.
+    /// </summary>
+    /// <param name="body">The page.</param>
+    /// <returns>Each identifier, in the order the page declares them.</returns>
+    private static IEnumerable<string> Identifiers(string body)
+    {
+        const string Marker = "id=\"";
+
+        var at = body.IndexOf(Marker, StringComparison.Ordinal);
+
+        while (at >= 0)
+        {
+            var start = at + Marker.Length;
+            var end = body.IndexOf('"', start);
+
+            if (end < 0)
+            {
+                yield break;
+            }
+
+            yield return body[start..end];
+
+            at = body.IndexOf(Marker, end, StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>
+    /// The buttons the page draws, with what a person hears when they reach one.
+    /// </summary>
+    /// <param name="body">The page.</param>
+    /// <returns>The identifier and the words of each.</returns>
+    private static (string Id, string Words)[] Buttons(string body)
+    {
+        var buttons = new List<(string Id, string Words)>();
+
+        var at = body.IndexOf("<button ", StringComparison.Ordinal);
+
+        while (at >= 0)
+        {
+            var opens = body.IndexOf('>', at);
+            var closes = body.IndexOf("</button>", at, StringComparison.Ordinal);
+
+            if (opens < 0 || closes < 0)
+            {
+                break;
+            }
+
+            var declared = body[at..opens];
+            const string Marker = "id=\"";
+            var named = declared.IndexOf(Marker, StringComparison.Ordinal);
+            var start = named + Marker.Length;
+
+            buttons.Add((
+                named >= 0 ? declared[start..declared.IndexOf('"', start)] : declared,
+                body[(opens + 1)..closes].Trim()));
+
+            at = body.IndexOf("<button ", closes, StringComparison.Ordinal);
+        }
+
+        return [.. buttons];
+    }
+
+    /// <summary>
+    /// The queue page as the built assembly carries it, which is the copy a server serves.
+    /// </summary>
+    /// <returns>The page.</returns>
+    private static string Queue()
+    {
+        var assembly = typeof(PluginUnderTest).Assembly;
+
+        var resource = assembly
+            .GetManifestResourceNames()
+            .Single(name => name.EndsWith("Web.queue.html", StringComparison.Ordinal));
+
+        using var stream = assembly.GetManifestResourceStream(resource)
+            ?? throw new InvalidOperationException($"The assembly carries no resource named {resource}.");
+
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+
+        return reader.ReadToEnd();
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/Web/PageRulesTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Web/PageRulesTests.cs
@@ -60,6 +60,13 @@ public class PageRulesTests
     ];
 
     /// <summary>
+    /// The fields of a request that carry a sentence somebody typed. A note is the requester's own
+    /// words and the second is what an operator wrote when they said no, and both are shown to
+    /// somebody who did not write them.
+    /// </summary>
+    private static readonly string[] TextAPersonTyped = ["RequesterNote", "DeclineNote"];
+
+    /// <summary>
     /// Nothing this plugin embeds turns a string into markup.
     /// <para>
     /// The count of assets read is asserted as well as the offenders, because the failure that
@@ -81,6 +88,47 @@ public class PageRulesTests
 
         Assert.NotEmpty(assets);
         Assert.Empty(offenders);
+    }
+
+    /// <summary>
+    /// The writing people did reaches the queue only through the one place that puts a string in as
+    /// text.
+    /// <para>
+    /// The leg above refuses the sinks wherever they are written. This one is the other direction:
+    /// it reads the code that draws a row and requires every field of a request to leave it through
+    /// that single call, so a field drawn some new way has to pass here before the sink list has
+    /// ever heard of it. The two pieces of writing this is for are the requester's note and the
+    /// sentence an operator writes with a decline, and both are asserted to be drawn at all, since
+    /// a rule about how a thing is rendered proves nothing over a page that renders it nowhere.
+    /// </para>
+    /// <para>
+    /// The bound is the same one this class carries throughout: this reads the page, it does not
+    /// run it.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void TheWritingPeopleDidReachesTheQueueOnlyAsText()
+    {
+        var body = Queue();
+
+        var writer = Between(body, "function cell(", "\n                    }");
+        Assert.Contains("target.textContent = text;", writer, StringComparison.Ordinal);
+
+        var drawing = Between(body, "function draw(", "\n                    }");
+
+        var straightIn = drawing
+            .Split('\n')
+            .Select(line => line.Trim())
+            .Where(line => line.Contains("request.", StringComparison.Ordinal))
+            .Where(line => !line.StartsWith("cell(row, ", StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.Empty(straightIn);
+
+        foreach (var typed in TextAPersonTyped)
+        {
+            Assert.Contains(typed, body, StringComparison.Ordinal);
+        }
     }
 
     /// <summary>
@@ -111,6 +159,32 @@ public class PageRulesTests
 
         Assert.NotEmpty(registered);
         Assert.Empty(unread);
+    }
+
+    /// <summary>
+    /// The queue page, which is the one that draws what people wrote.
+    /// </summary>
+    /// <returns>The page as the assembly carries it.</returns>
+    private static string Queue()
+        => Assets().Single(asset => asset.Name.EndsWith("Web.queue.html", StringComparison.Ordinal)).Body;
+
+    /// <summary>
+    /// One block of the page, from a marker to the end of what it opens.
+    /// </summary>
+    /// <param name="body">The page.</param>
+    /// <param name="opens">What the block starts with.</param>
+    /// <param name="closes">What ends it.</param>
+    /// <returns>The block, without either marker.</returns>
+    private static string Between(string body, string opens, string closes)
+    {
+        var at = body.IndexOf(opens, StringComparison.Ordinal);
+        Assert.True(at >= 0, "The page carries nothing beginning " + opens);
+
+        var start = at + opens.Length;
+        var end = body.IndexOf(closes, start, StringComparison.Ordinal);
+        Assert.True(end >= 0, "What begins " + opens + " is never closed.");
+
+        return body[start..end];
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Requests/Web/queue.html
+++ b/Jellyfin.Plugin.Requests/Web/queue.html
@@ -83,6 +83,7 @@
                                 <th scope="col">Requester</th>
                                 <th scope="col">In the library</th>
                                 <th scope="col">Note</th>
+                                <th scope="col">Decision</th>
                             </tr>
                         </thead>
                         <tbody class="requestsQueueRows"></tbody>
@@ -129,6 +130,20 @@
                     };
 
                     var kinds = { Movie: "Film", Series: "Series" };
+
+                    /*
+                     * The reasons a request can be declined for, as the model fixes them. An
+                     * operator sees the words rather than the value, and a reason this page has no
+                     * word for is shown as it came rather than dropped.
+                     */
+                    var reasons = {
+                        Other: "Another reason",
+                        AlreadyInTheLibrary: "Already in the library",
+                        AlreadyRequested: "Already asked for",
+                        CannotBeObtained: "Cannot be obtained",
+                        NotWanted: "Not wanted",
+                        NoRoomForIt: "No room for it",
+                    };
 
                     /*
                      * What the library holds of what was asked for. `Unknown` is a fourth answer
@@ -224,6 +239,21 @@
                         return request.AvailabilityCheckedAt ? answer + ", checked " + moment(request.AvailabilityCheckedAt) : answer;
                     }
 
+                    /*
+                     * What was decided, where anything was. The reason is one of a fixed set and the
+                     * note beside it is an operator's own sentence, which is the second of the two
+                     * pieces of writing on this page that a person typed.
+                     */
+                    function decided(request) {
+                        if (!request.DeclineReason) {
+                            return "";
+                        }
+
+                        var reason = reasons[request.DeclineReason] || request.DeclineReason;
+
+                        return request.DeclineNote ? reason + ", " + request.DeclineNote : reason;
+                    }
+
                     function draw(answer) {
                         var drawn = document.createDocumentFragment();
 
@@ -238,6 +268,7 @@
                             cell(row, request.RequestedByUserId);
                             cell(row, held(request));
                             cell(row, request.RequesterNote || "");
+                            cell(row, decided(request));
 
                             drawn.appendChild(row);
                         });


### PR DESCRIPTION
Closes #64.

Three conditions, and this is what each rests on.

## A request note containing markup renders as text

`TheWritingPeopleDidReachesTheQueueOnlyAsText` reads the code that draws a row
and requires every field of a request to leave it through the one call that
writes with `textContent`. That is the other direction from the sink list in the
same class, which refuses the known ways of turning a string into markup
wherever they are written: a field drawn some new way has to pass this before
that list has heard of the sink it used.

The second of the two pieces of writing this issue names was not on the page at
all, so the rule had nothing to hold over it. The decline reason and the
sentence written beside it are a column now, and the leg asserts both are drawn,
because a rule about how a thing is rendered proves nothing over a page that
renders it nowhere.

## The web assets pass the formatting check

    npx --yes prettier@3.6.2 --check --end-of-line auto "Jellyfin.Plugin.Requests/Web/*.{html,css,js}"
    All matched files use Prettier code style!

and the gate's own verdict on this head is in the checks below rather than
claimed here.

## Every control has a label, and the queue is worked with a keyboard

`PageControlsTests` holds both halves as far as reading the page can. A select
with no label is announced as a combo box and nothing else, so an operator hears
four of them and has to guess which is the state. An identifier on an element a
browser does not make focusable is a control only a pointer can work, which is
the cheap pager mistake and looks identical to one that works. Focus order is
the document's own, since a page that orders it by hand is a page whose order
stops matching what is drawn the first time a control moves.

**Nothing here runs the page.** That somebody can complete the work with a
keyboard is a claim about behaviour, and driving a browser to turn it into a
measurement is what `docs/testing.md` refuses. What is measured is that every
control is a real control and that each carries a name something can read out.

## The runs

At `3089fd1`, both frameworks:

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    0 Fehler

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!: Fehler: 0, erfolgreich: 510, gesamt: 510 (net9.0)
    Bestanden!: Fehler: 0, erfolgreich: 510, gesamt: 510 (net10.0)

Each new leg was watched failing first, on `net9.0`, and every edit reverted.

The writer no longer writing text:

    target.innerText = text;
    PageRulesTests.TheWritingPeopleDidReachesTheQueueOnlyAsText [FAIL]
    Fehler: 1, erfolgreich: 509, gesamt: 510

The note put into the row without going through it:

    row.appendChild(document.createElement("td")).textContent = request.RequesterNote;
    PageRulesTests.TheWritingPeopleDidReachesTheQueueOnlyAsText [FAIL]
    Fehler: 1, erfolgreich: 509, gesamt: 510

A label that no longer says what it names:

    <label class="requestsQueueControl">
    PageControlsTests.EveryControlOnTheQueueCarriesANameSomethingCanReadOut [FAIL]
    Fehler: 1, erfolgreich: 509, gesamt: 510

The pager's next button drawn as a styled element:

    <div class="raised" id="RequestsQueueNext">Next page</div>
    PageControlsTests.EverythingTheQueueReachesForByNameIsAControlAKeyboardReaches [FAIL]
    Fehler: 1, erfolgreich: 509, gesamt: 510

The second of those is the one worth reading twice. It writes the note with
`textContent`, so the sink list is unmoved and the page is still safe; what it
loses is the single path, which is the property this leg exists for.

No second person has read this. The evidence above stands in place of one.
