### PR TITLE
Name the double the refusal list sends a reader to

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj
+++ b/Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj
@@ -61,6 +61,10 @@
     <!-- The configuration document, for the same reason again: the settings and the value a fresh
          install runs for each are printed for an operator out of the class the plugin reads. -->
     <None Include="../docs/configuration.md" Link="docs/configuration.md" CopyToOutputDirectory="PreserveNewest" />
+    <!-- The testing document, because its refusal list names what replaces each refused test and
+         one of those replacements is a type in this project. A document naming an issue number goes
+         stale silently; a document naming a type can be read against the type. -->
+    <None Include="../docs/testing.md" Link="docs/testing.md" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.Requests.Tests/RepositoryDocumentsTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/RepositoryDocumentsTests.cs
@@ -145,6 +145,32 @@ public sealed class RepositoryDocumentsTests
     }
 
     /// <summary>
+    /// The refusal list names the double that replaces a real outbound call, and the double is still
+    /// called that.
+    /// <para>
+    /// The document went on saying that replacement did not exist yet, long after it did, because it
+    /// named the issue that would build it rather than the file that had been built. An issue number
+    /// stops being an address the moment the thing arrives, and nothing read the sentence. The repair
+    /// was to name the type, and this is what holds that name true: rename the double and
+    /// <c>nameof</c> follows it while the document does not, so the two disagree here rather than in
+    /// front of somebody looking for what to write instead of a real HTTPS call.
+    /// </para>
+    /// <para>
+    /// It reads the name and not the sentence around it. Prose naming the double and saying the wrong
+    /// thing about it passes, which is stated in the document rather than hidden by this leg.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void TheRefusalListNamesTheDoubleThatReplacesARealOutboundCall()
+    {
+        const string Testing = "docs/testing.md";
+
+        var document = File.ReadAllText(Beside(Testing.Replace('/', Path.DirectorySeparatorChar)));
+
+        Assert.Contains(nameof(Doubles.ASinkEndpoint), document, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// One file as it sits next to the suite.
     /// </summary>
     /// <param name="name">Its path, relative to the repository root.</param>

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -85,9 +85,17 @@ a test endpoint needs its certificate trusted, which means writing to a machine 
 is the third condition and the second one at once.
 
 What replaces it is an in-process HTTP double, so the client under test is exercised through its
-own handler pipeline and no socket is opened. It is #35. Until it exists there is no outbound call
-to test: #80 defines the backend interface with a null implementation behind it, and #87 is the
-proof that this plugin is complete with no backend at all.
+own handler pipeline and no socket is opened. It is
+`Jellyfin.Plugin.Requests.Tests/Doubles/ASinkEndpoint.cs`, and the outbound call it stands in front
+of is the notification sink, which posts a document to the one address an operator typed and reads
+a status back. What no double here reaches is a response body, because nothing in this plugin
+parses one, and the cases that need a client which does are what #35 is still open for.
+
+This paragraph named an issue rather than a file until #251, and went on saying the double did not
+exist for as long as it took somebody to read both.
+`TheRefusalListNamesTheDoubleThatReplacesARealOutboundCall` reds if the type is renamed or removed
+while this document names it. It reads the name and not the sentence around it, so prose naming the
+double and saying the wrong thing about it still passes.
 
 **A call refused by the server's authorisation policy.** Refused: the policy is evaluated by the
 server, so a test that a signed-in caller who is not an administrator is turned away from the queue
@@ -107,7 +115,8 @@ claims to be: what they leave open is that the server evaluates `RequiresElevati
 endpoints are evaluated under it. That is #51.
 
 Every replacement named above exists, either as something already in the tree or as an issue on
-this board:
+this board. The states move, and a paste taken once reads afterwards as a claim about today, so
+this one carries the commit it was read at, `1f5ad56`:
 
     for n in 20 35 50 51 52 54 56 61 64 115; do gh issue view $n --json number,state,title --jq '"\(.number)  \(.state)  \(.title)"'; done
     20  CLOSED  Prove the built plugin loads on a server of each claimed line
@@ -115,11 +124,11 @@ this board:
     50  CLOSED  Lay out the controller, the route prefix and the version rule
     51  OPEN  Decide the authorisation policy for every endpoint
     52  CLOSED  Create a request over the API
-    54  OPEN  Act on a request over the API
-    56  OPEN  Fix the error shape and the status codes
-    61  OPEN  Act on one request from the page
-    64  OPEN  Hold the page to the same rules as the rest of the tree
-    115  OPEN  Make the headless rule refusable rather than written down
+    54  CLOSED  Act on a request over the API
+    56  CLOSED  Fix the error shape and the status codes
+    61  CLOSED  Act on one request from the page
+    64  CLOSED  Hold the page to the same rules as the rest of the tree
+    115  CLOSED  Make the headless rule refusable rather than written down
 
     git ls-files scripts/
     scripts/verify-plugin-loads.sh


### PR DESCRIPTION
Closes #251

The third refusal in the headless rule's list said the in-process HTTP double did not exist yet.
It has existed since the notification sink landed, and `ASinkEndpoint` already carries a line
saying `docs/testing.md` names it, so the two files disagreed and the one a reader reaches first
was the wrong one. The evidence and the commands are on #251.

## What changed

The refusal now names `Jellyfin.Plugin.Requests.Tests/Doubles/ASinkEndpoint.cs` and the call it
stands in front of, and says what it does not reach: a response body, because nothing in this
plugin parses one. What that leaves is what #35 is still open for, pointed at rather than restated
here.

The paragraph asserting that every named replacement exists had drifted the same way. Its pasted
reading of ten issues was taken once and four of them have closed since. The reading is retaken and
carries the commit it was read at, `1f5ad56`, so the next reader can tell a stale paste from a
current one instead of trusting it.

## The guard, and what it does not hold

`TheRefusalListNamesTheDoubleThatReplacesARealOutboundCall` reads the document beside the suite and
asserts it names the type. `nameof` follows a rename and the string in the document does not, so a
renamed or removed double reds here rather than in front of a reader.

Watched failing, by taking the name back out of the document and leaving everything else:

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release --filter "FullyQualifiedName~TheRefusalListNamesTheDoubleThatReplacesARealOutboundCall"
       Assert.Contains() Failure: Sub-string not found
    Fehler!      : Fehler:     1, erfolgreich:     0, uebersprungen:     0, gesamt:     1 (net9.0)
       Assert.Contains() Failure: Sub-string not found
    Fehler!      : Fehler:     1, erfolgreich:     0, uebersprungen:     0, gesamt:     1 (net10.0)

Then restored, with the whole suite green on both claimed lines:

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler:     0, erfolgreich:   622, uebersprungen:     0, gesamt:   622 (net9.0)
    Bestanden!   : Fehler:     0, erfolgreich:   622, uebersprungen:     0, gesamt:   622 (net10.0)

It reads the name and not the sentence around it. Prose that names the double and says the wrong
thing about it passes, which is the residual and is written into the document rather than left for
somebody to discover. The direction where the type is renamed and the document is not rests on
`nameof` and the compiler rather than on an assertion, and no leg here demonstrates it.

## The means

Markdown for the document, because it is the document, and a leg in the existing suite for the
guard, in the file that already holds documents against the tree and by the mechanism that already
copies documents beside the test host. No language, runtime or dependency is added, and the leg is
refusable, executed and quotable like every other one here.

## What is not claimed

No server ran. The document also asserts what the four lint rules refuse and what the recorded
first-load procedure covers, and none of that was re-measured here; what this change touches is the
third refusal and the paragraph under the list.

This branch had no second reader. Nobody else read it before it was opened, and the transcripts
above stand in place of one.
