### PR TITLE
Send a request's movements to one address an operator chose, and never let it matter

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Configuration/ConfigurationRulesTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Configuration/ConfigurationRulesTests.cs
@@ -129,7 +129,8 @@ public class ConfigurationRulesTests
             OpenRequestsPerUser = 0,
             AcceptsMovies = false,
             AcceptsSeries = false,
-            FinishedRequestRetentionDays = 0
+            FinishedRequestRetentionDays = 0,
+            OutboundNoticeAddress = "example.invalid/hook"
         };
 
         var declared = typeof(PluginConfiguration)

--- a/Jellyfin.Plugin.Requests.Tests/Configuration/PluginConfigurationTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Configuration/PluginConfigurationTests.cs
@@ -26,7 +26,7 @@ namespace Jellyfin.Plugin.Requests.Tests.Configuration;
 public class PluginConfigurationTests
 {
     /// <summary>
-    /// Every setting this plugin has, with the value a fresh install runs. Four lines is the whole
+    /// Every setting this plugin has, with the value a fresh install runs. This is the whole
     /// configuration surface, and a change to any of them is a change to this list with a reason in
     /// the commit that made it.
     /// </summary>
@@ -37,7 +37,8 @@ public class PluginConfigurationTests
             { "AcceptsMovies", "true" },
             { "AcceptsSeries", "true" },
             { "FinishedRequestRetentionDays", "365" },
-            { "OpenRequestsPerUser", "10" }
+            { "OpenRequestsPerUser", "10" },
+            { "OutboundNoticeAddress", string.Empty }
         };
 
     /// <summary>
@@ -85,17 +86,23 @@ public class PluginConfigurationTests
     }
 
     /// <summary>
-    /// Every setting is a number or a switch, so nothing here can hold an address or a credential.
+    /// One setting holds text and it is the address a notice is posted to. Every other setting is a
+    /// number or a switch, so there is nowhere else here for an address or a credential to be typed.
     /// <para>
-    /// This is the guard on the sentence that a fresh install sends nothing outward, and it is
-    /// written over the shape rather than over the names because a name check passes for whatever
-    /// somebody called the field. The first outbound thing to arrive will want somewhere to type an
-    /// address, and where a credential lives and what may honestly be claimed about it is #85's
+    /// This used to say that no setting could hold either, which was the guard on a plugin that made
+    /// no outbound call at all. The outbound sink is that call, and it needs somewhere for an
+    /// operator to say where, so the guard narrows to the one field rather than being deleted: what
+    /// it is really for is a second one arriving quietly, and a credential is the second one it is
+    /// most against. Where a credential lives and what may honestly be claimed about it is #85's
     /// decision rather than a field added while doing something else.
+    /// </para>
+    /// <para>
+    /// It is written over the shape rather than over the names, because a name check passes for
+    /// whatever somebody called the field.
     /// </para>
     /// </summary>
     [Fact]
-    public void NoSettingCanHoldAnAddressOrACredential()
+    public void TheOnlySettingThatHoldsTextIsTheAddressANoticeIsPostedTo()
     {
         var carrying = Settings()
             .Where(setting => setting.PropertyType != typeof(int) && setting.PropertyType != typeof(bool))
@@ -103,7 +110,7 @@ public class PluginConfigurationTests
             .OrderBy(name => name, StringComparer.Ordinal)
             .ToArray();
 
-        Assert.Equal([], carrying);
+        Assert.Equal(["OutboundNoticeAddress is String"], carrying);
     }
 
     /// <summary>
@@ -116,12 +123,16 @@ public class PluginConfigurationTests
     /// </para>
     /// </summary>
     /// <param name="setting">The setting.</param>
-    /// <param name="expected">What it is on a fresh install, which this leg does not read.</param>
+    /// <param name="expected">
+    /// What it is on a fresh install, which this leg does not read. It is not asserted to be
+    /// anything here, because one setting's default is deliberately nothing at all: an install with
+    /// no address typed into it sends nothing anywhere.
+    /// </param>
     [Theory]
     [MemberData(nameof(TheSettingsAndTheirDefaults))]
     public void EverySettingIsReachableFromTheSettingsPage(string setting, string expected)
     {
-        Assert.NotEmpty(expected);
+        Assert.NotNull(expected);
 
         var page = SettingsPage();
 

--- a/Jellyfin.Plugin.Requests.Tests/Doubles/ASinkEndpoint.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/ASinkEndpoint.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jellyfin.Plugin.Requests.Tests.Doubles;
+
+/// <summary>
+/// Whatever an operator pointed the notification sink at, inside this process.
+/// <para>
+/// It is a message handler rather than a server on a port, so the sink's own client, its
+/// serialisation, its timeout and its error handling are all exercised and no socket is opened. That
+/// is the replacement <c>docs/testing.md</c> names for a real outbound call.
+/// </para>
+/// <para>
+/// The unhappy endpoints are the point of it. An endpoint that refuses the connection, one that
+/// answers with a failure and one that accepts the connection and then says nothing are the three
+/// shapes a notification sink meets in the field, and the last is the one that needs no clock here:
+/// it holds the send until the test lets go, so a suite can assert what happened while it is still
+/// holding.
+/// </para>
+/// </summary>
+internal sealed class ASinkEndpoint : HttpMessageHandler
+{
+    private readonly TaskCompletionSource _entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _released = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly ConcurrentQueue<SentNotice> _received = new ConcurrentQueue<SentNotice>();
+    private readonly HttpStatusCode? _answers;
+    private readonly bool _holds;
+
+    private ASinkEndpoint(HttpStatusCode? answers, bool holds)
+    {
+        _answers = answers;
+        _holds = holds;
+    }
+
+    /// <summary>
+    /// Gets everything that was posted to it, oldest first.
+    /// </summary>
+    public IReadOnlyList<SentNotice> Received => [.. _received];
+
+    /// <summary>
+    /// Gets a task that completes the moment a send reaches this endpoint, so a test can assert
+    /// against a delivery that is under way without waiting on a clock for it.
+    /// </summary>
+    public Task Entered => _entered.Task;
+
+    /// <summary>
+    /// An endpoint that takes what it is given and says so.
+    /// </summary>
+    /// <returns>An endpoint that answers 202.</returns>
+    public static ASinkEndpoint ThatAccepts() => new ASinkEndpoint(HttpStatusCode.Accepted, holds: false);
+
+    /// <summary>
+    /// An endpoint that answers, with something other than success.
+    /// </summary>
+    /// <param name="status">What it answers with.</param>
+    /// <returns>An endpoint that answers that.</returns>
+    public static ASinkEndpoint ThatAnswers(HttpStatusCode status) => new ASinkEndpoint(status, holds: false);
+
+    /// <summary>
+    /// An endpoint that is not there. The connection is refused the way the runtime refuses one,
+    /// rather than with an exception invented for the test.
+    /// </summary>
+    /// <returns>An endpoint nothing reaches.</returns>
+    public static ASinkEndpoint ThatRefusesTheConnection() => new ASinkEndpoint(answers: null, holds: false);
+
+    /// <summary>
+    /// An endpoint that accepts the connection and then says nothing until it is let go.
+    /// </summary>
+    /// <returns>An endpoint that holds every send.</returns>
+    public static ASinkEndpoint ThatNeverAnswers() => new ASinkEndpoint(HttpStatusCode.Accepted, holds: true);
+
+    /// <summary>
+    /// Lets go of every send this endpoint is holding.
+    /// </summary>
+    public void Release() => _released.TrySetResult();
+
+    /// <inheritdoc />
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var body = request.Content is null
+            ? string.Empty
+            : await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+        _received.Enqueue(new SentNotice(request.Method, request.RequestUri, body, request.Content?.Headers.ContentType?.MediaType));
+        _entered.TrySetResult();
+
+        if (_holds)
+        {
+            await _released.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        if (_answers is not HttpStatusCode answer)
+        {
+            throw new HttpRequestException("There is nothing listening at that address.");
+        }
+
+        return new HttpResponseMessage(answer);
+    }
+
+    /// <summary>
+    /// One thing that arrived at the endpoint.
+    /// </summary>
+    /// <param name="Method">How it was sent.</param>
+    /// <param name="Address">Where it was sent.</param>
+    /// <param name="Body">What it carried.</param>
+    /// <param name="MediaType">What it said it carried.</param>
+    internal sealed record SentNotice(HttpMethod Method, Uri? Address, string Body, string? MediaType);
+}

--- a/Jellyfin.Plugin.Requests.Tests/Notify/OutboundNoticeTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Notify/OutboundNoticeTests.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text.Json;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Notify;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Notify;
+
+/// <summary>
+/// The document that leaves the server, held to the shape somebody else's machine reads.
+/// <para>
+/// The expected field list below is written out by hand rather than read off the type. A list
+/// derived from the type agrees with the type on the day a field is added to it, which is the only
+/// day this page is worth having: the reader of this document is a script an operator wrote and this
+/// repository will never see, and it breaks silently at their end rather than loudly at this one.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class OutboundNoticeTests
+{
+    private static readonly Guid Asker = new Guid("7e000000-0000-0000-0000-000000000001");
+    private static readonly Guid Operator = new Guid("7e000000-0000-0000-0000-000000000002");
+    private static readonly Guid Joiner = new Guid("7e000000-0000-0000-0000-000000000003");
+    private static readonly DateTimeOffset Asked = new DateTimeOffset(2026, 8, 13, 9, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset Answered = new DateTimeOffset(2026, 8, 14, 17, 30, 0, TimeSpan.Zero);
+
+    /// <summary>
+    /// Every field the document carries, as a reader of it would write them down.
+    /// </summary>
+    /// <returns>The whole document, in the order it is declared.</returns>
+    public static IReadOnlyList<string> TheFieldsAReaderGets()
+        =>
+        [
+            "version",
+            "event",
+            "requestId",
+            "at",
+            "state",
+            "requestedByUserId",
+            "movedByUserId",
+            "kind",
+            "title",
+            "year"
+        ];
+
+    /// <summary>
+    /// The document is exactly those fields. Both halves matter: a field that disappeared breaks a
+    /// reader that used it, and a field that appeared is something that now leaves the server
+    /// without anybody having argued for it.
+    /// </summary>
+    [Fact]
+    public void TheDocumentIsExactlyTheFieldsWrittenDown()
+    {
+        Assert.Equal(TheFieldsAReaderGets(), FieldsOf(Declined()));
+    }
+
+    /// <summary>
+    /// Every document says which shape it is, including the ones where nothing optional was set. A
+    /// version that only appears sometimes is a version a reader cannot branch on.
+    /// </summary>
+    [Fact]
+    public void EveryDocumentCarriesTheVersionThisPluginWrites()
+    {
+        foreach (var notice in new[] { Asked_(), Declined(), Fulfilled() })
+        {
+            using var read = JsonDocument.Parse(JsonSerializer.Serialize(notice));
+
+            Assert.Equal(OutboundNotice.CurrentVersion, read.RootElement.GetProperty("version").GetInt32());
+        }
+    }
+
+    /// <summary>
+    /// What happened and what state it is in are words rather than numbers.
+    /// <para>
+    /// A number is what the enumeration happens to be ordered as today, and a value inserted in the
+    /// middle of either one would silently change what every past document meant. A reader comparing
+    /// against a word is unharmed by the same change.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void WhatHappenedAndWhatStateItIsInAreWordsRatherThanNumbers()
+    {
+        using var read = JsonDocument.Parse(JsonSerializer.Serialize(Declined()));
+
+        Assert.Equal("Declined", read.RootElement.GetProperty("event").GetString());
+        Assert.Equal("Declined", read.RootElement.GetProperty("state").GetString());
+        Assert.Equal("Movie", read.RootElement.GetProperty("kind").GetString());
+    }
+
+    /// <summary>
+    /// Neither note leaves the server, and neither do the provider identifiers or the people who
+    /// joined.
+    /// <para>
+    /// The request this is built from carries all four, so the assertion is about what the document
+    /// leaves behind rather than about a record that never had them. Both notes are free text
+    /// somebody typed, and either can hold a name, an address or anything else that this plugin has
+    /// no business posting to an address on somebody's behalf.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void NoNoteNoProviderIdentifierAndNobodyElseWaitingLeavesTheServer()
+    {
+        var written = JsonSerializer.Serialize(Declined());
+
+        Assert.DoesNotContain("please get this one", written, StringComparison.Ordinal);
+        Assert.DoesNotContain("we already have it in another cut", written, StringComparison.Ordinal);
+        Assert.DoesNotContain("tt0111161", written, StringComparison.Ordinal);
+        Assert.DoesNotContain(Joiner.ToString(), written, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// A request that has just arrived names nobody as having moved it, and it is stamped with when
+    /// it was asked for rather than with a state change that has not happened.
+    /// </summary>
+    [Fact]
+    public void ArrivingNamesNobodyAsHavingMovedItAndIsStampedWithWhenItWasAsked()
+    {
+        var notice = Asked_();
+
+        Assert.Null(notice.MovedByUserId);
+        Assert.Equal(Asked, notice.At);
+    }
+
+    /// <summary>
+    /// A movement names whoever made it and is stamped with when the request moved, which is what a
+    /// reader delivering a late message needs so it does not read as having just happened.
+    /// </summary>
+    [Fact]
+    public void AMovementNamesWhoMadeItAndWhenTheRequestMoved()
+    {
+        var notice = Declined();
+
+        Assert.Equal(Operator, notice.MovedByUserId);
+        Assert.Equal(Answered, notice.At);
+    }
+
+    /// <summary>
+    /// Fulfilment is decided by the library rather than by anybody, so the field for a mover is
+    /// absent rather than filled with whoever last touched the request.
+    /// </summary>
+    [Fact]
+    public void FulfilmentNamesNobodyBecauseNobodyDidIt()
+    {
+        Assert.Null(Fulfilled().MovedByUserId);
+    }
+
+    private static OutboundNotice Asked_() => OutboundNotice.For(Requested(), NoticeEvent.Asked);
+
+    private static OutboundNotice Declined()
+        => OutboundNotice.For(
+            Requested() with
+            {
+                State = RequestState.Declined,
+                StateChangedAt = Answered,
+                StateChangedByUserId = Operator,
+                DeclineReason = DeclineReason.AlreadyInTheLibrary,
+                DeclineNote = "we already have it in another cut"
+            },
+            NoticeEvent.Declined);
+
+    private static OutboundNotice Fulfilled()
+        => OutboundNotice.For(
+            Requested() with
+            {
+                State = RequestState.Fulfilled,
+                StateChangedAt = Answered,
+                StateChangedByUserId = null
+            },
+            NoticeEvent.Fulfilled);
+
+    private static MediaRequest Requested()
+        => new MediaRequest
+        {
+            Id = new Guid("7e000000-0000-0000-0000-0000000000aa"),
+            RequestedByUserId = Asker,
+            RequestedAt = Asked,
+            Kind = RequestedItemKind.Movie,
+            DisplayTitle = "The Shawshank Redemption",
+            DisplayYear = 1994,
+            ProviderIds = new Dictionary<string, string> { ["Imdb"] = "tt0111161" },
+            JoinedByUserIds = [Joiner],
+            RequesterNote = "please get this one",
+            StateChangedAt = Asked
+        };
+
+    private static IReadOnlyList<string> FieldsOf(OutboundNotice notice)
+    {
+        using var read = JsonDocument.Parse(JsonSerializer.Serialize(notice));
+
+        return [.. read.RootElement.EnumerateObject().Select(field => field.Name)];
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/Notify/OutboundSinkTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Notify/OutboundSinkTests.cs
@@ -1,0 +1,307 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Configuration;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Notify;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Notify;
+
+/// <summary>
+/// The one path anything this plugin has to say leaves the server on, and the property that makes it
+/// safe to have: nothing an endpoint does reaches a request.
+/// <para>
+/// Every leg runs against an endpoint inside this process, reached through the sink's own client and
+/// its own handler pipeline, so the serialisation, the bound on a send and the error handling are
+/// the real ones and no socket is opened. Nothing here waits on a clock: the endpoint that never
+/// answers holds the send until the test lets go of it, and the bound is proven by handing the sink
+/// no time at all rather than by outlasting one.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class OutboundSinkTests
+{
+    private const string Address = "https://example.invalid/hook";
+
+    private static readonly Guid Asker = new Guid("78000000-0000-0000-0000-000000000001");
+    private static readonly Guid Operator = new Guid("78000000-0000-0000-0000-000000000002");
+    private static readonly DateTimeOffset Noon = new DateTimeOffset(2026, 8, 14, 12, 0, 0, TimeSpan.Zero);
+
+    /// <summary>
+    /// A fresh install sends nothing, because nobody has said where to. This is the whole of how the
+    /// path is off, and it is asserted at the endpoint rather than off the setting, so it still says
+    /// something the day somebody adds a second way to configure an address.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AnInstallWhereNobodyTypedAnAddressSendsNothing()
+    {
+        var endpoint = ASinkEndpoint.ThatAccepts();
+        using var sink = Sink(endpoint, address: string.Empty);
+
+        Assert.False(sink.IsConfigured);
+
+        sink.Announce(Notice());
+        await sink.QuietAsync(CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Empty(endpoint.Received);
+    }
+
+    /// <summary>
+    /// An address that is not somewhere a notice can be posted is no sink either.
+    /// <para>
+    /// The rules refuse such a value when it arrives, so this is the second reading rather than the
+    /// only one. What it is for is the case the first cannot reach: a configuration file edited by
+    /// hand on a server that is already running.
+    /// </para>
+    /// </summary>
+    /// <param name="written">What is in the configuration file.</param>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Theory]
+    [InlineData("   ")]
+    [InlineData("example.invalid/hook")]
+    [InlineData("/hook")]
+    [InlineData("file:///tmp/hook")]
+    [InlineData("mailto:somebody@example.invalid")]
+    public async Task AnAddressANoticeCannotBePostedToIsNoSinkAtAll(string written)
+    {
+        var endpoint = ASinkEndpoint.ThatAccepts();
+        using var sink = Sink(endpoint, written);
+
+        Assert.False(sink.IsConfigured);
+
+        sink.Announce(Notice());
+        await sink.QuietAsync(CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Empty(endpoint.Received);
+    }
+
+    /// <summary>
+    /// With an address, the document is posted to it as JSON, once.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task TheDocumentIsPostedAsJsonToTheAddressTheOperatorTyped()
+    {
+        var endpoint = ASinkEndpoint.ThatAccepts();
+        using var sink = Sink(endpoint, Address);
+
+        Assert.True(sink.IsConfigured);
+
+        sink.Announce(Notice());
+        await sink.QuietAsync(CancellationToken.None).ConfigureAwait(true);
+
+        var sent = Assert.Single(endpoint.Received);
+
+        Assert.Equal(HttpMethod.Post, sent.Method);
+        Assert.Equal(new Uri(Address), sent.Address);
+        Assert.Equal("application/json", sent.MediaType);
+
+        using var read = JsonDocument.Parse(sent.Body);
+
+        Assert.Equal(OutboundNotice.CurrentVersion, read.RootElement.GetProperty("version").GetInt32());
+        Assert.Equal("Approved", read.RootElement.GetProperty("event").GetString());
+    }
+
+    /// <summary>
+    /// An endpoint that has taken the connection and is saying nothing does not hold whoever
+    /// announced.
+    /// <para>
+    /// This is the second condition of #78 in the form that can be watched. The request is moved and
+    /// written while the endpoint is still holding the send, and both assertions run before it is let
+    /// go. An announcement that handed its caller something to await would fail here rather than
+    /// somewhere subtle, which is why the interface hands back nothing.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AnEndpointStillHoldingTheSendDoesNotHoldTheRequestThatWasAnnounced()
+    {
+        var endpoint = ASinkEndpoint.ThatNeverAnswers();
+        using var sink = Sink(endpoint, Address);
+        var store = new InMemoryRequestStore();
+
+        var stored = await store.AddAsync(Requested(), CancellationToken.None).ConfigureAwait(true);
+
+        sink.Announce(OutboundNotice.For(stored.Request, NoticeEvent.Asked));
+
+        // The endpoint has the send and is not going to answer it. Everything below happens anyway.
+        await endpoint.Entered.ConfigureAwait(true);
+
+        var approved = RequestLifecycle.Move(
+            stored.Request,
+            RequestState.Approved,
+            Noon,
+            RequestCaller.Administrator(Operator));
+
+        var written = await store
+            .ReplaceAsync(approved, stored.Revision, CancellationToken.None)
+            .ConfigureAwait(true);
+
+        Assert.Equal(RequestState.Approved, written.Request.State);
+
+        var held = await store.GetAsync(stored.Request.Id, CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Equal(RequestState.Approved, held?.Request.State);
+
+        endpoint.Release();
+        await sink.QuietAsync(CancellationToken.None).ConfigureAwait(true);
+
+        // And it stayed moved after the endpoint finally answered, which is the half of the
+        // condition about a notification path reversing anything.
+        held = await store.GetAsync(stored.Request.Id, CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Equal(RequestState.Approved, held?.Request.State);
+    }
+
+    /// <summary>
+    /// An endpoint that is not there raises nothing at the caller and leaves the request where the
+    /// operator put it. The failure is written to the log instead, which is where somebody whose
+    /// messages stopped arriving looks.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AnEndpointThatRefusesTheConnectionLeavesTheRequestMovedAndSaysSoInTheLog()
+    {
+        var endpoint = ASinkEndpoint.ThatRefusesTheConnection();
+        var log = new RecordingLogger();
+        using var sink = Sink(endpoint, Address, log);
+        var store = new InMemoryRequestStore();
+
+        var stored = await store.AddAsync(Requested(), CancellationToken.None).ConfigureAwait(true);
+
+        var approved = RequestLifecycle.Move(
+            stored.Request,
+            RequestState.Approved,
+            Noon,
+            RequestCaller.Administrator(Operator));
+
+        var written = await store
+            .ReplaceAsync(approved, stored.Revision, CancellationToken.None)
+            .ConfigureAwait(true);
+
+        sink.Announce(OutboundNotice.For(written.Request, NoticeEvent.Approved));
+        await sink.QuietAsync(CancellationToken.None).ConfigureAwait(true);
+
+        var held = await store.GetAsync(stored.Request.Id, CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Equal(RequestState.Approved, held?.Request.State);
+        Assert.Contains(log.Lines, line => line.Message.Contains("could not deliver", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// An endpoint that never answers is given up on rather than waited out.
+    /// <para>
+    /// The bound is handed in as nothing, so the send is abandoned the moment it is made and the leg
+    /// needs no clock. With the bound removed this leg does not fail slowly, it does not finish at
+    /// all, which is the failure the bound exists against.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AnEndpointThatNeverAnswersIsGivenUpOnRatherThanWaitedOut()
+    {
+        var endpoint = ASinkEndpoint.ThatNeverAnswers();
+        var log = new RecordingLogger();
+        using var sink = Sink(endpoint, Address, log, TimeSpan.Zero);
+
+        sink.Announce(Notice());
+
+        await sink.QuietAsync(CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Contains(log.Lines, line => line.Message.Contains("could not deliver", StringComparison.Ordinal));
+
+        endpoint.Release();
+    }
+
+    /// <summary>
+    /// An endpoint that answers with a failure is a message that did not arrive and nothing more.
+    /// The status is in the log so an operator can tell a wrong address from a service that is down.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AnEndpointAnsweringWithAFailureIsAMessageLostAndNothingElse()
+    {
+        var endpoint = ASinkEndpoint.ThatAnswers(HttpStatusCode.InternalServerError);
+        var log = new RecordingLogger();
+        using var sink = Sink(endpoint, Address, log);
+
+        sink.Announce(Notice());
+        await sink.QuietAsync(CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Single(endpoint.Received);
+        Assert.Contains(
+            log.Lines,
+            line => line.Message.Contains(
+                ((int)HttpStatusCode.InternalServerError).ToString(CultureInfo.InvariantCulture),
+                StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Announcing several things and then waiting waits for all of them, rather than for the last
+    /// one. Without this the two legs above could assert against an endpoint that had received
+    /// nothing yet and pass for the wrong reason.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task WaitingForQuietWaitsForEverythingAnnouncedAndNotOnlyTheLast()
+    {
+        var endpoint = ASinkEndpoint.ThatAccepts();
+        using var sink = Sink(endpoint, Address);
+
+        for (var i = 0; i < 5; i++)
+        {
+            sink.Announce(Notice());
+        }
+
+        await sink.QuietAsync(CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Equal(5, endpoint.Received.Count);
+    }
+
+    private static OutboundSink Sink(
+        HttpMessageHandler endpoint,
+        string address,
+        RecordingLogger? log = null,
+        TimeSpan? answerWithin = null)
+        => new OutboundSink(
+            new FakeInstallSettings(new PluginConfiguration { OutboundNoticeAddress = address }),
+            endpoint,
+            log ?? new RecordingLogger(),
+            answerWithin ?? OutboundSink.DefaultAnswerWithin);
+
+    private static OutboundNotice Notice()
+        => OutboundNotice.For(
+            Requested() with
+            {
+                State = RequestState.Approved,
+                StateChangedAt = Noon,
+                StateChangedByUserId = Operator
+            },
+            NoticeEvent.Approved);
+
+    private static MediaRequest Requested()
+        => new MediaRequest
+        {
+            Id = new Guid("78000000-0000-0000-0000-0000000000aa"),
+            RequestedByUserId = Asker,
+            RequestedAt = Noon,
+            Kind = RequestedItemKind.Movie,
+            DisplayTitle = "Solaris",
+            DisplayYear = 1972,
+            ProviderIds = new Dictionary<string, string> { ["Imdb"] = "tt0069293" },
+            StateChangedAt = Noon
+        };
+}

--- a/Jellyfin.Plugin.Requests.Tests/Notify/OutboundSinkTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Notify/OutboundSinkTests.cs
@@ -250,13 +250,20 @@ public sealed class OutboundSinkTests
     }
 
     /// <summary>
-    /// Announcing several things and then waiting waits for all of them, rather than for the last
-    /// one. Without this the two legs above could assert against an endpoint that had received
-    /// nothing yet and pass for the wrong reason.
+    /// Every announcement is sent. Nothing is dropped because something was already in flight and
+    /// nothing is collapsed into one message, so five movements in the queue are five documents at
+    /// the endpoint.
+    /// <para>
+    /// What this leg does not prove is that waiting for quiet waits for all of them rather than for
+    /// the last one. Five sends against an endpoint that answers immediately all finish either way,
+    /// so a sink that tracked only the most recent delivery passes this leg. That property is held
+    /// by the chaining in <c>Both</c> and by nothing that fails when it is removed, and saying so is
+    /// cheaper than a leg that looks like a guard and is not one.
+    /// </para>
     /// </summary>
     /// <returns>A task that completes when the assertions have run.</returns>
     [Fact]
-    public async Task WaitingForQuietWaitsForEverythingAnnouncedAndNotOnlyTheLast()
+    public async Task EveryAnnouncementIsSentRatherThanDroppedWhileAnotherIsInFlight()
     {
         var endpoint = ASinkEndpoint.ThatAccepts();
         using var sink = Sink(endpoint, Address);

--- a/Jellyfin.Plugin.Requests.Tests/SiblingIndependenceTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/SiblingIndependenceTests.cs
@@ -82,6 +82,15 @@ public class SiblingIndependenceTests
         // is part of the same runtime.
         "System.ComponentModel",
         "System.Linq",
+
+        // The outbound notification sink posts a document to an address an operator typed, so the
+        // client, the pipeline its handler sits in and the address type all come from here. It is
+        // the one thing in this plugin that talks outward, it is off on every install where nobody
+        // typed an address, and these three assemblies are part of the runtime the server already
+        // runs on rather than a package this plugin carries.
+        "System.Net.Http",
+        "System.Net.Http.Json",
+        "System.Net.Primitives",
         "System.Runtime",
 
         // The store keeps requests as JSON, so the serialiser the framework already ships is what

--- a/Jellyfin.Plugin.Requests/Configuration/ConfigurationRules.cs
+++ b/Jellyfin.Plugin.Requests/Configuration/ConfigurationRules.cs
@@ -84,8 +84,39 @@ public static class ConfigurationRules
             });
         }
 
+        // An address is optional and an unusable one is not. Empty means no sink, which is the
+        // shipping state and nothing to refuse; anything typed has to be somewhere a notice can
+        // actually be posted, because the alternative is a sink that silently sends nothing while
+        // the settings page shows an address an operator believes in.
+        if (!string.IsNullOrWhiteSpace(configuration.OutboundNoticeAddress)
+            && !IsSomewhereANoticeCanBePosted(configuration.OutboundNoticeAddress))
+        {
+            problems.Add(new ConfigurationProblem
+            {
+                Setting = nameof(PluginConfiguration.OutboundNoticeAddress),
+                Why = string.Format(
+                    CultureInfo.InvariantCulture,
+                    "OutboundNoticeAddress is \"{0}\", which is not a complete http or https address. It has to be one a notice can be posted to, scheme included, or empty to send nothing at all.",
+                    configuration.OutboundNoticeAddress)
+            });
+        }
+
         return problems;
     }
+
+    /// <summary>
+    /// Whether an address is one a notice could be posted to.
+    /// <para>
+    /// Complete rather than relative, because there is nothing here for a relative address to be
+    /// relative to, and HTTP rather than any scheme the runtime can parse: a file or mail address
+    /// parses perfectly and is not a thing this plugin posts to.
+    /// </para>
+    /// </summary>
+    /// <param name="address">What the operator typed.</param>
+    /// <returns><see langword="true"/> where a notice could be posted there.</returns>
+    private static bool IsSomewhereANoticeCanBePosted(string address)
+        => Uri.TryCreate(address, UriKind.Absolute, out var parsed)
+            && (parsed.Scheme == Uri.UriSchemeHttp || parsed.Scheme == Uri.UriSchemeHttps);
 
     /// <summary>
     /// Whether this plugin can run on a configuration.

--- a/Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs
@@ -22,9 +22,9 @@ namespace Jellyfin.Plugin.Requests.Configuration;
 /// boolean added now would be the wrong shape rather than an early version of the right one.
 /// </para>
 /// <para>
-/// There are no notification switches. Every path they would switch is unbuilt, a fresh install
-/// sends nothing outward because there is nothing that could, and #79 is where the switches land
-/// beside the paths they turn off.
+/// There are no notification switches. One path is built and it is turned on by being pointed
+/// somewhere, which is <see cref="OutboundNoticeAddress"/> below; the rest are unbuilt, and #79 is
+/// where the switches land beside the paths they turn off rather than ahead of them.
 /// </para>
 /// <para>
 /// There is no bridge address and no credential. The only implementation of the bridge in this tree
@@ -97,4 +97,27 @@ public class PluginConfiguration : BasePluginConfiguration
     /// </para>
     /// </summary>
     public int FinishedRequestRetentionDays { get; set; } = 365;
+
+    /// <summary>
+    /// Gets or sets where a notice about a request is posted, or nothing to send none.
+    /// <para>
+    /// Empty on a fresh install, and empty is not a degraded setting: it is the whole of how the
+    /// outbound path is turned off, and it is off on every install where nobody has decided
+    /// otherwise. There is no second switch beside it, because two ways to express off is one of
+    /// them being wrong the day somebody sets the other.
+    /// </para>
+    /// <para>
+    /// <b>This is the one field in this class that sends anything anywhere.</b> What leaves the
+    /// server when it is set is written out in <c>docs/notifications.md</c> and counted in
+    /// <c>docs/personal-data.md</c>, because an operator answering for their users needs to read
+    /// what a value here costs before they type one rather than afterwards.
+    /// </para>
+    /// <para>
+    /// It is an address and never a credential. Anything a sink needs to authenticate with belongs
+    /// where #85 decides credentials are kept, and typing one into a query string here would put it
+    /// in this plugin's configuration file, in the settings page's markup and in every log line that
+    /// ever prints the address.
+    /// </para>
+    /// </summary>
+    public string OutboundNoticeAddress { get; set; } = string.Empty;
 }

--- a/Jellyfin.Plugin.Requests/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Requests/Configuration/configPage.html
@@ -42,6 +42,12 @@
                             <div class="fieldDescription">A finished request names a person, a title and a date. After this many days it is removed. Thirty days is the shortest period allowed, so the history cannot be switched off by setting this to nothing.</div>
                         </div>
 
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="RequestsOutboundNoticeAddress">Post a notice to</label>
+                            <input is="emby-input" type="url" id="RequestsOutboundNoticeAddress" />
+                            <div class="fieldDescription">Leave this empty and nothing is sent anywhere. With the complete address of a web hook here, scheme included, every movement in the queue is posted to it as a small JSON document naming the request, the title, and the identifiers of the person who asked and the person who answered. That leaves this server. It is never retried and nothing waits for it.</div>
+                        </div>
+
                         <div>
                             <button is="emby-button" type="submit" class="raised button-submit block emby-button">
                                 <span>Save</span>
@@ -91,6 +97,14 @@
                         AcceptsSeries: "#RequestsAcceptsSeries",
                     };
 
+                    // Read and written as typed, with no trimming and no default put in its place.
+                    // The server refuses an address it cannot post to and says which field, and a
+                    // page that quietly repaired the value would be a page disagreeing with the
+                    // file about what this install is set to.
+                    var texts = {
+                        OutboundNoticeAddress: "#RequestsOutboundNoticeAddress",
+                    };
+
                     function show(config) {
                         Object.keys(numbers).forEach(function (setting) {
                             page.querySelector(numbers[setting]).value = config[setting];
@@ -98,6 +112,10 @@
 
                         Object.keys(switches).forEach(function (setting) {
                             page.querySelector(switches[setting]).checked = config[setting];
+                        });
+
+                        Object.keys(texts).forEach(function (setting) {
+                            page.querySelector(texts[setting]).value = config[setting] || "";
                         });
                     }
 
@@ -108,6 +126,10 @@
 
                         Object.keys(switches).forEach(function (setting) {
                             config[setting] = page.querySelector(switches[setting]).checked;
+                        });
+
+                        Object.keys(texts).forEach(function (setting) {
+                            config[setting] = page.querySelector(texts[setting]).value;
                         });
 
                         return config;

--- a/Jellyfin.Plugin.Requests/Notify/IOutboundSink.cs
+++ b/Jellyfin.Plugin.Requests/Notify/IOutboundSink.cs
@@ -1,0 +1,53 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jellyfin.Plugin.Requests.Notify;
+
+/// <summary>
+/// The one place anything this plugin has to say leaves the server, and the shape that keeps it from
+/// mattering whether it arrives.
+/// <para>
+/// <b>Announcing returns nothing, and that is the whole design.</b> A method handing back a task is
+/// a method somebody awaits, and the day somebody awaits this one inside a transition is the day an
+/// approval fails because a chat service is having a bad day. There is no task to await here, so the
+/// mistake is not available: a caller that has just moved a request announces it and carries on, and
+/// what the endpoint does about it is between the sink and the endpoint.
+/// </para>
+/// <para>
+/// <b>The cost of that is admitted rather than hidden.</b> A notice can be lost, and nothing retries
+/// it or records that it went missing. That is the right trade for a courtesy message and the wrong
+/// one for a record, which is why the record is the server's activity log and not this.
+/// </para>
+/// </summary>
+public interface IOutboundSink
+{
+    /// <summary>
+    /// Gets a value indicating whether anything is sent at all.
+    /// <para>
+    /// It is false on every install where an operator has not typed an address, which is every fresh
+    /// one. Nothing above this asks it before announcing: a caller that had to would be a caller
+    /// that can forget to, and announcing into a sink that is off is already nothing happening.
+    /// </para>
+    /// </summary>
+    bool IsConfigured { get; }
+
+    /// <summary>
+    /// Sends the notice, eventually, or does not. Returns as soon as the delivery is under way and
+    /// never raises anything the caller has to handle.
+    /// </summary>
+    /// <param name="notice">What to say.</param>
+    void Announce(OutboundNotice notice);
+
+    /// <summary>
+    /// Waits until nothing announced so far is still in flight.
+    /// <para>
+    /// This exists for two callers and neither is on the path a request takes. The suite uses it to
+    /// assert what an endpoint received without waiting on a clock, and a shutdown can use it to let
+    /// a message in flight finish. Anything on a transition path that calls this has re-created the
+    /// blocking the interface above exists to prevent.
+    /// </para>
+    /// </summary>
+    /// <param name="cancellationToken">Gives up waiting.</param>
+    /// <returns>A task that completes when the sink is idle.</returns>
+    Task QuietAsync(CancellationToken cancellationToken);
+}

--- a/Jellyfin.Plugin.Requests/Notify/NoticeEvent.cs
+++ b/Jellyfin.Plugin.Requests/Notify/NoticeEvent.cs
@@ -1,0 +1,41 @@
+using System.Text.Json.Serialization;
+
+namespace Jellyfin.Plugin.Requests.Notify;
+
+/// <summary>
+/// What a notice is about, as the word that goes on the wire.
+/// <para>
+/// It is a vocabulary of its own rather than the request's state, because the two answer different
+/// questions. A state says where a request is; an event says what just happened to it, and a reader
+/// wanting to post "this was turned down" needs the second. The two agree today and would stop
+/// agreeing the moment a state is reachable by two routes.
+/// </para>
+/// <para>
+/// The names are serialised as written here, so this enumeration is part of the document and moving
+/// a name is a change to <see cref="OutboundNotice.CurrentVersion"/> rather than a rename.
+/// </para>
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<NoticeEvent>))]
+public enum NoticeEvent
+{
+    /// <summary>
+    /// Somebody asked for something that was not already in the queue.
+    /// </summary>
+    Asked = 0,
+
+    /// <summary>
+    /// An operator said yes.
+    /// </summary>
+    Approved = 1,
+
+    /// <summary>
+    /// An operator said no.
+    /// </summary>
+    Declined = 2,
+
+    /// <summary>
+    /// The thing that was asked for turned up in the library. Nobody moved this one, which is why a
+    /// notice carrying it names no mover.
+    /// </summary>
+    Fulfilled = 3
+}

--- a/Jellyfin.Plugin.Requests/Notify/OutboundNotice.cs
+++ b/Jellyfin.Plugin.Requests/Notify/OutboundNotice.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Text.Json.Serialization;
+using Jellyfin.Plugin.Requests.Model;
+
+namespace Jellyfin.Plugin.Requests.Notify;
+
+/// <summary>
+/// The document this plugin posts to an address an operator chose, and the whole of what leaves the
+/// server on that path.
+/// <para>
+/// <b>It is a contract with somebody this repository will never see.</b> Whoever configures the sink
+/// points it at a script, a chat bridge or an automation service they wrote, and that thing reads
+/// these field names. So the names are declared here rather than derived from how the properties
+/// happen to be spelled in C#, and <see cref="Version"/> is on every document rather than on the
+/// ones that needed it, because a reader that has to guess which shape it is holding is a reader
+/// that breaks on the first change.
+/// </para>
+/// <para>
+/// <b>What it carries is the smallest set an operator can act on.</b> Which request, what happened
+/// to it, when, what was asked for, and the identifiers of the person who asked and the person who
+/// moved it. Anything beyond that is a field somebody else's machine ends up storing, and this
+/// plugin is the reason it left.
+/// </para>
+/// <para>
+/// <b>What it deliberately does not carry.</b> Neither note, because both are free text somebody
+/// typed and either can hold anything at all, including a name or an address that this plugin has no
+/// business forwarding. The provider identifiers, because they place the title in third-party
+/// catalogues and the display title and year are what a person reads. Everybody who joined the
+/// request, because a notice about one movement is not a roster of everybody waiting. The history,
+/// because it is the record and this is a message. No user name of any kind appears, for the reason
+/// in <c>docs/personal-data.md</c>: this plugin holds a person as the server's identifier and never
+/// as a name, so it has none to send.
+/// </para>
+/// </summary>
+public sealed record OutboundNotice
+{
+    /// <summary>
+    /// The version this plugin writes today.
+    /// <para>
+    /// It moves when a reader that understood the old document would misread the new one, which is a
+    /// field removed, renamed, or given a different meaning. A field added beside the existing ones
+    /// does not move it: a reader that ignores what it does not recognise is unharmed, and bumping
+    /// for an addition trains readers to treat the number as noise.
+    /// </para>
+    /// </summary>
+    public const int CurrentVersion = 1;
+
+    /// <summary>
+    /// Gets which shape this document is. Always <see cref="CurrentVersion"/> as written here, and
+    /// present on every notice so that a reader never has to infer it from which fields it found.
+    /// </summary>
+    [JsonPropertyName("version")]
+    public int Version { get; init; } = CurrentVersion;
+
+    /// <summary>
+    /// Gets what happened, as one word a reader can branch on without comparing states.
+    /// </summary>
+    [JsonPropertyName("event")]
+    public required NoticeEvent Event { get; init; }
+
+    /// <summary>
+    /// Gets which request this is about, so a reader that keeps its own rows can recognise a second
+    /// notice about the same one instead of holding two.
+    /// </summary>
+    [JsonPropertyName("requestId")]
+    public required Guid RequestId { get; init; }
+
+    /// <summary>
+    /// Gets when it happened, which is the moment the request moved rather than the moment this was
+    /// sent. A sink that was unreachable for an hour delivers nothing late-looking when it comes
+    /// back, because the document says when the thing happened.
+    /// </summary>
+    [JsonPropertyName("at")]
+    public required DateTimeOffset At { get; init; }
+
+    /// <summary>
+    /// Gets the state the request is in now.
+    /// <para>
+    /// Written as a word, and the converter is on this property rather than on the model's own
+    /// enumeration. Putting it there would change how the store writes every request on disk, which
+    /// is a different document with a different reader and a migration behind it.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("state")]
+    [JsonConverter(typeof(JsonStringEnumConverter<RequestState>))]
+    public required RequestState State { get; init; }
+
+    /// <summary>
+    /// Gets the identifier of the person who asked. It is the server's own user identifier, which is
+    /// what this plugin holds; resolving it to a name is the reader's to do against the server it is
+    /// already talking to, and doing it here would send a name this plugin never stored.
+    /// </summary>
+    [JsonPropertyName("requestedByUserId")]
+    public required Guid RequestedByUserId { get; init; }
+
+    /// <summary>
+    /// Gets the identifier of whoever moved it, where a person did. It is absent where nothing did:
+    /// a request that arrived is not one somebody moved, and fulfilment is decided by the library
+    /// rather than by anybody.
+    /// </summary>
+    [JsonPropertyName("movedByUserId")]
+    public Guid? MovedByUserId { get; init; }
+
+    /// <summary>
+    /// Gets whether a film or a series was asked for. A word here for the same reason, and by the
+    /// same local converter, as the state above.
+    /// </summary>
+    [JsonPropertyName("kind")]
+    [JsonConverter(typeof(JsonStringEnumConverter<RequestedItemKind>))]
+    public required RequestedItemKind Kind { get; init; }
+
+    /// <summary>
+    /// Gets the title as it was asked for, which is what a person reading the message recognises.
+    /// </summary>
+    [JsonPropertyName("title")]
+    public required string Title { get; init; }
+
+    /// <summary>
+    /// Gets the year, where one was known. Two films share a title often enough that the year is
+    /// what makes a one-line message unambiguous.
+    /// </summary>
+    [JsonPropertyName("year")]
+    public int? Year { get; init; }
+
+    /// <summary>
+    /// The notice for a request as it stands, with what happened to it.
+    /// <para>
+    /// Built from the record rather than from arguments a caller assembles, so every path that
+    /// announces something sends the same fields and a new path cannot quietly send a different
+    /// document. The moment comes off the request as well, which is why nothing here reads a clock.
+    /// </para>
+    /// </summary>
+    /// <param name="request">The request the notice is about.</param>
+    /// <param name="what">What happened to it.</param>
+    /// <returns>The document to send.</returns>
+    /// <exception cref="ArgumentNullException">Where there is no request to describe.</exception>
+    public static OutboundNotice For(MediaRequest request, NoticeEvent what)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        return new OutboundNotice
+        {
+            Event = what,
+            RequestId = request.Id,
+            At = what == NoticeEvent.Asked ? request.RequestedAt : request.StateChangedAt,
+            State = request.State,
+            RequestedByUserId = request.RequestedByUserId,
+            MovedByUserId = what == NoticeEvent.Asked ? null : request.StateChangedByUserId,
+            Kind = request.Kind,
+            Title = request.DisplayTitle,
+            Year = request.DisplayYear
+        };
+    }
+}

--- a/Jellyfin.Plugin.Requests/Notify/OutboundSink.cs
+++ b/Jellyfin.Plugin.Requests/Notify/OutboundSink.cs
@@ -1,0 +1,240 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.Requests.Notify;
+
+/// <summary>
+/// The sink as an HTTP post to whatever an operator pointed it at.
+/// <para>
+/// <b>Nothing here is allowed to matter to a request.</b> The delivery is started on a thread of its
+/// own and the caller is not given it, so a handler that blocks, an address that refuses the
+/// connection and an endpoint that never answers all cost exactly the same as an endpoint that
+/// answered: nothing. Everything a send can fail with is caught and written to the server's log,
+/// which is where an operator whose messages stopped arriving looks.
+/// </para>
+/// <para>
+/// <b>Off is the shipping state and it is off by absence rather than by a switch.</b> An install
+/// where nobody typed an address has no sink at all: <see cref="IsConfigured"/> is false, announcing
+/// does nothing, and no client is ever built. That is why the address is the setting and there is no
+/// second one beside it saying whether to use it, which would be two ways to express the same off
+/// and one of them wrong.
+/// </para>
+/// <para>
+/// <b>It gives up rather than waiting.</b> A send is bounded by <see cref="DefaultAnswerWithin"/>,
+/// because an endpoint that accepts a connection and then says nothing holds the send open for as
+/// long as it likes, and a plugin that lets it is a plugin accumulating one of those per movement in
+/// the queue.
+/// </para>
+/// </summary>
+public sealed class OutboundSink : IOutboundSink, IDisposable
+{
+    /// <summary>
+    /// How long a send is given before it is abandoned.
+    /// <para>
+    /// Ten seconds is long enough for a service that is answering slowly and short enough that a
+    /// service which has stopped answering is noticed rather than accumulated. Nothing waits on it,
+    /// so the number is a bound on resources rather than on anybody's patience.
+    /// </para>
+    /// </summary>
+    public static readonly TimeSpan DefaultAnswerWithin = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// How the document is written. Declared once here rather than left to whatever the default is,
+    /// because the shape on the wire is the contract in <see cref="OutboundNotice"/> and a global
+    /// default changing under it would change what a reader receives.
+    /// </summary>
+    private static readonly JsonSerializerOptions AsWritten = new JsonSerializerOptions
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never
+    };
+
+    private readonly IInstallSettings _settings;
+    private readonly HttpClient _client;
+    private readonly ILogger _logger;
+    private readonly TimeSpan _answerWithin;
+    private readonly object _gate = new object();
+
+    private Task _inFlight = Task.CompletedTask;
+    private bool _disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OutboundSink"/> class.
+    /// </summary>
+    /// <param name="settings">
+    /// What this install is set to, read per notice rather than kept, so an operator who changes the
+    /// address gets the next message at the new one instead of at the next restart.
+    /// </param>
+    /// <param name="handler">
+    /// What actually sends. It is handed in rather than made here so the suite can put an endpoint
+    /// in the same process and exercise this class's own serialisation, timeout and error handling
+    /// without a socket, which is the headless rule in <c>docs/testing.md</c>.
+    /// </param>
+    /// <param name="logger">Where a failed delivery is written.</param>
+    /// <param name="answerWithin">
+    /// How long a send is given. It is a parameter so the bound can be proven rather than described:
+    /// a suite can set it to nothing and watch a send that would otherwise hang be abandoned.
+    /// </param>
+    /// <exception cref="ArgumentNullException">Where anything it needs is missing.</exception>
+    public OutboundSink(
+        IInstallSettings settings,
+        HttpMessageHandler handler,
+        ILogger logger,
+        TimeSpan answerWithin)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        ArgumentNullException.ThrowIfNull(handler);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _settings = settings;
+        _logger = logger;
+        _answerWithin = answerWithin;
+
+        // The client's own timeout is left off and the bound is applied per send instead. They are
+        // two mechanisms for one thing, and the one that can be handed a value is the one a test can
+        // prove bites.
+        _client = new HttpClient(handler, disposeHandler: false)
+        {
+            Timeout = Timeout.InfiniteTimeSpan
+        };
+    }
+
+    /// <inheritdoc />
+    public bool IsConfigured => Address() is not null;
+
+    /// <inheritdoc />
+    public void Announce(OutboundNotice notice)
+    {
+        ArgumentNullException.ThrowIfNull(notice);
+
+        if (_disposed || Address() is not Uri address)
+        {
+            return;
+        }
+
+        // Started rather than awaited, and started off this thread rather than inline. Inline, the
+        // delivery would run on the caller's thread as far as its first await, and a handler that
+        // blocks without one would hold the request that announced it. What this interface promises
+        // is that announcing costs a caller nothing, and that promise should not depend on how
+        // somebody else's handler is written.
+        var delivery = Task.Run(() => DeliverAsync(address, notice));
+
+        lock (_gate)
+        {
+            _inFlight = Both(_inFlight, delivery);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task QuietAsync(CancellationToken cancellationToken)
+    {
+        Task waiting;
+
+        lock (_gate)
+        {
+            waiting = _inFlight;
+        }
+
+        return waiting.WaitAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Drops the client. The handler is not disposed with it, because it was handed in and whoever
+    /// handed it in may still be using it.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _client.Dispose();
+    }
+
+    /// <summary>
+    /// One delivery, which either happens or is written to the log.
+    /// </summary>
+    /// <param name="address">Where the operator pointed it.</param>
+    /// <param name="notice">The document to send.</param>
+    /// <returns>A task that completes when the attempt is over, however it went.</returns>
+    private async Task DeliverAsync(Uri address, OutboundNotice notice)
+    {
+        using var giveUp = new CancellationTokenSource();
+        giveUp.CancelAfter(_answerWithin);
+
+        try
+        {
+            using var response = await _client
+                .PostAsJsonAsync(address, notice, AsWritten, giveUp.Token)
+                .ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "The notification sink answered {StatusCode} for the notice about request {RequestId}, so that message was not delivered. Nothing about the request changed.",
+                    (int)response.StatusCode,
+                    notice.RequestId);
+            }
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+        catch (Exception reason)
+#pragma warning restore CA1031
+        {
+            // Every outcome of a send is the same outcome here: the message did not arrive and the
+            // request is unaffected. Catching by name instead would leave whichever exception nobody
+            // listed to surface out of a task nothing observes, and the failure this sink exists to
+            // avoid is exactly a notification path deciding what happens to a request.
+            _logger.LogError(
+                reason,
+                "The notification sink could not deliver the notice about request {RequestId}. The request is unaffected and nothing will be retried.",
+                notice.RequestId);
+        }
+    }
+
+    /// <summary>
+    /// Where notices go, or nothing where this install sends none.
+    /// <para>
+    /// Read per call, and parsed rather than trusted: a value that is not an absolute HTTP address
+    /// is treated as no sink at all. <c>ConfigurationRules</c> refuses such a value when it arrives,
+    /// so this is the second reading rather than the only one, and the two agree on purpose. What it
+    /// is here for is the moment they cannot: a configuration file edited by hand on a server that
+    /// is already running.
+    /// </para>
+    /// </summary>
+    /// <returns>The address, or <see langword="null"/> where there is none to use.</returns>
+    private Uri? Address()
+    {
+        var written = _settings.Current.OutboundNoticeAddress;
+
+        if (string.IsNullOrWhiteSpace(written))
+        {
+            return null;
+        }
+
+        return Uri.TryCreate(written, UriKind.Absolute, out var address)
+            && (address.Scheme == Uri.UriSchemeHttp || address.Scheme == Uri.UriSchemeHttps)
+                ? address
+                : null;
+    }
+
+    /// <summary>
+    /// Both deliveries, as one thing to wait for. Written out rather than done with
+    /// <c>Task.WhenAll</c> so that a chain of announcements does not grow an array per announcement.
+    /// </summary>
+    /// <param name="earlier">What was already in flight.</param>
+    /// <param name="later">What has just been started.</param>
+    /// <returns>A task that completes when both have.</returns>
+    private static async Task Both(Task earlier, Task later)
+    {
+        await earlier.ConfigureAwait(false);
+        await later.ConfigureAwait(false);
+    }
+}

--- a/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Net.Http;
 using Jellyfin.Plugin.Requests.Api;
 using Jellyfin.Plugin.Requests.Bridge;
 using Jellyfin.Plugin.Requests.Configuration;
 using Jellyfin.Plugin.Requests.Fulfilment;
 using Jellyfin.Plugin.Requests.Identity;
+using Jellyfin.Plugin.Requests.Notify;
 using Jellyfin.Plugin.Requests.Seam;
 using Jellyfin.Plugin.Requests.Storage;
 using Jellyfin.Plugin.Requests.Time;
@@ -87,6 +89,22 @@ public sealed class PluginServiceRegistrator : IPluginServiceRegistrator
             provider.GetRequiredService<IKnownUsers>(),
             provider.GetRequiredService<ILogger<WantHandover>>(),
             WantHandover.DefaultAnswerWithin));
+
+        // The one path anything this plugin has to say leaves the server on. Registered on every
+        // install rather than only where an address is set, because whether one is set is a value in
+        // a file an operator edits while the server is running, and a container built at startup
+        // would answer with whatever was true then. The sink reads the address per notice and an
+        // install with none sends nothing, so the registration costs an object and no connection.
+        //
+        // The handler is built here and never shared. It is the socket pipeline the client sends
+        // through, and it is a constructor argument rather than something the sink makes so that the
+        // suite can put an endpoint in the same process, which is what keeps the outbound path
+        // testable under the headless rule.
+        serviceCollection.AddSingleton<IOutboundSink>(provider => new OutboundSink(
+            provider.GetRequiredService<IInstallSettings>(),
+            new SocketsHttpHandler(),
+            provider.GetRequiredService<ILogger<OutboundSink>>(),
+            OutboundSink.DefaultAnswerWithin));
 
         // The server's library, as the two questions this plugin asks of it. One per server, because
         // the instance subscribes to the library's own events and a second subscription would look

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,6 +20,7 @@ without this page moving with it, and again if the page cannot reach one of them
 | AcceptsSeries                | true    |
 | FinishedRequestRetentionDays | 365     |
 | OpenRequestsPerUser          | 10      |
+| OutboundNoticeAddress        |         |
 
 <!-- settings ends -->
 
@@ -57,6 +58,20 @@ requests are answered can keep asking.
 Where the quota is enforced is #114, and that is not built yet either. **Nothing refuses an
 eleventh open request today.**
 
+**OutboundNoticeAddress** is empty, and empty is the whole of how the outbound notification path is
+turned off. It is the only setting on this page that causes anything to leave this server, and it is
+the only one that holds text rather than a number or a switch.
+
+With an address in it, every movement in the queue is posted there as a small JSON document. What
+that document carries, what it deliberately does not, and what an operator is agreeing to by typing
+an address are in [notifications.md](notifications.md); the same fields are counted as what leaves
+the server in [personal-data.md](personal-data.md). Nothing waits for the post and nothing is
+retried, so a service that is down costs the messages sent while it was down and costs a request
+nothing.
+
+There is no second setting saying whether to use the address. Two ways to say off is one of them
+being wrong the day somebody sets the other, and an operator who wants it off empties the field.
+
 ## What is refused
 
 A plugin configuration is an XML file on the server, and the dashboard is not the only way one
@@ -64,11 +79,12 @@ arrives: an operator can edit that file, and a restore can put an older one back
 are read at both moments a configuration reaches this plugin, from the same list, in
 [`ConfigurationRules`](../Jellyfin.Plugin.Requests/Configuration/ConfigurationRules.cs).
 
-| Setting                      | Refused when | Because                                                                                        |
-| ---------------------------- | ------------ | ---------------------------------------------------------------------------------------------- |
-| OpenRequestsPerUser          | below 1      | nobody may have a request open, so every ask is refused by an install that still offers itself |
-| AcceptsMovies, AcceptsSeries | both off     | there is nothing anybody can ask for                                                           |
-| FinishedRequestRetentionDays | below 30     | the history is removed while people are still asking about it                                  |
+| Setting                      | Refused when                               | Because                                                                                         |
+| ---------------------------- | ------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| OpenRequestsPerUser          | below 1                                    | nobody may have a request open, so every ask is refused by an install that still offers itself  |
+| AcceptsMovies, AcceptsSeries | both off                                   | there is nothing anybody can ask for                                                            |
+| FinishedRequestRetentionDays | below 30                                   | the history is removed while people are still asking about it                                   |
+| OutboundNoticeAddress        | set to something that is not http or https | a notice cannot be posted there, so the sink would send nothing while the page shows an address |
 
 **Nothing is corrected on the way in.** A quota of zero is not raised to one and a retention of five
 days is not raised to thirty. An install running a value it substituted does something other than
@@ -87,10 +103,11 @@ Nothing has to be configured for the plugin to be usable: a person can ask for a
 an operator sees it in the queue and answers it, and the library is what says a request was
 fulfilled.
 
-Nothing is sent anywhere. There is no address to send to, no credential to hold and no switch that
-would turn sending on, because none of the paths that would carry it exist yet: the outbound
-notification sink is #78 and the bridge adapter is #82. `NoRequestBackend` is what a server without
-an external request service runs, and it is what every server runs today.
+Nothing is sent anywhere. The outbound notification sink exists and has nowhere to send to, because
+`OutboundNoticeAddress` is empty until an operator types one; there is no credential to hold and no
+other path that could carry anything, since the bridge adapter is #82 and is not built.
+`NoRequestBackend` is what a server without an external request service runs, and it is what every
+server runs today.
 
 ## What is deliberately not a setting
 
@@ -98,9 +115,10 @@ an external request service runs, and it is what every server runs today.
 as a per-user setting rather than a switch for the whole server, so a boolean here would be the
 wrong shape rather than an early version of the right one.
 
-**Notification switches.** Every path they would turn off is unbuilt. Switches for paths that do not
-exist would be settings an operator can change with no effect, which is worse than their absence.
-They land with the paths, in #79.
+**Notification switches.** One notification path exists and it is turned off by having nowhere to
+send to, which is `OutboundNoticeAddress` above rather than a switch beside it. The rest are unbuilt,
+and switches for paths that do not exist would be settings an operator can change with no effect,
+which is worse than their absence. They land with the paths, in #79.
 
 **A bridge address and a credential.** The only bridge in this tree is the one for a server that has
 none. A field for an address would be somewhere to type something nothing reads. #82 brings the

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -63,7 +63,86 @@ Issue #76 writes it, and telling the person who asked that their own request mov
 **One outbound sink.** An operator who wants a request to reach something outside the server points
 this at whatever they already run. It is one sink with a defined payload rather than a service this
 plugin knows the name of, so the plugin carries no vocabulary for anybody's product and nothing has
-to be updated here when one of them changes. Issue #78 defines it and its payload.
+to be updated here when one of them changes. It is built, it is off on every install where nobody
+has typed an address, and the section below is what it sends.
+
+## What the sink sends, and what it does not
+
+This is the only thing in this plugin that sends anything off the machine, and it is off until an
+operator sets `OutboundNoticeAddress` in the settings. Empty is the whole of how it is off; there is
+no second switch, for the reason in [configuration.md](configuration.md).
+
+With an address set, every movement in the queue is posted to it as one JSON document:
+
+```json
+{
+    "version": 1,
+    "event": "Approved",
+    "requestId": "0f9c9107-b31b-459e-81fa-6d35dac25e79",
+    "at": "2026-08-14T17:30:00+00:00",
+    "state": "Approved",
+    "requestedByUserId": "6b1f2c40-1f5a-4a53-9d0e-2b7a3c9d5e11",
+    "movedByUserId": "9c2d8b71-4e0c-4a1f-8f3d-11a2b3c4d5e6",
+    "kind": "Movie",
+    "title": "Solaris",
+    "year": 1972
+}
+```
+
+`event` is one of `Asked`, `Approved`, `Declined` and `Fulfilled`. It is a word rather than a number
+so that a value inserted into the middle of that list later cannot silently change what every past
+document meant, and `state` and `kind` are words for the same reason.
+
+`movedByUserId` is absent where nobody moved it. An arrival was not moved by anybody, and fulfilment
+is decided by the library rather than by a person.
+
+`at` is when the request moved, not when the message was sent. A sink that was unreachable for an
+hour delivers nothing that reads as having just happened when it comes back.
+
+### What it deliberately does not carry
+
+Neither note. `RequesterNote` and `DeclineNote` are free text somebody typed, and either can hold a
+name, an address or anything else. This plugin has no business forwarding that to a service an
+operator pointed it at, and a message a person reads does not need it.
+
+The provider identifiers, which place the title in third-party catalogues. The title and the year
+are what a person reads, and the request identifier is what a machine matches on.
+
+Everybody else waiting. A notice about one movement is not a roster, and a request several people
+joined would otherwise post all of them to somebody's chat service on every move.
+
+The history. That is the record, and this is a message.
+
+**No user name of any kind.** A person is held here as the server's own user identifier and never as
+a name, which is [personal-data.md](personal-data.md)'s account of the whole plugin, so this document
+has no name to send. A reader that wants one resolves the identifier against the server it is already
+talking to.
+
+### The version, and what moves it
+
+`version` is on every document rather than on the ones that needed it, because a reader that has to
+infer which shape it is holding breaks on the first change.
+
+It moves when a reader that understood the old document would misread the new one, which is a field
+removed, renamed, or given a different meaning. A field added beside the existing ones does not move
+it: a reader that ignores what it does not recognise is unharmed, and bumping for an addition trains
+readers to treat the number as noise.
+
+### What happens when the endpoint misbehaves
+
+**Nothing that reaches a request.** An approval must not fail because somebody's chat service is
+having a bad day, so the sink is handed the notice and the caller carries on; there is no task to
+await and therefore no way for a transition to end up waiting on one. An endpoint that refuses the
+connection, one that answers with a failure and one that accepts the connection and then says
+nothing all cost the same: a line in the server's log and nothing else.
+
+**A send is given ten seconds and then abandoned.** An endpoint that takes a connection and holds it
+would otherwise accumulate one of those per movement in the queue.
+
+**Nothing is retried and nothing is queued.** A message sent while the endpoint was down is lost, and
+this plugin does not remember that it was. That is the right trade for a courtesy and the wrong one
+for a record, which is why the record is the server's activity log and not this. An operator who
+needs to know what happened reads that log.
 
 ## Why there is no fourth
 
@@ -80,14 +159,15 @@ them sends anything to the maintainer at all, at any setting. That is not a prop
 design, it is a standing decision recorded on #113, and it has no opt-in.
 
 No path is meant to send anything until an operator turns it on, the activity log excepted because it
-is a record rather than a message. That is #79's condition rather than something this page builds,
-and until #79 lands it is a plan and not a property of the code.
+is a record rather than a message. The outbound sink holds that today by having nowhere to send to on
+a fresh install. Making it a property of every path, switchable per event, is #79, and until that
+lands it is a plan for the other paths rather than a property of the code.
 
 ## What this page does not do
 
-It does not say what any path sends. The activity log's wording is #75's, the session message's shape
-is #76's, and the sink's payload is #78's, and each of those is where the text a person actually
-reads is decided.
+It does not say what the other two paths send. The activity log's wording is #75's and the session
+message's shape is #76's, and each of those is where the text a person actually reads is decided. The
+sink's payload is above, because it is the one path that is built.
 
 It does not decide what happens when a path fails. An outbound sink pointed at something that has
 stopped answering is #78's and #86's, and nothing here says a failure to notify may move a request.

--- a/docs/personal-data.md
+++ b/docs/personal-data.md
@@ -73,15 +73,21 @@ because two copies of a path are two answers the day one of them moves.
 Everything above is in the queue file. The settings file holds no person at all, which is the whole
 of that class rather than a sample:
 
-    git grep -nE '^    public (const )?(int|bool) ' -- Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs
+    git grep -nE '^    public (const )?(int|bool|string) ' -- Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs
     Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:52:    public const int MinimumRetentionDays = 30;
     Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:67:    public int OpenRequestsPerUser { get; set; } = 10;
     Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:72:    public bool AcceptsMovies { get; set; } = true;
     Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:83:    public bool AcceptsSeries { get; set; } = true;
     Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:99:    public int FinishedRequestRetentionDays { get; set; } = 365;
+    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:123:    public string OutboundNoticeAddress { get; set; } = string.Empty;
 
-Three numbers, one of them the floor under another, and two switches. Nothing there is about
-anybody.
+Three numbers, one of them the floor under another, two switches, and one address. Nothing there is
+about anybody. The address is where a notice is posted and is empty until an operator types one; it
+names a machine rather than a person, and what typing one into it sends is the section on what
+leaves the server below.
+
+`PluginConfigurationTests` refuses a second setting of that shape, so a credential arriving beside
+it is a red suite rather than a thing to notice.
 
 ## Who on the machine can read it
 
@@ -148,10 +154,19 @@ current absence as a retention choice would be exactly that.
 
 ## What leaves the server
 
-**Nothing leaves the server today.** The plugin makes no outbound call of any kind:
+**Nothing leaves the server on a fresh install, and one path can be turned on.** The plugin makes
+exactly one outbound call, and it is the notification sink:
 
-    git grep -n 'HttpClient\|IHttpClientFactory\|WebRequest' -- Jellyfin.Plugin.Requests/ ; echo "exit=$?"
-    exit=1
+    git grep -ln 'HttpClient\|IHttpClientFactory\|WebRequest' -- Jellyfin.Plugin.Requests/
+    Jellyfin.Plugin.Requests/Notify/OutboundSink.cs
+
+It sends nothing until an operator sets `OutboundNoticeAddress`, which is empty on every install
+where nobody has decided otherwise, and there is no other way to turn it on. What it sends when it is
+on is a small JSON document per movement in the queue: the request's identifier, what happened to it,
+when, the title and year, and the identifiers of the person who asked and the person who answered. It
+carries neither note, no provider identifiers, nobody else waiting on the request, and no user name of
+any kind, because this plugin holds none. [notifications.md](notifications.md) is where that document
+is written out field by field.
 
 The bridge to an external request service has exactly one implementation in this tree, and it is the
 one for a server that has no backend:
@@ -171,11 +186,11 @@ recorded in [notifications.md](notifications.md) with the decision behind it.
 Three paths would carry something outward once they are built, and each is named here so that an
 operator can find out what turning one on would mean before it exists:
 
-| Path                | Issue | What would leave                                            | Off until         |
-| ------------------- | ----- | ----------------------------------------------------------- | ----------------- |
-| The bridge          | #82   | a title, and an external account for the person who asked   | a backend is set  |
-| The outbound sink   | #78   | a payload naming a person and a title, to an address chosen | an address is set |
-| The session message | #76   | nothing off the machine, a message to a dashboard session   | not decided yet   |
+| Path                | Issue | What leaves, or would                                                           | Off until         | Built |
+| ------------------- | ----- | ------------------------------------------------------------------------------- | ----------------- | ----- |
+| The outbound sink   | #78   | the identifiers of the asker and the answerer, the title, the year, the request | an address is set | yes   |
+| The bridge          | #82   | a title, and an external account for the person who asked                       | a backend is set  | no    |
+| The session message | #76   | nothing off the machine, a message to a dashboard session                       | not decided yet   | no    |
 
 The bridge names a person to the external service by an account the operator wrote into a table, and
 never by their name. That is the decision in [bridge.md](bridge.md), and the table is empty on a
@@ -183,7 +198,7 @@ fresh install, so a bridge configured and nothing else sends no attribution at a
 in #75 is the fourth path and it is not in the table because it writes into the server's own log,
 which does not leave the machine.
 
-**None of the three is built.** The rows say what each one is for, not what it does.
+**Only the first is built.** The other two rows say what each one is for, not what it does.
 
 ## What arrives from another plugin, and what this side trusts
 


### PR DESCRIPTION
**Superseded by #231 and closed unmerged. Nothing here was merged and nothing here
was rewritten.**

The two commits on this branch carry no `Signed-off-by` trailer, so the DCO check
refused them. Repairing that in place would mean rewriting a branch that has been
pushed, so the same two commits were cherry-picked onto the same base with the
trailer, under a new name, and this one is abandoned where it stands.

The trees are identical:

    git diff --stat notify/78-outbound-sink notify/78-outbound-sink-signed
    (nothing)

Everything this body carried, the evidence included, is in #231.
