### PR TITLE
Print the required set this branch protection actually holds

### DIFF
--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -138,9 +138,12 @@ command is right:
     call / build
     call / test
     Reject Trojan Source Unicode
+    Audit workflows (zizmor)
+    Check formatting
 
-Three of the fifteen. The set above is not applied: a ruleset is a repository
-setting rather than a file in this tree, and nothing in this change touches one.
+Five of the fifteen. The rest of the set above is not applied: a ruleset is a
+repository setting rather than a file in this tree, and nothing in this change
+touches one.
 #30 carries the application and the demonstration that a red check refuses a
 merge.
 


### PR DESCRIPTION
Part of #2.

`docs/quality-parity.md` printed a live reading of the required status checks on
`master` that no longer reproduces. It showed three contexts and said three of
the fifteen. The ruleset holds five.

The block this corrects is the one that says of itself that where the document
and the setting disagree, the command is right. A stale paste under that
sentence is worse than no paste: it reads as a measurement and is a copy.
CONTRIBUTING sends a reader to this document for which checks hold a merge, so
this is the page somebody trusts instead of asking.

## What was run

At `origin/master`, `454c1415bf313873984e4d18472af6799077d79d`, which is the
commit this branch is based on:

    gh api repos/iderex/jellyfin-plugin-requests/rules/branches/master \
      --jq '.[] | select(.type=="required_status_checks")
            | .parameters.required_status_checks[].context'
    call / build
    call / test
    Reject Trojan Source Unicode
    Audit workflows (zizmor)
    Check formatting

The two names that were added since the earlier reading are
`Audit workflows (zizmor)` and `Check formatting`. Both are already in the
document's own list of fifteen, so nothing about which set to require moves
here; what moves is how much of it is live.

## What is not changed

The rest of the paragraph is left as it stands. A ruleset is a repository
setting rather than a file in this tree, and this change touches no setting. Ten
of the fifteen are still not required and #30 still carries the application and
the demonstration that a red check refuses a merge.

The count sentence is widened rather than rewritten, so the page still says how
far the applied set is from the declared one rather than reporting agreement.

## Evidence

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror

```
Bestanden!   : Fehler:     0, erfolgreich:   606, übersprungen:     0, gesamt:   606, Dauer: 20 s - Jellyfin.Plugin.Requests.Tests.dll (net9.0)
Bestanden!   : Fehler:     0, erfolgreich:   606, übersprungen:     0, gesamt:   606, Dauer: 21 s - Jellyfin.Plugin.Requests.Tests.dll (net10.0)
```

The change is one document and no guard is added, so there is no new refusal to
watch bite. `RepositoryDocumentsTests` is what reads this file, and it reads the
links rather than this block.

**Nobody else has read this change.** There is no second reader for it tonight,
and the evidence above stands in place of one rather than beside one.
