### PR TITLE
Give an operator the path from an installed plugin to a working queue

### DIFF
--- a/docs/operating.md
+++ b/docs/operating.md
@@ -1,0 +1,161 @@
+# Operating this plugin
+
+The path from an installed plugin to a queue somebody can work, and the sequence to read when the
+queue stops moving. It is written for an operator who has never seen this plugin and does not want to
+read the rest of `docs/` first.
+
+Read the "This is not finished" section of [../README.md](../README.md) before any of it. One release
+exists, it carries the package for one of the two claimed server lines, and the packaged install path
+has not been tried on a server. Nothing below changes that.
+
+## From an installed plugin to a queue
+
+Five steps, in this order, because each one depends on the one above it.
+
+### 1. Check the server loaded it
+
+The dashboard's plugin list is the authority. A plugin that is installed and not `Active` is one the
+server refused to load, and every step below reads as broken until that is fixed. The reason is in
+the server's own log rather than anywhere in this plugin.
+
+### 2. Take the settings decisions
+
+The settings page is where the dashboard puts a plugin's settings, under this plugin's own name. What
+each setting is, what it defaults to and what value it refuses are in
+[configuration.md](configuration.md), which is the authority for all of it. What this page adds is
+the order to take them in and what each one costs you later.
+
+- **How many open requests one person may hold.** This is the setting an operator reaches for the
+  first time somebody files thirty in an evening. It counts what is still waiting for an answer
+  rather than everything a person has ever asked for, so a long-standing user does not run out
+  permanently. There is no value meaning "no limit", and that is refused on the page and again on
+  the server rather than accepted and quietly replaced.
+- **Which kinds of thing may be asked for.** Turning one off is how a server that holds only films
+  stops collecting series requests it will never answer.
+- **How long a finished request is kept.** It is a number today and nothing acts on it. A finished
+  request stays until somebody removes the file, which is stated in
+  [personal-data.md](personal-data.md) and is the honest reading of that field.
+- **The address a notice is posted to.** Leave it empty unless you have somewhere to receive one.
+  Empty means nothing is sent, and that is a supported way to run rather than a half-configured one.
+
+### 3. Know that approval is not a switch
+
+There is no setting that makes requests skip the queue. Every request arrives open and stays open
+until a person decides it, and per-person automatic approval is a later decision rather than a
+feature turned off.
+
+That matters on the first evening: an operator who expected approval to be optional and finds a queue
+filling up has not misconfigured anything, and there is nothing to look for.
+
+### 4. Find the queue
+
+This plugin registers a page of its own in the dashboard's main menu, beside the dashboard's own
+entries rather than inside the plugin list. The plugin list holds the settings; the menu entry holds
+the queue, because one is opened twice and the other every day.
+
+What the queue shows, and why each column earns its place in a decision, is [queue.md](queue.md).
+Approving and declining are done from that page, and a decline carries a reason and, where you write
+one, a sentence the person who asked will read.
+
+### 5. Give people a way to ask
+
+This is the step that decides whether the queue ever has anything in it, and it is the one this
+plugin does least for.
+
+**This plugin ships no way to find a title the server does not have.** There is no search here and no
+gesture on a television client that creates a request. That was decided rather than overlooked, and
+the reasoning is in [surface.md](surface.md) and in the README section above.
+
+So a request arrives by one of two routes. Either the browsing sibling plugin is installed and hands
+one across, which is the route the design is built around, or something drives the create endpoint
+directly, which is what an operator scripting against their own server would do. The endpoints, what
+they take and what they answer, are in [api.md](api.md).
+
+A person who has asked for something reads their own requests on a page this plugin serves, at
+`MediaRequests/v1/Page`, and what that address costs to hand out is written down in
+[surface.md](surface.md). It is worth reading before you send it to a household, because a browser
+opening an address sends no session and the credential therefore travels in the address.
+
+## Wiring an external request service
+
+**Nothing in this tree talks to one.** The only bridge that ships is the one for a server that has no
+service, it makes no call, and the settings carry no field for an address or a credential. There is
+nothing to wire today.
+
+That is not the same as nothing being decided, and the parts an operator will have to reason about
+are already written down. [bridge.md](bridge.md) is the authority for all three, and this section
+says which part of it answers which question.
+
+**The credential.** Where it goes, who on the machine can read it, and what is refused by name are
+under "Where a credential would live, and what may be claimed about it". The short version an
+operator needs before agreeing to type one in: it goes in the plugin's configuration file under the
+server's data directory, which means it is in your backups by design, readable by anything else
+loaded into the same server process, and readable by an administrator of the server over the API,
+because that is how the dashboard renders a plugin's settings page. Encrypting it at rest with a key
+on the same disk is refused rather than unimplemented, and the reason is written there.
+
+**Whose name a request arrives under.** The identity mapping is a table an operator keeps, one row
+per person, and it is empty on a fresh install. That is the shipping answer rather than a state on
+the way to one: with no rows, every request arrives at the service under the service's own account
+and it is told that a request was made and not by whom. Attribution is turned on one person at a time
+by writing a row, and writing that row is what says that person's account name may leave this server.
+Matching people by name is refused rather than built and switched off, because it is wrong in the
+direction that credits one person with another's request.
+
+**What each failure looks like.** This is the part no document can answer yet. The service being
+unreachable, refusing the credential, running a version the adapter does not know, and being asked
+about a title it has never heard of each need a decided behaviour, and none of them has one, because
+there is nothing here that could fail. Until that lands, an operator has nothing to read here, and a
+sequence written now would be an account of intentions rather than of behaviour.
+
+## When requests stop moving
+
+Read the panel at the top of the queue page, in the order below. It answers from this server process
+rather than from the install, so every moment on it is measured since the server last started, and
+the sentences say so. Stop at the first step that is wrong; the ones below it read as broken whenever
+a step above them is.
+
+**1. Is the panel answering at all?** A line saying that whether this plugin is working could not be
+read, above a queue that did answer, means the plugin is serving pages and the check behind the panel
+is not. Everything below this step is unread rather than healthy.
+
+**2. Could the requests be read?** A line saying the requests could not be read is the one failure
+that makes every count above it meaningless, and it is the first thing to fix. It names no path, on
+purpose. The server's own log names the file and says why, and that is where to go next. Nothing else
+on this page will be right until the store opens.
+
+**3. Do the counts show anything at all?** A queue with nothing in any state is almost never a broken
+plugin. It is step 5 of the setup above: nobody has a way to ask. Check that the browsing sibling is
+installed, or that whatever drives the create endpoint is still running, before looking at anything
+here.
+
+**4. When was something last written?** A line saying nothing has been written since this server
+started, on a server that has been up for a while and has people using it, points at the same place
+as step 3 rather than at the store. A moment here that is recent and a queue that has not moved
+points at a person rather than at the plugin.
+
+**5. When was the library last checked?** Approving a request does not fetch anything. What moves a
+request to fulfilled is this plugin noticing the title arrive in the server's own library, and that
+check runs on the library's own events and on a schedule. A line saying the library has not been
+checked since this server started, on a server that has been up for a while, is why approved requests
+are sitting still, and it is the most common cause of the complaint that the queue stops after
+approval.
+
+**6. What does the bridge say?** On most servers this reads that no external request service is set
+up, and that is the ordinary answer rather than a fault: approving is an answer and nothing is
+fetched. Where one is configured, a line saying it is not answering is a fact about that service and
+not about this plugin, and the moment it last answered is beside it.
+
+### What the sequence does not reach
+
+**It says nothing about a person's access.** A request that a person cannot see is a question about
+who they are and what they may read, and none of the six steps above touches it.
+
+**It is not a log.** Every step that ends at a file or a reason ends at the server's own log, because
+this plugin puts no path and no credential on that panel. That is the same rule everywhere else here:
+what one person learns about another's request is nothing, and a diagnostics surface is not an
+exception to it.
+
+**Nothing here was read on a running server.** The panel, its sentences and the order above are read
+off the page and the endpoint behind it in this repository. A session in front of a real install
+answering these six questions in this order is a different statement and is not made here.


### PR DESCRIPTION
Part of #102.

`docs/operating.md` is the operator guide that issue asks for: the path from an installed plugin to a
queue somebody can work, and the sequence to read when the queue stops moving.

## What it carries

Five ordered setup steps, because each depends on the one above it: check the server loaded the
plugin, take the settings decisions, know that approval is not a switch, find the queue, and give
people a way to ask. Every section points at the document that owns its subject rather than repeating
it, so a settings default or a credential position has one answer here and not two.

A six-step diagnostics sequence, ordered so the common failures are found first. Panel unreadable,
store unreadable, no counts at all, nothing written since the server started, library not checked
since the server started, then the bridge. The fifth step is the one this order exists for: approving
fetches nothing, so a queue that stops after approval is the library check and not the decision.

## What is stated as an absence rather than described as behaviour

**The retention setting is a number nothing acts on**, and the document says so rather than
describing a sweep. Measured at `origin/master`, `7cec0096925378fa9a2cdece094f0e9c3be472c6`:

    git grep -ln 'FinishedRequestRetentionDays' origin/master -- Jellyfin.Plugin.Requests/
    origin/master:Jellyfin.Plugin.Requests/Configuration/ConfigurationRules.cs
    origin/master:Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs
    origin/master:Jellyfin.Plugin.Requests/Configuration/configPage.html

The class that declares it, the rule that refuses a value under the floor, and the field on the
settings page. Nothing removes a finished request.

**There is no switch that makes requests skip the queue**, and the type that answers a caller says
the same:

    git grep -n -A 2 'It is false on every' origin/master -- Jellyfin.Plugin.Requests/Api/InstallCapabilities.cs
    origin/master:Jellyfin.Plugin.Requests/Api/InstallCapabilities.cs:44:    /// administrator will look at this" is wrong on a server where nobody will. It is false on every
    origin/master:Jellyfin.Plugin.Requests/Api/InstallCapabilities.cs-45-    /// install today, and automatic approval arrives as a per-user setting rather than a switch for
    origin/master:Jellyfin.Plugin.Requests/Api/InstallCapabilities.cs-46-    /// the whole server, decided on #113.

## What this does not close, and why

The second condition of #102 asks that the bridge section cover the credential, the identity mapping
and what each failure looks like. Two of the three are covered, by pointing at `docs/bridge.md`,
which is the authority for both and already carries them. The third is not, and it is not a wording
problem: nothing in this tree makes an outbound call, so no failure of an external service can occur
and none has a decided behaviour. Writing that section now would be an account of intentions rather
than of behaviour, which is the one thing an operator reading a diagnostics page cannot afford. It
belongs with #86, and the document says in those words that an operator has nothing to read there
yet.

## What was run

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    0 Warnung(en)
    0 Fehler

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler:     0, erfolgreich:   594, gesamt:   594 (net9.0)
    Bestanden!   : Fehler:     0, erfolgreich:   594, gesamt:   594 (net10.0)

    npx --yes prettier@3.6.2 --check "docs/operating.md"
    All matched files use Prettier code style!

The change is one file and it is inside the `Scope:` the issue declares:

    git diff --name-only origin/master...HEAD
    docs/operating.md

**No guard was added and none was watched failing.** This change is a document and adds no behaviour,
so there is nothing here to delete and see red. The suite run above is that nothing else moved. The
seven relative links this document carries were each resolved against the tree by hand rather than by
a check, because `EveryRepositoryPathTheseDocumentsLinkToIsInTheTree` runs over the documents an
arrival looks for and this is not one of them.

**Nothing in it was read on a running server.** The panel, its sentences and the order of the six
steps are read off the page and the endpoint behind it in this repository. A session in front of a
real install answering those six questions in that order is a different statement, and the document
says so in its own last paragraph rather than leaving it to be assumed.

**No second person has read this.** There is no second reader for it here, so this body carries the
evidence in place of one.

The means is Markdown in `docs/`, beside every other document this repository argues in, because the
subject is a sequence a person follows and there is nothing here for a check to decide.
