### PR TITLE
Refuse a socket in the suite, now that there is an outbound path to reach for

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -34,10 +34,10 @@ document.
 A refused test is not dropped. Each one below names what replaces it, and a proposal that fits a
 refusal is answered with that replacement rather than with a no.
 
-Three of the ways this rule gets broken are refused, and the rest of it is read by a person. The
+Four of the ways this rule gets broken are refused, and the rest of it is read by a person. The
 refusals are rules in the invariant lint, and each names the line above it stands for:
 
-    git grep -n "^  - id: no-browser-automation-package\|^  - id: no-certificate-store-access\|^  - id: suite-writes-only-under-the-run-directory" tools/opengrep/rules.yaml
+    git grep -n "^  - id: no-browser-automation-package\|^  - id: no-certificate-store-access\|^  - id: suite-writes-only-under-the-run-directory\|^  - id: suite-opens-no-socket" tools/opengrep/rules.yaml
 
 `no-browser-automation-package` refuses a reference to Playwright, Selenium, Puppeteer or WebDriver
 in the project, props, targets and lock files, which is how a display requirement arrives.
@@ -45,15 +45,17 @@ in the project, props, targets and lock files, which is how a display requiremen
 `certutil` in any script or workflow, which is the elevation form that outlives the run.
 `suite-writes-only-under-the-run-directory` refuses the seven calls that ask the machine for a
 location, anywhere in the test project except the run directory itself and its own tests.
+`suite-opens-no-socket` refuses the constructs that build a sending client, accept a connection or
+ask a resolver, anywhere in the test project, which is how a real network peer arrives now that the
+plugin has an outbound path at all.
 
-What is still read by a person and refused by nothing. A test that opens a socket passes: the
-mechanism for that refuses outbound calls at the handler the plugin resolves, and the plugin
-resolves no handler because it makes no outbound call. A display requirement arriving as something
-other than a package reference passes. A test that reaches a shared location without naming one of
-the seven calls passes, because the check is over source text and not over what a run did. A test
-needing a running server or a container engine passes. So a test breaking most of the lines above
-still builds and runs exactly like one that does not, and the three rules narrow that rather than
-closing it. #115 is where the rest of the gap is held.
+What is still read by a person and refused by nothing. A socket opened inside a package the suite
+calls passes, and so does an address handed to something that opens one on the suite's behalf,
+because the check over the network is source text like the other three. A display requirement
+arriving as something other than a package reference passes. A test that reaches a shared location
+without naming one of the seven calls passes, for the same reason. A test needing a running server
+or a container engine passes. So a test breaking several of the lines above still builds and runs
+exactly like one that does not, and the four rules narrow that rather than closing it.
 
 ### The refusals, and what replaces each
 

--- a/tools/opengrep/fixtures/network/OpensASocket.cs
+++ b/tools/opengrep/fixtures/network/OpensASocket.cs
@@ -1,0 +1,51 @@
+// Fixture for suite-opens-no-socket. This file is in no project and is never
+// compiled; it exists so the rule can be watched refusing the mistake it names.
+//
+// The near-miss is the first test written against the notification sink by
+// somebody who has not read docs/testing.md. The sink takes its handler as a
+// constructor argument, so handing it the real one instead of the endpoint
+// double is a one-word change and reads like the more honest test. What it
+// costs is the property the suite is built on: the test then asserts something
+// that is true only on a machine which can reach the address in it, and on the
+// machine that cannot it fails for a reason that has nothing to do with the
+// sink.
+
+namespace Jellyfin.Plugin.Requests.Tests.Fixtures;
+
+internal sealed class OpensASocket
+{
+    // Legal neighbour, left here on purpose: an endpoint double derives from
+    // HttpMessageHandler and is handed to the type under test, which is the
+    // shape this rule exists to keep, and the rule has to stay quiet on it.
+    public static OutboundSink ThroughTheDouble(IInstallSettings settings, ILogger logger)
+    {
+        var endpoint = ASinkEndpoint.ThatAccepts();
+
+        return new OutboundSink(settings, endpoint, logger, OutboundSink.DefaultAnswerWithin);
+    }
+
+    // The regression, in the spellings a test would actually reach for.
+    public static async Task ReachOut(IInstallSettings settings, ILogger logger)
+    {
+        var sending = new SocketsHttpHandler();
+        var sink = new OutboundSink(settings, sending, logger, OutboundSink.DefaultAnswerWithin);
+
+        using var client = new HttpClient(new HttpClientHandler());
+        _ = await client.GetStringAsync("https://requests.invalid/notices");
+
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        var connection = new TcpClient();
+        var raw = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        var serving = new HttpListener();
+        var byName = Dns.GetHostEntry("requests.invalid");
+        var addresses = await Dns.GetHostAddressesAsync("requests.invalid");
+
+        _ = sink;
+        _ = listener;
+        _ = connection;
+        _ = raw;
+        _ = serving;
+        _ = byName;
+        _ = addresses;
+    }
+}

--- a/tools/opengrep/rules.yaml
+++ b/tools/opengrep/rules.yaml
@@ -290,6 +290,56 @@ rules:
         - "Jellyfin.Plugin.Requests.Tests/Doubles/TestRunDirectory.cs"
         - "Jellyfin.Plugin.Requests.Tests/TestRunDirectoryTests.cs"
 
+  # Invariant (headless, #115): nothing in the suite opens a socket. Decided in
+  # docs/testing.md, whose first condition is that a test needs no network peer
+  # and whose replacement for a real outbound call is an in-process handler. The
+  # plugin's one outbound path takes its handler as a constructor argument, so
+  # the suite reaches that path by handing in a double and never by building the
+  # pipeline that sends. This refuses the constructs that build one anyway.
+  #
+  # Until the notification sink existed there was nothing here to get wrong, and
+  # that is why this rule arrives after the other three rather than with them.
+  # The near-miss now is the first test somebody writes against that sink: the
+  # double is one directory away, the real handler is one word away, and a test
+  # holding the second passes on a machine with connectivity and fails on the
+  # machine that has none, for a reason that has nothing to do with the sink.
+  # Constructing a client at all is refused here rather than only constructing a
+  # sending one, because the suite builds no client of its own on purpose: the
+  # client under test is the plugin's, built from the handler it was handed, and
+  # a client built here would be a second one nothing in the plugin owns.
+  #
+  # What it does not reach, and deliberately. It is over source text, so a socket
+  # opened inside a package the suite calls is invisible to it, as is an address
+  # handed to something that opens one on the suite's behalf. HttpMessageHandler
+  # is not among the patterns: deriving from it is how every endpoint double in
+  # Doubles/ is written, and it is the shape this rule exists to keep rather than
+  # to refuse.
+  - id: suite-opens-no-socket
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      Do not open a socket in the suite. Hand an HttpMessageHandler double to the
+      type under test, the way ASinkEndpoint is handed to OutboundSink, so the
+      client's own serialisation, timeout and error handling are all exercised
+      and nothing leaves the process (#115).
+    patterns:
+      - pattern-either:
+          - pattern: new HttpClient(...)
+          - pattern: new HttpClientHandler(...)
+          - pattern: new SocketsHttpHandler(...)
+          - pattern: new Socket(...)
+          - pattern: new TcpClient(...)
+          - pattern: new TcpListener(...)
+          - pattern: new HttpListener(...)
+          - pattern: Dns.GetHostEntry(...)
+          - pattern: Dns.GetHostEntryAsync(...)
+          - pattern: Dns.GetHostAddresses(...)
+          - pattern: Dns.GetHostAddressesAsync(...)
+    paths:
+      include:
+        - "Jellyfin.Plugin.Requests.Tests/**/*.cs"
+        - "tools/opengrep/fixtures/network/**/*.cs"
+
   # Invariant (model, #43): the history on a request is only ever appended to.
   # Decided in #43, whose second done-condition names this rule. Entries are
   # never edited or removed, and that is the only thing that makes the list


### PR DESCRIPTION
Closes #115.

The headless rule in `docs/testing.md` refuses a test that needs a real network peer. Three of the four ways it gets broken were already rules in the invariant lint; the network one was not, and the reason written on the issue was that the plugin resolved no handler because it made no outbound call. That is no longer true of the tree:

    git grep -n "SocketsHttpHandler\|HttpMessageHandler handler" -- Jellyfin.Plugin.Requests/
    Jellyfin.Plugin.Requests/Notify/OutboundSink.cs:87:        HttpMessageHandler handler,
    Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs:105:            new SocketsHttpHandler(),

So there is an outbound path, and reaching it with the handler that actually sends is one word away from reaching it with the endpoint double.

## What this adds

`suite-opens-no-socket` refuses, anywhere in the test project, the constructs that build a sending client, accept a connection or ask a resolver. Building a client at all is refused rather than only building a sending one: the suite owns no client on purpose, the one under test is the plugin's built from the handler it was handed, and a second one here would be a client no part of the plugin owns. Deriving from `HttpMessageHandler` stays legal, because that is how every endpoint double in `Doubles/` is written and is the shape the rule exists to keep.

The fixture carries the near-miss beside the legal neighbour, so the rule has to separate the real handler from the double rather than match on a type name.

## That it bites

The first done-condition of #115 asks for a test that opens a socket to be added deliberately and watched going red. That head is #233, based on this branch, carrying one test that hands `new SocketsHttpHandler()` to the sink. It builds with no warning and it passes, so nothing except the invariant lint separates it from a legitimate test. It is not merged.

It went red on exactly this rule and on nothing else:

    gh run view 31970393981 --repo Flowfin/jellyfin-plugin-requests --log-failed
    Refuse an invariant broken anywhere in the tree ... Jellyfin.Plugin.Requests.Tests/Notify/ASinkAgainstARealHandlerTests.cs
       ❯❯❱ tools.opengrep.suite-opens-no-socket
              32┆ using var sending = new SocketsHttpHandler();
    ##[error]Process completed with exit code 1.

    gh pr checks 233 --repo Flowfin/jellyfin-plugin-requests | grep "greppable"
    Enforce greppable invariants	fail	8s

That is the tree scan refusing the file in the test project, which is the half a fixture cannot show. The fixture is the other half, and the same job on this branch proves the rule still matches it:

    gh run view 31970382430 --repo Flowfin/jellyfin-plugin-requests --log | grep -A 20 "rules the fixtures made fire"
    == rules the fixtures made fire
    ...
    suite-opens-no-socket
    ...
    every declared rule fired on a fixture

The suite itself is unchanged by this and stays green on both claimed lines:

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!: Fehler: 0, erfolgreich: 546, gesamt: 546 (net9.0)
    Bestanden!: Fehler: 0, erfolgreich: 546, gesamt: 546 (net10.0)

## What is not claimed

The rule is over source text, like the other three. A socket opened inside a package the suite calls is invisible to it, and so is an address handed to something that opens one on the suite's behalf. `docs/testing.md` says that in those words and no issue is opened for it, because the bound is the mechanism rather than a gap in it.

No server ran and no container engine was available on the machine this was made on. Nothing here needed one.

Nobody else has read this change.
