### PR TITLE
Serve a person their own requests in a browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ what came before it. What landed before this file existed is in the git history,
 where it carries the pull request and the issue it came from, and rewriting it
 from memory into entries would be a description nobody measured.
 
+- A person signed in to the server can open a page in a browser and see what
+  they asked for and what happened to it, at `MediaRequests/v1/Page`. It shows
+  their own requests only, offers no decision, and is refused to a caller with
+  no session. What it costs to open one in a browser, which is a credential in
+  the address, is in [docs/surface.md](docs/surface.md).
+
 - The version starts at `0.1.0.0`. It was `1.0.0.0`, inherited from the
   template, which claimed a released first version of a plugin that has never
   been released.

--- a/Jellyfin.Plugin.Requests.Tests/Api/EndpointPolicyTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/EndpointPolicyTests.cs
@@ -65,6 +65,13 @@ public sealed class EndpointPolicyTests
         // an install accepts is a fact about somebody's server rather than about this version.
         "CapabilitiesController.CapabilitiesAsync GET Capabilities -> (the server's default)",
 
+        // The page a person opens in a browser to see their own requests. A signed-in person, and
+        // it is the policy that makes the page a page rather than a shell: a caller the server has
+        // not authenticated is turned away instead of being handed the document and left to meet
+        // the refusal on its first call. Nothing elevated is reachable from it, because everything
+        // it draws comes from the endpoint below that has nothing but the caller's own to return.
+        "MyRequestsPageController.Page GET Page -> (the server's default)",
+
         // Saying yes. A decision is an administrator's, in the transition table and here, and the
         // two answers have to agree: an endpoint reachable by a signed-in user would refuse every
         // such call in the model, which is a permission decided in two places.

--- a/Jellyfin.Plugin.Requests.Tests/Api/PublishedApiDocumentTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/PublishedApiDocumentTests.cs
@@ -77,6 +77,12 @@ public sealed class PublishedApiDocumentTests
         // before anybody configures anything.
         "GET MediaRequests/v1/Capabilities () -> 200:InstallCapabilities",
 
+        // The page a browser opens. One status and one shape, and the shape is a string because
+        // what comes back is a document rather than a record: a generated client that expected a
+        // record here would parse the markup. It refuses nothing of its own, so it publishes no
+        // failure; who may reach it is the server's evaluation of the policy and is not an answer.
+        "GET MediaRequests/v1/Page () -> 200:String",
+
         // One person's own requests. The parameters are the same six the queue takes, because the
         // difference between the two reads is what the store is asked rather than what the caller
         // may ask for.
@@ -260,6 +266,7 @@ public sealed class PublishedApiDocumentTests
         var unreadable = new StoreThatCannotBeRead();
 
         const string Capabilities = "GET MediaRequests/v1/Capabilities";
+        const string BrowserPage = "GET MediaRequests/v1/Page";
         const string Create = "POST MediaRequests/v1/Requests";
         const string Mine = "GET MediaRequests/v1/Requests";
         const string Queue = "GET MediaRequests/v1/Requests/Queue";
@@ -276,6 +283,11 @@ public sealed class PublishedApiDocumentTests
             await new CapabilitiesController(new FakeInstallSettings(), new NoRequestBackend())
                 .CapabilitiesAsync(CancellationToken.None)
                 .ConfigureAwait(true));
+
+        // The page. One call and one status: it reads no store and refuses nothing of its own, and
+        // the only way it answers with anything else is by being served out of an assembly that
+        // does not carry it, which raises rather than answering.
+        SawPage(BrowserPage, new MyRequestsPageController().Page());
 
         // Asking for something. The same body twice: the first is a new request and the second is
         // the caller already waiting for it, which is the endpoint's other success code.
@@ -339,7 +351,14 @@ public sealed class PublishedApiDocumentTests
 
         return answered;
 
-        void Saw<T>(string endpoint, ActionResult<T> came)
+        void Saw<T>(string endpoint, ActionResult<T> came) => Answered(endpoint, Status(came));
+
+        // The page answers with a document rather than a record, so it comes back as a result that
+        // carries its own content type instead of one the framework serialises. That is why it has
+        // a walk of its own here rather than going through the one above.
+        void SawPage(string endpoint, ContentResult came) => Answered(endpoint, came.StatusCode ?? 200);
+
+        void Answered(string endpoint, int status)
         {
             if (!answered.TryGetValue(endpoint, out var statuses))
             {
@@ -347,7 +366,7 @@ public sealed class PublishedApiDocumentTests
                 answered[endpoint] = statuses;
             }
 
-            statuses.Add(Status(came));
+            statuses.Add(status);
         }
     }
 

--- a/Jellyfin.Plugin.Requests.Tests/Web/BrowserPageTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Web/BrowserPageTests.cs
@@ -1,0 +1,269 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net.Mime;
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using Jellyfin.Plugin.Requests.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Xunit;
+
+using PluginUnderTest = global::Jellyfin.Plugin.Requests.Plugin;
+
+namespace Jellyfin.Plugin.Requests.Tests.Web;
+
+/// <summary>
+/// The page a person opens in a browser, held to what it may show and what it may reach.
+/// <para>
+/// The failure this exists against is the one a page of this kind walks into: it is built beside an
+/// administrator's queue, out of the same records, and the difference between the two is a decision
+/// about which fields are drawn and which endpoint is called. Neither difference is visible in a
+/// browser until the wrong person is looking at it.
+/// </para>
+/// <para>
+/// <b>The bound, and it is the same one every check over these assets carries.</b> Nothing here
+/// runs a browser and nothing here runs a server, which the headless rule in <c>docs/testing.md</c>
+/// settles and whose refusal list names the replacement. So what is held is that the page asks this
+/// plugin for one thing, that everything it draws is a field of the answer to that one thing, and
+/// that it offers no decision. That a caller with no session is turned away is the server's
+/// evaluation of the policy on the endpoint, and what is held here is that the policy is on it.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class BrowserPageTests
+{
+    /// <summary>
+    /// The elements a browser gives a person something to operate. Anything a page offers a
+    /// decision through is one of these, which is why the assertion is over them rather than over
+    /// the words on the page.
+    /// </summary>
+    private static readonly string[] Operable = ["<button", "<form", "<input", "<select", "<textarea"];
+
+    /// <summary>
+    /// A field of a request as the page names it while drawing a row.
+    /// </summary>
+    private static readonly Regex Drawn = new Regex(
+        @"request\.(?<field>[A-Za-z][A-Za-z0-9]*)",
+        RegexOptions.CultureInvariant,
+        TimeSpan.FromSeconds(5));
+
+    /// <summary>
+    /// The endpoint answers with the document the assembly carries, as HTML.
+    /// <para>
+    /// Read out of the manifest rather than off the working tree, because what a server returns is
+    /// the embedded copy: a page left out of the packaging builds clean and is a 500 on somebody's
+    /// server the first time a user opens it.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void TheEndpointAnswersWithThePageTheAssemblyCarries()
+    {
+        var answered = new MyRequestsPageController().Page();
+
+        Assert.Equal(MediaTypeNames.Text.Html, answered.ContentType, StringComparer.Ordinal);
+        Assert.Equal(200, answered.StatusCode);
+        Assert.Equal(Page(), answered.Content, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// The page is behind the server's own authentication rather than served to anybody.
+    /// <para>
+    /// A shell handed to a caller with no session and left to fail on its first call puts this
+    /// plugin's existence and shape in front of somebody who has not signed in, and reads to a
+    /// person as a broken page rather than as a closed door. The attribute is what the server
+    /// evaluates, so this reads the attribute; the invariant lint refuses the one attribute that
+    /// would turn it off, and this is the half that would still see it if the lint were not run.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void NothingOfThePageIsServedWithoutASession()
+    {
+        var action = PageAction();
+
+        Assert.Empty(action.GetCustomAttributes<AllowAnonymousAttribute>(inherit: true));
+        Assert.Empty(typeof(MyRequestsPageController).GetCustomAttributes<AllowAnonymousAttribute>(inherit: true));
+
+        var policies = action
+            .GetCustomAttributes<AuthorizeAttribute>(inherit: false)
+            .Select(authorize => authorize.Policy)
+            .ToArray();
+
+        // One attribute, and the policy on it is the server's own default rather than a name. There
+        // is no registered name for "any signed-in person", which is what docs/api.md sets out and
+        // what the endpoint that shipped a name for it cost.
+        Assert.Single(policies);
+        Assert.Null(policies[0]);
+    }
+
+    /// <summary>
+    /// The page asks this plugin for one thing and it is the caller's own requests.
+    /// <para>
+    /// The address is built against the page's own, so what is asserted is the relative part and
+    /// that there is one of it. A second call added to this page is a second thing a user's browser
+    /// asks for on their behalf, and it is the shape by which an administrator's answer arrives on
+    /// a page that was never meant to hold one.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void ThePageAsksForNothingButTheCallersOwnRequests()
+    {
+        var body = Page();
+
+        Assert.Equal(1, Occurrences(body, "fetch("));
+        Assert.Equal(1, Occurrences(body, "new URL("));
+        Assert.Contains(@"new URL(""Requests"", window.location.href)", body, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Nothing an administrator reaches is named on this page.
+    /// <para>
+    /// The elevated endpoints are read off the assembly rather than listed here, so an endpoint
+    /// added under elevation is covered by this the first time the suite runs rather than when
+    /// somebody remembers to extend a list. What it refuses is the route appearing on the page at
+    /// all, which is one step in front of the page calling it.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void NoRouteThatNeedsAnAdministratorAppearsOnThePage()
+    {
+        var body = Page();
+        var elevated = Elevated();
+
+        var named = elevated.Where(route => body.Contains(route, StringComparison.Ordinal)).ToArray();
+
+        Assert.NotEmpty(elevated);
+        Assert.Empty(named);
+    }
+
+    /// <summary>
+    /// Every field the page draws is one the caller's own answer carries.
+    /// <para>
+    /// This is the leg that holds the disclosure rather than the call. <c>MyRequest</c> names
+    /// nobody, so a page that can only draw its fields cannot draw a person; a row reaching for
+    /// something the queue's own shape carries, such as who asked, fails here rather than in a
+    /// browser. It also catches the field that is simply misspelled, which draws an empty cell and
+    /// looks like a request with nothing in it.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void EveryFieldThePageDrawsIsOneTheCallersOwnAnswerCarries()
+    {
+        var body = Page();
+
+        var carried = typeof(MyRequest)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Select(property => property.Name)
+            .ToArray();
+
+        var fields = Drawn
+            .Matches(body)
+            .Select(found => found.Groups["field"].Value)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(field => field, StringComparer.Ordinal)
+            .ToArray();
+
+        var outside = fields.Where(field => !carried.Contains(field, StringComparer.Ordinal)).ToArray();
+
+        Assert.NotEmpty(fields);
+        Assert.Empty(outside);
+    }
+
+    /// <summary>
+    /// The page offers no way to decide anything.
+    /// <para>
+    /// A control is how a decision arrives on a page, and this one has none: everything it could
+    /// offer is either an administrator's or waits on a state a request can be withdrawn into,
+    /// which is an open decision on #113. So the assertion is over the elements a person can
+    /// operate rather than over the words on the page, and it reds the moment one is added.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void ThePageCarriesNoControlAPersonCanOperate()
+    {
+        var body = Page();
+
+        var carried = Operable
+            .Where(element => body.Contains(element, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+
+        Assert.Empty(carried);
+        Assert.DoesNotContain(@"method: ""POST""", body, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The routes of every endpoint this plugin serves that needs an administrator.
+    /// </summary>
+    /// <returns>The templates, as they are written on the actions.</returns>
+    private static string[] Elevated()
+    {
+        return [.. typeof(RequestsControllerBase).Assembly
+            .GetTypes()
+            .Where(type => typeof(RequestsControllerBase).IsAssignableFrom(type) && !type.IsAbstract)
+            .SelectMany(type => type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+            .Where(method => method.GetCustomAttributes<AuthorizeAttribute>(inherit: false)
+                .Any(authorize => authorize.Policy is not null))
+            .SelectMany(method => method.GetCustomAttributes<HttpMethodAttribute>(inherit: false))
+            .Select(http => http.Template ?? string.Empty)
+            .Where(template => template.Length > 0)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(template => template, StringComparer.Ordinal)];
+    }
+
+    /// <summary>
+    /// The action that serves the page.
+    /// </summary>
+    /// <returns>The method.</returns>
+    private static MethodInfo PageAction()
+        => typeof(MyRequestsPageController).GetMethod(nameof(MyRequestsPageController.Page))
+            ?? throw new InvalidOperationException("The controller that serves the page carries no action for it.");
+
+    /// <summary>
+    /// The page as the built assembly carries it.
+    /// </summary>
+    /// <returns>The document.</returns>
+    private static string Page()
+    {
+        var assembly = typeof(PluginUnderTest).Assembly;
+        var name = string.Format(
+            CultureInfo.InvariantCulture,
+            "{0}.{1}",
+            typeof(PluginUnderTest).Namespace,
+            MyRequestsPageController.PageResource);
+
+        using var stream = assembly.GetManifestResourceStream(name)
+            ?? throw new InvalidOperationException($"The assembly carries no resource named {name}.");
+
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+
+        return reader.ReadToEnd();
+    }
+
+    /// <summary>
+    /// How many times one string appears in another.
+    /// </summary>
+    /// <param name="body">What to look in.</param>
+    /// <param name="looked">What to look for.</param>
+    /// <returns>The count.</returns>
+    private static int Occurrences(string body, string looked)
+    {
+        var found = 0;
+        var at = body.IndexOf(looked, StringComparison.Ordinal);
+
+        while (at >= 0)
+        {
+            found++;
+            at = body.IndexOf(looked, at + looked.Length, StringComparison.Ordinal);
+        }
+
+        return found;
+    }
+}

--- a/Jellyfin.Plugin.Requests/Api/MyRequestsPageController.cs
+++ b/Jellyfin.Plugin.Requests/Api/MyRequestsPageController.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Net.Mime;
+using System.Text;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Jellyfin.Plugin.Requests.Api;
+
+/// <summary>
+/// The page a person opens in a browser to see what they asked for.
+/// <para>
+/// <b>The dashboard cannot be it.</b> A plugin's pages live in the dashboard, the dashboard is the
+/// administrator's, and the queue page this plugin registers there is elevated by construction. So a
+/// user on a browser has no page at all unless this plugin serves one, which is what this endpoint
+/// does: a document returned from the same API the rest of this plugin answers on, under the same
+/// versioned prefix, behind the same authentication.
+/// </para>
+/// <para>
+/// <b>It is refused rather than served empty to a caller with no session.</b> The endpoint carries
+/// the server's default policy, so a caller the server has not authenticated never reaches the
+/// document. A shell served to anybody and left to fail on its first call would put this plugin's
+/// existence, its version and its shape in front of somebody who has not signed in, and would look
+/// to a person like a broken page rather than a closed door.
+/// </para>
+/// <para>
+/// <b>A browser navigating to an address sends no Jellyfin session.</b> A session here is a header
+/// or a query value and not a cookie, so a person opening this page in a new tab reaches it with the
+/// credential in the address. The server reads <c>api_key</c> from the query string on both claimed
+/// lines. What that costs, and it is a real cost, is in <c>docs/surface.md</c>: the value lands in
+/// the browser's history and in whatever log sits in front of the server. This endpoint neither
+/// creates that credential nor extends it, and the page it returns carries it no further than the
+/// one call it makes for the caller's own requests.
+/// </para>
+/// <para>
+/// A controller of its own rather than another action beside the queue, for the reason
+/// <see cref="CapabilitiesController"/> is one: it reads no request, needs no store and no clock,
+/// and putting it there would give the page the store's dependencies and give every store test a
+/// page to carry.
+/// </para>
+/// </summary>
+[Authorize]
+public sealed class MyRequestsPageController : RequestsControllerBase
+{
+    /// <summary>
+    /// The embedded document this endpoint answers with, relative to the plugin's own namespace.
+    /// <para>
+    /// It is a constant because the suite reads the same resource to hold the page to what it may
+    /// and may not do, and two spellings of one resource name is a check that passes over a
+    /// document nobody serves.
+    /// </para>
+    /// </summary>
+    public const string PageResource = "Web.mine.html";
+
+    /// <summary>
+    /// The page as the assembly carries it, read once.
+    /// <para>
+    /// Once rather than per call, because it is a file inside the assembly and cannot change while
+    /// the server is running, and a page read from the manifest on every request is a stream opened
+    /// once per person looking at their requests.
+    /// </para>
+    /// </summary>
+    private static readonly Lazy<string> Document = new Lazy<string>(Read);
+
+    /// <summary>
+    /// The page, for the person who is signed in.
+    /// </summary>
+    /// <returns>
+    /// The document, as HTML. It carries no request in itself: what it holds is the markup and the
+    /// script that asks this plugin for the caller's own requests, so the answer to who may see what
+    /// is decided by that endpoint rather than a second time here.
+    /// </returns>
+    [HttpGet("Page")]
+    [Authorize]
+    [Produces(MediaTypeNames.Text.Html)]
+    [ProducesResponseType<string>(StatusCodes.Status200OK)]
+    public ContentResult Page()
+    {
+        return new ContentResult
+        {
+            Content = Document.Value,
+            ContentType = MediaTypeNames.Text.Html,
+            StatusCode = StatusCodes.Status200OK
+        };
+    }
+
+    /// <summary>
+    /// The document out of the assembly.
+    /// </summary>
+    /// <returns>The page.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Where the assembly carries no such resource, which is a packaging failure rather than
+    /// anything a caller did. It is raised rather than answered as an empty page, because a blank
+    /// document with a 200 on it is the shape somebody spends an afternoon on.
+    /// </exception>
+    private static string Read()
+    {
+        var assembly = typeof(Plugin).Assembly;
+        var name = string.Format(
+            CultureInfo.InvariantCulture,
+            "{0}.{1}",
+            typeof(Plugin).Namespace,
+            PageResource);
+
+        using var stream = assembly.GetManifestResourceStream(name)
+            ?? throw new InvalidOperationException(
+                "This plugin was built without the page it serves to a browser, so there is nothing to return. The resource is " + name + ".");
+
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+
+        return reader.ReadToEnd();
+    }
+}

--- a/Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.csproj
+++ b/Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.csproj
@@ -40,6 +40,11 @@
     <EmbeddedResource Include="Web\shell.js" />
     <None Remove="Web\shell.css" />
     <EmbeddedResource Include="Web\shell.css" />
+    <!-- The page a person opens in a browser. It is embedded like the others and registered like
+         none of them: the dashboard serves what GetPages registers and the dashboard is the
+         administrator's, so this one is served by MyRequestsPageController instead. -->
+    <None Remove="Web\mine.html" />
+    <EmbeddedResource Include="Web\mine.html" />
   </ItemGroup>
 
 </Project>

--- a/Jellyfin.Plugin.Requests/Web/mine.html
+++ b/Jellyfin.Plugin.Requests/Web/mine.html
@@ -1,0 +1,259 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>My requests</title>
+
+        <!--
+            The style is here rather than in the shared stylesheet the dashboard pages use. That
+            file is reachable only under a name registered as a plugin page, and the dashboard
+            serves those to an administrator, so a user opening this page would meet a refusal
+            instead of a stylesheet. The same is true of the shared script, which is why nothing
+            below reaches for it either.
+        -->
+        <style>
+            :root {
+                color-scheme: light dark;
+            }
+
+            body {
+                font-family: system-ui, sans-serif;
+                margin: 0;
+                padding: 1.5rem;
+                line-height: 1.5;
+            }
+
+            h1 {
+                font-size: 1.5rem;
+                margin-top: 0;
+            }
+
+            table {
+                border-collapse: collapse;
+                width: 100%;
+            }
+
+            caption {
+                text-align: left;
+                padding-bottom: 0.5rem;
+            }
+
+            th,
+            td {
+                border-bottom: 1px solid rgba(128, 128, 128, 0.4);
+                padding: 0.4rem 0.6rem;
+                text-align: left;
+                vertical-align: top;
+            }
+        </style>
+    </head>
+    <body>
+        <main id="RequestsMinePage">
+            <h1>My requests</h1>
+
+            <!--
+                What this page is and is not. It shows one person their own requests and offers no
+                decision, because a decision is an administrator's and the endpoints that make one
+                require elevation. The reason it holds no control at all is that everything it
+                could offer is either an administrator's or waits on a state this plugin does not
+                have: cancelling something still open needs a state a request can be withdrawn
+                into, which is an open decision on #113.
+            -->
+            <p class="requestsMineMessage" role="status"></p>
+
+            <table>
+                <caption class="requestsMineSummary" aria-live="polite"></caption>
+                <thead>
+                    <tr>
+                        <th scope="col">Title</th>
+                        <th scope="col">Kind</th>
+                        <th scope="col">Where it stands</th>
+                        <th scope="col">Asked for</th>
+                        <th scope="col">Last moved</th>
+                        <th scope="col">In the library</th>
+                        <th scope="col">Your note</th>
+                        <th scope="col">Why</th>
+                    </tr>
+                </thead>
+                <tbody class="requestsMineRows"></tbody>
+            </table>
+        </main>
+
+        <script type="text/javascript">
+            (function () {
+                var page = document.querySelector("#RequestsMinePage");
+                var rows = page.querySelector(".requestsMineRows");
+                var summary = page.querySelector(".requestsMineSummary");
+                var message = page.querySelector(".requestsMineMessage");
+
+                /*
+                 * The largest page the endpoint serves. This page asks for it in one call and has
+                 * no pager, because a pager is a control and the only thing this page is for is
+                 * reading. Where somebody has more requests than that, the caption below says how
+                 * many matched as well as how many are drawn, so a person is never shown a
+                 * shortened list that reads as the whole of it.
+                 */
+                var most = 200;
+
+                /*
+                 * The words a person reads, per value the endpoint answers with. A value this page
+                 * has no word for is shown as it came rather than dropped, so a state added to the
+                 * model appears here as its own name instead of as a blank cell.
+                 */
+                var states = {
+                    Open: "Waiting for an answer",
+                    Approved: "Approved",
+                    Declined: "Declined",
+                    Fulfilled: "In the library",
+                    Failed: "Could not be obtained",
+                };
+
+                var kinds = { Movie: "Film", Series: "Series" };
+
+                var reasons = {
+                    Other: "Another reason",
+                    AlreadyInTheLibrary: "Already in the library",
+                    AlreadyRequested: "Already asked for",
+                    CannotBeObtained: "Cannot be obtained",
+                    NotWanted: "Not wanted",
+                    NoRoomForIt: "No room for it",
+                };
+
+                var availability = {
+                    Unknown: "Not checked",
+                    Absent: "No",
+                    Partial: "In part",
+                    Present: "Yes",
+                };
+
+                /*
+                 * Where this page reads from, resolved against its own address rather than built
+                 * from a host and a path. The endpoint that answers with the caller's own requests
+                 * is this page's sibling under the same versioned prefix, so a server behind a base
+                 * path is followed without this page knowing there is one.
+                 *
+                 * The credential is the one this page was opened with and is carried no further
+                 * than the call. A browser navigating to an address sends no Jellyfin session, so
+                 * the only way to reach an authenticated page in one is in the address itself; the
+                 * server reads it from there on both claimed lines. Nothing here stores it, and
+                 * docs/surface.md says plainly what that costs.
+                 */
+                function address() {
+                    var asked = new URL("Requests", window.location.href);
+                    var opened = new URLSearchParams(window.location.search);
+                    var carried = opened.get("api_key") || opened.get("ApiKey");
+
+                    asked.searchParams.set("take", String(most));
+
+                    if (carried) {
+                        asked.searchParams.set("api_key", carried);
+                    }
+
+                    return asked;
+                }
+
+                /*
+                 * One cell, with the string put in as a string. A title and a note are things a
+                 * person typed, and a page that turned either into markup would be a scripting hole
+                 * reachable by anybody who can file a request.
+                 */
+                function cell(row, text) {
+                    var target = document.createElement("td");
+                    target.textContent = text;
+                    row.appendChild(target);
+                    return target;
+                }
+
+                function moment(value) {
+                    return value ? new Date(value).toLocaleString() : "";
+                }
+
+                function title(request) {
+                    var written = request.DisplayTitle;
+
+                    if (request.DisplayYear) {
+                        written = written + " (" + request.DisplayYear + ")";
+                    }
+
+                    if (request.Seasons && request.Seasons.length) {
+                        written = written + ", seasons " + request.Seasons.join(", ");
+                    }
+
+                    return written;
+                }
+
+                function held(request) {
+                    return availability[request.Availability] || request.Availability;
+                }
+
+                /*
+                 * Why the answer was no, where it was. The reason is one of a fixed set and the
+                 * sentence beside it is what the operator wrote for this person to read, which is
+                 * the one piece of somebody else's writing this page shows at all.
+                 */
+                function why(request) {
+                    if (!request.DeclineReason) {
+                        return "";
+                    }
+
+                    var reason = reasons[request.DeclineReason] || request.DeclineReason;
+
+                    return request.DeclineNote ? reason + ", " + request.DeclineNote : reason;
+                }
+
+                function draw(answer) {
+                    var drawn = document.createDocumentFragment();
+
+                    answer.Requests.forEach(function (request) {
+                        var row = document.createElement("tr");
+
+                        cell(row, title(request));
+                        cell(row, kinds[request.Kind] || request.Kind);
+                        cell(row, states[request.State] || request.State);
+                        cell(row, moment(request.RequestedAt));
+                        cell(row, moment(request.StateChangedAt));
+                        cell(row, held(request));
+                        cell(row, request.YourNote || "");
+                        cell(row, why(request));
+
+                        drawn.appendChild(row);
+                    });
+
+                    rows.replaceChildren(drawn);
+
+                    if (answer.MatchCount === 0) {
+                        summary.textContent = "You have not asked for anything yet.";
+                        return;
+                    }
+
+                    summary.textContent = answer.Requests.length === answer.MatchCount ? answer.MatchCount + " in all" : "The first " + answer.Requests.length + " of " + answer.MatchCount;
+                }
+
+                function say(text) {
+                    message.textContent = text;
+                }
+
+                function read() {
+                    return fetch(address(), { headers: { Accept: "application/json" } })
+                        .then(function (answered) {
+                            if (!answered.ok) {
+                                throw new Error(String(answered.status));
+                            }
+
+                            return answered.json();
+                        })
+                        .then(function (answer) {
+                            say("");
+                            draw(answer);
+                        })
+                        .catch(function () {
+                            say("Your requests could not be read. If this page was opened from a link that has expired, sign in again and open it afresh.");
+                        });
+                }
+
+                read();
+            })();
+        </script>
+    </body>
+</html>

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ the requests a server already holds are in
 ## Which clients this reaches
 
 No cell of the reach matrix in docs/surface.md has been checked against a real
-client, and neither the channel nor the page it describes is on the mainline
-today.
+client, and the page now on the mainline is not a measurement of one; the
+channel it describes is still not built.
 
 That sentence is the whole claim this file makes about client reach, and it is
 the sentence the matrix opens with. The matrix itself, a row per client family

--- a/docs/api.md
+++ b/docs/api.md
@@ -255,6 +255,30 @@ themselves.
 The history is not in the answer. Every entry names the administrator who made the move, and a list a
 user reads is not an audit trail.
 
+## The page a browser opens
+
+    GET MediaRequests/v1/Page
+
+The one endpoint here that answers with a document rather than a record. It returns the page a person
+opens to see what they asked for, which exists because a plugin's own pages live in the dashboard and
+the dashboard is the administrator's. What the page is and what it deliberately does not do are in
+[surface.md](surface.md); this section is what a caller sees.
+
+It answers `text/html` and nothing else, and the document carries no request in itself: what it holds
+is markup and a script that calls `GET MediaRequests/v1/Requests` for whoever is reading it. So who
+may see what is decided by that endpoint and not a second time here.
+
+**It is refused rather than served empty to a caller with no session.** A shell handed to anybody and
+left to fail on its first call would put this plugin's existence and shape in front of somebody who
+has not signed in, and would read to a person as a broken page rather than as a closed door.
+
+**A browser navigating to an address sends no Jellyfin session.** A session here is a header or a
+query value, never a cookie, so a person opening this page in a tab reaches it with the credential in
+the address: `?api_key=` is read out of the query string by the server on both claimed lines. That is
+a real cost and it is stated here and in [surface.md](surface.md) rather than left to be discovered.
+This endpoint neither creates such a credential nor extends one, and the page carries what it was
+opened with no further than the one call it makes.
+
 ## Reading the queue
 
     GET MediaRequests/v1/Requests/Queue
@@ -455,6 +479,7 @@ reading the endpoint.
 | Endpoint                     | Policy                       | Who that is          |
 | ---------------------------- | ---------------------------- | -------------------- |
 | `GET Capabilities`           | the server's default         | any signed-in person |
+| `GET Page`                   | the server's default         | any signed-in person |
 | `POST Requests`              | the server's default         | any signed-in person |
 | `GET Requests`               | the server's default         | any signed-in person |
 | `GET Requests/Queue`         | `Policies.RequiresElevation` | an administrator     |

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -67,6 +67,59 @@ and it is the price of reaching a client nobody here can change. It is not the s
 placeholders into a real library, because a channel's folder is the plugin's own and disappears with
 it.
 
+## The page, as it is built
+
+The page is on the mainline and the channel is not, so this section is about the one of the three
+surfaces that exists beyond the API.
+
+It is served by this plugin rather than registered with the dashboard:
+
+    GET MediaRequests/v1/Page
+
+A plugin's registered pages are fetched through the dashboard, the dashboard is the administrator's,
+and the queue page this plugin registers there is elevated by construction. So a page for a user
+cannot be one of those, and this one is an endpoint under the same versioned prefix as the rest of
+the API, behind the same authentication. What it answers is in [api.md](api.md).
+
+It shows the caller's own requests and nothing else: the title as it was asked for, what sort of
+thing it is, where it stands, when it was asked for, when it last moved, whether the library holds
+it, the note the caller wrote, and the reason and the sentence an operator gave when the answer was
+no. It draws one call, `GET MediaRequests/v1/Requests`, whose answer names no person at all, which is
+what makes "shows nothing about anybody else" a property of the shape rather than of the page's care.
+
+**A caller with no session is refused rather than handed an empty page.** The endpoint carries the
+server's default policy. A shell served to anybody and left to fail on its first call puts this
+plugin's existence and shape in front of somebody who has not signed in, and reads to a person as a
+broken page rather than as a closed door.
+
+### The credential is in the address, and that costs something
+
+A browser navigating to an address sends no Jellyfin session. A session on this server is a header or
+a query value and never a cookie, so the only way a person opens an authenticated page in a tab is
+with the credential in the address, which the server reads out of `api_key` on both claimed lines.
+
+What that costs is real and is not softened here. The value lands in the browser's history, in
+whatever proxy log sits in front of the server, and in any link the person sends somebody else. This
+plugin neither creates such a credential nor extends one, and the page carries what it was opened
+with no further than the one call it makes, but neither of those undoes the first sentence. An
+operator handing this address to their household should treat it as handing over a session.
+
+### What the page does not do
+
+**It offers no decision and no control at all.** Approving and declining need an administrator, and
+cancelling something still open needs a state a request can be withdrawn into, which this plugin does
+not have: whether there is a cancelled state is an open decision on #113. So the page is a thing to
+read, and a control that could not do anything would be worse than none.
+
+**It has no pager.** It asks for the largest page the endpoint serves and says how many matched
+beside how many it drew, so somebody with more requests than that is told so rather than shown a
+shortened list that reads as the whole of it.
+
+**It borrows nothing from the dashboard.** The shared stylesheet and script the dashboard pages use
+are reachable only under a name registered as a plugin page, and those are served to an
+administrator, so a user asking for one would meet a refusal instead of a stylesheet. The page
+carries its own.
+
 ## What is not reached
 
 Nothing here is softened, and the parts that are claims rather than measurements say so.
@@ -79,7 +132,7 @@ measurement of reach.
 
 **A client with no browser cannot open the page.** That is what the page is: a document served over
 HTTP to a signed-in session. A client that draws its own interface and offers no way to open a URL
-gets nothing from #69.
+gets nothing from it.
 
 **A client that does not render channels gets nothing from the channel**, and there is no fallback
 for it inside this plugin beyond the API.
@@ -94,8 +147,8 @@ nothing to ask with. The gesture that creates a request arrives from the sibling
 
 ## The reach matrix
 
-No cell of the reach matrix in docs/surface.md has been checked against a real client, and neither
-the channel nor the page it describes is on the mainline today.
+No cell of the reach matrix in docs/surface.md has been checked against a real client, and the page
+now on the mainline is not a measurement of one; the channel it describes is still not built.
 
 That sentence is the first thing in this section because the table under it looks like a
 capability list and is not one. It is what the decision above would reach if it were built, written
@@ -106,7 +159,7 @@ before it looks. Each file becomes one line, so the count is 1 where the sentenc
 where a word of it has moved:
 
     for f in README.md docs/surface.md; do printf '%s: ' "$f"; tr -s '[:space:]' ' ' < "$f" \
-      | grep -c 'No cell of the reach matrix in docs/surface.md has been checked against a real client, and neither the channel nor the page it describes is on the mainline today.'; done
+      | grep -c 'No cell of the reach matrix in docs/surface.md has been checked against a real client, and the page now on the mainline is not a measurement of one; the channel it describes is still not built.'; done
     README.md: 1
     docs/surface.md: 1
 


### PR DESCRIPTION
Closes #69.

A plugin's own pages are fetched through the dashboard and the dashboard is the administrator's, so a user on a browser had no page at all. This adds the one `docs/surface.md` decided on, served by `MyRequestsPageController` at `GET MediaRequests/v1/Page`, under the same versioned prefix as the rest of the API and behind the same authentication.

## The three conditions

**A signed-in user can open the page and see their own requests.** The endpoint answers `text/html` with the document the assembly carries, and the document makes one call, to `GET MediaRequests/v1/Requests`, which returns the caller's own requests and nothing wider. It draws the title as it was asked for, the kind, where it stands, when it was asked for, when it last moved, whether the library holds it, the note the caller wrote, and the reason and sentence given when the answer was no.

**An unauthenticated request for the page is refused rather than served an empty shell.** The endpoint carries the server's default policy, taken by writing `[Authorize]` with nothing after it, which is what `docs/api.md` sets out for "any signed-in person" and what the endpoint that shipped a registered name for it cost.

**The page shows nothing about other users and offers no administrator action.** The answer it draws from names no person at all, including the caller's own identifier, so this is a property of the shape rather than of the page's care. Three legs hold it against the document the assembly carries: every field the page draws is a property of `MyRequest`, no route that needs an administrator is written on the page anywhere, and the page carries no element a person can operate.

## What is measured, and what is not

**No server ran and no browser ran.** Nothing in this suite starts either, which the headless rule in `docs/testing.md` settles and whose refusal list names the replacement: the endpoints tested in process and the formatting gate over the page. So what is proven is that the endpoint answers with the embedded document, that the document asks this plugin for one thing, and that the policy is on the action. That a caller with no session is turned away is the server's evaluation of that policy, and nothing here claims to have watched it happen.

**Six near-misses were watched failing**, each on a head carrying the defect and then reverted, run with `dotnet test --configuration Release -f net9.0`:

- Drawing `request.RequestedByUserId`, a field the queue's shape carries and the caller's own does not, reds `EveryFieldThePageDrawsIsOneTheCallersOwnAnswerCarries` with `Collection: ["RequestedByUserId"]`.
- Pointing the page's one call at `Requests/Queue` reds `ThePageAsksForNothingButTheCallersOwnRequests` and `NoRouteThatNeedsAnAdministratorAppearsOnThePage`, the second with `Collection: ["Requests/Queue"]`.
- Adding a button reds `ThePageCarriesNoControlAPersonCanOperate` with `Collection: ["<button"]`.
- `[AllowAnonymous]` on the action reds `NothingOfThePageIsServedWithoutASession` and three legs of `EndpointPolicyTests`.
- Dropping the page from the packaging reds five legs, the first with `The assembly carries no resource named Jellyfin.Plugin.Requests.Web.mine.html`.
- A markup sink on the page reds `NothingThePagesShipTurnsAStringIntoMarkup` with `Collection: ["Jellyfin.Plugin.Requests.Web.mine.html: innerHTML"]`, which is the existing rule reaching the new asset rather than a new one.

The build and the suite:

```
dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
Bestanden!: Fehler: 0, erfolgreich: 558, gesamt: 558 (net9.0)
Bestanden!: Fehler: 0, erfolgreich: 558, gesamt: 558 (net10.0)
```

The formatting gate over the new page and the changed documents:

```
npx --yes prettier@3.6.2 --check "**/*.{html,css,js,md}"
All matched files use Prettier code style!
```

Run locally with `--end-of-line auto`, because this clone has `core.autocrlf` true and the gate reads a checkout with the line endings git stores. The invariant lint was not run on this machine; that job fetches a Linux binary and it runs on the pull request.

## The credential is in the address, and that is stated rather than softened

A browser navigating to an address sends no Jellyfin session. A session on this server is a header or a query value and never a cookie, so a person opens this page with the credential in the address, which the server reads out of `api_key` on both claimed lines:

    git grep -n 'queryString\["api_key"\]' origin/release-10.11.z origin/master -- Jellyfin.Server.Implementations/Security/AuthorizationContext.cs
    origin/release-10.11.z:...:110:                token = queryString["api_key"];
    origin/master:...:110:                token = queryString["api_key"];

read against the server's own tree at `1fbd8739292cce610231be93daf43368733edf63` and `ae8723026d97b6d0f926638803edef338919b794`.

The cost is that the value lands in the browser's history, in whatever proxy log sits in front of the server, and in any link a person sends somebody else. `docs/surface.md` says an operator handing this address to their household should treat it as handing over a session. This endpoint neither creates such a credential nor extends one, and the page carries what it was opened with no further than its one call, and neither of those undoes the first sentence.

## What the page does not do

**It offers no way to cancel a request**, which #69's own body names alongside the two things it does. Cancelling needs a state a request can be withdrawn into and this plugin has none; whether there is a cancelled state is an open decision on #113. The page carries no control at all rather than one that could not do anything.

**It has no pager.** It asks for the largest page the endpoint serves and says how many matched beside how many it drew, so somebody with more requests than that is told so rather than shown a shortened list that reads as the whole of it.

**It borrows nothing from the dashboard.** The shared stylesheet and script are reachable only under a name registered as a plugin page and those are served to an administrator, so the page carries its own.

## One thing outside this change that it corrected

`docs/surface.md` and `README.md` both carried the sentence that no cell of the reach matrix has been checked against a real client "and neither the channel nor the page it describes is on the mainline today". The second half stops being true with this change. The sentence is corrected in both files, word for word, and the comparison the document hands a reader was re-run:

```
for f in README.md docs/surface.md; do printf '%s: ' "$f"; tr -s '[:space:]' ' ' < "$f" \
  | grep -c 'No cell of the reach matrix in docs/surface.md has been checked against a real client, and the page now on the mainline is not a measurement of one; the channel it describes is still not built.'; done
README.md: 1
docs/surface.md: 1
```

Every cell of the matrix still says `untested`, and this change measures none of them. A page existing is not a measurement of whether a client opens it.

## No second reader

Nobody else has read this change. There is no second reader on this board tonight, so the evidence above stands in place of one.
