### PR TITLE
Write every request transition to the server's activity log

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Api/ActOnARequestTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/ActOnARequestTests.cs
@@ -521,7 +521,7 @@ public sealed class ActOnARequestTests
     /// <param name="caller">Who the server says is calling.</param>
     /// <returns>The controller under test.</returns>
     private RequestsController ControllerFor(IRequestStore store, Guid? caller)
-        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), new FakeInstallSettings());
+        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), new FakeInstallSettings(), new RecordingJournal());
 
     /// <summary>
     /// The row a successful decision handed back, with the status code checked.

--- a/Jellyfin.Plugin.Requests.Tests/Api/ActOnManyRequestsTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/ActOnManyRequestsTests.cs
@@ -619,7 +619,7 @@ public sealed class ActOnManyRequestsTests
     /// <param name="caller">Who the server says is calling.</param>
     /// <returns>The controller under test.</returns>
     private RequestsController ControllerFor(IRequestStore store, Guid? caller)
-        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), new FakeInstallSettings());
+        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), new FakeInstallSettings(), new RecordingJournal());
 
     /// <summary>
     /// The entries an action came back with, with the status code checked.

--- a/Jellyfin.Plugin.Requests.Tests/Api/CreateRequestTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/CreateRequestTests.cs
@@ -365,7 +365,8 @@ public sealed class CreateRequestTests
             new TestClock(new DateTimeOffset(2026, 8, 9, 12, 0, 0, TimeSpan.Zero)),
             _identifiers,
             new FakeCallerIdentity(caller),
-            new FakeInstallSettings());
+            new FakeInstallSettings(),
+            new RecordingJournal());
 
     /// <summary>
     /// The answer, with the status code checked, so a leg cannot pass on a body that came back under

--- a/Jellyfin.Plugin.Requests.Tests/Api/ErrorSurfaceTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/ErrorSurfaceTests.cs
@@ -391,7 +391,7 @@ public sealed class ErrorSurfaceTests
     /// <param name="settings">What this install is set to.</param>
     /// <returns>The controller under test.</returns>
     private RequestsController ControllerFor(IRequestStore store, Guid? caller, IInstallSettings settings)
-        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), settings);
+        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), settings, new RecordingJournal());
 
     /// <summary>
     /// A second request in the store, so one of them can be moved out of the way.

--- a/Jellyfin.Plugin.Requests.Tests/Api/ListRequestsTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/ListRequestsTests.cs
@@ -620,5 +620,6 @@ public sealed class ListRequestsTests
             new TestClock(new DateTimeOffset(2026, 8, 9, 12, 0, 0, TimeSpan.Zero)),
             _identifiers,
             new FakeCallerIdentity(caller),
-            new FakeInstallSettings());
+            new FakeInstallSettings(),
+            new RecordingJournal());
 }

--- a/Jellyfin.Plugin.Requests.Tests/Api/PublishedApiDocumentTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/PublishedApiDocumentTests.cs
@@ -505,7 +505,7 @@ public sealed class PublishedApiDocumentTests
     /// <param name="settings">What this install is set to.</param>
     /// <returns>The controller under test.</returns>
     private RequestsController ControllerFor(IRequestStore store, Guid? caller, IInstallSettings settings)
-        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), settings);
+        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), settings, new RecordingJournal());
 
     /// <summary>
     /// A request as the store holds one.

--- a/Jellyfin.Plugin.Requests.Tests/CatalogueSplitTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/CatalogueSplitTests.cs
@@ -9,6 +9,7 @@ using Jellyfin.Plugin.Requests.Api;
 using Jellyfin.Plugin.Requests.Configuration;
 using Jellyfin.Plugin.Requests.Identity;
 using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Notify;
 using Jellyfin.Plugin.Requests.Storage;
 using Jellyfin.Plugin.Requests.Tests.Doubles;
 using Jellyfin.Plugin.Requests.Time;
@@ -84,9 +85,9 @@ public sealed class CatalogueSplitTests
     }
 
     /// <summary>
-    /// The controller takes five things and none of them can fetch anything. A metadata source
+    /// The controller takes six things and none of them can fetch anything. A metadata source
     /// arrives as something injected, so the constructor is where one would appear first, and a
-    /// sixth parameter fails here before anybody writes the call.
+    /// seventh parameter fails here before anybody writes the call.
     /// <para>
     /// Written as the exact list rather than as "nothing called a provider". A name test would pass
     /// the day somebody injects a fetcher under a name nobody predicted, which is the shape this
@@ -109,7 +110,8 @@ public sealed class CatalogueSplitTests
                 nameof(IClock),
                 nameof(IIdentifierSource),
                 nameof(ICallerIdentity),
-                nameof(IInstallSettings)),
+                nameof(IInstallSettings),
+                nameof(IActivityJournal)),
             string.Join(" | ", taken),
             StringComparer.Ordinal);
     }
@@ -143,5 +145,6 @@ public sealed class CatalogueSplitTests
             new TestClock(new DateTimeOffset(2026, 8, 11, 8, 0, 0, TimeSpan.Zero)),
             new SequentialIdentifierSource(),
             new FakeCallerIdentity(Operator),
-            new FakeInstallSettings());
+            new FakeInstallSettings(),
+            new RecordingJournal());
 }

--- a/Jellyfin.Plugin.Requests.Tests/Doubles/AnActivityLogThatRefuses.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/AnActivityLogThatRefuses.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Threading.Tasks;
+using Jellyfin.Data.Events;
+using Jellyfin.Database.Implementations.Entities;
+using MediaBrowser.Model.Activity;
+using MediaBrowser.Model.Querying;
+
+namespace Jellyfin.Plugin.Requests.Tests.Doubles;
+
+/// <summary>
+/// The server's activity log with the database behind it refusing every write.
+/// <para>
+/// It stands in for the case the plugin cannot do anything about: the entry describes a decision
+/// that is already in the store, and what is being asserted is that the decision stands and the
+/// failure is reported rather than raised at whoever clicked.
+/// </para>
+/// </summary>
+internal sealed class AnActivityLogThatRefuses : IActivityManager
+{
+    /// <inheritdoc />
+#pragma warning disable CS0067 // Nothing here raises it, which is what an activity log this plugin only writes to looks like.
+    public event EventHandler<GenericEventArgs<ActivityLogEntry>>? EntryCreated;
+#pragma warning restore CS0067
+
+    /// <inheritdoc />
+    public Task CreateAsync(ActivityLog entry)
+        => Task.FromException(new InvalidOperationException("The activity log could not be written to."));
+
+    /// <inheritdoc />
+    public Task<QueryResult<ActivityLogEntry>> GetPagedResultAsync(Jellyfin.Data.Queries.ActivityLogQuery query)
+        => throw new NotSupportedException("Nothing in this plugin reads the activity log.");
+
+    /// <inheritdoc />
+    public Task CleanAsync(DateTime startDate)
+        => throw new NotSupportedException("Nothing in this plugin cleans the activity log.");
+}

--- a/Jellyfin.Plugin.Requests.Tests/Doubles/RecordingJournal.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/RecordingJournal.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Notify;
+
+namespace Jellyfin.Plugin.Requests.Tests.Doubles;
+
+/// <summary>
+/// An activity log that keeps what was written to it instead of writing it anywhere.
+/// <para>
+/// The server's own activity log is a database on a running server, which the headless rule in
+/// <c>docs/testing.md</c> refuses. What a test here can assert is what this plugin asked to be
+/// written, which is every rule #75 states: one entry per move, what it says, and what it never
+/// carries.
+/// </para>
+/// </summary>
+internal sealed class RecordingJournal : IActivityJournal
+{
+    private readonly List<ActivityNote> _written = [];
+
+    /// <summary>
+    /// Gets every entry written, in the order it was written.
+    /// </summary>
+    public IReadOnlyList<ActivityNote> Written => _written;
+
+    /// <summary>
+    /// Gets or sets what to raise instead of writing, where the test is about a host that refused.
+    /// </summary>
+    public Exception? Refuses { get; set; }
+
+    /// <inheritdoc />
+    public Task WriteAsync(ActivityNote note, CancellationToken cancellationToken)
+    {
+        if (Refuses is Exception refusal)
+        {
+            return Task.FromException(refusal);
+        }
+
+        _written.Add(note);
+
+        return Task.CompletedTask;
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/Fulfilment/BothPathsTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Fulfilment/BothPathsTests.cs
@@ -118,7 +118,7 @@ public class BothPathsTests
 
         using var watcher = new LibraryWatcher(
             library,
-            new FulfilmentSweep(refusing, library, new TestClock(Asked), log),
+            new FulfilmentSweep(refusing, library, new TestClock(Asked), new RecordingJournal(), log),
             log);
 
         await store.AddAsync(Request(), CancellationToken.None);
@@ -150,7 +150,7 @@ public class BothPathsTests
     }
 
     private static FulfilmentSweep Sweep(IRequestStore store, ILibrary library)
-        => new FulfilmentSweep(store, library, new TestClock(Asked), new RecordingLogger());
+        => new FulfilmentSweep(store, library, new TestClock(Asked), new RecordingJournal(), new RecordingLogger());
 
     private static async Task<MediaRequest> Only(InMemoryRequestStore store)
         => (await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true)).Single().Request;

--- a/Jellyfin.Plugin.Requests.Tests/Fulfilment/FulfilmentSweepTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Fulfilment/FulfilmentSweepTests.cs
@@ -309,7 +309,7 @@ public class FulfilmentSweepTests
                 Asked,
                 RequestCaller.Administrator(Requester)));
 
-        var sweep = new FulfilmentSweep(moving, library, new TestClock(Asked), new RecordingLogger());
+        var sweep = new FulfilmentSweep(moving, library, new TestClock(Asked), new RecordingJournal(), new RecordingLogger());
 
         await store.AddAsync(Request(RequestedItemKind.Movie, "Tmdb", "603"), CancellationToken.None);
         library.Put(RequestedItemKind.Movie, "Tmdb", "603");
@@ -323,7 +323,7 @@ public class FulfilmentSweepTests
     }
 
     private static FulfilmentSweep Sweep(IRequestStore store, ILibrary library, TestClock clock)
-        => new FulfilmentSweep(store, library, clock, new RecordingLogger());
+        => new FulfilmentSweep(store, library, clock, new RecordingJournal(), new RecordingLogger());
 
     private static async Task<MediaRequest> Only(InMemoryRequestStore store)
         => (await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true)).Single().Request;

--- a/Jellyfin.Plugin.Requests.Tests/Notify/ActivityJournalTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Notify/ActivityJournalTests.cs
@@ -1,0 +1,298 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Api;
+using Jellyfin.Plugin.Requests.Fulfilment;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Notify;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Notify;
+
+/// <summary>
+/// What a move leaves in the server's activity log, which is #75.
+/// <para>
+/// The server's activity log is a database on a running server and the headless rule in
+/// <c>docs/testing.md</c> refuses one, so what is asserted here is what this plugin asked to be
+/// written. That is where every rule on this issue lives: one entry per transition, what the line
+/// says, and what it may never carry. Whether the entry is then readable in the dashboard is the
+/// second condition of #75 and is a procedure against a running server rather than a test.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class ActivityJournalTests
+{
+    private static readonly Guid Asker = new Guid("75000000-0000-0000-0000-000000000001");
+    private static readonly Guid Operator = new Guid("75000000-0000-0000-0000-000000000002");
+    private static readonly DateTimeOffset Started = new DateTimeOffset(2026, 8, 15, 9, 0, 0, TimeSpan.Zero);
+
+    private readonly SequentialIdentifierSource _identifiers = new SequentialIdentifierSource();
+
+    /// <summary>
+    /// A request walked through its life leaves one entry per transition and none for anything else.
+    /// <para>
+    /// This is the first condition of #75 and it is written as the walk rather than as three
+    /// separate legs, because what it has to catch is a path that writes no entry, and a leg per
+    /// path is a set somebody adds a fourth path to without adding a fourth leg. The two surfaces
+    /// that move a request share the one journal here for the same reason.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ARequestWalkedThroughItsLifeLeavesOneEntryPerTransition()
+    {
+        var store = new InMemoryRequestStore();
+        var journal = new RecordingJournal();
+        var library = new FakeLibrary();
+        var clock = new TestClock(Started);
+        var open = await AnOpenRequestAsync(store).ConfigureAwait(true);
+
+        // Asking for something is not a move. Nothing has been decided, the model appends no history
+        // entry for it, and an entry here would be this plugin announcing its own arrival in a list
+        // an operator reads for what the server did. Telling an administrator that something arrived
+        // is #76 and is a live message rather than a record.
+        Assert.Empty(journal.Written);
+
+        await Controller(store, journal)
+            .ApproveAsync(open.Request.Id, new ApproveRequestBody { Revision = open.Revision }, CancellationToken.None)
+            .ConfigureAwait(true);
+
+        library.Put(RequestedItemKind.Movie, "Tmdb", "603");
+        clock.Advance(TimeSpan.FromHours(2));
+
+        Assert.Equal(
+            1,
+            await new FulfilmentSweep(store, library, clock, journal, new RecordingLogger())
+                .SweepAsync(CancellationToken.None)
+                .ConfigureAwait(true));
+
+        Assert.Equal(2, journal.Written.Count);
+
+        var approved = journal.Written[0];
+        var fulfilled = journal.Written[1];
+
+        Assert.Equal("Request approved: The Conversation", approved.Name, StringComparer.Ordinal);
+        Assert.Equal("MediaRequestApproved", approved.Type, StringComparer.Ordinal);
+        Assert.Equal(Operator, approved.UserId);
+        Assert.Contains("Open to Approved", approved.ShortOverview, StringComparison.Ordinal);
+
+        Assert.Equal("Request fulfilled: The Conversation", fulfilled.Name, StringComparer.Ordinal);
+        Assert.Equal("MediaRequestFulfilled", fulfilled.Type, StringComparer.Ordinal);
+
+        // The plugin looked at the library and nobody decided anything, so the entry is attributed
+        // to nobody and says so in words as well. The server's entity has no nullable user, so an
+        // entry that only left the identifier empty would read in the dashboard as an entry whose
+        // user could not be resolved.
+        Assert.Equal(Guid.Empty, fulfilled.UserId);
+        Assert.Contains("by the plugin rather than by a person", fulfilled.ShortOverview, StringComparison.Ordinal);
+
+        // Enough to find the request again, which is the third thing the issue asks an entry to
+        // carry. It is in the text rather than in the entity's item identifier, because that field
+        // is a library item on the server's side and the dashboard offers it as a link.
+        Assert.Contains(
+            open.Request.Id.ToString(),
+            fulfilled.ShortOverview,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A decline writes an entry and the entry carries nothing of what the operator typed.
+    /// <para>
+    /// This is the third condition of #75. The note is the operator's message to one person, it can
+    /// be five hundred characters, and the activity list is read by every administrator on the
+    /// server, so a note reaching it is a disclosure nobody asked for and a wall of text in a list
+    /// of one-line entries.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ADeclineWritesAnEntryCarryingNothingTheOperatorTyped()
+    {
+        var store = new InMemoryRequestStore();
+        var journal = new RecordingJournal();
+        var open = await AnOpenRequestAsync(store).ConfigureAwait(true);
+
+        await Controller(store, journal)
+            .DeclineAsync(
+                open.Request.Id,
+                new DeclineRequestBody
+                {
+                    Revision = open.Revision,
+                    Reason = DeclineReason.Other,
+                    Note = "Ask me again after the disk arrives, and stop asking for this one at midnight."
+                },
+                CancellationToken.None)
+            .ConfigureAwait(true);
+
+        var entry = Assert.Single(journal.Written);
+
+        Assert.Equal("Request declined: The Conversation", entry.Name, StringComparer.Ordinal);
+        Assert.Equal("MediaRequestDeclined", entry.Type, StringComparer.Ordinal);
+        Assert.DoesNotContain("disk arrives", entry.Name, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("disk arrives", entry.ShortOverview, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("midnight", entry.ShortOverview, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// A write that moved nothing writes no entry.
+    /// <para>
+    /// The fulfilment sweep writes every time what it saw in the library changed, whether or not the
+    /// request moved. Without this the activity list gains a line every time a title's availability
+    /// is re-observed, which is the wall of entries the issue says is worse than none.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AnObservationThatMovedNothingWritesNoEntry()
+    {
+        var store = new InMemoryRequestStore();
+        var journal = new RecordingJournal();
+        var library = new FakeLibrary();
+        var clock = new TestClock(Started);
+        var open = await AnOpenRequestAsync(store).ConfigureAwait(true);
+
+        await Controller(store, journal)
+            .DeclineAsync(
+                open.Request.Id,
+                new DeclineRequestBody { Revision = open.Revision, Reason = DeclineReason.AlreadyInTheLibrary },
+                CancellationToken.None)
+            .ConfigureAwait(true);
+
+        // A declined request whose title then arrives. The sweep writes the new availability and the
+        // table refuses the move, so the store is written and the state is where it was.
+        library.Put(RequestedItemKind.Movie, "Tmdb", "603");
+        clock.Advance(TimeSpan.FromHours(1));
+
+        Assert.Equal(
+            0,
+            await new FulfilmentSweep(store, library, clock, journal, new RecordingLogger())
+                .SweepAsync(CancellationToken.None)
+                .ConfigureAwait(true));
+
+        var held = Assert.IsType<StoredRequest>(
+            await store.GetAsync(open.Request.Id, CancellationToken.None).ConfigureAwait(true));
+
+        Assert.Equal(LibraryAvailability.Present, held.Request.Availability);
+        Assert.Equal(RequestState.Declined, held.Request.State);
+        Assert.Single(journal.Written);
+    }
+
+    /// <summary>
+    /// A title longer than an entry carries is cut, and the cut is visible.
+    /// <para>
+    /// The title is a snapshot of what whoever asked typed and nothing caps it on the way here, so
+    /// without this one row of the operator's activity list is as long as somebody wanted it to be.
+    /// </para>
+    /// <para>
+    /// The two lengths are the cap and one character past it, which is the mistake somebody makes.
+    /// A leg written only against a title far longer than the cap passes with the comparison off by
+    /// one in either direction, because the cut lands in the same place either way; the pair is what
+    /// pins the threshold rather than the cutting.
+    /// </para>
+    /// </summary>
+    /// <param name="length">How long the title is.</param>
+    /// <param name="cut">Whether an entry built from it is expected to be cut.</param>
+    [Theory]
+    [InlineData(ActivityNote.TitleMaximumLength, false)]
+    [InlineData(ActivityNote.TitleMaximumLength + 1, true)]
+    public void ATitleLongerThanAnEntryCarriesIsCutAndSaysSo(int length, bool cut)
+    {
+        var before = AnAsk() with { DisplayTitle = new string('t', length) };
+        var moved = RequestLifecycle.Move(before, RequestState.Approved, Started, RequestCaller.Administrator(Operator));
+
+        var note = ActivityNote.For(before, moved);
+
+        Assert.NotNull(note);
+        Assert.Equal(
+            cut
+                ? "Request approved: " + new string('t', ActivityNote.TitleMaximumLength) + "..."
+                : "Request approved: " + new string('t', length),
+            note.Name,
+            StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// The activity log refusing a write does not undo a decision that has already been made.
+    /// <para>
+    /// The move is in the store by the time an entry is attempted, so an exception from the host
+    /// would answer the operator that their approval failed when it had not. This is the reason the
+    /// swallow is in <see cref="ServerActivityJournal"/> rather than left to each caller, and it is
+    /// read here against a journal that refuses everything.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AnActivityLogThatRefusesTheWriteDoesNotUndoTheDecision()
+    {
+        var store = new InMemoryRequestStore();
+        var logger = new RecordingLogger();
+        var journal = new ServerActivityJournal(new AnActivityLogThatRefuses(), logger);
+        var open = await AnOpenRequestAsync(store).ConfigureAwait(true);
+
+        var answered = await Controller(store, journal)
+            .ApproveAsync(open.Request.Id, new ApproveRequestBody { Revision = open.Revision }, CancellationToken.None)
+            .ConfigureAwait(true);
+
+        var held = Assert.IsType<StoredRequest>(
+            await store.GetAsync(open.Request.Id, CancellationToken.None).ConfigureAwait(true));
+
+        Assert.IsType<QueuedRequest>(Assert.IsAssignableFrom<ObjectResult>(answered.Result).Value);
+        Assert.Equal(RequestState.Approved, held.Request.State);
+
+        var reported = Assert.Single(logger.At(LogLevel.Warning));
+
+        Assert.Contains("activity log", reported.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.NotNull(reported.Exception);
+    }
+
+    /// <summary>
+    /// A controller writing its entries into the journal handed in.
+    /// </summary>
+    /// <param name="store">Where requests are kept.</param>
+    /// <param name="journal">Where the entries go.</param>
+    /// <returns>The controller.</returns>
+    private RequestsController Controller(InMemoryRequestStore store, IActivityJournal journal)
+        => new RequestsController(
+            store,
+            new TestClock(Started),
+            _identifiers,
+            new FakeCallerIdentity(Operator),
+            new FakeInstallSettings(),
+            journal);
+
+    /// <summary>
+    /// One open request in the store, with a provider identifier so the library can match it.
+    /// </summary>
+    /// <param name="store">Where it goes.</param>
+    /// <returns>The request and its revision.</returns>
+    private async Task<StoredRequest> AnOpenRequestAsync(InMemoryRequestStore store)
+        => await store.AddAsync(AnAsk(), CancellationToken.None).ConfigureAwait(true);
+
+    /// <summary>
+    /// The request every leg here starts from.
+    /// </summary>
+    /// <returns>The request.</returns>
+    private MediaRequest AnAsk()
+        => new MediaRequest
+        {
+            Id = _identifiers.NewId(),
+            RequestedByUserId = Asker,
+            RequestedAt = Started,
+            StateChangedAt = Started,
+            Kind = RequestedItemKind.Movie,
+            DisplayTitle = "The Conversation",
+            DisplayYear = 1974,
+            ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tmdb"] = "603" }
+        };
+}

--- a/Jellyfin.Plugin.Requests.Tests/SiblingIndependenceTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/SiblingIndependenceTests.cs
@@ -83,6 +83,13 @@ public class SiblingIndependenceTests
         "System.ComponentModel",
         "System.Linq",
 
+        // A title snapshot is cut to a line before it goes into an activity entry, and the cut is
+        // made over a span rather than by taking a substring because CA1846 refuses the substring
+        // and the analyzer posture in Directory.Build.props makes that refusal a build failure. The
+        // span type lives here. It is a facade over the runtime the server already runs on rather
+        // than a package this plugin carries, and it is excluded from the install with the rest.
+        "System.Memory",
+
         // The outbound notification sink posts a document to an address an operator typed, so the
         // client, the pipeline its handler sits in and the address type all come from here. It is
         // the one thing in this plugin that talks outward, it is off on every install where nobody

--- a/Jellyfin.Plugin.Requests.Tests/Web/QueueViewTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Web/QueueViewTests.cs
@@ -223,7 +223,8 @@ public sealed class QueueViewTests
             new TestClock(asked),
             _identifiers,
             new FakeCallerIdentity(new Guid("c1000000-0000-0000-0000-0000000000ad")),
-            new FakeInstallSettings());
+            new FakeInstallSettings(),
+            new RecordingJournal());
 
         var answered = await controller.QueueAsync(
             [Enum.Parse<RequestState>(SelectedValueOf(body, "RequestsQueueState"), false)],

--- a/Jellyfin.Plugin.Requests/Api/RequestsController.cs
+++ b/Jellyfin.Plugin.Requests/Api/RequestsController.cs
@@ -8,6 +8,7 @@ using Jellyfin.Plugin.Requests.Configuration;
 using Jellyfin.Plugin.Requests.Identity;
 using Jellyfin.Plugin.Requests.Intake;
 using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Notify;
 using Jellyfin.Plugin.Requests.Storage;
 using Jellyfin.Plugin.Requests.Time;
 using MediaBrowser.Common.Api;
@@ -96,6 +97,7 @@ public sealed class RequestsController : RequestsControllerBase
     private readonly IClock _clock;
     private readonly IIdentifierSource _identifiers;
     private readonly ICallerIdentity _callers;
+    private readonly IActivityJournal _journal;
     private readonly RequestIntake _intake;
 
     /// <summary>
@@ -109,20 +111,27 @@ public sealed class RequestsController : RequestsControllerBase
     /// What this install is set to. The intake reads the quota out of it on every ask, so the
     /// endpoint cannot ask without one.
     /// </param>
+    /// <param name="journal">
+    /// Where a move is written down so an operator can read it after a restart. It is a dependency
+    /// rather than something this controller reaches for, because a decision that is not written
+    /// down is the failure #75 is about and a test has to be able to see the entry without a server.
+    /// </param>
     public RequestsController(
         IRequestStore store,
         IClock clock,
         IIdentifierSource identifiers,
         ICallerIdentity callers,
-        IInstallSettings settings)
+        IInstallSettings settings,
+        IActivityJournal journal)
     {
         _store = store;
         _clock = clock;
         _identifiers = identifiers;
         _callers = callers;
+        _journal = journal;
 
         // Built here rather than injected, because it is this controller's use of the store rather
-        // than a sixth thing the server has to supply. CatalogueSplitTests reads the list this
+        // than one more thing the server has to supply. CatalogueSplitTests reads the list this
         // constructor takes, and a request intake that arrived as a dependency would read as one.
         _intake = new RequestIntake(store, settings);
     }
@@ -726,6 +735,14 @@ public sealed class RequestsController : RequestsControllerBase
         try
         {
             var written = await _store.ReplaceAsync(moved, revision, cancellationToken).ConfigureAwait(false);
+
+            // After the write and never before it. An entry describing a decision the store then
+            // refused would be a line in the operator's activity list for something that did not
+            // happen, and the activity log is the one record here that outlives a restart.
+            if (ActivityNote.For(held.Request, written.Request) is ActivityNote note)
+            {
+                await _journal.WriteAsync(note, cancellationToken).ConfigureAwait(false);
+            }
 
             return new DecidedRequest { Id = id, Request = Queued(written) };
         }

--- a/Jellyfin.Plugin.Requests/Fulfilment/FulfilmentSweep.cs
+++ b/Jellyfin.Plugin.Requests/Fulfilment/FulfilmentSweep.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Notify;
 using Jellyfin.Plugin.Requests.Storage;
 using Jellyfin.Plugin.Requests.Time;
 using Microsoft.Extensions.Logging;
@@ -49,6 +50,7 @@ public sealed class FulfilmentSweep
     private readonly IRequestStore _store;
     private readonly ILibrary _library;
     private readonly IClock _clock;
+    private readonly IActivityJournal _journal;
     private readonly ILogger _logger;
 
     /// <summary>
@@ -57,22 +59,29 @@ public sealed class FulfilmentSweep
     /// <param name="store">Where the requests are.</param>
     /// <param name="library">What the server holds.</param>
     /// <param name="clock">The injected clock, so an observation's time is one a test can set.</param>
+    /// <param name="journal">
+    /// Where a move is written down. This path is the one nobody watched happen, so the entry is
+    /// the only thing that tells an operator afterwards that a request moved on its own.
+    /// </param>
     /// <param name="logger">The server's log, where a refused write is reported.</param>
     /// <exception cref="ArgumentNullException">Where anything it needs is missing.</exception>
     public FulfilmentSweep(
         IRequestStore store,
         ILibrary library,
         IClock clock,
+        IActivityJournal journal,
         ILogger logger)
     {
         ArgumentNullException.ThrowIfNull(store);
         ArgumentNullException.ThrowIfNull(library);
         ArgumentNullException.ThrowIfNull(clock);
+        ArgumentNullException.ThrowIfNull(journal);
         ArgumentNullException.ThrowIfNull(logger);
 
         _store = store;
         _library = library;
         _clock = clock;
+        _journal = journal;
         _logger = logger;
     }
 
@@ -220,6 +229,14 @@ public sealed class FulfilmentSweep
                 "A request moved while the library was being looked at for it, so this observation was dropped and the next look will make it again.");
 
             return false;
+        }
+
+        // After the write, for the reason the endpoint writes its entry after one. Nothing this
+        // path moves was asked for by a person, so the entry is what the operator has instead of
+        // having been there.
+        if (ActivityNote.For(request, observed) is ActivityNote note)
+        {
+            await _journal.WriteAsync(note, cancellationToken).ConfigureAwait(false);
         }
 
         return moves;

--- a/Jellyfin.Plugin.Requests/Notify/ActivityNote.cs
+++ b/Jellyfin.Plugin.Requests/Notify/ActivityNote.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Globalization;
+using Jellyfin.Plugin.Requests.Model;
+
+namespace Jellyfin.Plugin.Requests.Notify;
+
+/// <summary>
+/// One line for the server's activity log, built from a move a request has already made.
+/// <para>
+/// It is a record of this plugin's own rather than the server's entity, for two reasons. The entity
+/// is a database row with a settable identifier and a row version, so building one is a thing only
+/// the code that talks to the host should do; and every rule this issue is actually about - what an
+/// entry says, how long it is, what it may never carry - is a rule about text, which is testable
+/// here and is not testable through a host nothing in this suite runs.
+/// </para>
+/// <para>
+/// <b>An entry is built from four fields of the request and from nothing else.</b> The two states,
+/// the identifier, the title snapshot and who made the move are all of it. That is what keeps the
+/// third condition of #75 a property of this type rather than a thing to remember: the note text
+/// nobody else may read is never reached for, the configuration is not in scope here at all, and no
+/// path on the server's disk is either.
+/// </para>
+/// </summary>
+public sealed record ActivityNote
+{
+    /// <summary>
+    /// The longest a title may be inside an entry before the rest of it is dropped.
+    /// <para>
+    /// A title arrives from whoever asked and is capped nowhere else on the way here, so an entry
+    /// built without this is one row of the operator's activity list carrying five hundred
+    /// characters somebody typed. Sixty is a line, and what is cut is replaced by an ellipsis so a
+    /// reader can see that something was.
+    /// </para>
+    /// </summary>
+    public const int TitleMaximumLength = 60;
+
+    /// <summary>
+    /// Gets the line the dashboard shows. Short, because these sit among the server's own entries
+    /// and everything else the operator's plugins have to say.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Gets the second line, which carries the move and the identifier that finds the request again.
+    /// </summary>
+    public required string ShortOverview { get; init; }
+
+    /// <summary>
+    /// Gets the machine-readable word for what happened, which is what an operator filtering their
+    /// activity list has to match on. It names this plugin and the state moved into, so a second
+    /// plugin writing about its own requests does not collide with these.
+    /// </summary>
+    public required string Type { get; init; }
+
+    /// <summary>
+    /// Gets the Jellyfin user the entry is attributed to, or <see cref="Guid.Empty"/> where this
+    /// plugin made the move on its own after looking at the library. The server's entity has no
+    /// nullable user, so the empty identifier is what "nobody" is on that side, and the text says
+    /// so in words rather than leaving a reader to know that.
+    /// </summary>
+    public required Guid UserId { get; init; }
+
+    /// <summary>
+    /// Builds the entry for a move that has happened.
+    /// <para>
+    /// Both states are taken from the two requests rather than from the last history entry. The
+    /// history is the model's record and this is the server's, and reading one out of the other
+    /// would make an entry that is silently wrong the day a move appends two.
+    /// </para>
+    /// </summary>
+    /// <param name="before">The request as it was read.</param>
+    /// <param name="after">The request as the move left it.</param>
+    /// <returns>The entry, or <see langword="null"/> where the two states are the same and nothing moved.</returns>
+    /// <exception cref="ArgumentNullException">Where either request is absent.</exception>
+    public static ActivityNote? For(MediaRequest before, MediaRequest after)
+    {
+        ArgumentNullException.ThrowIfNull(before);
+        ArgumentNullException.ThrowIfNull(after);
+
+        if (before.State == after.State)
+        {
+            // A write that changed something other than the state, which the fulfilment sweep makes
+            // every time it observes availability without moving anything. An entry for one of those
+            // is the wall of entries this issue says is worse than none.
+            return null;
+        }
+
+        var by = after.StateChangedByUserId;
+
+        return new ActivityNote
+        {
+            Name = string.Create(
+                CultureInfo.InvariantCulture,
+                $"Request {Word(after.State)}: {Shortened(after.DisplayTitle)}"),
+            ShortOverview = by is null
+                ? string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"{before.State} to {after.State}, by the plugin rather than by a person. Request {after.Id}.")
+                : string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"{before.State} to {after.State}. Request {after.Id}."),
+            Type = "MediaRequest" + after.State,
+            UserId = by ?? Guid.Empty
+        };
+    }
+
+    /// <summary>
+    /// The title as it goes into an entry, cut to <see cref="TitleMaximumLength"/>.
+    /// </summary>
+    /// <param name="title">The title snapshot on the request.</param>
+    /// <returns>The title, or as much of it as an entry carries.</returns>
+    private static string Shortened(string title)
+        => title.Length <= TitleMaximumLength
+            ? title
+            : string.Concat(title.AsSpan(0, TitleMaximumLength), "...");
+
+    /// <summary>
+    /// The state as the first line says it, which is a verb rather than the enumeration's own name.
+    /// </summary>
+    /// <param name="state">The state moved into.</param>
+    /// <returns>The word.</returns>
+    private static string Word(RequestState state) => state switch
+    {
+        RequestState.Open => "reopened",
+        RequestState.Approved => "approved",
+        RequestState.Declined => "declined",
+        RequestState.Fulfilled => "fulfilled",
+        RequestState.Failed => "failed",
+        _ => "moved"
+    };
+}

--- a/Jellyfin.Plugin.Requests/Notify/IActivityJournal.cs
+++ b/Jellyfin.Plugin.Requests/Notify/IActivityJournal.cs
@@ -1,0 +1,32 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jellyfin.Plugin.Requests.Notify;
+
+/// <summary>
+/// Where a move a request made is written down so it survives a restart.
+/// <para>
+/// This is the record and <see cref="IOutboundSink"/> is the courtesy, which is why the two have
+/// different shapes. A notice can be lost and nothing says so; an entry here is the answer to what
+/// the server did, an operator reads it in a dashboard that is already in front of them, and it is
+/// there whether or not anybody was connected when it happened.
+/// </para>
+/// <para>
+/// <b>Writing an entry never raises.</b> A move that has already been written to the store is a
+/// decision that has been taken, and an activity log that is unavailable is not a reason to answer
+/// the operator that their decision failed. The implementation that reaches the server logs its own
+/// failure and returns, which is the one place that trade is made rather than a thing every caller
+/// has to remember; what a caller owes instead is to write the entry only after the store accepted
+/// the move, so an entry never claims something that did not happen.
+/// </para>
+/// </summary>
+public interface IActivityJournal
+{
+    /// <summary>
+    /// Writes one entry.
+    /// </summary>
+    /// <param name="note">What to say, built by <see cref="ActivityNote.For"/>.</param>
+    /// <param name="cancellationToken">Gives up writing.</param>
+    /// <returns>A task that completes when the entry has been written or given up on.</returns>
+    Task WriteAsync(ActivityNote note, CancellationToken cancellationToken);
+}

--- a/Jellyfin.Plugin.Requests/Notify/ServerActivityJournal.cs
+++ b/Jellyfin.Plugin.Requests/Notify/ServerActivityJournal.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Database.Implementations.Entities;
+using MediaBrowser.Model.Activity;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.Requests.Notify;
+
+/// <summary>
+/// The server's own activity log, as the one call this plugin makes to it.
+/// <para>
+/// This is the only place that names the host's activity manager, so the reach exists once and
+/// everything above it takes <see cref="IActivityJournal"/> instead. The shape of the host call is
+/// the same on both claimed lines: <c>CreateAsync</c> takes the entity below and the entity is
+/// constructed from a name, a type and a user.
+/// </para>
+/// <para>
+/// <b>The entity's <c>ItemId</c> is deliberately left unset.</b> It is a library item's identifier
+/// on the server's side and the dashboard offers it as a link, so putting a request's identifier
+/// there would give an operator a link to an item that does not exist. The identifier is in the
+/// text instead, where it is something to search for rather than something to click.
+/// </para>
+/// </summary>
+public sealed class ServerActivityJournal : IActivityJournal
+{
+    private readonly IActivityManager _activity;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ServerActivityJournal"/> class.
+    /// </summary>
+    /// <param name="activity">The server's activity log.</param>
+    /// <param name="logger">Where a refused write is reported.</param>
+    /// <exception cref="ArgumentNullException">Where there is nothing to write to or nothing to report on.</exception>
+    public ServerActivityJournal(IActivityManager activity, ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _activity = activity;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task WriteAsync(ActivityNote note, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(note);
+
+        var entry = new ActivityLog(note.Name, note.Type, note.UserId)
+        {
+            ShortOverview = note.ShortOverview,
+            LogSeverity = LogLevel.Information
+        };
+
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            await _activity.CreateAsync(entry).ConfigureAwait(false);
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+        catch (Exception failed)
+#pragma warning restore CA1031
+        {
+            // The decision this describes is already in the store. Raising here would answer the
+            // operator that their approval failed when it did not, and the failure that actually
+            // happened is one the operator can do nothing about from the queue page. So it lands in
+            // the log they would go to next, with the move in it, and the call carries on.
+            //
+            // Every exception rather than a named set: the host writes to a database this plugin
+            // does not own, on two server generations, and the set it can raise is not knowable
+            // from here. A named set would turn the unknown member into the thing this comment says
+            // must not happen.
+            _logger.LogWarning(
+                failed,
+                "A request moved and the entry for it could not be written to the server's activity log. The move itself was written and stands; what is lost is the line an operator would have read in the dashboard. {Entry}",
+                note.ShortOverview);
+        }
+    }
+}

--- a/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
@@ -11,6 +11,7 @@ using Jellyfin.Plugin.Requests.Storage;
 using Jellyfin.Plugin.Requests.Time;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Plugins;
+using MediaBrowser.Model.Activity;
 using MediaBrowser.Model.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -90,6 +91,14 @@ public sealed class PluginServiceRegistrator : IPluginServiceRegistrator
             provider.GetRequiredService<ILogger<WantHandover>>(),
             WantHandover.DefaultAnswerWithin));
 
+        // The record every move leaves behind, which is the server's own activity log rather than
+        // anything this plugin keeps. Registered beside the sink below and not instead of it: the
+        // sink is a courtesy that may be lost, and this is the line an operator reads afterwards in
+        // a dashboard they already have open.
+        serviceCollection.AddSingleton<IActivityJournal>(provider => new ServerActivityJournal(
+            provider.GetRequiredService<IActivityManager>(),
+            provider.GetRequiredService<ILogger<ServerActivityJournal>>()));
+
         // The one path anything this plugin has to say leaves the server on. Registered on every
         // install rather than only where an address is set, because whether one is set is a value in
         // a file an operator edits while the server is running, and a container built at startup
@@ -119,6 +128,7 @@ public sealed class PluginServiceRegistrator : IPluginServiceRegistrator
             provider.GetRequiredService<IRequestStore>(),
             provider.GetRequiredService<ILibrary>(),
             provider.GetRequiredService<IClock>(),
+            provider.GetRequiredService<IActivityJournal>(),
             provider.GetRequiredService<ILogger<FulfilmentSweep>>()));
 
         // The event half of the fulfilment check. A hosted service rather than something built when

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -45,7 +45,7 @@ work from this plugin. The interface is `IActivityManager`:
 
 This is the path that is always on, because it is a record rather than a message: nobody is
 interrupted by it and it is the thing an operator reads afterwards when somebody asks what happened.
-Issue #75 writes it.
+It is built, and what an entry says is the section below.
 
 **A message to a live session.** An administrator with the dashboard open is told that something
 arrived, through the connection the server already holds to that session. It reaches nobody who is
@@ -144,6 +144,61 @@ this plugin does not remember that it was. That is the right trade for a courtes
 for a record, which is why the record is the server's activity log and not this. An operator who
 needs to know what happened reads that log.
 
+## What an activity entry says
+
+One entry per transition and none for anything else. Asking for something is not a transition:
+nothing has been decided, the model appends no history entry for it, and an entry there would be this
+plugin announcing its own arrival in a list an operator reads for what the server did. Telling an
+administrator that something arrived is a live message and is #76. An observation that changed a
+title's availability without moving the request writes nothing here either, because a line per
+re-observation is the wall of entries this page's own rule refuses.
+
+Each entry is three pieces of text and a user, and they are built from four fields of the request:
+the two states, the identifier, the title snapshot, and who made the move.
+
+| Piece           | What it holds                                                                       |
+| --------------- | ----------------------------------------------------------------------------------- |
+| `Name`          | `Request approved: <title>`, with the title cut to a line                           |
+| `ShortOverview` | the two states, whether a person or the plugin moved it, and the request identifier |
+| `Type`          | `MediaRequest` followed by the state moved into, which is what a filter matches on  |
+| `UserId`        | the administrator who decided, or the empty identifier where the plugin observed    |
+
+The title is cut because it is a snapshot of what whoever asked typed and nothing caps it on the way
+here, so an entry built without the cut is one row of the activity list as long as somebody wanted it
+to be. What is cut is replaced by an ellipsis, so a reader can see that something was.
+
+**A move the plugin made says so in words as well as by the empty identifier.** The server's entity
+has no nullable user, so an entry that only left the identifier empty reads in the dashboard as an
+entry whose user could not be resolved, which is a different statement from nobody having decided
+anything.
+
+### What an entry never carries
+
+The note an operator types with a decline, and the note the requester wrote. Both can be five hundred
+characters, both are a message to one person, and the activity list is read by every administrator on
+the server.
+
+A credential and a path on the server's disk. Neither is reachable from where an entry is built: the
+only input is the request, and the configuration and the file system are not in scope there.
+
+The request identifier is in the text rather than in the entity's `ItemId`. That field is a library
+item on the server's side and the dashboard offers it as a link, so a request identifier there is a
+link to an item that does not exist.
+
+### What the entry is not proof of
+
+That an operator can read it in the dashboard. Nothing in the suite runs a server, which the headless
+rule in [`docs/testing.md`](testing.md) settles, so what is asserted is what this plugin asked to be
+written. Reading the entries back on a running server of each claimed line is the second condition of
+#75 and is a procedure somebody runs where a server can be started.
+
+### When the activity log itself refuses
+
+The move is in the store before the entry is attempted, so a decision is never undone by a log that
+would not take a line about it. The failure is reported to the server's log with the move in it and
+the call carries on. What is lost is the line an operator would have read in the dashboard, and this
+plugin holds nothing that would let it be written later.
+
 ## Why there is no fourth
 
 Because the fourth is the first of six. Growing an integration per messaging service is how a plugin
@@ -165,9 +220,9 @@ lands it is a plan for the other paths rather than a property of the code.
 
 ## What this page does not do
 
-It does not say what the other two paths send. The activity log's wording is #75's and the session
-message's shape is #76's, and each of those is where the text a person actually reads is decided. The
-sink's payload is above, because it is the one path that is built.
+It does not say what the session message sends. That shape is #76's, and it is where the text a
+person actually reads on that path is decided. The activity entry and the sink's payload are both
+above, because those are the two paths that are built.
 
 It does not decide what happens when a path fails. An outbound sink pointed at something that has
 stopped answering is #78's and #86's, and nothing here says a failure to notify may move a request.


### PR DESCRIPTION
Part of #75.

A decision made here left nothing behind that survived a restart. The history on the record is this plugin's own and is only readable through this plugin's own surfaces, so an operator asking what happened to a request last week had the server log or nothing. The activity log is where they already look, it is in the dashboard with no work from this side, and it is the one record on both claimed lines that outlives a restart.

## What lands

Three new types in `Notify/`. `ActivityNote` is the entry as text, built by a pure static from a move that has already happened. `IActivityJournal` is where one is written. `ServerActivityJournal` is the one place that names the host's activity manager, which keeps that reach in a single file the way `ServerKnownUsers` and `ServerLibrary` already do.

The write is wired at the two places a transition is made, which is `DecideAsync` in the controller for both operator decisions from a row and from a batch, and `LookAsync` in the fulfilment sweep for a request that moved because the library changed. Both write after the store accepted the move and never before, so an entry never claims a decision the store then refused.

An arrival writes nothing. Nothing has been decided, the model appends no history entry for it, and an entry there would be this plugin announcing itself in a list an operator reads for what the server did. Telling an administrator that something arrived is a live message and is #76.

## The host call, measured on both lines

The interface and the entity are the same shape on both claimed lines, read out of the packages each target framework compiles against with a `MetadataLoadContext` over the reference assemblies rather than from the server's source:

    ### MediaBrowser.Model.Activity.IActivityManager  [MediaBrowser.Model.dll]
        Task CreateAsync(Jellyfin.Database.Implementations.Entities.ActivityLog)
        Task<QueryResult<ActivityLogEntry>> GetPagedResultAsync(ActivityLogQuery)
        Task CleanAsync(System.DateTime)

    ### Jellyfin.Database.Implementations.Entities.ActivityLog  [Jellyfin.Database.Implementations.dll]
        System.Void .ctor(System.String, System.String, System.Guid)
        System.String Overview
        System.String ShortOverview
        System.String ItemId
        Microsoft.Extensions.Logging.LogLevel LogSeverity

Identical output for `jellyfin.model` and `jellyfin.database.implementations` at `10.11.11` on `net9.0` and at `12.0.0-rc4` on `net10.0`, which are the two versions `Jellyfin.Plugin.Requests.csproj` pins per framework. Both assemblies are already on the reference list in `SiblingIndependenceTests`, so this adds no Jellyfin assembly to the package.

## What an entry carries, and what it never does

`Name` is `Request approved: <title>` with the title cut to sixty characters and an ellipsis where it was cut. `ShortOverview` is the two states, whether a person or the plugin moved it, and the request identifier. `Type` is `MediaRequest` followed by the state moved into, which is what an operator filtering the list matches on. The user is the administrator who decided, or the empty identifier where the plugin observed, and in that case the text says so in words as well: the server's entity has no nullable user, so an entry that only left the identifier empty reads in the dashboard as one whose user could not be resolved.

The note an operator types with a decline is never in an entry, and neither is the requester's. Both can be five hundred characters, both are a message to one person, and the activity list is read by every administrator on the server. A credential and a path on the disk are not reachable from where an entry is built at all, because the only input is the request.

The request identifier is in the text and not in the entity's `ItemId`. That field is a library item on the server's side and the dashboard offers it as a link, so a request identifier there is a link to an item that does not exist.

## The suite

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
        0 Warnung(en)
        0 Fehler

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release --no-build
        Bestanden!   : Fehler: 0, erfolgreich: 552, gesamt: 552 (net9.0)
        Bestanden!   : Fehler: 0, erfolgreich: 552, gesamt: 552 (net10.0)

Those words are the runner's own, in German, because that is the language of the machine this ran on.

## Each guard watched failing

One at a time, rebuilt each time, with the suite filtered to the new legs. Every run below covers both target frameworks and the counts are per framework.

Removing the entry write from `DecideAsync`:

    Fehler: 4, erfolgreich: 1, gesamt: 5
    ARequestWalkedThroughItsLifeLeavesOneEntryPerTransition [FAIL]
    ADeclineWritesAnEntryCarryingNothingTheOperatorTyped [FAIL]
    AnObservationThatMovedNothingWritesNoEntry [FAIL]
    AnActivityLogThatRefusesTheWriteDoesNotUndoTheDecision [FAIL]

Removing the entry write from the sweep's `LookAsync`:

    Fehler: 1, erfolgreich: 4, gesamt: 5
    ARequestWalkedThroughItsLifeLeavesOneEntryPerTransition [FAIL]

Removing the guard that returns nothing when the two states are the same:

    Fehler: 1, erfolgreich: 4, gesamt: 5
    AnObservationThatMovedNothingWritesNoEntry [FAIL]

Removing the catch in `ServerActivityJournal`:

    Fehler: 1, erfolgreich: 5, gesamt: 6
    AnActivityLogThatRefusesTheWriteDoesNotUndoTheDecision [FAIL]

The title cut, with the comparison moved by one character:

    Fehler: 1, erfolgreich: 5, gesamt: 6
    ATitleLongerThanAnEntryCarriesIsCutAndSaysSo(length: 61, cut: True) [FAIL]

That last one is why the leg is a pair rather than one case. Written only against a title far longer than the cap, it passed with the comparison off by one in either direction, because the cut lands in the same place either way. The two lengths that pin it are the cap and one character past it, and the first version of the leg was watched passing under the mistake before it was changed.

## What this does not close

The second condition of #75, that the entries are readable in the dashboard on both claimed server lines. Nothing in the suite runs a server, which the headless rule in `docs/testing.md` settles, so what is asserted here is what this plugin asked to be written. That condition is a procedure against a running server in the shape `scripts/verify-plugin-loads.sh` already uses, and the container engine on the machine this was made on is not answering:

    docker version --format '{{.Server.Version}}'
    failed to connect to the docker API at npipe:////./pipe/dockerDesktopLinuxEngine

So this says `Part of #75` rather than closing it.

## One thing that reached outside the issue's declared scope

`Scope:` on #75 names the notification code and the test project. The wiring reaches `Api/RequestsController.cs`, `Fulfilment/FulfilmentSweep.cs` and `PluginServiceRegistrator.cs`, because the issue's first condition is that every transition appends an entry and those are where the transitions are made. The reach is one line at each of the two move sites plus a constructor argument, and the alternative was landing a journal nothing calls.

`System.Memory` joins the exact reference list in `SiblingIndependenceTests`, and it is not a choice. CA1846 refuses the substring that cuts a long title, and the analyzer posture in `Directory.Build.props` makes that refusal a build failure, so the span overload is forced and the facade comes with it. It is a facade over the runtime the server already runs on and is excluded from the install with the rest. The list caught the addition before anything else did, which is the list doing its job.

## Not read by anybody else

Nothing here had a second reader. The evidence above is what stands in place of one.
