### PR TITLE
Bind every way of asking to the quota an operator sets

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Api/ActOnARequestTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/ActOnARequestTests.cs
@@ -521,7 +521,7 @@ public sealed class ActOnARequestTests
     /// <param name="caller">Who the server says is calling.</param>
     /// <returns>The controller under test.</returns>
     private RequestsController ControllerFor(IRequestStore store, Guid? caller)
-        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller));
+        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), new FakeInstallSettings());
 
     /// <summary>
     /// The row a successful decision handed back, with the status code checked.

--- a/Jellyfin.Plugin.Requests.Tests/Api/ActOnManyRequestsTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/ActOnManyRequestsTests.cs
@@ -619,7 +619,7 @@ public sealed class ActOnManyRequestsTests
     /// <param name="caller">Who the server says is calling.</param>
     /// <returns>The controller under test.</returns>
     private RequestsController ControllerFor(IRequestStore store, Guid? caller)
-        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller));
+        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), new FakeInstallSettings());
 
     /// <summary>
     /// The entries an action came back with, with the status code checked.

--- a/Jellyfin.Plugin.Requests.Tests/Api/CreateRequestTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/CreateRequestTests.cs
@@ -364,7 +364,8 @@ public sealed class CreateRequestTests
             store,
             new TestClock(new DateTimeOffset(2026, 8, 9, 12, 0, 0, TimeSpan.Zero)),
             _identifiers,
-            new FakeCallerIdentity(caller));
+            new FakeCallerIdentity(caller),
+            new FakeInstallSettings());
 
     /// <summary>
     /// The answer, with the status code checked, so a leg cannot pass on a body that came back under

--- a/Jellyfin.Plugin.Requests.Tests/Api/ErrorSurfaceTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/ErrorSurfaceTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.Requests.Api;
+using Jellyfin.Plugin.Requests.Configuration;
 using Jellyfin.Plugin.Requests.Model;
 using Jellyfin.Plugin.Requests.Storage;
 using Jellyfin.Plugin.Requests.Tests.Doubles;
@@ -51,7 +52,9 @@ public sealed class ErrorSurfaceTests
         (RequestFailureCode.TheTableRefusesTheMove, 409),
         (RequestFailureCode.TheRequestNamesNothing, 409),
         (RequestFailureCode.TheCallerMayNotMakeThisMove, 403),
-        (RequestFailureCode.TheStoreCouldNotBeRead, 503)
+        (RequestFailureCode.TheStoreCouldNotBeRead, 503),
+        (RequestFailureCode.TheyAreAtTheirQuota, 409),
+        (RequestFailureCode.ThisInstallCannotRun, 503)
     ];
 
     private readonly SequentialIdentifierSource _identifiers = new SequentialIdentifierSource();
@@ -236,6 +239,19 @@ public sealed class ErrorSurfaceTests
                 .CreateAsync(AFilm(), CancellationToken.None)
                 .ConfigureAwait(true)));
 
+        // The asker already has the one request this install allows, which is the request added at
+        // the top of this method. A quota of one rather than ten keeps the fixture to the request
+        // that is already there instead of nine more that prove nothing extra.
+        Add("POST Requests from somebody at their quota", elevated: false, Of(
+            await ControllerFor(store, Asker, new FakeInstallSettings(new PluginConfiguration { OpenRequestsPerUser = 1 }))
+                .CreateAsync(AFilm(), CancellationToken.None)
+                .ConfigureAwait(true)));
+
+        Add("POST Requests on an install the plugin cannot run on", elevated: false, Of(
+            await ControllerFor(store, Asker, new InstallSettingsThatCannotBeRead())
+                .CreateAsync(AFilm(), CancellationToken.None)
+                .ConfigureAwait(true)));
+
         Add("GET Requests with a page larger than the cap", elevated: false, Of(
             await ControllerFor(store, Asker)
                 .MineAsync(take: RequestsController.MaximumPageSize + 1, cancellationToken: CancellationToken.None)
@@ -364,7 +380,18 @@ public sealed class ErrorSurfaceTests
     /// <param name="caller">Who the server says is calling.</param>
     /// <returns>The controller under test.</returns>
     private RequestsController ControllerFor(IRequestStore store, Guid? caller)
-        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller));
+        => ControllerFor(store, caller, new FakeInstallSettings());
+
+    /// <summary>
+    /// A controller over one store, one caller and one install, for the two refusals that are about
+    /// what this server is set to rather than about the call.
+    /// </summary>
+    /// <param name="store">Where requests are kept.</param>
+    /// <param name="caller">Who the server says is calling.</param>
+    /// <param name="settings">What this install is set to.</param>
+    /// <returns>The controller under test.</returns>
+    private RequestsController ControllerFor(IRequestStore store, Guid? caller, IInstallSettings settings)
+        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), settings);
 
     /// <summary>
     /// A second request in the store, so one of them can be moved out of the way.

--- a/Jellyfin.Plugin.Requests.Tests/Api/ListRequestsTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/ListRequestsTests.cs
@@ -619,5 +619,6 @@ public sealed class ListRequestsTests
             store,
             new TestClock(new DateTimeOffset(2026, 8, 9, 12, 0, 0, TimeSpan.Zero)),
             _identifiers,
-            new FakeCallerIdentity(caller));
+            new FakeCallerIdentity(caller),
+            new FakeInstallSettings());
 }

--- a/Jellyfin.Plugin.Requests.Tests/Api/PublishedApiDocumentTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/PublishedApiDocumentTests.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.Requests.Api;
 using Jellyfin.Plugin.Requests.Bridge;
+using Jellyfin.Plugin.Requests.Configuration;
 using Jellyfin.Plugin.Requests.Model;
 using Jellyfin.Plugin.Requests.Storage;
 using Jellyfin.Plugin.Requests.Tests.Doubles;
@@ -92,10 +93,11 @@ public sealed class PublishedApiDocumentTests
 
         // Asking for something. Two success codes with one shape: 201 is a new request and 200 is
         // one that was joined or was already the caller's, and a client tells them apart by the
-        // status or by the outcome in the body.
+        // status or by the outcome in the body. The 409 is the person's own quota, which is the one
+        // refusal here that is about the asker rather than about the body or the server.
         "POST MediaRequests/v1/Requests"
             + " (body@Body:CreateRequestBody)"
-            + " -> 200:CreatedRequest, 201:CreatedRequest, 400:RequestFailure, 403:RequestFailure, 503:RequestFailure",
+            + " -> 200:CreatedRequest, 201:CreatedRequest, 400:RequestFailure, 403:RequestFailure, 409:RequestFailure, 503:RequestFailure",
 
         // Saying yes to several at once. Three codes where the single decision publishes six, and
         // the three that are missing are the point: a request that is not there, one that moved and
@@ -282,6 +284,14 @@ public sealed class PublishedApiDocumentTests
         Saw(Create, await ControllerFor(store, Asker).CreateAsync(new CreateRequestBody { Title = "No kind" }, CancellationToken.None).ConfigureAwait(true));
         Saw(Create, await ControllerFor(store, caller: null).CreateAsync(AFilm(), CancellationToken.None).ConfigureAwait(true));
         Saw(Create, await ControllerFor(unreadable, Asker).CreateAsync(AFilm(), CancellationToken.None).ConfigureAwait(true));
+
+        // The asker is now waiting for the film the two calls above put in the queue, so an install
+        // allowing one open request refuses the next thing they ask for.
+        Saw(
+            Create,
+            await ControllerFor(store, Asker, new FakeInstallSettings(new PluginConfiguration { OpenRequestsPerUser = 1 }))
+                .CreateAsync(ASeries(), CancellationToken.None)
+                .ConfigureAwait(true));
 
         Saw(Mine, await ControllerFor(store, Asker).MineAsync(cancellationToken: CancellationToken.None).ConfigureAwait(true));
         Saw(Mine, await ControllerFor(store, Asker).MineAsync(take: RequestsController.MaximumPageSize + 1, cancellationToken: CancellationToken.None).ConfigureAwait(true));
@@ -484,7 +494,18 @@ public sealed class PublishedApiDocumentTests
     /// <param name="caller">Who the server says is calling.</param>
     /// <returns>The controller under test.</returns>
     private RequestsController ControllerFor(IRequestStore store, Guid? caller)
-        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller));
+        => ControllerFor(store, caller, new FakeInstallSettings());
+
+    /// <summary>
+    /// A controller wired to one store, one identity and one install, for the answer that depends on
+    /// what this server is set to.
+    /// </summary>
+    /// <param name="store">Where requests are kept.</param>
+    /// <param name="caller">Who the server says is calling.</param>
+    /// <param name="settings">What this install is set to.</param>
+    /// <returns>The controller under test.</returns>
+    private RequestsController ControllerFor(IRequestStore store, Guid? caller, IInstallSettings settings)
+        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), settings);
 
     /// <summary>
     /// A request as the store holds one.
@@ -521,5 +542,18 @@ public sealed class PublishedApiDocumentTests
         Title = "The Conversation",
         Year = 1974,
         ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tmdb"] = "605" }
+    };
+
+    /// <summary>
+    /// A second thing to ask for, so a person already waiting for the film above is asking for
+    /// something the queue does not hold rather than joining what they are already on.
+    /// </summary>
+    /// <returns>The body.</returns>
+    private static CreateRequestBody ASeries() => new CreateRequestBody
+    {
+        Kind = RequestedItemKind.Series,
+        Title = "The Singing Detective",
+        Year = 1986,
+        ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tvdb"] = "76423" }
     };
 }

--- a/Jellyfin.Plugin.Requests.Tests/CatalogueSplitTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/CatalogueSplitTests.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.Requests.Api;
+using Jellyfin.Plugin.Requests.Configuration;
 using Jellyfin.Plugin.Requests.Identity;
 using Jellyfin.Plugin.Requests.Model;
 using Jellyfin.Plugin.Requests.Storage;
@@ -83,9 +84,9 @@ public sealed class CatalogueSplitTests
     }
 
     /// <summary>
-    /// The controller takes four things and none of them can fetch anything. A metadata source
+    /// The controller takes five things and none of them can fetch anything. A metadata source
     /// arrives as something injected, so the constructor is where one would appear first, and a
-    /// fifth parameter fails here before anybody writes the call.
+    /// sixth parameter fails here before anybody writes the call.
     /// <para>
     /// Written as the exact list rather than as "nothing called a provider". A name test would pass
     /// the day somebody injects a fetcher under a name nobody predicted, which is the shape this
@@ -102,7 +103,13 @@ public sealed class CatalogueSplitTests
             .Select(parameter => parameter.ParameterType.Name);
 
         Assert.Equal(
-            string.Join(" | ", nameof(IRequestStore), nameof(IClock), nameof(IIdentifierSource), nameof(ICallerIdentity)),
+            string.Join(
+                " | ",
+                nameof(IRequestStore),
+                nameof(IClock),
+                nameof(IIdentifierSource),
+                nameof(ICallerIdentity),
+                nameof(IInstallSettings)),
             string.Join(" | ", taken),
             StringComparer.Ordinal);
     }
@@ -135,5 +142,6 @@ public sealed class CatalogueSplitTests
             store,
             new TestClock(new DateTimeOffset(2026, 8, 11, 8, 0, 0, TimeSpan.Zero)),
             new SequentialIdentifierSource(),
-            new FakeCallerIdentity(Operator));
+            new FakeCallerIdentity(Operator),
+            new FakeInstallSettings());
 }

--- a/Jellyfin.Plugin.Requests.Tests/Intake/RequestQuotaTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Intake/RequestQuotaTests.cs
@@ -1,0 +1,311 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Configuration;
+using Jellyfin.Plugin.Requests.Intake;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Intake;
+
+/// <summary>
+/// How many things one person may be waiting for, enforced where a request is made rather than at
+/// each surface that makes one.
+/// <para>
+/// The legs below call the intake directly. That is the point of them: a quota checked in an
+/// endpoint is a quota the seam does not have, and a second surface added later is a second place
+/// somebody has to remember. What these hold is the property that there is one place, so the
+/// question "can this caller get past it" has one answer.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class RequestQuotaTests
+{
+    private static readonly Guid Asker = new Guid("c5000000-0000-0000-0000-000000000001");
+    private static readonly Guid SomebodyElse = new Guid("c5000000-0000-0000-0000-000000000002");
+    private static readonly DateTimeOffset Noon = new DateTimeOffset(2026, 8, 13, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly SequentialIdentifierSource _identifiers = new SequentialIdentifierSource();
+
+    /// <summary>
+    /// Somebody at their limit is refused, and the refusal carries what they hold and what the limit
+    /// is rather than a sentence a surface would have to read.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task SomebodyAtTheirLimitIsRefusedByTheIntakeItself()
+    {
+        var store = new InMemoryRequestStore();
+
+        await FillAsync(store, Asker, RequestState.Open, 2).ConfigureAwait(true);
+
+        var refused = await Assert.ThrowsAsync<RequestQuotaReachedException>(
+            () => Intake(store, quota: 2).AskAsync(Something(Asker), RequestCaller.User(Asker), CancellationToken.None))
+            .ConfigureAwait(true);
+
+        Assert.Equal(2, refused.Held);
+        Assert.Equal(2, refused.Limit);
+
+        // Nothing was written. A refusal that stored the request and then complained would be worse
+        // than no limit at all, because the queue would disagree with what the caller was told.
+        Assert.Equal(2, (await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true)).Count);
+    }
+
+    /// <summary>
+    /// One place under their limit is one more thing they may ask for.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task SomebodyUnderTheirLimitIsNotRefused()
+    {
+        var store = new InMemoryRequestStore();
+
+        await FillAsync(store, Asker, RequestState.Open, 1).ConfigureAwait(true);
+
+        var asked = await Intake(store, quota: 2)
+            .AskAsync(Something(Asker), RequestCaller.User(Asker), CancellationToken.None)
+            .ConfigureAwait(true);
+
+        Assert.Equal(IntakeOutcome.Created, asked.Outcome);
+    }
+
+    /// <summary>
+    /// A finished request frees the place it held. This is the difference between a quota and a
+    /// lifetime allowance, and getting it wrong means a person whose asks were all answered can
+    /// never ask again.
+    /// </summary>
+    /// <param name="finished">The state the answered request is in.</param>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Theory]
+    [InlineData(RequestState.Fulfilled)]
+    [InlineData(RequestState.Declined)]
+    [InlineData(RequestState.Failed)]
+    public async Task AFinishedRequestFreesThePlaceItHeld(RequestState finished)
+    {
+        var store = new InMemoryRequestStore();
+
+        await FillAsync(store, Asker, finished, 2).ConfigureAwait(true);
+
+        var asked = await Intake(store, quota: 2)
+            .AskAsync(Something(Asker), RequestCaller.User(Asker), CancellationToken.None)
+            .ConfigureAwait(true);
+
+        Assert.Equal(IntakeOutcome.Created, asked.Outcome);
+    }
+
+    /// <summary>
+    /// An approved request is not finished and still holds its place. It is the state this is
+    /// easiest to get wrong in: the operator has answered, and the thing has not arrived.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AnApprovedRequestStillHoldsItsPlace()
+    {
+        var store = new InMemoryRequestStore();
+
+        await FillAsync(store, Asker, RequestState.Approved, 1).ConfigureAwait(true);
+
+        await Assert.ThrowsAsync<RequestQuotaReachedException>(
+            () => Intake(store, quota: 1).AskAsync(Something(Asker), RequestCaller.User(Asker), CancellationToken.None))
+            .ConfigureAwait(true);
+    }
+
+    /// <summary>
+    /// Joining somebody else's request is one more thing this person is waiting for, so it is bound
+    /// by the quota as well. Without this leg the limit is one anybody can walk around by asking for
+    /// what is already in the queue.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task JoiningSomebodyElsesRequestIsBoundByItToo()
+    {
+        var store = new InMemoryRequestStore();
+
+        await FillAsync(store, Asker, RequestState.Open, 1).ConfigureAwait(true);
+
+        var theirs = Something(SomebodyElse);
+        await store.AddAsync(theirs, CancellationToken.None).ConfigureAwait(true);
+
+        await Assert.ThrowsAsync<RequestQuotaReachedException>(
+            () => Intake(store, quota: 1).AskAsync(
+                theirs with { Id = _identifiers.NewId(), RequestedByUserId = Asker },
+                RequestCaller.User(Asker),
+                CancellationToken.None))
+            .ConfigureAwait(true);
+
+        var held = await store.FindForUserAsync(Asker, CancellationToken.None).ConfigureAwait(true);
+        Assert.Single(held);
+    }
+
+    /// <summary>
+    /// Asking again for something they are already waiting for is never refused for the quota. It
+    /// takes no new place in the queue, and a person who asks twice out of impatience being told
+    /// they are at their limit is a limit that reads as broken.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AskingAgainForSomethingTheyAreAlreadyWaitingForIsNotRefused()
+    {
+        var store = new InMemoryRequestStore();
+
+        var already = Something(Asker);
+        await store.AddAsync(already, CancellationToken.None).ConfigureAwait(true);
+
+        var asked = await Intake(store, quota: 1)
+            .AskAsync(
+                already with { Id = _identifiers.NewId() },
+                RequestCaller.User(Asker),
+                CancellationToken.None)
+            .ConfigureAwait(true);
+
+        Assert.Equal(IntakeOutcome.AlreadyWaiting, asked.Outcome);
+    }
+
+    /// <summary>
+    /// An administrator is not subject to it, and neither is the plugin acting on its own
+    /// observation. No surface hands either of those in when something is asked for today, so this
+    /// is the leg that holds the rule at the one place it is decided.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AnAdministratorAndThePluginAreNotSubjectToIt()
+    {
+        var store = new InMemoryRequestStore();
+
+        await FillAsync(store, Asker, RequestState.Open, 1).ConfigureAwait(true);
+
+        var byAdministrator = await Intake(store, quota: 1)
+            .AskAsync(Something(Asker), RequestCaller.Administrator(Asker), CancellationToken.None)
+            .ConfigureAwait(true);
+
+        Assert.Equal(IntakeOutcome.Created, byAdministrator.Outcome);
+
+        var byPlugin = await Intake(store, quota: 1)
+            .AskAsync(Something(Asker), RequestCaller.Plugin, CancellationToken.None)
+            .ConfigureAwait(true);
+
+        Assert.Equal(IntakeOutcome.Created, byPlugin.Outcome);
+    }
+
+    /// <summary>
+    /// The count is of that person and nobody else. A quota measured over the whole queue would
+    /// refuse a person who has asked for nothing on a busy server.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task SomebodyElsesRequestsDoNotCountAgainstThem()
+    {
+        var store = new InMemoryRequestStore();
+
+        await FillAsync(store, SomebodyElse, RequestState.Open, 5).ConfigureAwait(true);
+
+        var asked = await Intake(store, quota: 1)
+            .AskAsync(Something(Asker), RequestCaller.User(Asker), CancellationToken.None)
+            .ConfigureAwait(true);
+
+        Assert.Equal(IntakeOutcome.Created, asked.Outcome);
+    }
+
+    /// <summary>
+    /// The two states that count are the two the model says count, read off the model rather than
+    /// restated here, so a state added to the lifecycle without a decision about the quota shows up
+    /// as a difference instead of being counted or not by accident.
+    /// </summary>
+    [Fact]
+    public void TheStatesThatCountAreTheOnesStillWaitingForAnAnswer()
+    {
+        var counted = Enum.GetValues<RequestState>()
+            .Where(state => RequestQuota.CountsAgainstIt(A(Asker) with { State = state }))
+            .ToArray();
+
+        Assert.Equal([RequestState.Open, RequestState.Approved], counted);
+    }
+
+    /// <summary>
+    /// A quota nobody filled in refuses rather than admits. No configuration produces one, because
+    /// the settings refuse a stored value below one on the way in and on the way out, and the
+    /// direction is what matters: a limit that defaults to nothing is not a limit.
+    /// </summary>
+    [Fact]
+    public void AQuotaNobodyFilledInRefuses()
+    {
+        Assert.True(default(RequestQuota).IsReachedBy(0));
+        Assert.False(new RequestQuota(1).IsReachedBy(0));
+        Assert.True(new RequestQuota(1).IsReachedBy(1));
+    }
+
+    /// <summary>
+    /// The intake over one store, with the quota this install is set to.
+    /// </summary>
+    /// <param name="store">Where requests are kept.</param>
+    /// <param name="quota">How many open or approved requests one person may hold.</param>
+    /// <returns>The intake under test.</returns>
+    private static RequestIntake Intake(IRequestStore store, int quota)
+        => new RequestIntake(
+            store,
+            new FakeInstallSettings(new PluginConfiguration { OpenRequestsPerUser = quota }));
+
+    /// <summary>
+    /// A request as somebody asked for it.
+    /// </summary>
+    /// <param name="asker">Who asked.</param>
+    /// <returns>The request.</returns>
+    private static MediaRequest A(Guid asker) => new MediaRequest
+    {
+        Id = new Guid("c5000000-0000-0000-0000-0000000000ff"),
+        RequestedByUserId = asker,
+        RequestedAt = Noon,
+        StateChangedAt = Noon,
+        Kind = RequestedItemKind.Movie,
+        DisplayTitle = "Sans Soleil",
+        DisplayYear = 1983
+    };
+
+    /// <summary>
+    /// Requests for one person, already in the store and in one state.
+    /// </summary>
+    /// <param name="store">Where they go.</param>
+    /// <param name="asker">Who asked for them.</param>
+    /// <param name="state">What state they are in.</param>
+    /// <param name="howMany">How many to write.</param>
+    /// <returns>A task that completes when they are in the store.</returns>
+    private async Task FillAsync(InMemoryRequestStore store, Guid asker, RequestState state, int howMany)
+    {
+        for (var index = 0; index < howMany; index++)
+        {
+            await store.AddAsync(
+                Something(asker) with { State = state, StateChangedAt = Noon },
+                CancellationToken.None).ConfigureAwait(true);
+        }
+    }
+
+    /// <summary>
+    /// A request for something nothing else in these tests asks for, so a leg about counting is
+    /// never a leg about joining.
+    /// </summary>
+    /// <param name="asker">Who is asking.</param>
+    /// <returns>The request.</returns>
+    private MediaRequest Something(Guid asker)
+    {
+        var id = _identifiers.NewId();
+
+        return A(asker) with
+        {
+            Id = id,
+            DisplayTitle = "Title " + id.ToString("N", CultureInfo.InvariantCulture),
+            ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["Tmdb"] = id.ToString("N", CultureInfo.InvariantCulture)
+            }
+        };
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/Seam/WantHandoverTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Seam/WantHandoverTests.cs
@@ -157,6 +157,47 @@ public class WantHandoverTests
     }
 
     /// <summary>
+    /// A want for somebody already at their quota is refused, and nothing is written.
+    /// <para>
+    /// The seam is the second way a request is made, and a way in that is not bound by the limit is
+    /// the way around it. Nothing here re-checks the quota: what this holds is that the one place it
+    /// is applied is under this path too, which is what makes the limit a property of the plugin
+    /// rather than of one endpoint.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AWantForSomebodyAtTheirQuotaIsRefusedAndSaysSo()
+    {
+        var store = new InMemoryRequestStore();
+        var log = new RecordingLogger();
+        var settings = new FakeInstallSettings(new PluginConfiguration { OpenRequestsPerUser = 1 });
+
+        await store.AddAsync(
+            new MediaRequest
+            {
+                Id = new Guid("44444444-4444-4444-4444-444444444444"),
+                RequestedByUserId = Asker,
+                RequestedAt = Noon,
+                StateChangedAt = Noon,
+                Kind = RequestedItemKind.Movie,
+                DisplayTitle = "Solaris",
+                DisplayYear = 1972,
+                ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tmdb"] = "593" }
+            },
+            CancellationToken.None);
+
+        var accepted = await Seam(store, settings, log).AcceptAsync(Want(), CancellationToken.None);
+
+        Assert.False(accepted);
+        Assert.Single(await store.GetAllAsync(CancellationToken.None));
+        Assert.Contains(
+            nameof(HandoverRefusal.TheyAreAtTheirQuota),
+            Assert.Single(log.At(LogLevel.Warning)).Message,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// A kind this install is set not to accept is refused, and the refusal names itself in the log.
     /// The setting is read on every handover rather than held, so an operator turning a kind off
     /// means the next want of that kind.

--- a/Jellyfin.Plugin.Requests.Tests/Web/QueueViewTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Web/QueueViewTests.cs
@@ -222,7 +222,8 @@ public sealed class QueueViewTests
             store,
             new TestClock(asked),
             _identifiers,
-            new FakeCallerIdentity(new Guid("c1000000-0000-0000-0000-0000000000ad")));
+            new FakeCallerIdentity(new Guid("c1000000-0000-0000-0000-0000000000ad")),
+            new FakeInstallSettings());
 
         var answered = await controller.QueueAsync(
             [Enum.Parse<RequestState>(SelectedValueOf(body, "RequestsQueueState"), false)],

--- a/Jellyfin.Plugin.Requests/Api/RequestFailure.cs
+++ b/Jellyfin.Plugin.Requests/Api/RequestFailure.cs
@@ -79,11 +79,21 @@ public sealed record RequestFailure
 
         RequestFailureCode.TheCallerMayNotMakeThisMove => StatusCodes.Status403Forbidden,
 
+        // A conflict as well, and for the reason the three above are: the call is well formed and
+        // the state of this person's queue refuses it. A 403 would say they may not ask, which is
+        // not true tomorrow, or after an operator answers one of the things they are waiting for.
+        RequestFailureCode.TheyAreAtTheirQuota => StatusCodes.Status409Conflict,
+
         // Nothing is wrong with the call and the answer is not available. A 500 would say this
         // plugin broke, which is one of the two possibilities and not the likely one: a store that
         // cannot be read is usually a disk or a file, and telling an operator to try again later is
         // the true statement.
         RequestFailureCode.TheStoreCouldNotBeRead => StatusCodes.Status503ServiceUnavailable,
+
+        // Unavailable for the same reason and not a 500: the call was fine, this server is set to
+        // something the plugin cannot run on, and an operator fixing the settings makes the same
+        // call work.
+        RequestFailureCode.ThisInstallCannotRun => StatusCodes.Status503ServiceUnavailable,
 
         _ => throw new ArgumentOutOfRangeException(
             nameof(code),

--- a/Jellyfin.Plugin.Requests/Api/RequestFailureCode.cs
+++ b/Jellyfin.Plugin.Requests/Api/RequestFailureCode.cs
@@ -69,5 +69,24 @@ public enum RequestFailureCode
     /// path on the server's disk is exactly what an error may not carry. The caller is told the
     /// answer is unavailable rather than that its call was wrong, because its call was not.
     /// </summary>
-    TheStoreCouldNotBeRead = 7
+    TheStoreCouldNotBeRead = 7,
+
+    /// <summary>
+    /// The person calling is already waiting for as many open or approved requests as this install
+    /// allows. Nothing about the call is wrong and it becomes possible again as soon as one of the
+    /// things they asked for is answered, which is what separates it from a body that cannot be
+    /// acted on.
+    /// <para>
+    /// The sentence a person reads is #70's rather than this code's. What is here is the value a
+    /// client branches on.
+    /// </para>
+    /// </summary>
+    TheyAreAtTheirQuota = 8,
+
+    /// <summary>
+    /// What this install is set to is something the plugin cannot run on, so the call could not be
+    /// judged against it. A fault on this server rather than anything the caller sent, and the same
+    /// answer the seam gives a sibling for the same reason.
+    /// </summary>
+    ThisInstallCannotRun = 9
 }

--- a/Jellyfin.Plugin.Requests/Api/RequestsController.cs
+++ b/Jellyfin.Plugin.Requests/Api/RequestsController.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Configuration;
 using Jellyfin.Plugin.Requests.Identity;
 using Jellyfin.Plugin.Requests.Intake;
 using Jellyfin.Plugin.Requests.Model;
@@ -104,11 +105,16 @@ public sealed class RequestsController : RequestsControllerBase
     /// <param name="clock">The injected clock, so a request's times are testable.</param>
     /// <param name="identifiers">Where a new request's identifier comes from.</param>
     /// <param name="callers">The server's answer to who is calling.</param>
+    /// <param name="settings">
+    /// What this install is set to. The intake reads the quota out of it on every ask, so the
+    /// endpoint cannot ask without one.
+    /// </param>
     public RequestsController(
         IRequestStore store,
         IClock clock,
         IIdentifierSource identifiers,
-        ICallerIdentity callers)
+        ICallerIdentity callers,
+        IInstallSettings settings)
     {
         _store = store;
         _clock = clock;
@@ -116,10 +122,9 @@ public sealed class RequestsController : RequestsControllerBase
         _callers = callers;
 
         // Built here rather than injected, because it is this controller's use of the store rather
-        // than a fifth thing the server has to supply. CatalogueSplitTests counts what this
-        // controller is constructed from, and a request intake that arrived as a dependency would
-        // read as one.
-        _intake = new RequestIntake(store);
+        // than a sixth thing the server has to supply. CatalogueSplitTests reads the list this
+        // constructor takes, and a request intake that arrived as a dependency would read as one.
+        _intake = new RequestIntake(store, settings);
     }
 
     /// <summary>
@@ -139,6 +144,7 @@ public sealed class RequestsController : RequestsControllerBase
     [ProducesResponseType<CreatedRequest>(StatusCodes.Status200OK)]
     [ProducesResponseType<RequestFailure>(StatusCodes.Status400BadRequest)]
     [ProducesResponseType<RequestFailure>(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType<RequestFailure>(StatusCodes.Status409Conflict)]
     [ProducesResponseType<RequestFailure>(StatusCodes.Status503ServiceUnavailable)]
     public async Task<ActionResult<CreatedRequest>> CreateAsync(
         [FromBody] CreateRequestBody body,
@@ -184,11 +190,32 @@ public sealed class RequestsController : RequestsControllerBase
 
         try
         {
-            answer = await AskAsync(incoming, cancellationToken).ConfigureAwait(false);
+            answer = await AskAsync(incoming, RequestCaller.User(asker), cancellationToken).ConfigureAwait(false);
         }
         catch (RequestStoreLoadException)
         {
             return TheStoreCouldNotBeRead();
+        }
+        catch (RequestQuotaReachedException atTheirQuota)
+        {
+            // The numbers are the caller's own and say nothing about anybody else's queue, which is
+            // why they may be reported: how many things this person is waiting for is something they
+            // can already read off their own page.
+            return Failed(
+                RequestFailureCode.TheyAreAtTheirQuota,
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    "You are waiting for {0} requests and this server allows {1} at once. One of them has to be answered before you can ask for something else.",
+                    atTheirQuota.Held,
+                    atTheirQuota.Limit));
+        }
+        catch (InvalidConfigurationException)
+        {
+            // Nothing from the exception reaches the caller. It names the settings that are wrong,
+            // which is the operator's business and not the asker's, and the server log carries it.
+            return Failed(
+                RequestFailureCode.ThisInstallCannotRun,
+                "This server is set to something the plugin cannot run on, so nothing can be asked for until an operator corrects it. The server log says which setting.");
         }
 
         // 201 with no Location header, on purpose. Nothing reads one request back yet, so a
@@ -1210,11 +1237,19 @@ public sealed class RequestsController : RequestsControllerBase
     /// </para>
     /// </summary>
     /// <param name="incoming">The ask, as a request that does not exist yet.</param>
+    /// <param name="caller">
+    /// Who is asking. This endpoint hands in an ordinary user whoever they are, because the server
+    /// tells it which person is calling and not whether that person administers this server, and a
+    /// caller built as an administrator on a guess would exempt somebody from the quota on one.
+    /// </param>
     /// <param name="cancellationToken">Cancels the call.</param>
     /// <returns>What the caller is now waiting for and what asking did.</returns>
-    private async Task<CreatedRequest> AskAsync(MediaRequest incoming, CancellationToken cancellationToken)
+    private async Task<CreatedRequest> AskAsync(
+        MediaRequest incoming,
+        RequestCaller caller,
+        CancellationToken cancellationToken)
     {
-        var intake = await _intake.AskAsync(incoming, cancellationToken).ConfigureAwait(false);
+        var intake = await _intake.AskAsync(incoming, caller, cancellationToken).ConfigureAwait(false);
 
         return new CreatedRequest
         {

--- a/Jellyfin.Plugin.Requests/Intake/RequestIntake.cs
+++ b/Jellyfin.Plugin.Requests/Intake/RequestIntake.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Configuration;
 using Jellyfin.Plugin.Requests.Model;
 using Jellyfin.Plugin.Requests.Storage;
 
@@ -36,17 +37,26 @@ public sealed class RequestIntake
     public const int JoinAttempts = 3;
 
     private readonly IRequestStore _store;
+    private readonly IInstallSettings _settings;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RequestIntake"/> class.
     /// </summary>
     /// <param name="store">Where requests are kept.</param>
-    /// <exception cref="ArgumentNullException">Where there is no store to ask.</exception>
-    public RequestIntake(IRequestStore store)
+    /// <param name="settings">
+    /// What this install is set to, read per ask rather than kept, so an operator raising the quota
+    /// applies to the next person who asks rather than to the next restart.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// Where there is no store to ask, or nothing to read the settings from.
+    /// </exception>
+    public RequestIntake(IRequestStore store, IInstallSettings settings)
     {
         ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(settings);
 
         _store = store;
+        _settings = settings;
     }
 
     /// <summary>
@@ -58,18 +68,38 @@ public sealed class RequestIntake
     /// </para>
     /// </summary>
     /// <param name="incoming">The request as the surface built it.</param>
+    /// <param name="caller">
+    /// Who is asking and with what authority. It is here so the quota binds every surface at one
+    /// place: a surface that forgot to check it cannot get past this, because there is no way to ask
+    /// without saying who is asking.
+    /// </param>
     /// <param name="cancellationToken">Cancels the call.</param>
     /// <returns>The request the asker is now waiting for, and what asking did.</returns>
-    /// <exception cref="ArgumentNullException">Where there is no request to ask with.</exception>
+    /// <exception cref="ArgumentNullException">
+    /// Where there is no request to ask with, or nobody is named as asking.
+    /// </exception>
     /// <exception cref="RequestStoreLoadException">Where the store cannot be read.</exception>
+    /// <exception cref="RequestQuotaReachedException">
+    /// Where the person asking is already waiting for as many open or approved requests as this
+    /// install allows.
+    /// </exception>
+    /// <exception cref="Configuration.InvalidConfigurationException">
+    /// Where this install is set to something the plugin cannot run on, so there is no quota to
+    /// judge the ask against. Nothing is written, and it is raised rather than defaulted because a
+    /// number nobody chose is how a limit stops being one.
+    /// </exception>
     /// <exception cref="RequestConcurrencyException">
     /// Where a join was refused <see cref="JoinAttempts"/> times because the request kept moving
     /// underneath the write. That is a contended request rather than a fault, and it is raised
     /// rather than retried forever so the caller answers instead of spinning.
     /// </exception>
-    public async Task<IntakeResult> AskAsync(MediaRequest incoming, CancellationToken cancellationToken)
+    public async Task<IntakeResult> AskAsync(
+        MediaRequest incoming,
+        RequestCaller caller,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(incoming);
+        ArgumentNullException.ThrowIfNull(caller);
 
         for (var attempt = 1; ; attempt++)
         {
@@ -98,6 +128,9 @@ public sealed class RequestIntake
 
             if (joining is not StoredRequest existing)
             {
+                await RefuseWhereTheyAreAtTheirQuotaAsync(ask, caller, cancellationToken)
+                    .ConfigureAwait(false);
+
                 var added = await _store.AddAsync(ask, cancellationToken).ConfigureAwait(false);
 
                 return new IntakeResult(added, IntakeOutcome.Created);
@@ -115,6 +148,16 @@ public sealed class RequestIntake
             if (alreadyWaiting && unabsorbed.Length == 0)
             {
                 return new IntakeResult(existing, IntakeOutcome.AlreadyWaiting);
+            }
+
+            if (!alreadyWaiting)
+            {
+                // Joining is one more thing this person is waiting for, so it is bound by the quota
+                // exactly as making a request is. The case above is not: somebody already on the
+                // request takes no new place in the queue, and refusing them would be refusing an
+                // ask that changes nothing.
+                await RefuseWhereTheyAreAtTheirQuotaAsync(ask, caller, cancellationToken)
+                    .ConfigureAwait(false);
             }
 
             // A want is written even where the person is already waiting, because the want is what a
@@ -144,6 +187,58 @@ public sealed class RequestIntake
                 // and the decision may come out differently: an operator who declined it meanwhile
                 // makes it no longer joinable, and the next pass creates instead.
             }
+        }
+    }
+
+    /// <summary>
+    /// Refuses the ask where the person is already waiting for as many things as this install
+    /// allows, and does nothing where they are not.
+    /// <para>
+    /// <b>An administrator is not subject to it, and neither is the plugin itself.</b> The first is
+    /// this issue's rule: an operator answering their own server is not the person a quota exists to
+    /// bound. The second is a shape rather than a case anything reaches today, because nothing makes
+    /// a request on the plugin's own behalf; a limit that applied to it would be a limit on the
+    /// server's own housekeeping. No surface hands an administrator in here yet, because neither the
+    /// endpoint nor the seam can say whether the person calling is one, so the exemption is provable
+    /// against the model and unreachable from outside it until they can.
+    /// </para>
+    /// <para>
+    /// <b>The count is a snapshot and two asks arriving together can both pass it.</b> The store is
+    /// atomic per request and says so, so nothing here can hold a person's whole set still while it
+    /// counts. What that costs is one request over the limit for somebody asking twice in the same
+    /// instant, and what the alternative costs is a lock across every request in the queue on the
+    /// path every ask takes. The limit is a bound on a person's habit rather than a security
+    /// boundary, and this is written down rather than left for somebody to find in a race.
+    /// </para>
+    /// </summary>
+    /// <param name="ask">What is being asked for, which names the person asking.</param>
+    /// <param name="caller">Who is asking and with what authority.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>Nothing. It either returns or refuses.</returns>
+    /// <exception cref="RequestQuotaReachedException">Where they are at their limit.</exception>
+    private async Task RefuseWhereTheyAreAtTheirQuotaAsync(
+        MediaRequest ask,
+        RequestCaller caller,
+        CancellationToken cancellationToken)
+    {
+        var roles = caller.RolesOn(ask);
+
+        if (roles.HasFlag(RequestActor.Administrator) || roles.HasFlag(RequestActor.Plugin))
+        {
+            return;
+        }
+
+        var quota = new RequestQuota(_settings.Current.OpenRequestsPerUser);
+
+        var theirs = await _store
+            .FindForUserAsync(ask.RequestedByUserId, cancellationToken)
+            .ConfigureAwait(false);
+
+        var held = RequestQuota.CountedIn(theirs.Select(stored => stored.Request));
+
+        if (quota.IsReachedBy(held))
+        {
+            throw new RequestQuotaReachedException(held, quota.Limit);
         }
     }
 

--- a/Jellyfin.Plugin.Requests/Model/RequestQuota.cs
+++ b/Jellyfin.Plugin.Requests/Model/RequestQuota.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Jellyfin.Plugin.Requests.Model;
+
+/// <summary>
+/// How many things one person may be waiting for at once, and what counts against that.
+/// <para>
+/// <b>What is scarce is what nobody has answered yet.</b> A request that is open or approved is one
+/// somebody still has to act on, and those are the two states counted here. A fulfilled, declined or
+/// failed request is finished, so counting it would turn the setting into a lifetime cap: a person
+/// whose asks are all answered would run out permanently, which is not what an operator setting "ten
+/// open requests" means.
+/// </para>
+/// <para>
+/// It is a value with no store behind it, so the rule can be asked directly rather than through a
+/// surface. What reads the queue is <see cref="Intake.RequestIntake"/>; what decides is here.
+/// </para>
+/// <para>
+/// A default instance carries a limit of nothing and therefore refuses everything. That direction is
+/// deliberate: a quota nobody filled in should refuse rather than admit, and no configuration
+/// produces one, because <see cref="Configuration.ConfigurationRules"/> refuses a stored value below
+/// one on the way in and on the way out.
+/// </para>
+/// </summary>
+/// <param name="Limit">How many open or approved requests one person may be waiting for.</param>
+public readonly record struct RequestQuota(int Limit)
+{
+    /// <summary>
+    /// Whether this request is one of the ones a person's quota is measured in.
+    /// </summary>
+    /// <param name="request">The request being counted.</param>
+    /// <returns>
+    /// <see langword="true"/> where it is open or approved, which are the two states somebody still
+    /// owes an answer or a delivery on.
+    /// </returns>
+    public static bool CountsAgainstIt(MediaRequest? request)
+        => request is not null
+            && request.State is RequestState.Open or RequestState.Approved;
+
+    /// <summary>
+    /// How many of these requests count against a quota.
+    /// </summary>
+    /// <param name="theirs">
+    /// Every request the person is waiting for, whether they asked first or joined somebody else's.
+    /// Joining counts, because a joined request is one they are waiting for and the queue holds it
+    /// for them as much as for whoever asked first.
+    /// </param>
+    /// <returns>The number of them that are open or approved, and zero where there are none.</returns>
+    public static int CountedIn(IEnumerable<MediaRequest>? theirs)
+        => theirs?.Count(CountsAgainstIt) ?? 0;
+
+    /// <summary>
+    /// Whether somebody holding this many is at their limit.
+    /// </summary>
+    /// <param name="held">How many open or approved requests they are waiting for.</param>
+    /// <returns>
+    /// <see langword="true"/> where another one may not be added. The comparison is "at least",
+    /// not "more than", so a person holding exactly the limit is at it rather than one past it.
+    /// </returns>
+    public bool IsReachedBy(int held) => held >= Limit;
+}

--- a/Jellyfin.Plugin.Requests/Model/RequestQuotaReachedException.cs
+++ b/Jellyfin.Plugin.Requests/Model/RequestQuotaReachedException.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Globalization;
+
+namespace Jellyfin.Plugin.Requests.Model;
+
+/// <summary>
+/// Thrown when somebody asks for something and is already waiting for as many things as they are
+/// allowed to.
+/// <para>
+/// A refusal rather than a queue that grows anyway, because the quota is the only thing between one
+/// enthusiastic person and every open request on the server, and a limit that is applied later is a
+/// limit applied against habits people already have.
+/// </para>
+/// <para>
+/// The limit and the number held are carried as values so a surface can say them without reading
+/// English out of a message. The sentence a person is shown is not this message: what a user reads
+/// when the answer is "not yet" is #70's, written once and rendered by every surface, and this
+/// message is what reaches a log.
+/// </para>
+/// </summary>
+public sealed class RequestQuotaReachedException : InvalidOperationException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequestQuotaReachedException"/> class for
+    /// somebody at their limit.
+    /// </summary>
+    /// <param name="held">How many open or approved requests they are already waiting for.</param>
+    /// <param name="limit">How many they are allowed to be waiting for.</param>
+    public RequestQuotaReachedException(int held, int limit)
+        : base(Describe(held, limit))
+    {
+        Held = held;
+        Limit = limit;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequestQuotaReachedException"/> class. Present
+    /// because the analyzers ask every exception for the three ordinary constructors; the
+    /// constructor above is the one this type exists for.
+    /// </summary>
+    public RequestQuotaReachedException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequestQuotaReachedException"/> class with a
+    /// message of the caller's own. See the note on the parameterless constructor.
+    /// </summary>
+    /// <param name="message">The message.</param>
+    public RequestQuotaReachedException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequestQuotaReachedException"/> class with a
+    /// message and an inner exception. See the note on the parameterless constructor.
+    /// </summary>
+    /// <param name="message">The message.</param>
+    /// <param name="innerException">The inner exception.</param>
+    public RequestQuotaReachedException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    /// Gets how many open or approved requests the person was already waiting for.
+    /// </summary>
+    public int Held { get; }
+
+    /// <summary>
+    /// Gets how many they are allowed to be waiting for.
+    /// </summary>
+    public int Limit { get; }
+
+    private static string Describe(int held, int limit)
+        => string.Format(
+            CultureInfo.InvariantCulture,
+            "This person is waiting for {0} open or approved requests and the limit is {1}. Something they asked for has to be answered before they can ask for another.",
+            held,
+            limit);
+}

--- a/Jellyfin.Plugin.Requests/Seam/HandoverRefusal.cs
+++ b/Jellyfin.Plugin.Requests/Seam/HandoverRefusal.cs
@@ -84,5 +84,13 @@ public enum HandoverRefusal
     /// an exception for the same reason every other entry is, and what actually went wrong is on
     /// this server's log at error level with the fault itself.
     /// </summary>
-    SomethingBeneathThisSeamFailed = 11
+    SomethingBeneathThisSeamFailed = 11,
+
+    /// <summary>
+    /// The person the want names is already waiting for as many open or approved requests as this
+    /// install allows. A want arriving over the seam is somebody asking for something, so it is
+    /// bound by the same quota as an ask over the endpoint; a path that was not would be the way
+    /// around the limit rather than a second way to ask.
+    /// </summary>
+    TheyAreAtTheirQuota = 12
 }

--- a/Jellyfin.Plugin.Requests/Seam/WantHandover.cs
+++ b/Jellyfin.Plugin.Requests/Seam/WantHandover.cs
@@ -121,7 +121,7 @@ public sealed class WantHandover : IWantHandover
         ArgumentOutOfRangeException.ThrowIfLessThan(answerWithin, TimeSpan.Zero);
 
         _store = store;
-        _intake = new RequestIntake(store);
+        _intake = new RequestIntake(store, settings);
         _clock = clock;
         _identifiers = identifiers;
         _settings = settings;
@@ -288,13 +288,19 @@ public sealed class WantHandover : IWantHandover
         try
         {
             intake = await WithinTheBoundAsync(
-                _intake.AskAsync(incoming, cancellationToken)).ConfigureAwait(false);
+                _intake.AskAsync(incoming, RequestCaller.User(want.RequestedByUserId), cancellationToken)).ConfigureAwait(false);
         }
         catch (RequestStoreLoadException)
         {
             // The store says which file and why in its own log line. What is added here is which
             // want was lost because of it, so the two can be put together.
             return Refused(want, HandoverRefusal.TheStoreCouldNotBeReached);
+        }
+        catch (RequestQuotaReachedException)
+        {
+            // The numbers are not carried across: the contract answers whether the want was taken
+            // and nothing else, and an operator who needs to know why reads the refusal in the log.
+            return Refused(want, HandoverRefusal.TheyAreAtTheirQuota);
         }
         catch (RequestConcurrencyException)
         {

--- a/docs/api.md
+++ b/docs/api.md
@@ -219,6 +219,21 @@ A body that cannot become a request is refused with `400` and the field that is 
 client can put the message beside the box somebody typed in rather than having to read English to
 work out which one. The shape is the one every failure of this API comes back in, below.
 
+**How many things one person may be waiting for is bounded, and this is where the bound is applied.**
+Somebody already waiting for as many open or approved requests as the install allows is refused with
+`409` and `TheyAreAtTheirQuota`, carrying how many they hold and what the limit is. It is a `409`
+rather than a `403` because nothing about the call is wrong and the same call works as soon as one of
+the things they asked for is answered. Joining somebody else's request counts, because it is one more
+thing they are waiting for; asking again for something they are already on writes nothing and is
+therefore never refused for this. A finished request frees the place, so the setting is a bound on
+what is open rather than a lifetime allowance. Which requests count and what the limit is are
+`OpenRequestsPerUser` in [configuration.md](configuration.md).
+
+Reading the setting is also a way this call can fail. Where the stored configuration is something the
+plugin cannot run on, the install is refused on the read rather than corrected, so the ask answers
+`503` and `ThisInstallCannotRun` and nothing is written. That is a fault on the server, the log says
+which setting, and the message here does not.
+
 ## Reading your own requests
 
     GET MediaRequests/v1/Requests
@@ -369,16 +384,18 @@ seen before still parses and still says which class it is. What that costs is tw
 absent most of the time, which is cheaper than a client reading five shapes, four of them from an
 example rather than from a contract.
 
-| Code                          | Status | What happened                                              |
-| ----------------------------- | ------ | ---------------------------------------------------------- |
-| `InvalidBody`                 | `400`  | The body cannot become what it is for. `field` says where. |
-| `NoUserOnTheCall`             | `403`  | Authenticated, and no person behind it.                    |
-| `NoSuchRequest`               | `404`  | The store holds no request with that identifier.           |
-| `MovedSinceItWasRead`         | `409`  | Somebody moved it between the read and this call.          |
-| `TheTableRefusesTheMove`      | `409`  | The transition table has no such move from where it is.    |
-| `TheRequestNamesNothing`      | `409`  | It carries no identifier, so only a decline is available.  |
-| `TheCallerMayNotMakeThisMove` | `403`  | The table allows the move and does not admit this caller.  |
-| `TheStoreCouldNotBeRead`      | `503`  | The queue could not be read. Nothing was changed.          |
+| Code                          | Status | What happened                                                 |
+| ----------------------------- | ------ | ------------------------------------------------------------- |
+| `InvalidBody`                 | `400`  | The body cannot become what it is for. `field` says where.    |
+| `NoUserOnTheCall`             | `403`  | Authenticated, and no person behind it.                       |
+| `NoSuchRequest`               | `404`  | The store holds no request with that identifier.              |
+| `MovedSinceItWasRead`         | `409`  | Somebody moved it between the read and this call.             |
+| `TheTableRefusesTheMove`      | `409`  | The transition table has no such move from where it is.       |
+| `TheRequestNamesNothing`      | `409`  | It carries no identifier, so only a decline is available.     |
+| `TheCallerMayNotMakeThisMove` | `403`  | The table allows the move and does not admit this caller.     |
+| `TheStoreCouldNotBeRead`      | `503`  | The queue could not be read. Nothing was changed.             |
+| `TheyAreAtTheirQuota`         | `409`  | They are waiting for as many requests as this install allows. |
+| `ThisInstallCannotRun`        | `503`  | The settings are something the plugin cannot run on.          |
 
 Each code has exactly one status code, decided in one place, so a client may branch on either and
 never find them disagreeing. A client that does not know a code falls back on the status, which is
@@ -391,6 +408,10 @@ request has to be attributable to somebody to exist at all.
 `TheStoreCouldNotBeRead` is `503` rather than `500`. A store that cannot be read is usually a disk or
 a file rather than this plugin being broken, and telling an operator to try again is the true
 statement. Nothing was changed when it is answered.
+
+`ThisInstallCannotRun` is `503` for the same reason and is the same answer the seam gives a sibling
+plugin for the same cause. The call was fine, this server is set to something that cannot be honoured,
+and an operator changing one field makes the identical call work.
 
 **Nothing in a message names a person, a path on the server disk, or an exception.** The three are
 one rule with three shapes: a user identifier tells a caller about somebody else, a path tells


### PR DESCRIPTION
Part of #114. The quota is enforced where a request is created, and two of the
four conditions are met with evidence. The other two are unchanged and the
reasons are below.

## Where it is applied, and why there

`RequestIntake` is the one place both surfaces go through, so the limit is
applied there rather than in each of them. `AskAsync` now takes the caller
beside the ask, which means there is no way to ask without saying who is asking,
and a surface added later inherits the limit instead of having to remember it.

The first condition asks that it be proven by a test calling the model directly,
and `RequestQuotaTests` does exactly that: every leg calls `AskAsync` with no
endpoint and no seam in front of it.

    DOTNET_CLI_UI_LANGUAGE=en dotnet test Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj --configuration Release -warnaserror -f net9.0 --filter "FullyQualifiedName~RequestQuotaTests"
    Passed!  - Failed:     0, Passed:    12, Skipped:     0, Total:    12

`AWantForSomebodyAtTheirQuotaIsRefusedAndSaysSo` is the same rule seen from the
seam, because a way in that is not bound by the limit is the way around it.

## What counts, and what frees a place

Open and approved, which are the two states somebody still owes an answer or a
delivery on. `AFinishedRequestFreesThePlaceItHeld` runs over fulfilled, declined
and failed; `AnApprovedRequestStillHoldsItsPlace` is the one that is easiest to
get wrong, because the operator has answered and the thing has not arrived.
Counting the finished ones would turn the setting into a lifetime allowance and
a person whose asks were all answered could never ask again.

Joining somebody else's request counts, because it is one more thing they are
waiting for and the limit would otherwise be one anybody walks around by asking
for what is already in the queue. Asking again for something they are already on
writes nothing and is never refused for this.

## The four guards, watched failing

Each edit was made on `net9.0`, the suite run, and the edit reverted.

The check removed from the path that creates:

    Failed RequestQuotaTests.AnApprovedRequestStillHoldsItsPlace
    Failed RequestQuotaTests.SomebodyAtTheirLimitIsRefusedByTheIntakeItself
    Failed!  - Failed:     2, Passed:    10, Skipped:     0, Total:    12

The check removed from the path that joins:

    Failed RequestQuotaTests.JoiningSomebodyElsesRequestIsBoundByItToo
    Failed!  - Failed:     1, Passed:    46, Skipped:     0, Total:    47

The administrator exemption removed:

    Failed RequestQuotaTests.AnAdministratorAndThePluginAreNotSubjectToIt
    Failed!  - Failed:     1, Passed:    11, Skipped:     0, Total:    12

The seam handing in the plugin instead of the person who asked:

    Failed WantHandoverTests.AWantForSomebodyAtTheirQuotaIsRefusedAndSaysSo
    Failed!  - Failed:     1, Passed:    34, Skipped:     0, Total:    35

## The two conditions this does not meet

**The message a person reads is #70's and this does not write it.** The third
condition asks that somebody at their quota get the message from #70 rather than
a generic failure. What they get here is a failure of its own class,
`TheyAreAtTheirQuota`, carrying how many they hold and what the limit is, which
is what a surface needs to render #70's sentence once that sentence exists. The
string in this change is the one that reaches a log and an API caller, and #70
is where the sentence rendered by every surface is decided.

**The fourth condition is unchanged and is a plan question.** A value of nothing
meaning no limit is refused by the settings page and by the validation on both
the save and the read, and the measurement of that is already on the issue from
12 August. Nothing here moves it in either direction.

## Two things this widened that the issue does not name

**A second failure code.** Reading the settings is how the quota is known, and
this install refuses a configuration it cannot honour on the read rather than
correcting it, so asking for something can now fail that way.
`ThisInstallCannotRun` is `503` and is the same answer the seam already gives a
sibling for the same cause. Without it that refusal would have escaped an
endpoint as an exception.

**Files outside the issue's declared scope.** `Scope:` on #114 names the model
code, the controllers and the test project. `Seam/WantHandover.cs` and
`Seam/HandoverRefusal.cs` are touched because the seam is one of the callers the
issue requires to be bound, and `docs/api.md` because the suite refuses a
failure code that is not published there and a status an endpoint answers with
that the document does not carry. Both are named here rather than left to be
found in the diff.

## What is not claimed

**The count is a snapshot and two asks arriving in the same instant can both
pass it.** The store is atomic per request and says so, so nothing here holds a
person's whole set still while it counts. What that costs is one request over
the limit for somebody asking twice in the same moment; what the alternative
costs is a lock across the queue on the path every ask takes. The limit is a
bound on a person's habit rather than a security boundary, and the method says
so in its own words.

**Nothing here was run against a server.** Every run below is the suite.

## The runs

At `cbfb007`, both frameworks:

    DOTNET_CLI_UI_LANGUAGE=en dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Passed!  - Failed:     0, Passed:   525, Skipped:     0, Total:   525 (net9.0)
    Passed!  - Failed:     0, Passed:   525, Skipped:     0, Total:   525 (net10.0)

    npx --yes prettier@3.6.2 --check "docs/api.md"
    All matched files use Prettier code style!

No second person has read this. The evidence above stands in place of one.
