### PR TITLE
Link the reporting form the security policy describes

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,10 @@ Use GitHub's private vulnerability reporting for this repository: the **Security
 tab, then **Report a vulnerability**. It is enabled here, and it opens a draft
 advisory only you and the maintainer can read.
 
+The form is here, without navigating:
+
+<https://github.com/Flowfin/jellyfin-plugin-requests/security/advisories/new>
+
 That is the route. Do not open a public issue for a security problem, and do not
 put one in a pull request body: both are readable by anybody the moment they are
 written, including by whoever would use what you found.


### PR DESCRIPTION
Closes #246


## What changed

Two lines in `SECURITY.md`: the address of the reporting form, attached to the
paragraph that already describes it. Nothing else is touched.

    https://github.com/Flowfin/jellyfin-plugin-requests/security/advisories/new

## What failure it prevents

`SECURITY.md` tells the reader to use private vulnerability reporting through the
Security tab, and then makes them find it. Somebody with something to report
is at the point of most friction, and the document answers the question with
directions instead of a door.

The measurable half: Scorecard scores this policy 4 of 10 with `no linked
content found`, and that alert has been sitting open unread. 16 repositories
of this fleet were in the same state.

## The means

The line is attached to the paragraph that names the Security tab, found by
that wording rather than by a line number, because the policies are worded
differently across the fleet and several wrap "**Security**" and "tab" onto
separate lines. Where that paragraph was not found, the repository was
reported and skipped rather than having the address appended to the end of a
document that sent the reader elsewhere two paragraphs earlier.

An autolink in angle brackets rather than a titled link, so that the address
is visible as text to somebody reading the raw file over ssh.

## Evidence

The address exists, checked against an invented one so that the check can
distinguish:

```
$ curl -o /dev/null -w %{http_code} .../security/advisories/new
200
$ curl -o /dev/null -w %{http_code} .../security/advisories/erfunden
404
```

And the route is open on this repository, which is what makes the address a
statement rather than a hope:

```
$ gh api repos/Flowfin/jellyfin-plugin-requests/private-vulnerability-reporting --jq .enabled
true
```

What Scorecard reported before the change:

```
SecurityPolicyID  score is 4: security policy file detected:
                  Warn: no linked content found
```

## What this does not do

It does not write a security policy where none exists. 13 repositories of this
fleet report `score is 0: security policy file not detected`, and each of those
wants a document about that project rather than an inserted line.

It does not add a response time. 6 repositories score 9 because their policy
says little about disclosure and timelines, and this change touches neither.
A promise about how fast a report is answered is mine to make, not
a line a script can insert.

Nothing else in the document was re-read for statements this change makes
false. The paragraph it attaches to was; the rest was not.

## Who read this

The same hand wrote the change and this text, and there is no second reader
on this board. Under the account rule that nothing reaches the mainline that
only its own author has read, that rule is NOT satisfied here. The change is
two lines of Markdown in a document that already describes the route they
point at, which is the smallest surface a change can have.