### PR TITLE
Hand the sink the handler that sends, so the rule can be watched refusing it

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Notify/ASinkAgainstARealHandlerTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Notify/ASinkAgainstARealHandlerTests.cs
@@ -1,0 +1,41 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
+using Jellyfin.Plugin.Requests.Configuration;
+using Jellyfin.Plugin.Requests.Notify;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Notify;
+
+/// <summary>
+/// The near-miss <c>suite-opens-no-socket</c> exists to refuse, written the way somebody who has not
+/// read <c>docs/testing.md</c> would write it. It compiles and it passes, so the only thing that
+/// separates it from a legitimate test is the rule.
+/// <para>
+/// This file is never merged. It is here so the refusal can be watched happening on a head that
+/// carries it, which is what the first done-condition of #115 asks for.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class ASinkAgainstARealHandlerTests
+{
+    /// <summary>
+    /// An install where nobody typed an address sends nothing, asserted against the handler that
+    /// would actually have sent it.
+    /// </summary>
+    [Fact]
+    public void AnInstallWhereNobodyTypedAnAddressSendsNothing()
+    {
+        using var sending = new SocketsHttpHandler();
+        using var sink = new OutboundSink(
+            new FakeInstallSettings(new PluginConfiguration()),
+            sending,
+            new RecordingLogger(),
+            OutboundSink.DefaultAnswerWithin);
+
+        Assert.False(sink.IsConfigured);
+    }
+}


### PR DESCRIPTION
Part of #115. **This is never merged.** It exists so the rule added in #232 can be watched refusing something rather than only described.

The first done-condition of #115 is that a test which opens a socket fails, proven by adding one deliberately and watching it go red. This head is that test: one leg of the notification sink written the way somebody who has not read `docs/testing.md` would write it, handing `new SocketsHttpHandler()` to the sink instead of the endpoint double.

It builds with no warning and it passes:

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    0 Warnung(en)
    0 Fehler

so nothing except `Enforce greppable invariants` separates it from a legitimate test. The base of this pull request is the branch carrying the rule, so the diff is the defect alone.

The refusal happened and is recorded on #232:

    gh pr checks 233 --repo Flowfin/jellyfin-plugin-requests | grep "greppable"
    Enforce greppable invariants	fail	8s

    gh run view 31970393981 --repo Flowfin/jellyfin-plugin-requests --log-failed
       tools.opengrep.suite-opens-no-socket
              32| using var sending = new SocketsHttpHandler();
    ##[error]Process completed with exit code 1.

Closed without merging.
