### PR TITLE
Say where a bridge credential would live and what may be claimed about it

### DIFF
--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -9,8 +9,8 @@ It is not the whole of the bridge. The interface is
 [`IRequestBackend`](../Jellyfin.Plugin.Requests/Bridge/IRequestBackend.cs), the implementation every
 server without a service runs is
 [`NoRequestBackend`](../Jellyfin.Plugin.Requests/Bridge/NoRequestBackend.cs), and how a submission is
-made, what happens when the service misbehaves and where a credential lives are separate questions
-this page does not answer.
+made and what happens when the service misbehaves are separate questions this page does not answer.
+Where a credential lives is answered at the end of it.
 
 ## The mapping
 
@@ -148,6 +148,79 @@ where the judgement is written down for a reader.
 The other half of the same claim is that only one implementation ships. Every server this plugin runs
 on resolves `NoRequestBackend` until an adapter replaces that one registration, and the suite refuses
 a second implementation arriving in the plugin assembly unnamed for the same reason.
+
+## Where a credential would live, and what may be claimed about it
+
+**There is no credential today and nothing here holds one.** The only implementation of the bridge in
+this tree is the one for a server that has no service, it makes no call, and the configuration
+carries no field for an address or for a secret. Everything below is what will be true the day the
+adapter in #82 adds one, written now so that it is a position rather than a description written
+afterwards to fit whatever was built.
+
+### Where it goes
+
+In the settings file, beside every other setting. That is the row already written down in
+[`storage.md`](storage.md), `plugin-configurations/Jellyfin.Plugin.Requests.xml` under the server's
+own data directory, and it is where it goes because it is where the server puts a plugin's
+configuration. The host decides that and this plugin does not choose it:
+
+    ### MediaBrowser.Common.Plugins.BasePlugin`1  [MediaBrowser.Common.dll]
+        System.String get_ConfigurationFilePath()
+        System.Void SaveConfiguration(TConfigurationType)
+
+    ### MediaBrowser.Common.Configuration.IApplicationPaths  [MediaBrowser.Common.dll]
+        System.String get_PluginConfigurationsPath()
+
+Read out of the reference assemblies each target framework compiles against, `jellyfin.common` at
+`10.11.11` on `net9.0` and at `12.0.0-rc4` on `net10.0`, with identical output on both. A plugin that
+wrote its secret somewhere else would be a plugin whose secret is not in the operator's backup and
+not in their restore, which is a worse failure than the one it would be avoiding.
+
+### Who on the machine can read it
+
+Everybody who can read that file, and the list is longer than an operator expects.
+
+The account the server runs as, which is what reads it on every start. Anybody with administrative
+rights on the machine. Anybody holding a backup of the server's data directory, because the file is
+in it by design and the row in `storage.md` says it is required. Any other plugin loaded into the
+same server process, which can read the file directly, and that is the same position
+[`seam.md`](seam.md) takes about a caller inside the process: anything in there can already read this
+plugin's files.
+
+And an administrator of the server over the API, because the dashboard reads a plugin's configuration
+back in order to render its page. This plugin's own page does exactly that for the settings that
+exist today:
+
+    git grep -n "getPluginConfiguration" -- Jellyfin.Plugin.Requests/Configuration/configPage.html
+    Jellyfin.Plugin.Requests/Configuration/configPage.html:145:                                return ApiClient.getPluginConfiguration(RequestsConfig.pluginUniqueId);
+    Jellyfin.Plugin.Requests/Configuration/configPage.html:158:                        ApiClient.getPluginConfiguration(RequestsConfig.pluginUniqueId)
+
+So the protection a credential gets here is the protection the server's data directory gets, and this
+page claims no more than that.
+
+### What is refused by name
+
+**Encrypting it at rest with a key on the same disk.** The key has to be readable by the same process
+that reads the file, so anything that can read one can read the other, and what it buys is the
+appearance of protection. That is worse than buying nothing: a page saying the credential is
+encrypted changes what an operator does about a stolen backup. It is refused here rather than left as
+an idea somebody has later and half builds.
+
+**A second place to put it.** An environment variable or a file of its own would be somewhere the
+operator's backup does not reach and somewhere the dashboard cannot show, which trades one honest
+exposure for two ways to lose the value.
+
+### What is claimed
+
+Four things, and each is a rule about this plugin's own code rather than about the machine. It is
+never written to a log. It is never included in anything a diagnostics route produces. It is never
+returned to a page or an endpoint that does not need it. And it is never sent anywhere except the
+service the operator configured.
+
+**None of the four is enforced, because there is nothing yet to enforce them over.** The lint rule
+that would refuse a log or a diagnostics call reaching it, and the test that would assert it does not
+appear in a log written during a bridge failure, are the other two conditions of #85, and both
+quantify over a value that does not exist. They land with the adapter in #82 and not before.
 
 ## Where the list of words came from
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -103,9 +103,12 @@ Nothing has to be configured for the plugin to be usable: a person can ask for a
 an operator sees it in the queue and answers it, and the library is what says a request was
 fulfilled.
 
-Nothing is sent anywhere. The outbound notification sink exists and has nowhere to send to, because
+Nothing leaves the server. The outbound notification sink exists and has nowhere to send to, because
 `OutboundNoticeAddress` is empty until an operator types one; there is no credential to hold and no
-other path that could carry anything, since the bridge adapter is #82 and is not built.
+other path that could carry anything, since the bridge adapter is #82 and is not built. What does
+happen on a fresh install is that every transition is written to the server's own activity log, which
+stays on the machine and is a record rather than a message. What an entry says is
+[`notifications.md`](notifications.md).
 `NoRequestBackend` is what a server without an external request service runs, and it is what every
 server runs today.
 
@@ -115,14 +118,18 @@ server runs today.
 as a per-user setting rather than a switch for the whole server, so a boolean here would be the
 wrong shape rather than an early version of the right one.
 
-**Notification switches.** One notification path exists and it is turned off by having nowhere to
-send to, which is `OutboundNoticeAddress` above rather than a switch beside it. The rest are unbuilt,
-and switches for paths that do not exist would be settings an operator can change with no effect,
-which is worse than their absence. They land with the paths, in #79.
+**Notification switches.** Two paths exist and neither has a switch. The activity log is always on
+and is meant to be: it is a record rather than a message, it stays on the server, and an operator who
+could turn it off would be able to lose the answer to what happened to a request. The outbound sink
+is turned off by having nowhere to send to, which is `OutboundNoticeAddress` above rather than a
+switch beside it. The rest are unbuilt, and switches for paths that do not exist would be settings an
+operator can change with no effect, which is worse than their absence. They land with the paths, in
+#79.
 
 **A bridge address and a credential.** The only bridge in this tree is the one for a server that has
 none. A field for an address would be somewhere to type something nothing reads. #82 brings the
-adapter, and #85 decides where a credential is kept and what may honestly be claimed about it.
+adapter; where a credential is kept when there is one, who on the machine can read it, and what is
+refused by name are in [`bridge.md`](bridge.md).
 
 ## What an uninstall leaves behind
 


### PR DESCRIPTION
Part of #85. Part of #75.

Two documents, and both are about saying what is true of a path or a value that is not built yet, which is the one point at which such a sentence can be written without already contradicting something.

## The credential position, which is #85's third condition

`docs/bridge.md` now ends with where a bridge credential goes, who on the machine can read it, what is refused by name, and what is claimed about it.

It goes in the settings file, which is the row `docs/storage.md` already carries and which the server decides the location of rather than this plugin choosing it:

    ### MediaBrowser.Common.Plugins.BasePlugin`1  [MediaBrowser.Common.dll]
        System.String get_ConfigurationFilePath()
        System.Void SaveConfiguration(TConfigurationType)

    ### MediaBrowser.Common.Configuration.IApplicationPaths  [MediaBrowser.Common.dll]
        System.String get_PluginConfigurationsPath()

Read out of the reference assemblies each target framework compiles against, `jellyfin.common` at `10.11.11` on `net9.0` and at `12.0.0-rc4` on `net10.0`, with identical output on both.

Who can read it is everybody who can read that file, and the page lists them rather than summarising: the account the server runs as, anybody with administrative rights on the machine, anybody with a backup of the data directory, any other plugin in the same process, and an administrator over the API, because the dashboard reads a plugin's configuration back to render its page. That last one is not an assumption about the server, it is what this plugin's own page does today:

    git grep -n "getPluginConfiguration" -- Jellyfin.Plugin.Requests/Configuration/configPage.html
    Jellyfin.Plugin.Requests/Configuration/configPage.html:145:                                return ApiClient.getPluginConfiguration(RequestsConfig.pluginUniqueId);
    Jellyfin.Plugin.Requests/Configuration/configPage.html:158:                        ApiClient.getPluginConfiguration(RequestsConfig.pluginUniqueId)

Encrypting it at rest with a key on the same disk is refused by name, which is what #85 asks for in those words, and so is putting it anywhere other than the settings file.

## The four claims, and that none of them is enforced

The page claims the credential is never logged, never in a diagnostics document, never returned where it is not needed, and never sent anywhere but the configured service. It then says in bold that none of the four is enforced, because there is nothing yet to enforce them over. That is the negative disclosure this issue's other two conditions rest on, and it says so rather than leaving a reader to infer it from the absence of a check.

## The sentence my own change made false

`docs/configuration.md` said that one notification path exists and that it is turned off by having nowhere to send to. That was true until the activity log path landed in #234 and it is not now. Two paths exist, the activity log is always on, and it is meant to be, because an operator who could turn it off would be able to lose the answer to what happened to a request. The fresh-install section also said nothing is sent anywhere, when what it means is that nothing leaves the server, and something is now written on every transition.

The same page pointed at #85 for where a credential is kept. It points at `bridge.md` instead, which now holds the answer.

## What this does not close

#85 stays open on its first two conditions, and both wait on the same thing. The lint rule that would refuse a log or a diagnostics call reaching the credential, and the test that would assert it does not appear in a log written during a bridge failure, quantify over a value that does not exist:

    git grep -n "class .*IRequestBackend" -- Jellyfin.Plugin.Requests/
    Jellyfin.Plugin.Requests/Bridge/NoRequestBackend.cs:23:public sealed class NoRequestBackend : IRequestBackend

One implementation and it is the one for a server with no service. Both land with the adapter in #82.

#75 stays open on its second condition, which is a running server rather than anything in a document.

## The suite

Documents only, and no code changed, so this is the suite unmoved rather than evidence for anything here:

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release
        Bestanden!   : Fehler: 0, erfolgreich: 552, gesamt: 552 (net9.0)
        Bestanden!   : Fehler: 0, erfolgreich: 552, gesamt: 552 (net10.0)

Those words are the runner's own, in German, because that is the language of the machine this ran on.

One thing found while formatting, worth knowing before somebody else meets it. The command block under "who can read it" was first written inside a bullet, and Prettier is not idempotent on an indented code block nested in a list item: each pass added two spaces of indentation, so a formatted file would still fail the check. It is a paragraph-level block now and two passes leave it identical.

## Not read by anybody else

Nothing here had a second reader. The commands above are what stands in place of one.
