### PR TITLE
Read what the queue page shows against the page that exists

### DIFF
--- a/docs/queue.md
+++ b/docs/queue.md
@@ -18,7 +18,9 @@ Each item below says what it is, why the decision needs it, and where it comes f
 today. The last part is what makes the list checkable rather than aspirational. An item nothing here
 can answer is work that has to be named, and two of the six are exactly that.
 
-The measurements are read at `e667f895b81f6fc62b7778de601fde607068fb17`, which is `master`.
+The measurements are read at `8e60f101df6c05815c24fbf083ffe8c2eab6b89e`, which is `master`. Every
+command below was re-run at that commit rather than carried over from the reading the list was first
+written at.
 
 ## Who asked, and when
 
@@ -156,13 +158,54 @@ a request sitting in approved forever, which is the `Failed` state and is #82 an
 
 ## What the page shows today
 
-The page is a shell. It says so about itself:
+The page was a shell when this list was written and it is not one now. It draws rows, from #60, and
+each row carries the decisions its state admits, from #61:
 
-    git grep -n "The queue view is not built yet" -- Jellyfin.Plugin.Requests/Web/queue.html
-    Jellyfin.Plugin.Requests/Web/queue.html:29:                    <p>The queue view is not built yet.</p>
+    git grep -n "cell(row, " -- Jellyfin.Plugin.Requests/Web/queue.html
+    Jellyfin.Plugin.Requests/Web/queue.html:304:                    function cell(row, text) {
+    Jellyfin.Plugin.Requests/Web/queue.html:527:                            cell(row, title(request));
+    Jellyfin.Plugin.Requests/Web/queue.html:528:                            cell(row, RequestsShell.named("kind", request.Kind));
+    Jellyfin.Plugin.Requests/Web/queue.html:529:                            cell(row, RequestsShell.named("queue.state", request.State));
+    Jellyfin.Plugin.Requests/Web/queue.html:530:                            cell(row, moment(request.RequestedAt));
+    Jellyfin.Plugin.Requests/Web/queue.html:531:                            cell(row, moment(request.StateChangedAt));
+    Jellyfin.Plugin.Requests/Web/queue.html:532:                            cell(row, request.RequestedByUserId);
+    Jellyfin.Plugin.Requests/Web/queue.html:533:                            cell(row, held(request));
+    Jellyfin.Plugin.Requests/Web/queue.html:534:                            cell(row, request.RequesterNote || "");
+    Jellyfin.Plugin.Requests/Web/queue.html:535:                            cell(row, decided(request));
 
-So the second condition of #59 is unmet in full and is #60's to meet. Of the six items, four can be
-rendered from the answer the queue endpoint already gives, and two cannot be rendered at all until
-that answer carries them: whether the same title was asked for before and what was decided, and how
-much this person is asking for. Those two are work on the endpoint, and a page built without them
-would meet the list only by dropping the two hardest items from it.
+The first of those ten lines is the function that writes a cell and the other nine are the cells one
+row carries. The tenth column beside them is the decisions that row admits, which is #61:
+
+    git grep -n "decide(row, request)" -- Jellyfin.Plugin.Requests/Web/queue.html
+    Jellyfin.Plugin.Requests/Web/queue.html:359:                    function decide(row, request) {
+    Jellyfin.Plugin.Requests/Web/queue.html:536:                            decide(row, request);
+
+Read against the six items above, that is four of them and part of a fifth.
+
+What is asked for is there, with the seasons and the requester's note. Whether the server already
+holds it is there, with the time the answer was read, which is the `held` call. What approving will
+do next is answered per install rather than per row and is the panel beside the queue, which is #63.
+
+Who asked is on the page as the identifier the answer carries and not as a name:
+
+    git grep -n "cell(row, request.RequestedByUserId)" -- Jellyfin.Plugin.Requests/Web/queue.html
+    Jellyfin.Plugin.Requests/Web/queue.html:532:                            cell(row, request.RequestedByUserId);
+
+The item above says turning one into the other is the server's own user list, which the dashboard
+reaches without leaving the server. Nothing on the page does that turning, so an operator reads a
+column of identifiers where the argument for the item was that a decision is about a person. That is
+work on the page rather than on the answer, and it is the one part of this list that is short for a
+reason no endpoint has to fix.
+
+Two items cannot be rendered at all until the queue answer carries them, which is what it carries:
+
+    git grep -c "get; init;" -- Jellyfin.Plugin.Requests/Api/QueuedRequest.cs
+    Jellyfin.Plugin.Requests/Api/QueuedRequest.cs:18
+
+Eighteen properties and none of them is a prior decision on the same title or a count of what this
+person already has open. Both facts are in the store and neither reaches the queue answer, so both
+are work on the endpoint. A page built without them would meet the list only by dropping the two
+hardest items from it.
+
+Nothing here was read from a running dashboard. What is measured is what the page draws, read out of
+the file, which is the bound every check over these assets carries.


### PR DESCRIPTION
Part of #59. It does not close it, and the section this replaces is where the two remaining items are named.

`docs/queue.md` ends with a section reading the list against the page. That reading was taken when the page was a shell, and it quotes the sentence the page said so with. The page stopped being a shell when #60 landed, so the command under the claim prints nothing:

    git grep -n "The queue view is not built yet" -- Jellyfin.Plugin.Requests/Web/queue.html ; echo "exit=$?"
    exit=1

A pasted command that no longer prints what is beside it is worse than no evidence, because a reader who re-runs it is left deciding which of the two to trust. It was found while finishing #61, which is one of the two issues the old text names as the work that had not happened yet.

## What the new section says, and how each half was read

Four of the six items are drawn, and the cells are read out of the page rather than counted by eye:

    git grep -n "cell(row, " -- Jellyfin.Plugin.Requests/Web/queue.html

prints the function that writes a cell and the nine cells one row carries, and the tenth column beside them is the decisions that row admits:

    git grep -n "decide(row, request)" -- Jellyfin.Plugin.Requests/Web/queue.html

Both outputs are pasted into the document in full.

The fifth item is where the page is short, and it is short for a reason no endpoint has to fix. Who asked is drawn as the identifier the queue answer carries:

    git grep -n "cell(row, request.RequestedByUserId)" -- Jellyfin.Plugin.Requests/Web/queue.html
    Jellyfin.Plugin.Requests/Web/queue.html:532:                            cell(row, request.RequestedByUserId);

The item itself argues that turning that into a name is the server's own user list, which the dashboard reaches without leaving the server. Nothing on the page does that turning, so an operator reads a column of identifiers where the argument for the item was that a decision is about a person. The old section did not say this, because when it was written there was no column to say it about.

The two items the queue answer cannot carry are unchanged, and the number under them was re-read:

    git grep -c "get; init;" -- Jellyfin.Plugin.Requests/Api/QueuedRequest.cs
    Jellyfin.Plugin.Requests/Api/QueuedRequest.cs:18

Eighteen properties, none of them a prior decision on the same title or a count of what this person already has open.

## The commit the document is read at

The header line moves from `e667f89` to `8e60f10`, and that is a claim about every command in the file rather than about the new section alone. Each one was re-run at the new commit and each prints what is pasted beside it: the three greps over `QueuedRequest.cs`, the two over `PluginConfiguration.cs` and the one over `InstallCapabilities.cs`. The only one that did not reproduce is the one this change removes.

## What is not claimed

Nothing was read from a running dashboard, which the headless rule in `docs/testing.md` settles, and the new section says so in its own last line. What is measured is what the page draws, read out of the file.

No test guards this document and none is added here. `RepositoryDocumentsTests` reads the documents an arrival looks for and the links between them, which this change does not touch, and nothing in this tree compares a pasted command against its output. That is the class of defect this change repairs by hand, and it stays repairable only by hand.

    dotnet test Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj --configuration Release --framework net9.0 --filter "FullyQualifiedName~RepositoryDocumentsTests"
    Bestanden!   : Fehler: 0, erfolgreich: 9, übersprungen: 0, gesamt: 9

Prettier was run against a copy carrying the line endings a Linux checkout has, because this working tree is checked out with carriage returns and every tracked page fails the check for that reason alone:

    npx --yes prettier@3.6.2 --check .fmtcheck/queue.md
    Checking formatting...
    All matched files use Prettier code style!

This had no second reader. Nobody else has read this change, and the checks on this pull request are what stands in place of one.
