### PR TITLE
Decide that an uninstall removes nothing, and say what is left

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Configuration/UninstallTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Configuration/UninstallTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Configuration;
+
+/// <summary>
+/// What an uninstall takes with it.
+/// <para>
+/// The decision is that this plugin removes nothing it wrote, and the argument is in
+/// <see cref="Jellyfin.Plugin.Requests.Plugin.OnUninstalling"/>. A decision recorded only in prose
+/// is one the next person deletes a queue against by accident, so it is held here instead: the two
+/// files are written, the server's call is made, and both are compared byte for byte afterwards.
+/// </para>
+/// <para>
+/// What this cannot say is what the server itself removes. Nothing here runs one, and the
+/// directories underneath are the host's; what is measured is this plugin's own behaviour when it
+/// is told it is going away.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class UninstallTests
+{
+    /// <summary>
+    /// An uninstall leaves the queue and the settings exactly as they were.
+    /// <para>
+    /// The bytes are compared rather than the existence of the files, because a file emptied is a
+    /// queue lost as surely as a file deleted and it passes an existence check.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void AnUninstallRemovesNothingThisPluginWrote()
+    {
+        using var host = new PluginHost();
+
+        var queue = Path.Combine(host.Plugin.DataFolderPath, "requests.json");
+        var settings = host.Plugin.ConfigurationFilePath;
+
+        Directory.CreateDirectory(host.Plugin.DataFolderPath);
+        File.WriteAllText(queue, "{\"Requests\":[]}", Encoding.UTF8);
+        File.WriteAllText(settings, "<PluginConfiguration />", Encoding.UTF8);
+
+        var queueBefore = File.ReadAllBytes(queue);
+        var settingsBefore = File.ReadAllBytes(settings);
+
+        host.Plugin.OnUninstalling();
+
+        Assert.True(File.Exists(queue), "The queue is gone after an uninstall, and nobody asked for that.");
+        Assert.True(File.Exists(settings), "The settings are gone after an uninstall, and nobody asked for that.");
+        Assert.True(queueBefore.SequenceEqual(File.ReadAllBytes(queue)), "The queue was rewritten by an uninstall.");
+        Assert.True(settingsBefore.SequenceEqual(File.ReadAllBytes(settings)), "The settings were rewritten by an uninstall.");
+    }
+
+    /// <summary>
+    /// The command an operator is given removes what is left and nothing else.
+    /// <para>
+    /// The two paths in that command are read off the host rather than out of the document, so a
+    /// data folder or a configuration file that moves reds this instead of leaving an operator
+    /// running a command that deletes nothing, or worse, something else. The document is where the
+    /// command is written for a person; this is what keeps it true.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void WhatTheDocumentedCommandRemovesIsWhatIsActuallyLeft()
+    {
+        using var host = new PluginHost();
+
+        var written = File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "docs", "configuration.md"), Encoding.UTF8);
+        var removal = written[written.IndexOf("## What an uninstall leaves behind", StringComparison.Ordinal)..];
+
+        var queue = Path.GetRelativePath(host.ApplicationPaths.ProgramDataPath, host.Plugin.DataFolderPath)
+            .Replace(Path.DirectorySeparatorChar, '/');
+
+        var settings = Path.GetRelativePath(host.ApplicationPaths.ProgramDataPath, host.Plugin.ConfigurationFilePath)
+            .Replace(Path.DirectorySeparatorChar, '/');
+
+        Assert.Contains(queue, removal, StringComparison.Ordinal);
+        Assert.Contains(settings, removal, StringComparison.Ordinal);
+    }
+}

--- a/Jellyfin.Plugin.Requests/Plugin.cs
+++ b/Jellyfin.Plugin.Requests/Plugin.cs
@@ -71,6 +71,31 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     }
 
     /// <summary>
+    /// What an uninstall removes, which is nothing this plugin wrote.
+    /// <para>
+    /// Two files are on the disk and both are the operator's own: the queue is what people asked
+    /// for and the settings are what the operator chose. Deleting either here is a delete with no
+    /// undo, no copy and no warning, taken on a click somebody may have made by mistake.
+    /// </para>
+    /// <para>
+    /// <b>Nothing says which kind of uninstall this is.</b> The server calls this with no argument,
+    /// so a removal meant to be final and one that is a step in putting the plugin back are the
+    /// same call, and this side cannot tell them apart. A decision that is right for one of them
+    /// and destroys data on the other is not a decision, it is a coin toss on somebody else's
+    /// queue.
+    /// </para>
+    /// <para>
+    /// The other half of the answer is not code. What stays, and the command that removes it, are
+    /// in <c>docs/configuration.md</c>, because a plugin that leaves data behind and does not say
+    /// so is the reason people distrust uninstalling anything.
+    /// </para>
+    /// </summary>
+    public override void OnUninstalling()
+    {
+        base.OnUninstalling();
+    }
+
+    /// <summary>
     /// The pages this plugin puts in the dashboard, and the two files they share.
     /// <para>
     /// Two pages rather than one, because an operator opens the queue every day and the settings

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -105,3 +105,53 @@ They land with the paths, in #79.
 **A bridge address and a credential.** The only bridge in this tree is the one for a server that has
 none. A field for an address would be somewhere to type something nothing reads. #82 brings the
 adapter, and #85 decides where a credential is kept and what may honestly be claimed about it.
+
+## What an uninstall leaves behind
+
+**This plugin removes nothing when it is uninstalled.** Both files it wrote stay where they are, and
+they are the two rows of the table under "What is on the disk, and where" in
+[storage.md](storage.md).
+
+The reason is that neither file is the plugin's. The queue is what people asked for and the settings
+are what an operator chose, and there is no copy of either. The call the server makes carries
+nothing that says which kind of uninstall this is, so a removal meant to be final and one that is a
+step in putting the plugin back arrive here identically. Deleting on both is a queue lost to a click
+somebody may have made by mistake, and there is no undo.
+
+That is a decision with a cost, and the cost is the rest of this section. What is in those files is
+personal: a request says a named person asked for a named title on a date. An operator who is
+finished with this plugin should be able to remove that in one step, without knowing anything about
+how the plugin works.
+
+### Removing what is left
+
+Both paths are relative to the server's data directory. Where that directory is differs by
+installation and by operating system, and this document does not name it, for the reason
+[storage.md](storage.md) gives: the server is the authority for its own paths. Run these from
+inside it, with the server stopped.
+
+On Linux and macOS:
+
+    rm -rf ./plugins/Jellyfin.Plugin.Requests
+    rm -f ./plugin-configurations/Jellyfin.Plugin.Requests.xml
+
+On Windows, in PowerShell:
+
+    Remove-Item -Recurse -Force .\plugins\Jellyfin.Plugin.Requests
+    Remove-Item -Force .\plugin-configurations\Jellyfin.Plugin.Requests.xml
+
+The first removes the queue and any write that was in flight; the second removes the settings. After
+both, nothing this plugin wrote is on the disk.
+
+`WhatTheDocumentedCommandRemovesIsWhatIsActuallyLeft` reads those two paths off the host rather than
+out of this document and requires them to appear here, so a data folder or a configuration file that
+moves reds the suite instead of leaving an operator running a command that deletes nothing.
+
+### What is not said here
+
+**Nothing measured what the server itself removes.** The paragraphs above are about what this plugin
+does when it is told it is going away, which is what `AnUninstallRemovesNothingThisPluginWrote`
+holds. Whether the server deletes the directory it installed the plugin into, or anything beside it,
+is the server's own behaviour on a running install, and no run on this board has asked it. The
+commands above are written so that they are right either way: a path that is already gone is a
+command that removes nothing.


### PR DESCRIPTION
Part of #98.

The decision this issue exists to take is taken here, with the guard that keeps
it and the writing that pays for it. Two of the three conditions are met; the
second is unchanged and the reason it cannot be met from this board is already
on the issue.

## The decision

**An uninstall removes nothing this plugin wrote.**

Neither file is the plugin's. The queue is what people asked for and the
settings are what an operator chose, and there is no copy of either. The call
the server makes carries nothing that says which kind of uninstall this is:

    grep -o '"M:MediaBrowser.Common.Plugins.IPlugin.OnUninstalling"' ~/.nuget/packages/jellyfin.common/10.11.0/lib/net9.0/MediaBrowser.Common.xml
    "M:MediaBrowser.Common.Plugins.IPlugin.OnUninstalling"

No argument, on either line, so a removal meant to be final and one that is a
step in putting the plugin back arrive here identically. A rule that is right
for one of them and destroys data on the other is a coin toss on somebody
else's queue.

## The first condition

`AnUninstallRemovesNothingThisPluginWrote` writes both files, makes the call the
server makes, and compares the bytes afterwards. The bytes rather than the
existence, because a file emptied is a queue lost as surely as one deleted and
it passes an existence check.

## The third condition

`docs/configuration.md` gains a section saying what stays and giving the command
that removes it, on Linux, macOS and Windows, written from the server's data
directory so an operator runs it knowing only where that is.

`WhatTheDocumentedCommandRemovesIsWhatIsActuallyLeft` reads the data folder and
the configuration file off the host and requires both in that section, so a path
that moves reds the suite instead of leaving an operator running a command that
deletes nothing.

## What is not claimed

**Nothing here measured what the server itself removes.** Whether it deletes the
directory it installed the plugin into, or anything beside it, is its own
behaviour on a running install and no run on this board has asked it. The
section says so in its own words, and the commands are written so they are right
either way: a path already gone is a command that removes nothing.

The second condition asks for the exact paths on every supported platform. That
is unchanged by this, and the measurement on the issue from 11 August still
stands.

## The runs

At `91b4b58`, both frameworks:

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!: Fehler: 0, erfolgreich: 512, gesamt: 512 (net9.0)
    Bestanden!: Fehler: 0, erfolgreich: 512, gesamt: 512 (net10.0)

    npx --yes prettier@3.6.2 --check --end-of-line auto "docs/configuration.md"
    All matched files use Prettier code style!

Both guards were watched failing on `net9.0` and each edit reverted.

A delete added to the override:

    System.IO.File.Delete(System.IO.Path.Combine(DataFolderPath, "requests.json"));
    UninstallTests.AnUninstallRemovesNothingThisPluginWrote [FAIL]
    Fehler: 1, erfolgreich: 511, gesamt: 512

The document naming a settings file nothing writes:

    rm -f ./plugin-configurations/Requests.xml
    UninstallTests.WhatTheDocumentedCommandRemovesIsWhatIsActuallyLeft [FAIL]
    Fehler: 1, erfolgreich: 511, gesamt: 512

No second person has read this. The evidence above stands in place of one.
