### PR TITLE
Write down what is held about a person, and what the catalogue route actually is

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,17 @@ both, and a machine with only the .NET 9 SDK has not been tried.
 GPL-3.0. The full text is in [LICENSE](LICENSE), and it is the authority for the
 terms, the warranty disclaimer and the limitation of liability.
 
-Jellyfin plugins are linked against GPLv3 server code, so a plugin distributed
-to others has to be under the GPLv3 or a permissive license compatible with it.
+A plugin is compiled against the server's libraries and ships as an assembly
+that links them, so the terms those libraries carry reach the compiled result
+whatever the source says. The packages this one compiles against declare
+GPL-3.0-only, which is what makes GPL-3.0 the licence here rather than a
+preference:
+
+    grep -h '<license type' ~/.nuget/packages/jellyfin.controller/*/jellyfin.controller.nuspec | sort -u
+        <license type="expression">GPL-3.0-only</license>
+
+The server's own repository carries GPL-2.0 in its licence file, so those two do
+not agree, and [docs/catalogue.md](docs/catalogue.md) is where both are measured
+and where what follows from them is written out.
 
 See [NOTICE.md](NOTICE.md) for the intended-use notice.

--- a/docs/catalogue.md
+++ b/docs/catalogue.md
@@ -1,0 +1,156 @@
+# The official catalogue, and what it asks for
+
+A Jellyfin server offers its operator a list of plugins without anybody adding a repository to it.
+That list is the official catalogue, and reaching it is the difference between a plugin people find
+and one they have to be told about. This page says what that route actually is, checks this
+repository against it, and states the licence position for a compiled plugin.
+
+## There is no submission form, and no published list of requirements
+
+The catalogue is built from a repository of git submodules. What decides which repositories are in
+it is a script that enumerates one organisation and takes the names that start with a prefix:
+
+    gh api repos/jellyfin/jellyfin-meta-plugins/contents/update_submodules.py --jq '.content' \
+      | base64 -d | grep -n 'PAGINATION_URL = \|startswith'
+    43:PAGINATION_URL = "https://api.github.com/orgs/jellyfin/repos?sort=created&per_page={per}&page={page}"
+    59:        if _name.startswith("jellyfin-plugin-"):
+    75:    if not repo.startswith("jellyfin-plugin-"):
+
+Read at `0e692e6ad050dbad63ef25089a97de6f5e85ee45`, which is that file's blob today:
+
+    gh api repos/jellyfin/jellyfin-meta-plugins/contents/update_submodules.py --jq '.sha'
+    0e692e6ad050dbad63ef25089a97de6f5e85ee45
+
+The building is one script per plugin directory, run over every submodule:
+
+    gh api repos/jellyfin/jellyfin-meta-plugins/contents/build_all.sh --jq '.content' \
+      | base64 -d | grep -n "find . -maxdepth"
+    18:for plugin in $(find . -maxdepth 1 -mindepth 1 -type d -name 'jellyfin-plugin-*' | sort); do
+
+So there is nothing to submit and nothing to satisfy in the sense of a checklist. What that
+repository publishes about itself is a set of build and release tools rather than a set of
+conditions a candidate is measured against:
+
+    gh api repos/jellyfin/jellyfin-meta-plugins/contents/README.md --jq '.content' | base64 -d | head -2
+    Plugin tools
+    ============
+
+**The list below is therefore derived from the tooling that would build this repository, not from a
+document anybody publishes.** Anything offered here as a requirement that is not read off that
+tooling would be a claim about a process nobody outside it can see.
+
+## Checked against this repository
+
+| What the route needs                               | Where that is decided                        | Here          |
+| -------------------------------------------------- | -------------------------------------------- | ------------- |
+| A name beginning `jellyfin-plugin-`                | `update_submodules.py:59`, `build_all.sh:18` | met           |
+| A repository in the `jellyfin` organisation        | `update_submodules.py:43`                    | not met, #113 |
+| A `build.yaml` at the root carrying `version`      | `build_plugin.sh`                            | met           |
+| One plugin per repository, built from `build.yaml` | `build_plugin.sh`                            | not met, #110 |
+
+The name is met, and it is met by accident rather than by decision: this repository is called
+`jellyfin-plugin-requests` because that is what a Jellyfin plugin repository is called.
+
+    gh repo view Flowfin/jellyfin-plugin-requests --json name,owner --jq '"\(.owner.login)/\(.name)"'
+    Flowfin/jellyfin-plugin-requests
+
+The organisation is the whole of the gate and it is not something a change in this tree can meet. It
+is the submission decision, and the section at the end of this page says where that stands.
+
+The `build.yaml` requirement is met and the command that reads it is worth quoting, because it reads
+one file by name:
+
+    gh api repos/jellyfin/jellyfin-meta-plugins/contents/build_plugin.sh --jq '.content' \
+      | base64 -d | grep -n 'meta_version=\|JPRM --verbosity'
+    53:meta_version=$(grep -Po '^ *version: * "*\K[^"$]+' "${PLUGIN}/build.yaml")
+    61:zipfile=$($JPRM --verbosity=debug plugin build "${PLUGIN}" --output="${ARTIFACT_DIR}" --version="${VERSION}") && {
+    62:    $JPRM --verbosity=debug repo add --url=${JELLYFIN_REPO_URL} "${JELLYFIN_REPO}" "${zipfile}"
+
+**That route builds one package per repository, and this repository claims two server lines.**
+`build.yaml` is the 10.11 line and `build-jf12.yaml` is the 12.0 line, and nothing in that script
+looks for a second file. A repository built by it offers the 10.11 package and nothing for the other
+line. Carrying both lines into one manifest is #110, and it is named here because it is the same
+problem seen from the catalogue's side rather than a new one.
+
+One more property of that route, which is a fact rather than a requirement. The version in the
+package is not the version in `build.yaml`:
+
+    gh api repos/jellyfin/jellyfin-meta-plugins/contents/build_plugin.sh --jq '.content' \
+      | base64 -d | grep -n 'VERSION_SUFFIX:-\|VERSION IS OVERWRITTEN'
+    51:VERSION_SUFFIX=${VERSION_SUFFIX:-$(date -u +%y%m.%d%H.%M%S)}
+    56:# !!! VERSION IS OVERWRITTEN HERE
+
+The last three segments are replaced by a timestamp of the build. An operator installing from the
+official catalogue therefore sees a version this repository never minted, which is worth knowing
+before reading [versioning.md](versioning.md) as though it described what such a user would see.
+
+## The licence position for a compiled plugin
+
+This is not a free choice and it is not a formality. A plugin is compiled against the server's
+libraries and shipped as an assembly that links them, so the terms those libraries carry reach the
+compiled result whatever a source file says.
+
+Three facts, and they do not agree with each other.
+
+This repository is GPL-3.0:
+
+    head -2 LICENSE
+                        GNU GENERAL PUBLIC LICENSE
+                           Version 3, 29 June 2007
+
+The packages this plugin compiles against declare GPL-3.0-only in their own metadata, on both
+claimed lines:
+
+    grep -h '<license type' ~/.nuget/packages/jellyfin.controller/10.11.11/jellyfin.controller.nuspec \
+        ~/.nuget/packages/jellyfin.controller/12.0.0-rc4/jellyfin.controller.nuspec
+        <license type="expression">GPL-3.0-only</license>
+        <license type="expression">GPL-3.0-only</license>
+
+The server's own repository carries the second version of that licence rather than the third:
+
+    gh api repos/jellyfin/jellyfin/license --jq '{spdx: .license.spdx_id, name: .license.name}'
+    {"name":"GNU General Public License v2.0","spdx":"GPL-2.0"}
+
+    gh api repos/jellyfin/jellyfin/contents/LICENSE --jq '.content' | base64 -d | sed -n '2p'
+                           Version 2, June 1991
+
+**What this repository does follows from the packages, because they are what it links.** They say
+GPL-3.0-only, this repository is GPL-3.0, and a compiled plugin distributed to anybody is under
+those terms rather than under something chosen here. A permissive licence on the source would not
+change what the compiled result may be distributed under.
+
+**What is not resolved here is the disagreement between the package metadata and the server
+repository's own licence file.** Whether the GPL-2.0 in that file carries an "or later" election is
+not answerable from the file itself: the sentence that offers the choice appears in the appendix
+that the text of GPL-2.0 carries in every copy of it, and an election is a statement a project makes
+about its own program rather than a line of that appendix. If the operative terms were GPL-2.0 with
+no such election, a GPL-3.0 work could not be distributed as one with it, and that is a question for
+whoever distributes rather than something this tree can measure.
+
+Nothing in the catalogue tooling checks a licence at all, which is why this section is here rather
+than in the table above.
+
+## The submission decision
+
+**It has not been taken.** It is decision 11 on #113 and no answer to that number has been written
+there.
+
+The decision is not whether to send an entry somewhere, because there is nowhere to send one. It is
+whether this repository moves into the `jellyfin` organisation, which is the only thing the
+enumeration above reaches. That carries who owns the repository, who can publish a release from it
+and under whose rules it is maintained, and none of those is a packaging question.
+
+What each answer costs, so that the decision is made against the costs rather than against a
+preference:
+
+**Staying outside.** The plugin is not in the list every server already shows, so an operator finds
+it only by being told the manifest URL and adding it by hand. That is most people never finding it.
+Nothing else changes: the release route in [RELEASING.md](RELEASING.md) already publishes without
+feeding any catalogue, and the two-line packaging problem above stays this board's own.
+
+**Moving in.** The plugin appears wherever a Jellyfin server does. The repository is no longer this
+account's, releases are made under that organisation's process, and the version an operator installs
+is the timestamp the build script writes rather than the one minted here.
+
+This page records that the question is open and what it costs. Answering it is not something a
+document in this repository can do.

--- a/docs/personal-data.md
+++ b/docs/personal-data.md
@@ -1,0 +1,218 @@
+# What this plugin holds about a person
+
+A request record says that a named person asked for a named title on a date. That is more revealing
+than most of what a media server holds, and an operator running this for other people has to be able
+to answer for it without reading the source.
+
+This page is the account. It collects what other issues on this board decided rather than deciding
+anything itself, and each section says where the decision lives. Where something is not decided or
+not built, this page says so in those words instead of describing an intention as a behaviour.
+
+## Every field that can name a person
+
+The record is one type, and everything below is a property of it or of an entry in its history. The
+identifiers are derived rather than listed from memory:
+
+    git grep -nE 'public (required )?(Guid|Guid\?|IReadOnlyList<Guid>) ' -- Jellyfin.Plugin.Requests/Model/
+    Jellyfin.Plugin.Requests/Model/MediaRequest.cs:60:    public required Guid Id { get; init; }
+    Jellyfin.Plugin.Requests/Model/MediaRequest.cs:67:    public required Guid RequestedByUserId { get; init; }
+    Jellyfin.Plugin.Requests/Model/MediaRequest.cs:144:    public IReadOnlyList<Guid> JoinedByUserIds { get; init; } = [];
+    Jellyfin.Plugin.Requests/Model/MediaRequest.cs:165:    public IReadOnlyList<Guid> WantIds
+    Jellyfin.Plugin.Requests/Model/MediaRequest.cs:189:    public Guid? StateChangedByUserId { get; init; }
+    Jellyfin.Plugin.Requests/Model/RequestCaller.cs:52:    public Guid? UserId { get; }
+    Jellyfin.Plugin.Requests/Model/RequestHistoryEntry.cs:44:    public Guid? ByUserId { get; init; }
+
+Four of those seven name a person. What each one is, and what it is for:
+
+| Field                               | Who it names                                         | Where it is written |
+| ----------------------------------- | ---------------------------------------------------- | ------------------- |
+| `MediaRequest.RequestedByUserId`    | the person who asked                                 | the queue file      |
+| `MediaRequest.JoinedByUserIds`      | everybody else who asked for the same title          | the queue file      |
+| `MediaRequest.StateChangedByUserId` | whoever last moved it, usually an operator           | the queue file      |
+| `RequestHistoryEntry.ByUserId`      | whoever made that one move, for every move ever made | the queue file      |
+
+The other three name nothing about a person. `MediaRequest.Id` and `MediaRequest.WantIds` are this
+plugin's own identifier for a request and the browsing sibling's identifiers for the asks it handed
+over. `RequestCaller.UserId` is who is making the call being handled right now, and it is an argument
+passed between methods rather than a stored field: what reaches the disk is the record above, and the
+store writes that record whole.
+
+    git grep -n 'public MediaRequest? Request' -- Jellyfin.Plugin.Requests/Storage/PersistedRequest.cs
+    Jellyfin.Plugin.Requests/Storage/PersistedRequest.cs:29:    public MediaRequest? Request { get; init; }
+
+**A person is held as the server's user identifier and never as a name.** No field carries a user
+name, a display name, an email address or an external account. Whoever the identifier belongs to is a
+question the server answers, and this plugin does not copy the answer into its own file.
+
+### Two fields carry free text somebody typed
+
+    git grep -nE 'public string\? (RequesterNote|DeclineNote)' -- Jellyfin.Plugin.Requests/Model/MediaRequest.cs
+    Jellyfin.Plugin.Requests/Model/MediaRequest.cs:209:    public string? RequesterNote
+    Jellyfin.Plugin.Requests/Model/MediaRequest.cs:242:    public string? DeclineNote
+
+`RequesterNote` is what the person asking wrote, and `DeclineNote` is what the operator wrote back.
+Both are bounded in length and neither is bounded in content. Anybody can write a name, an address or
+anything else into one, and nothing in this plugin reads them for that or could. They are listed here
+because a document about personal data that only lists the identifiers would be describing the fields
+that are easy to reason about.
+
+### What is stored beside a person is the revealing part
+
+`DisplayTitle`, `DisplayYear`, `ProviderIds`, `Kind` and `Seasons` say what was asked for.
+`RequestedAt`, `StateChangedAt` and every `At` in the history say when. None of them names anybody,
+and all of them sit on the same record as the identifier of the person who asked. What the file holds
+is therefore not a list of titles and not a list of people, it is a list of who wanted what, and
+when.
+
+## Where it is
+
+Two files, both under the server's own data directory, and the table of them is in
+[storage.md](storage.md) under "What is on the disk, and where". This page does not repeat the paths,
+because two copies of a path are two answers the day one of them moves.
+
+Everything above is in the queue file. The settings file holds no person at all, which is the whole
+of that class rather than a sample:
+
+    git grep -nE '^    public (const )?(int|bool) ' -- Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs
+    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:52:    public const int MinimumRetentionDays = 30;
+    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:67:    public int OpenRequestsPerUser { get; set; } = 10;
+    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:72:    public bool AcceptsMovies { get; set; } = true;
+    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:83:    public bool AcceptsSeries { get; set; } = true;
+    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:99:    public int FinishedRequestRetentionDays { get; set; } = 365;
+
+Three numbers, one of them the floor under another, and two switches. Nothing there is about
+anybody.
+
+## Who on the machine can read it
+
+**This plugin sets no permission on either file.** Nothing in it asks for one:
+
+    git grep -n 'UnixFileMode\|SetUnixFileMode\|FileSecurity\|SetAccessControl' -- Jellyfin.Plugin.Requests/ ; echo "exit=$?"
+    exit=1
+
+So the queue is readable by whoever can read the server's data directory, under whatever the server
+process and the operating system give a file created there. An operator who wants it narrower
+narrows the directory, and that is a property of their installation rather than something this plugin
+can promise.
+
+**Anything running inside the server process can read it too**, and that is not a defect this plugin
+could repair. It is the same boundary the seam is written against, and the section below says what
+follows from it.
+
+**What was not measured.** No permission was read off a running server on either claimed line.
+Whether a container image, a package or a manual install leaves that directory readable to other
+accounts on the machine is a fact about the installation, and no run on this board has asked one.
+
+## How long it is kept
+
+`FinishedRequestRetentionDays` is a setting, 365 by default, with a floor of 30.
+[configuration.md](configuration.md) carries the number, the reason it is a field and the reason the
+floor exists, and this page does not restate the argument.
+
+**Nothing removes anything today.** The setting is read where it is validated and nowhere else:
+
+    git grep -ln 'FinishedRequestRetentionDays' -- Jellyfin.Plugin.Requests/
+    Jellyfin.Plugin.Requests/Configuration/ConfigurationRules.cs
+    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs
+    Jellyfin.Plugin.Requests/Configuration/configPage.html
+
+The class that declares it, the rule that refuses a value under the floor, and the field on the
+settings page. There is no sweep, no scheduled task and no code path that deletes a finished request,
+so a server running this plugin keeps every request forever, whatever the number says. What builds
+the thing that enforces it is #49.
+
+An operator answering for this today should read the number as a plan and the file as the fact.
+
+## What happens when a Jellyfin user is deleted
+
+**Nothing.** No part of this plugin is told that a user was removed, and nothing looks:
+
+    git grep -n 'IUserManager' -- Jellyfin.Plugin.Requests/
+    Jellyfin.Plugin.Requests/Seam/ServerKnownUsers.cs:15:    private readonly IUserManager _users;
+    Jellyfin.Plugin.Requests/Seam/ServerKnownUsers.cs:22:    public ServerKnownUsers(IUserManager users)
+
+That one reference asks whether a user exists when a want arrives over the seam. It is a question
+about the present, not a subscription to a deletion, and nothing in this plugin acts on an account
+going away.
+
+So a request record outlives the account it names. The identifier stays in the file, in up to four
+places for one deleted person: their own requests, requests they joined that somebody else asked for,
+and every decision they made as an operator, which is written into the record and into its history.
+
+**What the rule should be is open, and it is open for a reason rather than by neglect.** The history
+a decision is written into is append-only and a lint rule refuses any other writer, so stripping an
+identifier out of past entries is not a small change to make while implementing a sweep. #49 holds
+the question and states the three answers that are available, each of which leaves something
+different behind. This page cannot state a behaviour that has not been decided, and describing the
+current absence as a retention choice would be exactly that.
+
+## What leaves the server
+
+**Nothing leaves the server today.** The plugin makes no outbound call of any kind:
+
+    git grep -n 'HttpClient\|IHttpClientFactory\|WebRequest' -- Jellyfin.Plugin.Requests/ ; echo "exit=$?"
+    exit=1
+
+The bridge to an external request service has exactly one implementation in this tree, and it is the
+one for a server that has no backend:
+
+    git grep -n ': IRequestBackend' -- Jellyfin.Plugin.Requests/
+    Jellyfin.Plugin.Requests/Bridge/NoRequestBackend.cs:23:public sealed class NoRequestBackend : IRequestBackend
+
+There is no metadata lookup either. This plugin calls no metadata source at all, which is a lint rule
+rather than a habit:
+
+    git grep -n 'id: no-call-to-a-metadata-source' -- tools/opengrep/rules.yaml
+    tools/opengrep/rules.yaml:479:  - id: no-call-to-a-metadata-source
+
+And nothing reports anything to this project, at any setting, by design and with no opt-in. That is
+recorded in [notifications.md](notifications.md) with the decision behind it.
+
+Three paths would carry something outward once they are built, and each is named here so that an
+operator can find out what turning one on would mean before it exists:
+
+| Path                | Issue | What would leave                                            | Off until         |
+| ------------------- | ----- | ----------------------------------------------------------- | ----------------- |
+| The bridge          | #82   | a title, and an external account for the person who asked   | a backend is set  |
+| The outbound sink   | #78   | a payload naming a person and a title, to an address chosen | an address is set |
+| The session message | #76   | nothing off the machine, a message to a dashboard session   | not decided yet   |
+
+The bridge names a person to the external service by an account the operator wrote into a table, and
+never by their name. That is the decision in [bridge.md](bridge.md), and the table is empty on a
+fresh install, so a bridge configured and nothing else sends no attribution at all. The activity log
+in #75 is the fourth path and it is not in the table because it writes into the server's own log,
+which does not leave the machine.
+
+**None of the three is built.** The rows say what each one is for, not what it does.
+
+## What arrives from another plugin, and what this side trusts
+
+A request can arrive from the browsing sibling instead of from a person using the API, and that path
+has no session behind it. It carries a user identifier that this plugin cannot verify.
+
+**The sibling's own permission check is the only check on that path, and this side is trusting it.** A
+want that arrives over the seam is attributed to whoever the caller says asked for it. Anybody
+evaluating this plugin should read that as it stands rather than as a check that is implied
+somewhere.
+
+That is a boundary rather than a hole. The caller is another plugin inside the same server process,
+which can already read this plugin's file and write it, so a check here would refuse nothing that is
+not already possible and would read afterwards as protection.
+
+What this side does check is that the identifier names somebody the server has, and a handover naming
+a user it does not have is refused with nothing stored.
+[seam.md](seam.md) carries the same conclusion at length, in the section on what this side trusts and
+what it checks anyway, and #118 is where it was stated.
+
+## What this page does not say
+
+**It states no legal position.** What a given operator has to do under the law they run under depends
+on where they are and who their users are, and this page is an account of what the software holds so
+that somebody who has to answer that question can.
+
+**Nothing here was measured on a running server.** Every command above reads this repository. File
+permissions on a real install, and what a real queue holds after a year, are not in it.
+
+**It carries no list of the request states or of the transitions.** Those are in
+[lifecycle.md](lifecycle.md), printed from the code that decides them, and a copy here would drift
+against it.


### PR DESCRIPTION
Part of #104 and part of #112. Two documents and one corrected sentence in
`README.md`. No code changes, which is why the two land together rather than
moving the mainline twice under the same reader.

## The account of what is held about a person, #104

`docs/personal-data.md` is new. Every field that can name somebody is derived by
a command in the document rather than listed from memory, so a field added to
the record shows up as a difference between the list and what the command
prints. Four of the seven identifiers on the model name a person; the other
three are this plugin's own identifier, the sibling's identifiers for the asks
it handed over, and an argument that never reaches the disk.

The two free-text fields are named as well. A document that lists only the
identifiers describes the half that is easy to reason about, and anybody can
type a name into a note.

The paths are referenced out of `docs/storage.md` rather than copied. Two copies
of a path are two answers the day one of them moves.

Three sections are negative and are written to stay that way.

    git grep -ln 'FinishedRequestRetentionDays' -- Jellyfin.Plugin.Requests/
    Jellyfin.Plugin.Requests/Configuration/ConfigurationRules.cs
    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs
    Jellyfin.Plugin.Requests/Configuration/configPage.html

The class, the rule that refuses a value under the floor, and the field on the
page. Nothing reads the number to remove anything, so a server keeps every
finished request whatever the setting says.

    git grep -n 'IUserManager' -- Jellyfin.Plugin.Requests/
    Jellyfin.Plugin.Requests/Seam/ServerKnownUsers.cs:15:    private readonly IUserManager _users;
    Jellyfin.Plugin.Requests/Seam/ServerKnownUsers.cs:22:    public ServerKnownUsers(IUserManager users)

That reference asks whether a user exists when a want arrives. Nothing is told
that an account went away, so a record outlives the person it names.

    git grep -n 'HttpClient\|IHttpClientFactory\|WebRequest' -- Jellyfin.Plugin.Requests/ ; echo "exit=$?"
    exit=1

No outbound call of any kind exists, so nothing leaves the server today. The
three paths that would carry something out are in a table with what each would
send and what it is off until, and the table says none of them is built.

The document also carries the conclusion #118 asks the security documentation to
repeat: a want that arrives over the seam is attributed to whoever the caller
says asked for it, and the sibling's own permission check is the only check on
that path.

## The catalogue route and the licence, #112

`README.md` said this plugin links GPLv3 server code. The server's own
repository carries GPL-2.0:

    gh api repos/jellyfin/jellyfin/license --jq '{spdx: .license.spdx_id, name: .license.name}'
    {"name":"GNU General Public License v2.0","spdx":"GPL-2.0"}

What is true is narrower, and it is about the packages rather than the
repository, because the packages are what the compiled assembly links:

    grep -h '<license type' ~/.nuget/packages/jellyfin.controller/*/jellyfin.controller.nuspec | sort -u
        <license type="expression">GPL-3.0-only</license>

`docs/catalogue.md` carries both, and it does not resolve the disagreement
between them. Whether the GPL-2.0 in that file carries an "or later" election is
not answerable from the file, because the sentence that offers the choice is in
the appendix every copy of GPL-2.0 carries.

The same document measures what the catalogue is. There is no submission form
and no published list of requirements:

    gh api repos/jellyfin/jellyfin-meta-plugins/contents/update_submodules.py --jq '.content' | base64 -d | grep -n 'PAGINATION_URL = \|startswith'
    43:PAGINATION_URL = "https://api.github.com/orgs/jellyfin/repos?sort=created&per_page={per}&page={page}"
    59:        if _name.startswith("jellyfin-plugin-"):
    75:    if not repo.startswith("jellyfin-plugin-"):

Entries are submodules of one repository, chosen by enumerating one organisation
and taking the names that begin with a prefix. So the requirement table in the
document is derived from the tooling that would build this repository rather
than from a list somebody imagined, and it has four rows. Two are met. The
organisation is the whole of the gate and no change in this tree reaches it. The
fourth is that the build script reads `build.yaml` by name, so a repository
claiming two server lines has one of them built.

## What neither issue closes on

**#104's second condition is not met.** It asks that the retention period and
the account-deletion behaviour match what #49 implemented. The period matches: a
setting with nothing enforcing it, and the document says exactly that. The
deletion behaviour has not been decided, three answers are open on #49 and they
differ in what is left behind afterwards, so there is no behaviour for a
document to state.

**#112's third condition is not met.** The submission decision is recorded as
not taken, with what each answer costs, and taking it is not something a
document in this repository can do.

## The runs

At `a8fd66c`:

    DOTNET_CLI_UI_LANGUAGE=en dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Passed!  - Failed:     0, Passed:   512, Skipped:     0, Total:   512 (net9.0)
    Passed!  - Failed:     0, Passed:   512, Skipped:     0, Total:   512 (net10.0)

    npx --yes prettier@3.6.2 --check "docs/personal-data.md" "docs/catalogue.md" "README.md"
    All matched files use Prettier code style!

Every command quoted inside both documents was run against this branch and its
output pasted from the run rather than typed from memory.

No guard is added here, because neither issue's scope reaches the test project
and there is nothing in a document for a suite to refuse. That is the reason the
commands are in the documents themselves.

No second person has read this. The evidence above stands in place of one.
