### PR TITLE
Enforce the retention period that was a number nothing acted on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ what came before it. What landed before this file existed is in the git history,
 where it carries the pull request and the issue it came from, and rewriting it
 from memory into entries would be a description nobody measured.
 
+- `FinishedRequestRetentionDays` is enforced. A scheduled task removes a request
+  that has been fulfilled, declined or failed for longer than that number of
+  days, counted from the move that finished it, and it runs daily and at
+  startup. A request nobody has answered is never removed by age. Until now the
+  number was a setting nothing acted on and a server kept every request.
+
 - A person signed in to the server can open a page in a browser and see what
   they asked for and what happened to it, at `MediaRequests/v1/Page`. It shows
   their own requests only, offers no decision, and is refused to a caller with

--- a/Jellyfin.Plugin.Requests.Tests/Doubles/StoreThatMovesARequestUnderTheRemoval.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/StoreThatMovesARequestUnderTheRemoval.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+
+namespace Jellyfin.Plugin.Requests.Tests.Doubles;
+
+/// <summary>
+/// A store that lets somebody else move a request in the window between a caller reading it and the
+/// same caller removing it.
+/// <para>
+/// It is <see cref="StoreThatMovesARequestUnderTheWrite"/> for the other write the interface has.
+/// The window cannot be reached from outside a call: a test can move a request before the removal
+/// or after it, and either one is decided before the removal is attempted. This moves it during,
+/// once, on the first removal it is asked to make, which is the only way to watch a caller meet the
+/// store's own refusal of a removal it had every reason to believe was safe.
+/// </para>
+/// <para>
+/// The move goes through the same interface every other caller uses, so what the caller under test
+/// meets is the store's refusal and not one this double invented.
+/// </para>
+/// </summary>
+internal sealed class StoreThatMovesARequestUnderTheRemoval : IRequestStore
+{
+    private readonly IRequestStore _inner;
+    private readonly Func<MediaRequest, MediaRequest> _move;
+    private bool _moved;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StoreThatMovesARequestUnderTheRemoval"/> class.
+    /// </summary>
+    /// <param name="inner">The store that actually holds the requests.</param>
+    /// <param name="move">
+    /// What the other caller does to the request, applied once, immediately before the first
+    /// removal this store is asked to make.
+    /// </param>
+    public StoreThatMovesARequestUnderTheRemoval(IRequestStore inner, Func<MediaRequest, MediaRequest> move)
+    {
+        _inner = inner;
+        _move = move;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>Not what this double is about, so it answers as a store that has written nothing.</remarks>
+    public DateTimeOffset? LastWrittenAt => null;
+
+    /// <inheritdoc />
+    public Task<StoredRequest?> GetAsync(Guid id, CancellationToken cancellationToken)
+        => _inner.GetAsync(id, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<StoredRequest>> GetAllAsync(CancellationToken cancellationToken)
+        => _inner.GetAllAsync(cancellationToken);
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<StoredRequest>> FindForUserAsync(Guid userId, CancellationToken cancellationToken)
+        => _inner.FindForUserAsync(userId, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<StoredRequest>> FindByProviderIdentifierAsync(
+        RequestedItemKind kind,
+        string provider,
+        string value,
+        CancellationToken cancellationToken)
+        => _inner.FindByProviderIdentifierAsync(kind, provider, value, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<StoredRequest?> FindByWantAsync(Guid wantId, CancellationToken cancellationToken)
+        => _inner.FindByWantAsync(wantId, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<RequestPage> PageAsync(RequestQuery query, CancellationToken cancellationToken)
+        => _inner.PageAsync(query, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<StoredRequest> AddAsync(MediaRequest request, CancellationToken cancellationToken)
+        => _inner.AddAsync(request, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<StoredRequest> ReplaceAsync(
+        MediaRequest request,
+        long expectedRevision,
+        CancellationToken cancellationToken)
+        => _inner.ReplaceAsync(request, expectedRevision, cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<bool> RemoveAsync(Guid id, long expectedRevision, CancellationToken cancellationToken)
+    {
+        if (!_moved)
+        {
+            _moved = true;
+
+            var held = await _inner.GetAsync(id, cancellationToken).ConfigureAwait(false);
+
+            if (held is StoredRequest current)
+            {
+                await _inner
+                    .ReplaceAsync(_move(current.Request), current.Revision, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
+
+        return await _inner.RemoveAsync(id, expectedRevision, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/Storage/RetentionSweepTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Storage/RetentionSweepTests.cs
@@ -1,0 +1,324 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Configuration;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Storage;
+
+/// <summary>
+/// The retention period enforced rather than declared, which is #49's second condition.
+/// <para>
+/// Every period here is proven by moving the injected clock, so nothing waits and a slow machine
+/// gets the same answer as a fast one. The dates are the store's and the model's own
+/// <see cref="MediaRequest.StateChangedAt"/>, never the wall clock.
+/// </para>
+/// </summary>
+public class RetentionSweepTests
+{
+    private static readonly DateTimeOffset Asked = new DateTimeOffset(2026, 3, 1, 12, 0, 0, TimeSpan.Zero);
+    private static readonly Guid Requester = new Guid("7a4e2f18-6b0c-4d39-95e7-1f8a3c6d2b40");
+    private static readonly Guid Operator = new Guid("2c9f5a31-0d84-49b6-8f2e-5b7c1a0e6d93");
+
+    /// <summary>
+    /// A fulfilled request older than the period is gone, and the run says it removed one. The
+    /// clock is moved one day past the configured year rather than to some distant date, so what
+    /// the assertion rests on is the period and not the size of the jump.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task AFulfilledRequestKeptPastThePeriodIsRemoved()
+    {
+        var store = new InMemoryRequestStore();
+        var clock = new TestClock(Asked);
+        var settings = new FakeInstallSettings();
+        var sweep = Sweep(store, settings, clock);
+
+        await store.AddAsync(Finished(RequestState.Fulfilled), CancellationToken.None);
+
+        clock.Advance(TimeSpan.FromDays(settings.Current.FinishedRequestRetentionDays + 1));
+
+        Assert.Equal(1, await sweep.SweepAsync(CancellationToken.None));
+        Assert.Empty(await store.GetAllAsync(CancellationToken.None));
+    }
+
+    /// <summary>
+    /// A finished request that has not yet been kept for the whole period stays. This is the leg
+    /// that makes the one above about a period rather than about being finished: the same request,
+    /// one day short.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task AFinishedRequestOneDayShortOfThePeriodIsKept()
+    {
+        var store = new InMemoryRequestStore();
+        var clock = new TestClock(Asked);
+        var settings = new FakeInstallSettings();
+        var sweep = Sweep(store, settings, clock);
+
+        await store.AddAsync(Finished(RequestState.Fulfilled), CancellationToken.None);
+
+        clock.Advance(TimeSpan.FromDays(settings.Current.FinishedRequestRetentionDays - 1));
+
+        Assert.Equal(0, await sweep.SweepAsync(CancellationToken.None));
+        Assert.Single(await store.GetAllAsync(CancellationToken.None));
+    }
+
+    /// <summary>
+    /// A request nobody has answered is never removed, however long it has been sitting there. The
+    /// period is about how long a finished record is kept, and an open request that vanished on its
+    /// anniversary would be this plugin quietly answering it with nothing.
+    /// </summary>
+    /// <param name="state">The two states somebody still owes something on.</param>
+    /// <returns>The running test.</returns>
+    [Theory]
+    [InlineData(RequestState.Open)]
+    [InlineData(RequestState.Approved)]
+    public async Task ARequestNobodyHasFinishedIsNeverRemoved(RequestState state)
+    {
+        var store = new InMemoryRequestStore();
+        var clock = new TestClock(Asked);
+        var settings = new FakeInstallSettings();
+        var sweep = Sweep(store, settings, clock);
+
+        var request = state == RequestState.Open
+            ? Open()
+            : RequestLifecycle.Move(Open(), RequestState.Approved, Asked, RequestCaller.Administrator(Operator));
+
+        await store.AddAsync(request, CancellationToken.None);
+
+        clock.Advance(TimeSpan.FromDays(settings.Current.FinishedRequestRetentionDays * 5));
+
+        Assert.Equal(0, await sweep.SweepAsync(CancellationToken.None));
+        Assert.Single(await store.GetAllAsync(CancellationToken.None));
+    }
+
+    /// <summary>
+    /// All three finished states are reached, not only the fulfilled one the first leg uses. A
+    /// declined request is the one that holds the most about a person, because it carries what an
+    /// operator wrote about their ask, and a failed one is finished by the same reading.
+    /// </summary>
+    /// <param name="state">The state the request was left in.</param>
+    /// <returns>The running test.</returns>
+    [Theory]
+    [InlineData(RequestState.Declined)]
+    [InlineData(RequestState.Failed)]
+    public async Task EveryFinishedStateIsReachedByThePeriod(RequestState state)
+    {
+        var store = new InMemoryRequestStore();
+        var clock = new TestClock(Asked);
+        var settings = new FakeInstallSettings();
+        var sweep = Sweep(store, settings, clock);
+
+        await store.AddAsync(Finished(state), CancellationToken.None);
+
+        clock.Advance(TimeSpan.FromDays(settings.Current.FinishedRequestRetentionDays + 1));
+
+        Assert.Equal(1, await sweep.SweepAsync(CancellationToken.None));
+        Assert.Empty(await store.GetAllAsync(CancellationToken.None));
+    }
+
+    /// <summary>
+    /// The period runs from the move that finished the request and not from the day it was asked
+    /// for. A request open for a year and declined yesterday has been finished for a day, and the
+    /// other reading would delete it the moment an operator answered it.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task ThePeriodRunsFromTheMoveAndNotFromTheAsk()
+    {
+        var store = new InMemoryRequestStore();
+        var clock = new TestClock(Asked);
+        var settings = new FakeInstallSettings();
+        var sweep = Sweep(store, settings, clock);
+
+        clock.Advance(TimeSpan.FromDays(settings.Current.FinishedRequestRetentionDays));
+
+        var declined = RequestLifecycle.Decline(
+            Open(),
+            DeclineReason.CannotBeObtained,
+            null,
+            clock.UtcNow,
+            RequestCaller.Administrator(Operator));
+
+        await store.AddAsync(declined, CancellationToken.None);
+
+        Assert.Equal(0, await sweep.SweepAsync(CancellationToken.None));
+        Assert.Single(await store.GetAllAsync(CancellationToken.None));
+    }
+
+    /// <summary>
+    /// An operator with a shorter period gets the shorter period, and the run reads it per run
+    /// rather than holding what it was built with. This is what makes the setting a setting.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task ThePeriodIsTheOneTheInstallIsSetTo()
+    {
+        var store = new InMemoryRequestStore();
+        var clock = new TestClock(Asked);
+        var settings = new FakeInstallSettings(
+            new PluginConfiguration { FinishedRequestRetentionDays = PluginConfiguration.MinimumRetentionDays });
+        var sweep = Sweep(store, settings, clock);
+
+        await store.AddAsync(Finished(RequestState.Fulfilled), CancellationToken.None);
+
+        clock.Advance(TimeSpan.FromDays(PluginConfiguration.MinimumRetentionDays + 1));
+
+        Assert.Equal(1, await sweep.SweepAsync(CancellationToken.None));
+        Assert.Empty(await store.GetAllAsync(CancellationToken.None));
+    }
+
+    /// <summary>
+    /// An install whose stored settings this plugin will not run on removes nothing at all, and the
+    /// refusal reaches the caller. A run that deleted what a valid period would have reached and
+    /// then refused would leave an operator repairing a number after the data it governed had gone.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task AnInstallWhoseSettingsAreRefusedRemovesNothing()
+    {
+        var store = new InMemoryRequestStore();
+        var clock = new TestClock(Asked);
+        var stored = new PluginConfiguration
+        {
+            FinishedRequestRetentionDays = PluginConfiguration.MinimumRetentionDays - 1
+        };
+        var sweep = Sweep(store, new ServerInstallSettings(() => stored), clock);
+
+        await store.AddAsync(Finished(RequestState.Fulfilled), CancellationToken.None);
+
+        clock.Advance(TimeSpan.FromDays(3650));
+
+        await Assert.ThrowsAsync<InvalidConfigurationException>(
+            () => sweep.SweepAsync(CancellationToken.None));
+
+        Assert.Single(await store.GetAllAsync(CancellationToken.None));
+    }
+
+    /// <summary>
+    /// A request that moved between the read and the removal is left alone rather than removed
+    /// anyway. The case this is really about is a declined request an operator has just approved:
+    /// removing it on the revision the sweep read would delete the decision they made a moment ago.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task ARequestThatMovedUnderTheRunIsLeftAlone()
+    {
+        var held = new InMemoryRequestStore();
+        var clock = new TestClock(Asked);
+        var settings = new FakeInstallSettings();
+
+        var declined = await held.AddAsync(
+            RequestLifecycle.Decline(
+                Open(),
+                DeclineReason.CannotBeObtained,
+                null,
+                Asked,
+                RequestCaller.Administrator(Operator)),
+            CancellationToken.None);
+
+        clock.Advance(TimeSpan.FromDays(settings.Current.FinishedRequestRetentionDays + 1));
+
+        // The operator changes their mind while the run is walking: the request is approved at the
+        // revision the store currently holds, so the revision the sweep read no longer names what
+        // is there.
+        var moving = new StoreThatMovesARequestUnderTheRemoval(
+            held,
+            request => RequestLifecycle.Move(
+                request,
+                RequestState.Approved,
+                clock.UtcNow,
+                RequestCaller.Administrator(Operator)));
+
+        Assert.Equal(0, await Sweep(moving, settings, clock).SweepAsync(CancellationToken.None));
+
+        var left = Assert.Single(await held.GetAllAsync(CancellationToken.None));
+
+        Assert.Equal(declined.Request.Id, left.Request.Id);
+        Assert.Equal(RequestState.Approved, left.Request.State);
+    }
+
+    /// <summary>
+    /// What this sweep calls finished is what <see cref="RequestQuota"/> calls finished, over every
+    /// value of <see cref="RequestState"/> rather than over the ones somebody thought of. A state
+    /// added to the model with no answer here would otherwise be kept forever or deleted at once,
+    /// depending on which way the two definitions happened to fall apart.
+    /// </summary>
+    [Fact]
+    public void FinishedMeansWhatTheQuotaAlreadyMeansByIt()
+    {
+        foreach (var state in Enum.GetValues<RequestState>())
+        {
+            var request = state == RequestState.Open
+                ? Open()
+                : Open() with { State = state, StateChangedAt = Asked };
+
+            Assert.NotEqual(RequestQuota.CountsAgainstIt(request), RetentionSweep.IsFinished(request));
+        }
+    }
+
+    /// <summary>
+    /// A store holding both kinds loses only the expired ones, which is the shape a real queue is
+    /// in. Asserted by identity rather than by count, so a run that removed the wrong one and kept
+    /// the right number is red.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task OnlyTheExpiredOnesGo()
+    {
+        var store = new InMemoryRequestStore();
+        var clock = new TestClock(Asked);
+        var settings = new FakeInstallSettings();
+        var sweep = Sweep(store, settings, clock);
+
+        var expired = await store.AddAsync(Finished(RequestState.Fulfilled), CancellationToken.None);
+        var open = await store.AddAsync(Open(), CancellationToken.None);
+
+        clock.Advance(TimeSpan.FromDays(settings.Current.FinishedRequestRetentionDays + 1));
+
+        var recent = await store.AddAsync(
+            Finished(RequestState.Declined) with { StateChangedAt = clock.UtcNow },
+            CancellationToken.None);
+
+        Assert.Equal(1, await sweep.SweepAsync(CancellationToken.None));
+
+        var left = (await store.GetAllAsync(CancellationToken.None))
+            .Select(stored => stored.Request.Id)
+            .ToHashSet();
+
+        Assert.DoesNotContain(expired.Request.Id, left);
+        Assert.Contains(open.Request.Id, left);
+        Assert.Contains(recent.Request.Id, left);
+    }
+
+    private static RetentionSweep Sweep(IRequestStore store, IInstallSettings settings, TestClock clock)
+        => new RetentionSweep(store, settings, clock, NullLogger.Instance);
+
+    private static MediaRequest Open()
+        => new MediaRequest
+        {
+            Id = Guid.NewGuid(),
+            RequestedByUserId = Requester,
+            RequestedAt = Asked,
+            Kind = RequestedItemKind.Movie,
+            DisplayTitle = "A film somebody asked for",
+            StateChangedAt = Asked,
+            ProviderIds = new Dictionary<string, string> { ["Tmdb"] = "603" }
+        };
+
+    /// <summary>
+    /// A request left in a finished state at <see cref="Asked"/>, so the period is measured from a
+    /// moment the test names.
+    /// </summary>
+    /// <param name="state">Which finished state.</param>
+    /// <returns>The request.</returns>
+    private static MediaRequest Finished(RequestState state)
+        => Open() with { State = state, StateChangedAt = Asked };
+}

--- a/Jellyfin.Plugin.Requests/Api/QueueContext.cs
+++ b/Jellyfin.Plugin.Requests/Api/QueueContext.cs
@@ -28,9 +28,10 @@ public sealed record QueueContext
     /// <summary>
     /// Gets what was already decided about the same work, most recent first.
     /// <para>
-    /// Bounded by nothing but the store. A finished request is kept until the retention period is
-    /// enforced, which is #49 and is not built, so today this is every decision ever made about that
-    /// work rather than the ones inside the period an operator configured.
+    /// Bounded by the store, which <see cref="Storage.RetentionSweep"/> now bounds in turn: a
+    /// finished request is removed once it has been finished for longer than this install keeps
+    /// them, so this is every decision inside that period rather than every decision ever made about
+    /// that work.
     /// </para>
     /// </summary>
     public IReadOnlyList<EarlierDecision> EarlierDecisions { get; init; } = [];

--- a/Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs
@@ -93,7 +93,7 @@ public class PluginConfiguration : BasePluginConfiguration
     /// <para>
     /// The number is here rather than in the code, decided on #113, so an operator with a different
     /// answer changes a field instead of asking for a release. <see cref="MinimumRetentionDays"/> is
-    /// the floor under it, and what removes an expired request is #49.
+    /// the floor under it, and what removes an expired request is <see cref="Storage.RetentionSweep"/>.
     /// </para>
     /// </summary>
     public int FinishedRequestRetentionDays { get; set; } = 365;

--- a/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
@@ -156,5 +156,17 @@ public sealed class PluginServiceRegistrator : IPluginServiceRegistrator
         // registered so that the one it constructs is built from the same objects as everything
         // above rather than from a second set.
         serviceCollection.AddSingleton<IScheduledTask, FulfilmentTask>();
+
+        // What removes a finished request once it has been kept for as long as this install says.
+        // The settings are taken as the seam rather than read here, because the period is a value an
+        // operator changes while the server is running and a number captured at startup would be the
+        // one they replaced.
+        serviceCollection.AddSingleton(provider => new RetentionSweep(
+            provider.GetRequiredService<IRequestStore>(),
+            provider.GetRequiredService<IInstallSettings>(),
+            provider.GetRequiredService<IClock>(),
+            provider.GetRequiredService<ILogger<RetentionSweep>>()));
+
+        serviceCollection.AddSingleton<IScheduledTask, RetentionTask>();
     }
 }

--- a/Jellyfin.Plugin.Requests/Storage/RetentionSweep.cs
+++ b/Jellyfin.Plugin.Requests/Storage/RetentionSweep.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Configuration;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Time;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.Requests.Storage;
+
+/// <summary>
+/// Removes a finished request once it has been kept for as long as the install says to keep it.
+/// This is the half of #49 the retention period was a number without: until it existed, a server
+/// kept every request a person ever made, whatever
+/// <see cref="PluginConfiguration.FinishedRequestRetentionDays"/> said.
+/// <para>
+/// <b>Removed rather than stripped of its requester.</b> A request whose requester has been taken
+/// off it is a row saying somebody asked for a title, which still says that the title was asked for
+/// on this server on that date and leaves a record that answers nothing anybody wanted to ask. The
+/// period exists so the data stops existing, and half of it stopping is the shape that reads as
+/// deletion in a document and is not one in the file.
+/// </para>
+/// <para>
+/// <b>What counts as finished is the partition the model already draws.</b>
+/// <see cref="RequestQuota"/> says of the same five states that open and approved are the ones
+/// somebody still owes an answer or a delivery on and that fulfilled, declined and failed are
+/// finished. That sentence is the one this reads, so the two cannot mean different things by the
+/// word: <see cref="IsFinished"/> is the complement of
+/// <see cref="RequestQuota.CountsAgainstIt"/> and is asserted to be over every value of
+/// <see cref="RequestState"/>.
+/// </para>
+/// <para>
+/// <b>The clock starts when the request last moved, not when it was asked for.</b> A request
+/// declined a year after it was made has been finished for no time at all, and
+/// <see cref="MediaRequest.StateChangedAt"/> is the moment it reached the state it is in. That also
+/// makes the one legal way back out of a finished state honest: a declined request an operator
+/// later approves, or a failed one that arrives after all, moves and therefore starts its period
+/// again from the move rather than being removed out from under the person who asked.
+/// </para>
+/// <para>
+/// <b>An install whose settings cannot be honoured removes nothing.</b> The period is read through
+/// <see cref="IInstallSettings"/>, which refuses a stored configuration this plugin cannot run on
+/// rather than correcting it, so a file holding a retention below the floor stops this run with the
+/// refusal instead of deleting against a number nobody chose.
+/// </para>
+/// </summary>
+public sealed class RetentionSweep
+{
+    private readonly IRequestStore _store;
+    private readonly IInstallSettings _settings;
+    private readonly IClock _clock;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RetentionSweep"/> class.
+    /// </summary>
+    /// <param name="store">Where the requests are, and what removes one.</param>
+    /// <param name="settings">What this install is set to, read per run rather than held.</param>
+    /// <param name="clock">The injected clock, so a period is proven by moving time rather than by waiting.</param>
+    /// <param name="logger">The server's log, where a removal and a refused one are reported.</param>
+    /// <exception cref="ArgumentNullException">Where anything it needs is missing.</exception>
+    public RetentionSweep(
+        IRequestStore store,
+        IInstallSettings settings,
+        IClock clock,
+        ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(settings);
+        ArgumentNullException.ThrowIfNull(clock);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _store = store;
+        _settings = settings;
+        _clock = clock;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Whether this request is one the retention period applies to.
+    /// </summary>
+    /// <param name="request">The request being judged.</param>
+    /// <returns>
+    /// <see langword="true"/> where it is fulfilled, declined or failed, which are the three states
+    /// <see cref="RequestQuota"/> already calls finished.
+    /// </returns>
+    public static bool IsFinished(MediaRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        return !RequestQuota.CountsAgainstIt(request);
+    }
+
+    /// <summary>
+    /// Removes every finished request that has been finished for longer than this install keeps
+    /// them.
+    /// </summary>
+    /// <param name="cancellationToken">Cancels the run between requests.</param>
+    /// <returns>How many requests this run removed.</returns>
+    /// <exception cref="InvalidConfigurationException">
+    /// Where the stored settings hold a retention period this plugin will not act on. Nothing is
+    /// removed in that case, including requests a shorter period would not have reached: a run that
+    /// deleted what it could and then refused would leave an operator repairing a number after the
+    /// data it governed had already gone.
+    /// </exception>
+    public async Task<int> SweepAsync(CancellationToken cancellationToken)
+    {
+        // Read before anything is walked, so a refusal happens before the first removal rather than
+        // between two of them.
+        var keepForDays = _settings.Current.FinishedRequestRetentionDays;
+        var keepFor = TimeSpan.FromDays(keepForDays);
+
+        var held = await _store.GetAllAsync(cancellationToken).ConfigureAwait(false);
+        var removeWhatMovedBefore = _clock.UtcNow - keepFor;
+        var removed = 0;
+
+        foreach (var stored in held)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var request = stored.Request;
+
+            if (!IsFinished(request) || request.StateChangedAt > removeWhatMovedBefore)
+            {
+                continue;
+            }
+
+            try
+            {
+                if (await _store.RemoveAsync(request.Id, stored.Revision, cancellationToken).ConfigureAwait(false))
+                {
+                    removed++;
+                }
+            }
+            catch (RequestConcurrencyException)
+            {
+                // Somebody moved this request between the read and the removal, so what was decided
+                // above was decided about a request that no longer exists in that shape. A declined
+                // request an operator has just approved is exactly this case, and removing it on a
+                // retry would delete the decision they made a moment ago. The next run reads it as
+                // it now is.
+                _logger.LogDebug(
+                    "A request moved while it was being removed for age, so it was left alone and the next run will look at it again.");
+            }
+        }
+
+        // At information rather than debug: this is the plugin deleting somebody's record without
+        // anybody asking it to, and an operator answering for what is held should be able to find
+        // that it happened in the log they already read.
+        if (removed > 0 && _logger.IsEnabled(LogLevel.Information))
+        {
+            _logger.LogInformation(
+                "Removed {Removed} finished request(s) that had been finished for longer than the {Days} day(s) this install keeps them for.",
+                removed,
+                keepForDays);
+        }
+
+        return removed;
+    }
+}

--- a/Jellyfin.Plugin.Requests/Storage/RetentionTask.cs
+++ b/Jellyfin.Plugin.Requests/Storage/RetentionTask.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Model.Tasks;
+
+namespace Jellyfin.Plugin.Requests.Storage;
+
+/// <summary>
+/// What makes the retention period happen without an operator remembering, which is the half of
+/// #49's second condition a number in a settings file cannot be.
+/// <para>
+/// It runs on a schedule and at startup. The schedule is what an unattended server needs; startup
+/// is what a server that was switched off for a month needs, because a period that only elapses
+/// while the machine is running is not the period an operator set.
+/// </para>
+/// <para>
+/// Daily, and the interval is stated rather than tuned. The shortest period this plugin will accept
+/// is thirty days, so a run a day removes a record within a day of its period ending, which is as
+/// close as anything short of a timer per request gets and is a walk of the store rather than a
+/// watch on it.
+/// </para>
+/// </summary>
+public sealed class RetentionTask : IScheduledTask
+{
+    private static readonly TimeSpan Interval = TimeSpan.FromDays(1);
+
+    private readonly RetentionSweep _sweep;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RetentionTask"/> class.
+    /// </summary>
+    /// <param name="sweep">The one thing that decides what has been kept long enough.</param>
+    /// <exception cref="ArgumentNullException">Where no sweep was given.</exception>
+    public RetentionTask(RetentionSweep sweep)
+    {
+        ArgumentNullException.ThrowIfNull(sweep);
+
+        _sweep = sweep;
+    }
+
+    /// <inheritdoc />
+    public string Name => "Remove finished requests that have been kept long enough";
+
+    /// <inheritdoc />
+    public string Description =>
+        "Deletes requests that were fulfilled, declined or failed longer ago than this install keeps them for.";
+
+    /// <inheritdoc />
+    public string Category => "Requests";
+
+    /// <summary>
+    /// Gets the identifier the server keeps this task's schedule under. Written out rather than
+    /// derived from the type name, so renaming the class does not silently discard an interval an
+    /// operator changed.
+    /// </summary>
+    public string Key => "RequestsRetention";
+
+    /// <inheritdoc />
+    public IEnumerable<TaskTriggerInfo> GetDefaultTriggers() =>
+    [
+        new TaskTriggerInfo { Type = TaskTriggerInfoType.StartupTrigger },
+        new TaskTriggerInfo { Type = TaskTriggerInfoType.IntervalTrigger, IntervalTicks = Interval.Ticks }
+    ];
+
+    /// <inheritdoc />
+    public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(progress);
+
+        progress.Report(0);
+
+        await _sweep.SweepAsync(cancellationToken).ConfigureAwait(false);
+
+        progress.Report(100);
+    }
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -335,9 +335,10 @@ nobody built are different statements, so the field is absent rather than empty:
 second as the first would tell an operator that nothing has ever been decided about a title on a
 route that never looked.
 
-**`Context.EarlierDecisions` is bounded by nothing but the store.** A finished request is kept until
-the retention period is enforced, which is #49 and is not built, so this is every decision ever made
-about that work rather than the ones inside the period an operator configured.
+**`Context.EarlierDecisions` is bounded by the store, and the store is bounded by the retention
+period.** `RetentionSweep` removes a finished request once it has been finished for longer than
+`FinishedRequestRetentionDays`, so this is every decision inside that period rather than every
+decision ever made about that work.
 
 **Nothing under `Context` says who.** An earlier decision carries the answer, when it was made, the
 seasons it covered and the reason, and never the person who asked for it or the person who decided

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,10 +44,21 @@ different answer changes it without waiting for a release. The floor is there so
 set to nothing: zero would delete the history quietly and leave the queue answering that question
 with no.
 
-What removes an expired request is #49, and it is not built yet. **Until it is, nothing enforces this
-number**, and a server running this plugin keeps every finished request. That is a gap rather than a
-setting an operator can rely on, and it is written here rather than left for somebody to discover
-from a store that never shrinks.
+What removes an expired request is the scheduled task **Remove finished requests that have been kept
+long enough**, in the `Requests` category of the server's task list. It runs daily and at startup,
+and it removes a request that has been fulfilled, declined or failed for longer than this number
+says. The period is measured from the move that finished the request rather than from the day it was
+asked for, so a request answered after sitting open for a year is kept for the whole period after
+the answer. Startup is one of its triggers because a period that only elapses while the machine is
+running is not the period that was set.
+
+Removed rather than anonymised. A row that has lost its requester still says the title was asked for
+on this server on that date and answers nothing anybody wanted to ask, so the period ends with the
+record gone.
+
+**What this does not reach is a request that is still open or approved**, at any age. Those are the
+two states somebody still owes an answer or a delivery on, and a request that disappeared on its
+anniversary would be this plugin answering it with nothing.
 
 **OpenRequestsPerUser** is 10. The quota is the only thing between one person and the whole disk,
 and a limit introduced after people have habits is enforced against those habits rather than in

--- a/docs/operating.md
+++ b/docs/operating.md
@@ -32,9 +32,10 @@ the order to take them in and what each one costs you later.
   the server rather than accepted and quietly replaced.
 - **Which kinds of thing may be asked for.** Turning one off is how a server that holds only films
   stops collecting series requests it will never answer.
-- **How long a finished request is kept.** It is a number today and nothing acts on it. A finished
-  request stays until somebody removes the file, which is stated in
-  [personal-data.md](personal-data.md) and is the honest reading of that field.
+- **How long a finished request is kept.** A daily task removes a request that has been fulfilled,
+  declined or failed for longer than this, counted from the move that finished it. A request nobody
+  has answered is never removed by age. What is held and for how long is
+  [personal-data.md](personal-data.md).
 - **The address a notice is posted to.** Leave it empty unless you have somewhere to receive one.
   Empty means nothing is sent, and that is a supported way to run rather than a half-configured one.
 

--- a/docs/personal-data.md
+++ b/docs/personal-data.md
@@ -115,19 +115,41 @@ accounts on the machine is a fact about the installation, and no run on this boa
 [configuration.md](configuration.md) carries the number, the reason it is a field and the reason the
 floor exists, and this page does not restate the argument.
 
-**Nothing removes anything today.** The setting is read where it is validated and nowhere else:
+**A request that has been finished for longer than that is deleted.** The setting is read where it
+is validated and by the thing that acts on it:
 
     git grep -ln 'FinishedRequestRetentionDays' -- Jellyfin.Plugin.Requests/
     Jellyfin.Plugin.Requests/Configuration/ConfigurationRules.cs
     Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs
     Jellyfin.Plugin.Requests/Configuration/configPage.html
+    Jellyfin.Plugin.Requests/Storage/RetentionSweep.cs
 
-The class that declares it, the rule that refuses a value under the floor, and the field on the
-settings page. There is no sweep, no scheduled task and no code path that deletes a finished request,
-so a server running this plugin keeps every request forever, whatever the number says. What builds
-the thing that enforces it is #49.
+The class that declares it, the rule that refuses a value under the floor, the field on the settings
+page, and the sweep. `RetentionTask` is what runs the sweep without anybody remembering to: daily and
+at startup, in the server's own task list under `Requests`.
 
-An operator answering for this today should read the number as a plan and the file as the fact.
+Deleted rather than anonymised. A record stripped of its requester still says a title was asked for
+on this server on that date, and keeping that is not what a retention period is for.
+
+**Finished means fulfilled, declined or failed**, which is the same partition the quota already
+draws, and the suite asserts the two agree over every state rather than leaving them to drift. An
+open or approved request is never removed by age, because those are the two somebody still owes an
+answer or a delivery on.
+
+**The period runs from the move that finished the request**, `StateChangedAt`, and not from the day
+it was asked for. A request answered after a year open is kept for the whole period after the
+answer, and a declined request an operator later approves has left the finished set and starts again
+if it comes back to it.
+
+**An install whose settings this plugin will not run on deletes nothing.** The period is read through
+the same seam that refuses a stored configuration rather than correcting it, so a file holding a
+retention below the floor stops the run with the refusal instead of deleting against a number nobody
+chose.
+
+**What was not measured.** No run of this task on a server has been watched. What is measured is the
+sweep, against the store the plugin ships, on both claimed target frameworks; that the server lists
+and starts the task on either line is the same unrun procedure every other scheduled behaviour here
+carries, in [testing.md](testing.md).
 
 ## What happens when a Jellyfin user is deleted
 
@@ -151,6 +173,9 @@ identifier out of past entries is not a small change to make while implementing 
 the question and states the three answers that are available, each of which leaves something
 different behind. This page cannot state a behaviour that has not been decided, and describing the
 current absence as a retention choice would be exactly that.
+
+The retention period above is not that rule and does not stand in for it. It reaches a record when
+the record is old, whoever it names, and a deleted person's identifier sits in the file until then.
 
 ## What leaves the server
 

--- a/docs/queue.md
+++ b/docs/queue.md
@@ -135,9 +135,10 @@ anybody made.
 
 **Two things this deliberately does not carry.** It never says who asked for the earlier one or who
 decided it: the operator can read that on the request itself, and repeating it here would put a
-person's name beside a title they did not ask for this time. And it is bounded by nothing but the
-store. Enforcing the retention period is #49 and is not built, so this is every decision ever made
-about that work rather than the ones inside the period an operator configured:
+person's name beside a title they did not ask for this time. And it is bounded by the store, which is
+now bounded in turn: `RetentionSweep` removes a finished request once it has been finished for longer
+than this install keeps them, so what an operator sees here is every decision inside that period
+rather than every decision ever made about that work:
 
     git grep -n "FinishedRequestRetentionDays" -- Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs
     Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:99:    public int FinishedRequestRetentionDays { get; set; } = 365;
@@ -247,9 +248,10 @@ than two fields because neither is a property of the request: both are worked ou
 store holds, and a request knows nothing about its neighbours.
 
 **What is short here is a cell an operator cannot read rather than an item nobody answered.** A row
-for a title decided a dozen times carries a dozen lines in one cell, because nothing bounds the set
-and #49 is what would. That is a shape somebody should look at on a real queue before it is called
-finished, and it is not the absence this section was written about.
+for a title decided a dozen times carries a dozen lines in one cell. The retention period bounds how
+far back the set reaches and nothing bounds how many decisions fall inside it. That is a shape
+somebody should look at on a real queue before it is called finished, and it is not the absence this
+section was written about.
 
 Nothing here was read from a running dashboard. What is measured is what the page draws, read out of
 the file, which is the bound every check over these assets carries.

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -55,7 +55,9 @@ What is not decided here, and where it is:
 
 - What happens to a write interrupted halfway is #46.
 - The on-disk shape, its version, and the rules for changing it are below.
-- How long a finished request is kept is #49, and the number itself is decision 5 on #113.
+- How long a finished request is kept is `FinishedRequestRetentionDays`, and what acts on it is
+  `RetentionSweep` beside this store, driven by a scheduled task. What happens to a record when the
+  person it names is deleted is still open and is #49.
 
 ## The three questions the store is asked
 


### PR DESCRIPTION
Part of #49.

## What was wrong

`FinishedRequestRetentionDays` has been on the configuration since `f880594`,
365 by default with a floor of 30, and nothing read it except the rule that
refuses a value under the floor. A server therefore kept every request anybody
ever made, whatever an operator had set. `docs/personal-data.md` said so in its
own words, under a heading called "How long it is kept":

    git grep -n "Nothing removes anything today" origin/master -- docs/personal-data.md
    origin/master:docs/personal-data.md:118:**Nothing removes anything today.** The setting is read where it is validated and nowhere else:

The settings page has been promising the opposite to every operator who read it:

    git grep -n "config.retention.description" origin/master -- Jellyfin.Plugin.Requests/Localisation/Strings/en.json
    origin/master:Jellyfin.Plugin.Requests/Localisation/Strings/en.json:15:  "config.retention.description": "A finished request names a person, a title and a date. After this many days it is removed. Thirty days is the shortest period allowed, so the history cannot be switched off by setting this to nothing.",

## What this adds

`Storage/RetentionSweep.cs` removes a request that has been finished for longer
than the install keeps them. `Storage/RetentionTask.cs` runs it daily and at
startup, in the server's own task list under `Requests`. Startup is a trigger
because a period that only elapses while the machine is running is not the
period an operator set.

Four decisions in it, each with a leg that fails without it.

**Finished means fulfilled, declined or failed, and it is not a second
definition.** `RequestQuota` already draws that partition and says why:

    git grep -n "is finished, so counting it would turn the setting" -- Jellyfin.Plugin.Requests/Model/RequestQuota.cs

`RetentionSweep.IsFinished` is the complement of `RequestQuota.CountsAgainstIt`,
and `FinishedMeansWhatTheQuotaAlreadyMeansByIt` asserts the two disagree nowhere
over `RequestState`, so a value added to the model cannot land on one side here
and the other side there.

**The period runs from `StateChangedAt` and not from `RequestedAt`.** A request
answered after a year open has been finished for no time at all, and measuring
from the ask would delete it the moment an operator answered it.

**A conflicting removal is dropped rather than retried.** The case is a declined
request an operator has just approved: retrying at the revision the store now
holds would delete the decision they made a moment ago.

**An install whose settings are refused removes nothing**, including records a
valid period would not have reached. A run that deleted what it could and then
refused would leave an operator repairing a number after the data it governed had
already gone.

Removed rather than stripped of the requester. A row that has lost its requester
still says a title was asked for on this server on that date, which answers
nothing anybody wanted to ask and is not what a retention period is for.

## The means

C# in this plugin's own assembly, `IScheduledTask` for the thing that runs it.
Both are forced rather than chosen: the sweep runs inside a Jellyfin server
process against a store this repository already owns, and a task the server lists
and schedules is the interface the host offers for exactly this. It adds no
language, no runtime and no dependency, and `FulfilmentTask` beside it is the
same shape, so the suites that exist judge it without a parallel apparatus.

## Evidence

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Der Buildvorgang wurde erfolgreich ausgeführt.
        0 Warnung(en)
        0 Fehler

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler:     0, erfolgreich:   606, übersprungen:     0, gesamt:   606 - Jellyfin.Plugin.Requests.Tests.dll (net9.0)
    Bestanden!   : Fehler:     0, erfolgreich:   606, übersprungen:     0, gesamt:   606 - Jellyfin.Plugin.Requests.Tests.dll (net10.0)

Twelve of those legs are the new ones, and the counts below are that filter:

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release --filter "FullyQualifiedName~RetentionSweepTests" --nologo

### Four near-misses watched failing

Each one is a change somebody would actually make, applied on top of the branch
and then reverted.

**Dropping the finished check**, so age alone decides. Three legs red on both
frameworks:

    Fehler ... RetentionSweepTests.ARequestNobodyHasFinishedIsNeverRemoved(state: Open)
    Fehler ... RetentionSweepTests.ARequestNobodyHasFinishedIsNeverRemoved(state: Approved)
    Fehler ... RetentionSweepTests.OnlyTheExpiredOnesGo

**Measuring from `RequestedAt` instead of `StateChangedAt`**, which is the field
a reader reaches for first. Two red on both frameworks.

**Retrying the removal at the revision the store now holds** when it conflicts,
which reads like robustness and is the one that deletes an operator's decision.
One red on both frameworks.

**Using `MinimumRetentionDays` instead of reading the setting**, so the period is
a constant and the refusal never happens. Two red on both frameworks.

### What is not claimed

**No server ran.** Docker is not answering on the machine this was made on:

    docker version --format '{{.Server.Version}}'
    failed to connect to the docker API at npipe:////./pipe/dockerDesktopLinuxEngine

So nothing shows a Jellyfin server listing this task, starting it, or removing a
record. What is measured is the sweep, against the store the plugin ships, on
both claimed target frameworks. That the server picks up a scheduled task by
scanning the assembly is the pattern `FulfilmentTask` already relies on and is
not re-proven here.

**The formatting gate was run with the line ending difference accounted for.**
This clone is checked out with CRLF, so the pinned command flags all eighteen
markdown files including ones untouched here. Run with `--end-of-line auto` it
passes:

    npx --yes prettier@3.6.2 --end-of-line auto --check "docs/*.md" "CHANGELOG.md"
    All matched files use Prettier code style!

**This does not close #49.** Its first condition is that deleting a Jellyfin user
leaves no request record naming them, and what that rule should be is an open
question on that issue, because the history a decision is written into is
append-only and refused to every other writer. The retention period is not that
rule and does not stand in for it: it reaches a record when the record is old,
whoever it names.

**Nobody else has read this.** There was no second reader on this board tonight,
and the evidence above stands in place of one.
