### PR TITLE
Say in docs/seam.md that the endpoints are the boundary

### DIFF
--- a/docs/seam.md
+++ b/docs/seam.md
@@ -174,7 +174,7 @@ for somebody to infer from the first.
 `IRequestStore` is public, and the plugin registers it into the container the server hands it:
 
     git grep -n 'AddSingleton<IRequestStore>' -- Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
-    Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs:52:        serviceCollection.AddSingleton<IRequestStore>(provider => new FileRequestStore(
+    Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs:63:        serviceCollection.AddSingleton<IRequestStore>(provider => new FileRequestStore(
 
 That collection is the server's own, not one this plugin keeps to itself, so the registration sits
 where everything else in the process can be resolved from. What the interface answers is not
@@ -184,9 +184,28 @@ a query over all of them.
 What this does not say is that another plugin can reach it. Naming a type means having the type, and
 whether a second plugin in one process can name this one is the assembly-loading question #117 asks
 and nobody here has measured. So what is written down is an exposure of unmeasured reachability,
-which is neither a leak that has been shown nor a safety anybody has earned. The rule the API keeps,
-that a caller reads their own requests and never another person's, is enforced at the endpoints in
-`docs/api.md` and not by the store beneath them.
+which is neither a leak that has been shown nor a safety anybody has earned.
+
+**The boundary is the endpoints, and the store beneath them is not one.** The rule the API keeps,
+that a caller reads their own requests and never another person's, is enforced where those calls
+arrive and is written down in `docs/api.md`. A caller already inside the server process is outside
+that rule, and this document says so instead of leaving it to be worked out from the registration
+above.
+
+That sentence is here in its own right because it is wider than the position it follows from. What
+"What this side trusts, and what it checks anyway" argues below is about one handover: a caller in
+this process can read this plugin's store and write its files whatever the seam does, so a check on
+the seam would protect against nothing that is not already possible. Reading that as covering
+everything this plugin puts into the server's container is an extension of it, and an extension
+nobody wrote down is the kind somebody discovers later and disagrees with.
+
+What taking it gives up is the narrower answer, which is to make the store's contract internal to
+the assembly or to hand the container something smaller. Either removes an exposure nobody has
+shown is reachable, and either reaches through `Jellyfin.Plugin.Requests/Storage/` and the whole
+suite derived from `RequestStoreContract`. It becomes the right change the day somebody measures
+the reachability and finds it, and that measurement is cheap: a second assembly in the same process
+trying to resolve the type answers it. Until then this rests on an argument rather than on a fact,
+and it should read that way.
 
 ## An undone gesture does not cross the seam
 


### PR DESCRIPTION
Closes #91.

`docs/seam.md` already recorded that `IRequestStore` is public and goes into the container the server hands the plugin, and that whether a second plugin can name the type is unmeasured. What it did not say is what that means for the rule the API keeps. A reader had to carry the trust position from further down the page across to it, and that position was written about one handover rather than about everything this plugin registers.

This states the wider form in its own sentence, in the section that raises it.

## What the three conditions stand at

**`docs/seam.md` records the refusal and the reason, so it is a decision rather than a gap.** Met before this change, under "No read crosses back, and that is a refusal rather than a gap": the contract is one way, a query back would make each side hold a piece of the other's state, and the duplicate case is answered where the handover happens.

**No interface this plugin implements or exposes lets a caller in the server process read another user's request state.** This is the condition the issue stayed open on, and it is answered by taking the boundary at the endpoints rather than by narrowing what the container holds. The tree is unchanged and says what it said:

```
git grep -n "AddSingleton<IRequestStore>" -- Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs:63:        serviceCollection.AddSingleton<IRequestStore>(provider => new FileRequestStore(

git grep -n "Task<IReadOnlyList<StoredRequest>> GetAllAsync\|Task<RequestPage> PageAsync" -- Jellyfin.Plugin.Requests/Storage/IRequestStore.cs
Jellyfin.Plugin.Requests/Storage/IRequestStore.cs:103:    Task<IReadOnlyList<StoredRequest>> GetAllAsync(CancellationToken cancellationToken);
Jellyfin.Plugin.Requests/Storage/IRequestStore.cs:193:    Task<RequestPage> PageAsync(RequestQuery query, CancellationToken cancellationToken);
```

So the document now says the boundary is the endpoints and the store beneath them is not one, says that this is wider than the handover position it follows from, and keeps the exposure recorded as unmeasured rather than as safe. Making the store's contract internal or handing the container something smaller stays the right change the day somebody measures the reachability and finds it, and the paragraph says so with what that change would cost.

**The user-facing answer is the M8 surface, and `docs/seam.md` names it.** Met before this change and untouched here: the same section sends a reader to `docs/surface.md` for the channel and the page.

## The correction inside the change

The block pastes the registration line, and the number had gone stale:

```
git grep -n "AddSingleton<IRequestStore>" origin/master -- Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
origin/master:Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs:63:        serviceCollection.AddSingleton<IRequestStore>(provider => new FileRequestStore(
```

The document said 52. It was found by running the command the document carries rather than by reading around it, and the reading it supports does not move.

## Choosing the means

Markdown in `docs/`, because the artefact is a position somebody has to be able to read and disagree with, and every other statement of that kind on this board lives there. Nothing here is a behaviour, so nothing here could be a test instead: the claim is about what the tree already does, and the commands that establish it are quoted in the paragraph rather than asserted by a run.

## The suite

Green on both claimed lines with the change in the tree, at `1781f1a`:

```
dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
Bestanden!   : Fehler:     0, erfolgreich:   631, übersprungen:     0, gesamt:   631 (net9.0)
Bestanden!   : Fehler:     0, erfolgreich:   631, übersprungen:     0, gesamt:   631 (net10.0)
```

```
npx --yes prettier@3.6.2 --check "docs/seam.md"
Checking formatting...
All matched files use Prettier code style!
```

## What is not claimed

No guard was added, so nothing was watched failing. A paragraph of prose is not refusable by anything in this tree, and no check reads what this section says; the sentence stands on the commands quoted beside it and on a reader.

No server ran. Nothing here shows a second plugin failing or succeeding at resolving `IRequestStore` in a live process, which is the measurement the paragraph itself calls cheap and outstanding.

This change has had no second reader. The evidence above stands in place of one.
