### PR TITLE
Answer availability for the person reading the row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ what came before it. What landed before this file existed is in the git history,
 where it carries the pull request and the issue it came from, and rewriting it
 from memory into entries would be a description nobody measured.
 
+- Whether the title somebody asked for has arrived is now answered for them
+  rather than for the server. Their own list asks the library on their behalf, so
+  a person restricted by a parental rating or without access to the library a
+  file sits in is told the same thing about that title as somebody whose server
+  does not have it. Until now the row carried what the server holds, which said
+  that a library they cannot open has something in it. The lookup is made only
+  for the rows on the page being returned.
+
 - The person who asked is told when their own request is answered. Approving,
   declining or fulfilling a request pushes one message to that person's
   signed-in clients and to nobody else's, carrying the title and, on a decline,

--- a/Jellyfin.Plugin.Requests.Tests/Api/ActOnARequestTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/ActOnARequestTests.cs
@@ -521,7 +521,7 @@ public sealed class ActOnARequestTests
     /// <param name="caller">Who the server says is calling.</param>
     /// <returns>The controller under test.</returns>
     private RequestsController ControllerFor(IRequestStore store, Guid? caller)
-        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), new FakeInstallSettings(), new RecordingJournal(), new RecordingSink(), new RecordingRequesterNotice());
+        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), new FakeInstallSettings(), new RecordingJournal(), new RecordingSink(), new RecordingRequesterNotice(), new FakeLibrary());
 
     /// <summary>
     /// The row a successful decision handed back, with the status code checked.

--- a/Jellyfin.Plugin.Requests.Tests/Api/ActOnManyRequestsTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/ActOnManyRequestsTests.cs
@@ -619,7 +619,7 @@ public sealed class ActOnManyRequestsTests
     /// <param name="caller">Who the server says is calling.</param>
     /// <returns>The controller under test.</returns>
     private RequestsController ControllerFor(IRequestStore store, Guid? caller)
-        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), new FakeInstallSettings(), new RecordingJournal(), new RecordingSink(), new RecordingRequesterNotice());
+        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), new FakeInstallSettings(), new RecordingJournal(), new RecordingSink(), new RecordingRequesterNotice(), new FakeLibrary());
 
     /// <summary>
     /// The entries an action came back with, with the status code checked.

--- a/Jellyfin.Plugin.Requests.Tests/Api/CreateRequestTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/CreateRequestTests.cs
@@ -368,7 +368,8 @@ public sealed class CreateRequestTests
             new FakeInstallSettings(),
             new RecordingJournal(),
             new RecordingSink(),
-            new RecordingRequesterNotice());
+            new RecordingRequesterNotice(),
+            new FakeLibrary());
 
     /// <summary>
     /// The answer, with the status code checked, so a leg cannot pass on a body that came back under

--- a/Jellyfin.Plugin.Requests.Tests/Api/ErrorSurfaceTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/ErrorSurfaceTests.cs
@@ -391,7 +391,7 @@ public sealed class ErrorSurfaceTests
     /// <param name="settings">What this install is set to.</param>
     /// <returns>The controller under test.</returns>
     private RequestsController ControllerFor(IRequestStore store, Guid? caller, IInstallSettings settings)
-        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), settings, new RecordingJournal(), new RecordingSink(), new RecordingRequesterNotice());
+        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), settings, new RecordingJournal(), new RecordingSink(), new RecordingRequesterNotice(), new FakeLibrary());
 
     /// <summary>
     /// A second request in the store, so one of them can be moved out of the way.

--- a/Jellyfin.Plugin.Requests.Tests/Api/ListRequestsTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/ListRequestsTests.cs
@@ -623,5 +623,6 @@ public sealed class ListRequestsTests
             new FakeInstallSettings(),
             new RecordingJournal(),
             new RecordingSink(),
-            new RecordingRequesterNotice());
+            new RecordingRequesterNotice(),
+            new FakeLibrary());
 }

--- a/Jellyfin.Plugin.Requests.Tests/Api/PublishedApiDocumentTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/PublishedApiDocumentTests.cs
@@ -552,7 +552,7 @@ public sealed class PublishedApiDocumentTests
     /// <param name="settings">What this install is set to.</param>
     /// <returns>The controller under test.</returns>
     private RequestsController ControllerFor(IRequestStore store, Guid? caller, IInstallSettings settings)
-        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), settings, new RecordingJournal(), new RecordingSink(), new RecordingRequesterNotice());
+        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), settings, new RecordingJournal(), new RecordingSink(), new RecordingRequesterNotice(), new FakeLibrary());
 
     /// <summary>
     /// The health endpoint over one store, with nothing behind the bridge and no sweep having run,

--- a/Jellyfin.Plugin.Requests.Tests/Api/QueueContextTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/QueueContextTests.cs
@@ -436,5 +436,6 @@ public sealed class QueueContextTests
             new FakeInstallSettings(),
             new RecordingJournal(),
             new RecordingSink(),
-            new RecordingRequesterNotice());
+            new RecordingRequesterNotice(),
+            new FakeLibrary());
 }

--- a/Jellyfin.Plugin.Requests.Tests/CatalogueSplitTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/CatalogueSplitTests.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.Requests.Api;
 using Jellyfin.Plugin.Requests.Configuration;
+using Jellyfin.Plugin.Requests.Fulfilment;
 using Jellyfin.Plugin.Requests.Identity;
 using Jellyfin.Plugin.Requests.Model;
 using Jellyfin.Plugin.Requests.Notify;
@@ -113,7 +114,8 @@ public sealed class CatalogueSplitTests
                 nameof(IInstallSettings),
                 nameof(IActivityJournal),
                 nameof(IOutboundSink),
-                nameof(IRequesterNotice)),
+                nameof(IRequesterNotice),
+                nameof(ILibrary)),
             string.Join(" | ", taken),
             StringComparer.Ordinal);
     }
@@ -150,5 +152,6 @@ public sealed class CatalogueSplitTests
             new FakeInstallSettings(),
             new RecordingJournal(),
             new RecordingSink(),
-            new RecordingRequesterNotice());
+            new RecordingRequesterNotice(),
+            new FakeLibrary());
 }

--- a/Jellyfin.Plugin.Requests.Tests/Doubles/FakeLibrary.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/FakeLibrary.cs
@@ -20,10 +20,18 @@ namespace Jellyfin.Plugin.Requests.Tests.Doubles;
 /// A title is held under one provider identifier and matches a request that names it under any
 /// spelling of the provider name, which is the rule the real lookup is written to.
 /// </para>
+/// <para>
+/// A title can also be kept from one person, which is what a parental rating or a library they
+/// cannot open does on a real server. The double takes that as a list rather than modelling ratings,
+/// because what this plugin has to get right is asking on the caller's behalf and believing the
+/// answer; which of the server's rules produced it is the server's own and is not reachable from
+/// here.
+/// </para>
 /// </summary>
 internal sealed class FakeLibrary : ILibrary
 {
     private readonly Dictionary<(RequestedItemKind Kind, string Provider, string Value), List<int>> _held = [];
+    private readonly HashSet<(Guid Reader, RequestedItemKind Kind, string Provider, string Value)> _hidden = [];
 
     /// <inheritdoc />
     public event EventHandler<LibraryChangeEventArgs>? Changed;
@@ -33,6 +41,13 @@ internal sealed class FakeLibrary : ILibrary
     /// still looks, and a test about writes has to be able to tell the two apart.
     /// </summary>
     public int Lookups { get; private set; }
+
+    /// <summary>
+    /// Gets the people this library has been asked on behalf of, in the order it was asked, with one
+    /// entry per lookup. A test about who the question was asked as needs the list rather than the
+    /// count.
+    /// </summary>
+    public List<Guid> AskedFor { get; } = [];
 
     /// <summary>
     /// Puts a title in the library.
@@ -57,6 +72,17 @@ internal sealed class FakeLibrary : ILibrary
         => _held.Remove((kind, provider.ToUpperInvariant(), value));
 
     /// <summary>
+    /// Keeps a title this library holds out of one person's sight, the way a rating above theirs or
+    /// a library they have no access to does.
+    /// </summary>
+    /// <param name="reader">The person who may not see it.</param>
+    /// <param name="kind">What sort of thing it is.</param>
+    /// <param name="provider">The provider naming it.</param>
+    /// <param name="value">The identifier under that provider.</param>
+    public void Hide(Guid reader, RequestedItemKind kind, string provider, string value)
+        => _hidden.Add((reader, kind, provider.ToUpperInvariant(), value));
+
+    /// <summary>
     /// Raises what the server raises when the library gains or loses something.
     /// </summary>
     /// <param name="kind">What sort of thing changed.</param>
@@ -69,13 +95,39 @@ internal sealed class FakeLibrary : ILibrary
         RequestedItemKind kind,
         IReadOnlyDictionary<string, string> providerIds,
         CancellationToken cancellationToken)
+        => Holding(Guid.Empty, kind, providerIds, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<LibraryHolding> HoldingSeenByAsync(
+        Guid userId,
+        RequestedItemKind kind,
+        IReadOnlyDictionary<string, string> providerIds,
+        CancellationToken cancellationToken)
+        => Holding(userId, kind, providerIds, cancellationToken);
+
+    /// <summary>
+    /// The one lookup, as the server or as one person.
+    /// </summary>
+    /// <param name="reader">Whose sight to answer for, or the empty identifier for the server's.</param>
+    /// <param name="kind">What sort of thing is being asked about.</param>
+    /// <param name="providerIds">The identifiers to match on.</param>
+    /// <param name="cancellationToken">Cancels the lookup.</param>
+    /// <returns>What is held.</returns>
+    private Task<LibraryHolding> Holding(
+        Guid reader,
+        RequestedItemKind kind,
+        IReadOnlyDictionary<string, string> providerIds,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(providerIds);
         cancellationToken.ThrowIfCancellationRequested();
 
         Lookups++;
+        AskedFor.Add(reader);
 
         var seasons = providerIds
+            .Where(identifier => reader == Guid.Empty
+                || !_hidden.Contains((reader, kind, identifier.Key.ToUpperInvariant(), identifier.Value)))
             .Select(identifier => _held.TryGetValue(
                 (kind, identifier.Key.ToUpperInvariant(), identifier.Value), out var found) ? found : null)
             .FirstOrDefault(found => found is not null);

--- a/Jellyfin.Plugin.Requests.Tests/Notify/ActivityJournalTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Notify/ActivityJournalTests.cs
@@ -271,7 +271,8 @@ public sealed class ActivityJournalTests
             new FakeInstallSettings(),
             journal,
             new RecordingSink(),
-            new RecordingRequesterNotice());
+            new RecordingRequesterNotice(),
+            new FakeLibrary());
 
     /// <summary>
     /// One open request in the store, with a provider identifier so the library can match it.

--- a/Jellyfin.Plugin.Requests.Tests/Notify/QuietByDefaultTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Notify/QuietByDefaultTests.cs
@@ -331,7 +331,8 @@ public sealed class QuietByDefaultTests
             settings,
             journal,
             sink,
-            new RecordingRequesterNotice());
+            new RecordingRequesterNotice(),
+            new FakeLibrary());
 
     /// <summary>
     /// One open request, with a provider identifier the library can match.

--- a/Jellyfin.Plugin.Requests.Tests/Notify/TellingTheRequesterTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Notify/TellingTheRequesterTests.cs
@@ -319,7 +319,8 @@ public sealed class TellingTheRequesterTests
             new FakeInstallSettings(),
             new RecordingJournal(),
             new RecordingSink(),
-            told);
+            told,
+            new FakeLibrary());
 
     /// <summary>
     /// A sweep telling the path handed in.

--- a/Jellyfin.Plugin.Requests.Tests/SiblingIndependenceTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/SiblingIndependenceTests.cs
@@ -42,9 +42,14 @@ public class SiblingIndependenceTests
 
         // The seam refuses a handover naming somebody this server does not have, in #118, and the
         // only member of the server's user manager that answers on both claimed lines hands back the
-        // user record. Nothing here reads that record: the answer is thrown away and its presence is
-        // the whole result. The reference is the price of asking, it arrives with the server's own
+        // user record. The reference is the price of asking, it arrives with the server's own
         // libraries, and it is excluded from the install with them.
+        //
+        // This comment said nothing here reads that record, which stopped being true with #71. A
+        // request row on somebody's own page says whether what they asked for has arrived, and that
+        // is answered by a library query made as them; the server's query takes the record rather
+        // than an identifier, so the record is handed straight to it. Nothing reads a field on it
+        // either way.
         "Jellyfin.Database.Implementations",
         "MediaBrowser.Common",
         "MediaBrowser.Controller",

--- a/Jellyfin.Plugin.Requests.Tests/Surface/AvailabilityIsAnsweredPerCallerTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Surface/AvailabilityIsAnsweredPerCallerTests.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Api;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Surface;
+
+/// <summary>
+/// What a person is told about whether the title they asked for has arrived, and who that answer is
+/// computed for. This is #71.
+/// <para>
+/// The disclosure this guards is narrow, and saying which one it is matters because the wider one is
+/// closed elsewhere. Nothing this plugin serves aggregates across people, and a row on somebody's
+/// own page names a title they supplied themselves, so the title is not the leak. The leak is the
+/// sentence beside it: "the server has this now" about a title in a library the reader cannot open
+/// is a statement about that library, and about a rating somebody set for them.
+/// </para>
+/// <para>
+/// So the row's availability is not read off the record. The value on the record is what the server
+/// holds, which is what the fulfilment sweep needs and is not a fact this reader is entitled to. The
+/// row carries a second answer, asked of the library on the reader's behalf.
+/// </para>
+/// <para>
+/// <b>What no test here reaches is the server applying a rating.</b> The library seam is this
+/// plugin's own, for the reason <see cref="Jellyfin.Plugin.Requests.Fulfilment.ILibrary"/> gives,
+/// and what turns a user record into a narrower set of items is the server's own query in
+/// <c>ServerLibrary</c>, which nothing in this repository runs. What is held here is that the
+/// question is asked as the reader and that the answer is believed. <c>docs/surface.md</c> says the
+/// same thing in the same words.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class AvailabilityIsAnsweredPerCallerTests
+{
+    private static readonly DateTimeOffset Started = new DateTimeOffset(2026, 8, 21, 9, 0, 0, TimeSpan.Zero);
+    private static readonly Guid Grown = new Guid("71000000-0000-0000-0000-000000000001");
+    private static readonly Guid Child = new Guid("71000000-0000-0000-0000-000000000002");
+
+    private readonly SequentialIdentifierSource _identifiers = new SequentialIdentifierSource();
+
+    /// <summary>
+    /// The leg this issue exists for. Two people asked for the same film, the server has it, and one
+    /// of them may not see it. The one who may is told it is there, and the one who may not is told
+    /// exactly what somebody whose server does not have it is told.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ATitleTheReaderMayNotOpenReadsTheSameAsOneTheServerDoesNotHave()
+    {
+        var store = new InMemoryRequestStore();
+        await AskAsync(store, Grown, "Tmdb", "603").ConfigureAwait(true);
+        await AskAsync(store, Child, "Tmdb", "603").ConfigureAwait(true);
+
+        var library = new FakeLibrary();
+        library.Put(RequestedItemKind.Movie, "Tmdb", "603");
+        library.Hide(Child, RequestedItemKind.Movie, "Tmdb", "603");
+
+        Assert.Equal(LibraryAvailability.Present, await OnlyRowAsync(store, library, Grown).ConfigureAwait(true));
+        Assert.Equal(LibraryAvailability.Absent, await OnlyRowAsync(store, library, Child).ConfigureAwait(true));
+    }
+
+    /// <summary>
+    /// The question is asked on the reader's behalf rather than as the server. Without this leg, a
+    /// controller calling the unrestricted lookup would pass the one above on a library that happened
+    /// to hold nothing, and would leak on every library that holds something.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task TheLookupIsMadeAsTheReaderAndNeverAsTheServer()
+    {
+        var store = new InMemoryRequestStore();
+        await AskAsync(store, Child, "Tmdb", "603").ConfigureAwait(true);
+
+        var library = new FakeLibrary();
+        library.Put(RequestedItemKind.Movie, "Tmdb", "603");
+
+        await OnlyRowAsync(store, library, Child).ConfigureAwait(true);
+
+        Assert.Equal([Child], library.AskedFor);
+    }
+
+    /// <summary>
+    /// The row is not the record. A request the sweep has already written
+    /// <see cref="LibraryAvailability.Present"/> on still reads as absent to a person who may not
+    /// see the title, which is the case a controller trusting the stored value would fail.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task TheAnswerOnTheRecordIsNotTheAnswerTheReaderIsGiven()
+    {
+        var store = new InMemoryRequestStore();
+        var asked = await AskAsync(store, Child, "Tmdb", "603").ConfigureAwait(true);
+
+        await store.ReplaceAsync(
+            asked with { Availability = LibraryAvailability.Present, AvailabilityCheckedAt = Started },
+            1,
+            CancellationToken.None).ConfigureAwait(true);
+
+        var library = new FakeLibrary();
+        library.Put(RequestedItemKind.Movie, "Tmdb", "603");
+        library.Hide(Child, RequestedItemKind.Movie, "Tmdb", "603");
+
+        Assert.Equal(LibraryAvailability.Absent, await OnlyRowAsync(store, library, Child).ConfigureAwait(true));
+    }
+
+    /// <summary>
+    /// A request naming no provider is not looked up at all, and its row says nothing rather than
+    /// saying the server has none of it. Nothing can be matched on, so
+    /// <see cref="LibraryAvailability.Absent"/> would be the answer of something that looked, and
+    /// nothing looked. It is the state the fulfilment sweep leaves such a request in.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ARequestNamingNoProviderIsNotLookedUpAndSaysNothing()
+    {
+        var store = new InMemoryRequestStore();
+        await AskAsync(store, Child, provider: null, value: null).ConfigureAwait(true);
+
+        var library = new FakeLibrary();
+
+        Assert.Equal(LibraryAvailability.Unknown, await OnlyRowAsync(store, library, Child).ConfigureAwait(true));
+        Assert.Equal(0, library.Lookups);
+    }
+
+    /// <summary>
+    /// The bound. The lookup is per row and per reader, so what stops it growing with a person's
+    /// history is that it is made over the page being returned rather than over everything the store
+    /// matched. Five requests, a page of two, two lookups.
+    /// <para>
+    /// This is the leg that fails if somebody resolves availability before the paging, which is the
+    /// natural way to write it and is fine until an install has a year of finished requests in it.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task OnlyTheRowsOnThePageAreLookedUp()
+    {
+        var store = new InMemoryRequestStore();
+
+        for (var i = 0; i < 5; i++)
+        {
+            await AskAsync(store, Child, "Tmdb", i.ToString(CultureInfo.InvariantCulture)).ConfigureAwait(true);
+        }
+
+        var library = new FakeLibrary();
+        var page = Page(await Controller(store, library, Child).MineAsync(
+            null,
+            null,
+            RequestQueryOrder.RequestedAt,
+            false,
+            0,
+            2,
+            CancellationToken.None).ConfigureAwait(true));
+
+        Assert.Equal(2, page.Requests.Count);
+        Assert.Equal(5, page.MatchCount);
+        Assert.Equal(2, library.Lookups);
+    }
+
+    /// <summary>
+    /// The page, with the status code checked.
+    /// </summary>
+    /// <param name="answered">What the action returned.</param>
+    /// <returns>The page.</returns>
+    private static RequestsPage<MyRequest> Page(ActionResult<RequestsPage<MyRequest>> answered)
+    {
+        var result = Assert.IsType<OkObjectResult>(answered.Result);
+        Assert.Equal(200, result.StatusCode);
+        return Assert.IsType<RequestsPage<MyRequest>>(result.Value);
+    }
+
+    /// <summary>
+    /// Puts a request in the store.
+    /// </summary>
+    /// <param name="store">Where it goes.</param>
+    /// <param name="asker">Who asked.</param>
+    /// <param name="provider">The provider naming the title, or nothing where the ask carries none.</param>
+    /// <param name="value">The identifier under that provider.</param>
+    /// <returns>The request as it was stored.</returns>
+    private async Task<MediaRequest> AskAsync(
+        InMemoryRequestStore store,
+        Guid asker,
+        string? provider,
+        string? value)
+    {
+        var request = new MediaRequest
+        {
+            Id = _identifiers.NewId(),
+            RequestedByUserId = asker,
+            RequestedAt = Started,
+            StateChangedAt = Started,
+            Kind = RequestedItemKind.Movie,
+            DisplayTitle = value ?? "A film nobody named",
+            ProviderIds = provider is null || value is null
+                ? new Dictionary<string, string>(StringComparer.Ordinal)
+                : new Dictionary<string, string>(StringComparer.Ordinal) { [provider] = value }
+        };
+
+        var stored = await store.AddAsync(request, CancellationToken.None).ConfigureAwait(true);
+        return stored.Request;
+    }
+
+    /// <summary>
+    /// What one reader is told about the single request of theirs in the store.
+    /// </summary>
+    /// <param name="store">Where the requests are.</param>
+    /// <param name="library">The library to ask.</param>
+    /// <param name="reader">Who is reading.</param>
+    /// <returns>The availability on their one row.</returns>
+    private async Task<LibraryAvailability> OnlyRowAsync(
+        InMemoryRequestStore store,
+        FakeLibrary library,
+        Guid reader)
+    {
+        var page = Page(await Controller(store, library, reader).MineAsync(
+            null,
+            null,
+            RequestQueryOrder.RequestedAt,
+            false,
+            0,
+            RequestsController.DefaultPageSize,
+            CancellationToken.None).ConfigureAwait(true));
+
+        return page.Requests.Single().Availability;
+    }
+
+    /// <summary>
+    /// A controller wired to one store, one library and one caller.
+    /// </summary>
+    /// <param name="store">Where requests are kept.</param>
+    /// <param name="library">The library it asks.</param>
+    /// <param name="caller">Who the server says is calling.</param>
+    /// <returns>The controller under test.</returns>
+    private RequestsController Controller(IRequestStore store, FakeLibrary library, Guid caller)
+        => new RequestsController(
+            store,
+            new TestClock(Started),
+            _identifiers,
+            new FakeCallerIdentity(caller),
+            new FakeInstallSettings(),
+            new RecordingJournal(),
+            new RecordingSink(),
+            new RecordingRequesterNotice(),
+            library);
+}

--- a/Jellyfin.Plugin.Requests.Tests/Surface/WhatAPersonIsToldTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Surface/WhatAPersonIsToldTests.cs
@@ -232,5 +232,6 @@ public sealed class WhatAPersonIsToldTests
             new FakeInstallSettings(new PluginConfiguration { OpenRequestsPerUser = allowed }),
             new RecordingJournal(),
             new RecordingSink(),
-            new RecordingRequesterNotice());
+            new RecordingRequesterNotice(),
+            new FakeLibrary());
 }

--- a/Jellyfin.Plugin.Requests.Tests/Web/QueueViewTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Web/QueueViewTests.cs
@@ -226,7 +226,8 @@ public sealed class QueueViewTests
             new FakeInstallSettings(),
             new RecordingJournal(),
             new RecordingSink(),
-            new RecordingRequesterNotice());
+            new RecordingRequesterNotice(),
+            new FakeLibrary());
 
         var answered = await controller.QueueAsync(
             [Enum.Parse<RequestState>(SelectedValueOf(body, "RequestsQueueState"), false)],

--- a/Jellyfin.Plugin.Requests/Api/RequestsController.cs
+++ b/Jellyfin.Plugin.Requests/Api/RequestsController.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.Requests.Configuration;
+using Jellyfin.Plugin.Requests.Fulfilment;
 using Jellyfin.Plugin.Requests.Identity;
 using Jellyfin.Plugin.Requests.Intake;
 using Jellyfin.Plugin.Requests.Localisation;
@@ -101,6 +102,7 @@ public sealed class RequestsController : RequestsControllerBase
     private readonly IActivityJournal _journal;
     private readonly IOutboundSink _sink;
     private readonly IRequesterNotice _told;
+    private readonly ILibrary _library;
     private readonly RequestIntake _intake;
 
     /// <summary>
@@ -130,6 +132,11 @@ public sealed class RequestsController : RequestsControllerBase
     /// endpoint has to be able to see is that exactly one person was told and which one, and that
     /// is not visible through a server nothing here runs.
     /// </param>
+    /// <param name="library">
+    /// The server's library, asked what one person may see of a title. A request row on somebody's
+    /// own page says whether what they asked for has arrived, and that sentence is answered for the
+    /// reader rather than for the server, which is #71.
+    /// </param>
     public RequestsController(
         IRequestStore store,
         IClock clock,
@@ -138,7 +145,8 @@ public sealed class RequestsController : RequestsControllerBase
         IInstallSettings settings,
         IActivityJournal journal,
         IOutboundSink sink,
-        IRequesterNotice told)
+        IRequesterNotice told,
+        ILibrary library)
     {
         _store = store;
         _clock = clock;
@@ -147,6 +155,7 @@ public sealed class RequestsController : RequestsControllerBase
         _journal = journal;
         _sink = sink;
         _told = told;
+        _library = library;
 
         // Built here rather than injected, because it is this controller's use of the store rather
         // than one more thing the server has to supply. CatalogueSplitTests reads the list this
@@ -327,13 +336,61 @@ public sealed class RequestsController : RequestsControllerBase
 
         var page = query.PageOf(theirs);
 
+        var rows = new List<MyRequest>(page.Requests.Count);
+
+        foreach (var stored in page.Requests)
+        {
+            rows.Add(Mine(
+                stored.Request,
+                reader,
+                await SeenByAsync(stored.Request, reader, cancellationToken).ConfigureAwait(false)));
+        }
+
         return Ok(new RequestsPage<MyRequest>
         {
-            Requests = [.. page.Requests.Select(stored => Mine(stored.Request, reader))],
+            Requests = rows,
             MatchCount = page.MatchCount,
             Skip = query.Skip,
             Take = query.Take
         });
+    }
+
+    /// <summary>
+    /// What one person may see of the title a request names.
+    /// <para>
+    /// <b>The lookup is per row and per reader, and the page is the bound on it.</b> It is made over
+    /// the rows being returned rather than over everything the store matched, so the cost is the page
+    /// size and not the length of somebody's history. With a year of retention the second of those is
+    /// unbounded, and a per-row lookup over it is the shape that is fine in a suite and slow on the
+    /// server that uses this plugin most.
+    /// </para>
+    /// <para>
+    /// <b>A request naming no identifier is not looked up.</b> Nothing can be matched on, so the
+    /// answer stays <see cref="LibraryAvailability.Unknown"/>, which is the same thing
+    /// <c>FulfilmentSweep</c> leaves such a request at. Answering
+    /// <see cref="LibraryAvailability.Absent"/> would say the server does not have it, and nothing
+    /// looked.
+    /// </para>
+    /// </summary>
+    /// <param name="request">The request being shown.</param>
+    /// <param name="reader">The person it is being shown to.</param>
+    /// <param name="cancellationToken">Cancels the lookup.</param>
+    /// <returns>What that person may see of it.</returns>
+    private async Task<LibraryAvailability> SeenByAsync(
+        MediaRequest request,
+        Guid reader,
+        CancellationToken cancellationToken)
+    {
+        if (request.ProviderIds.Count == 0)
+        {
+            return LibraryAvailability.Unknown;
+        }
+
+        var holding = await _library
+            .HoldingSeenByAsync(reader, request.Kind, request.ProviderIds, cancellationToken)
+            .ConfigureAwait(false);
+
+        return FulfilmentRule.AvailabilityOf(request, holding);
     }
 
     /// <summary>
@@ -1009,8 +1066,13 @@ public sealed class RequestsController : RequestsControllerBase
     /// </summary>
     /// <param name="request">The stored request.</param>
     /// <param name="reader">Who is reading it.</param>
+    /// <param name="availability">
+    /// What this reader may see of the title, answered for them rather than read off the record. The
+    /// value on the record is what the server holds, which is a fact about the server's libraries
+    /// and not one this person is entitled to.
+    /// </param>
     /// <returns>The row.</returns>
-    private static MyRequest Mine(MediaRequest request, Guid reader)
+    private static MyRequest Mine(MediaRequest request, Guid reader, LibraryAvailability availability)
     {
         var asked = request.RequestedByUserId == reader;
 
@@ -1031,7 +1093,7 @@ public sealed class RequestsController : RequestsControllerBase
             YourNote = asked ? request.RequesterNote : null,
             DeclineReason = request.DeclineReason,
             DeclineNote = request.DeclineNote,
-            Availability = request.Availability
+            Availability = availability
         };
     }
 

--- a/Jellyfin.Plugin.Requests/Fulfilment/ILibrary.cs
+++ b/Jellyfin.Plugin.Requests/Fulfilment/ILibrary.cs
@@ -52,4 +52,33 @@ public interface ILibrary
         RequestedItemKind kind,
         IReadOnlyDictionary<string, string> providerIds,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// What the server holds of one title, as one person is allowed to see it.
+    /// <para>
+    /// This is the same question as <see cref="HoldingOfAsync"/> asked on somebody's behalf, and the
+    /// two are separate members because the answers are different facts. The sweep asks what the
+    /// server has, because that decides whether a request was fulfilled and that is not a fact about
+    /// any reader. A surface asks what a reader may see, because "it is here" about a title in a
+    /// library that reader cannot open is a statement about that library, which is #71.
+    /// </para>
+    /// </summary>
+    /// <param name="userId">The person the answer is for.</param>
+    /// <param name="kind">What sort of thing is being asked about.</param>
+    /// <param name="providerIds">
+    /// The external identifiers to look it up by, keyed by provider name, matched the same way
+    /// <see cref="HoldingOfAsync"/> matches them.
+    /// </param>
+    /// <param name="cancellationToken">Cancels the lookup.</param>
+    /// <returns>
+    /// What that person may see of it, or <see cref="LibraryHolding.Nothing"/> where they may see
+    /// none of it. A title the server holds and this person may not open is answered exactly like a
+    /// title the server does not hold, because that is the answer the server gives them everywhere
+    /// else.
+    /// </returns>
+    Task<LibraryHolding> HoldingSeenByAsync(
+        Guid userId,
+        RequestedItemKind kind,
+        IReadOnlyDictionary<string, string> providerIds,
+        CancellationToken cancellationToken);
 }

--- a/Jellyfin.Plugin.Requests/Fulfilment/ServerLibrary.cs
+++ b/Jellyfin.Plugin.Requests/Fulfilment/ServerLibrary.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
+using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.Requests.Model;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.TV;
@@ -27,17 +28,25 @@ namespace Jellyfin.Plugin.Requests.Fulfilment;
 public sealed class ServerLibrary : ILibrary, IDisposable
 {
     private readonly ILibraryManager _library;
+    private readonly IUserManager _users;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ServerLibrary"/> class.
     /// </summary>
     /// <param name="library">The server's library.</param>
-    /// <exception cref="ArgumentNullException">Where no library was given.</exception>
-    public ServerLibrary(ILibraryManager library)
+    /// <param name="users">
+    /// The server's users, so a lookup made on somebody's behalf can be made as them. It is the
+    /// user record the server's own query takes, which is why this reference is here rather than a
+    /// user identifier being enough.
+    /// </param>
+    /// <exception cref="ArgumentNullException">Where no library or no users were given.</exception>
+    public ServerLibrary(ILibraryManager library, IUserManager users)
     {
         ArgumentNullException.ThrowIfNull(library);
+        ArgumentNullException.ThrowIfNull(users);
 
         _library = library;
+        _users = users;
         _library.ItemAdded += OnItemChanged;
         _library.ItemRemoved += OnItemChanged;
     }
@@ -50,6 +59,47 @@ public sealed class ServerLibrary : ILibrary, IDisposable
         RequestedItemKind kind,
         IReadOnlyDictionary<string, string> providerIds,
         CancellationToken cancellationToken)
+        => Holding(kind, providerIds, null, cancellationToken);
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// A user identifier the server does not have is answered with nothing rather than with the
+    /// unrestricted answer. Falling back to the wider lookup is the failure this whole member exists
+    /// to prevent, and it would happen exactly when the caller is least known.
+    /// </remarks>
+    public Task<LibraryHolding> HoldingSeenByAsync(
+        Guid userId,
+        RequestedItemKind kind,
+        IReadOnlyDictionary<string, string> providerIds,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(providerIds);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var reader = userId == Guid.Empty ? null : _users.GetUserById(userId);
+
+        return reader is null
+            ? Task.FromResult(LibraryHolding.Nothing)
+            : Holding(kind, providerIds, reader, cancellationToken);
+    }
+
+    /// <summary>
+    /// The one lookup, made as the server or as one of its users.
+    /// </summary>
+    /// <param name="kind">What sort of thing is being asked about.</param>
+    /// <param name="providerIds">The identifiers to match on.</param>
+    /// <param name="reader">
+    /// The person to ask as, or <see langword="null"/> to ask as the server. The server's own query
+    /// carries what it applies to a user, so handing it the record is what applies the rating and
+    /// the library access rather than anything decided here.
+    /// </param>
+    /// <param name="cancellationToken">Cancels the lookup.</param>
+    /// <returns>What is held.</returns>
+    private Task<LibraryHolding> Holding(
+        RequestedItemKind kind,
+        IReadOnlyDictionary<string, string> providerIds,
+        User? reader,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(providerIds);
         cancellationToken.ThrowIfCancellationRequested();
@@ -61,7 +111,7 @@ public sealed class ServerLibrary : ILibrary, IDisposable
 
         var wanted = kind == RequestedItemKind.Series ? BaseItemKind.Series : BaseItemKind.Movie;
 
-        var found = _library.GetItemList(new InternalItemsQuery
+        var query = new InternalItemsQuery
         {
             IncludeItemTypes = [wanted],
             HasAnyProviderId = new Dictionary<string, string>(providerIds, StringComparer.OrdinalIgnoreCase),
@@ -73,7 +123,14 @@ public sealed class ServerLibrary : ILibrary, IDisposable
             // The server creates rows for media it knows about and does not have, and counting one
             // of those as arrived is the exact failure this whole path exists to avoid.
             IsVirtualItem = false
-        });
+        };
+
+        if (reader is not null)
+        {
+            query.SetUser(reader);
+        }
+
+        var found = _library.GetItemList(query);
 
         if (found.Count == 0)
         {

--- a/docs/api.md
+++ b/docs/api.md
@@ -287,6 +287,33 @@ themselves.
 The history is not in the answer. Every entry names the administrator who made the move, and a list a
 user reads is not an audit trail.
 
+### What a person may learn about a title here
+
+The row says whether what they asked for has arrived. That sentence is answered for the person
+reading it and not for the server, and this is the rule the whole surface is held to.
+
+A reader may learn, of a title they asked for themselves, whether the server holds something they
+would be allowed to open. They may learn nothing about a title they did not ask for, because nothing
+this API serves aggregates across people: there is no count of who else is waiting, no row belonging
+to anybody else, and no answer that says a title has already been asked for.
+
+**Why the availability is not simply read off the record.** The value stored on a request is what the
+server holds, which is what the fulfilment check needs and is a fact about the server's libraries. A
+person restricted by a parental rating, or without access to the library a file sits in, is not
+entitled to it: "it is here" about a title they cannot open tells them what is in that library and
+what somebody set for them. So the row carries a second answer, from a library lookup made as the
+reader, and a title they may not see reads exactly like a title the server does not have. That is the
+answer the server gives them everywhere else.
+
+**The lookup is per row, per reader, and bounded by the page.** It is made over the rows being
+returned rather than over everything the store matched, because with a year of retention the second
+of those is not bounded by anything. A request naming no provider identifier is not looked up at all
+and its row says nothing: absent would be the answer of something that looked.
+
+**What is not claimed.** Which items a user record narrows a query to is the server's own rule. This
+plugin hands the record to the server's query and believes what comes back; no test here exercises a
+rating, and `ServerLibrary` is the one part of that path nothing in this repository runs.
+
 ## The page a browser opens
 
     GET MediaRequests/v1/Page
@@ -644,7 +671,10 @@ asked for, which is a weaker disclosure than a row and still a disclosure, is op
 
 ## What is not decided here
 
-- Whether a user may ever be told that a title has already been asked for is open between #51 and #71.
+- Whether a user may ever be told that a title has already been asked for. #51 and #71 disagreed
+  about it and both closed without adding the feature, so nothing here aggregates across people and
+  the question does not arise against anything that ships. It becomes live again the day something
+  does aggregate, and it is not settled by either issue having closed.
 - The capability endpoint is #55.
 - Which of these a page calls, and what an operator sees while an action on several is running, is
   the administrator surface rather than this document. The endpoints promise what is written above

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -137,6 +137,14 @@ gets nothing from it.
 **A client that does not render channels gets nothing from the channel**, and there is no fallback
 for it inside this plugin beyond the API.
 
+**A person is never told a title is here when they would not be allowed to open it.** Both surfaces
+draw the same rows from the same endpoint, so what each class of user may learn about a title is one
+rule in one place rather than one per surface, and it is written down under "What a person may learn
+about a title here" in [`docs/api.md`](api.md). What is worth carrying here is the shape of it: a
+title the reader may not see reads exactly like a title the server does not have, so neither surface
+can say more than the other, and neither can be widened without widening the endpoint underneath
+both.
+
 **On a server with no browsing sibling installed, there is no way to ask for anything from a
 television client at all.** This is the sharpest one and it is certain rather than a claim about
 clients. This plugin ships no way to find a title the server does not have, decided on #113, because


### PR DESCRIPTION
Closes #71.

A row on somebody's own requests page says whether the title they asked for has arrived. The value came off the record, and the value on the record is what the server holds. So a person restricted by a parental rating, or without access to the library a file sits in, was told that a library they cannot open has something in it, and told what somebody had set for them.

The row now carries a second answer, from a library lookup made on that person's behalf.

## The three conditions

**The rule is written down: what each class of user may learn about a title from this plugin.** `docs/api.md` gains "What a person may learn about a title here", under the endpoint the rule is a property of. A reader may learn, of a title they asked for themselves, whether the server holds something they would be allowed to open; they may learn nothing about a title they did not ask for, because nothing this API serves aggregates across people. `docs/surface.md` points at it rather than repeating it, since both surfaces draw the same rows from the same endpoint and two copies of one rule drift apart.

**A test asserts a user restricted by parental rating learns nothing about a title above it through any surface here.** `ATitleTheReaderMayNotOpenReadsTheSameAsOneTheServerDoesNotHave` puts one film in the library, has two people ask for it, keeps it from one of them, and asserts the two rows: `Present` for the one who may open it and `Absent` for the one who may not. Absent is the same answer somebody whose server does not have the title gets, so the two states are indistinguishable from the row.

Beside it, `TheLookupIsMadeAsTheReaderAndNeverAsTheServer` asserts who the question was asked as, and `TheAnswerOnTheRecordIsNotTheAnswerTheReaderIsGiven` puts `Present` on the stored request and still expects `Absent` on the row.

**Where a rule cannot be applied cheaply, the feature is dropped rather than shipped leaking.** The field is kept and the rule is applied, which is this condition's answer rather than an exception to it: it applies to a rule that cannot be applied cheaply, and this one is merely not free. What it costs is a library lookup per row per reader, and it is bounded in this change rather than afterwards.

## The bound, and the leg that holds it

The lookup is made over the rows on the page being returned rather than over everything the store matched. With a year of retention a person's list is not bounded by the quota, and a per-row lookup over it is the shape that is fine in a suite and slow on the server that uses this plugin most.

`OnlyTheRowsOnThePageAreLookedUp` puts five requests in the store, asks for a page of two, and asserts two lookups. A request naming no provider identifier is not looked up at all and its row stays `Unknown`, which is where the fulfilment sweep leaves such a request; `Absent` would be the answer of something that looked.

## The near-misses, watched failing

Each was put in one at a time, the suite run, then reverted.

```
the per-reader lookup replaced by the unrestricted one
Fehler!      : Fehler:     3, erfolgreich:   633, gesamt:   636 (net9.0)
  AvailabilityIsAnsweredPerCallerTests.ATitleTheReaderMayNotOpenReadsTheSameAsOneTheServerDoesNotHave
  AvailabilityIsAnsweredPerCallerTests.TheAnswerOnTheRecordIsNotTheAnswerTheReaderIsGiven
  AvailabilityIsAnsweredPerCallerTests.TheLookupIsMadeAsTheReaderAndNeverAsTheServer

the row taking the stored value instead of the resolved one
Fehler!      : Fehler:     4, erfolgreich:   632, gesamt:   636 (net9.0)
  the three above, and OnlyTheRowsOnThePageAreLookedUp

the resolution moved ahead of the paging
Fehler!      : Fehler:     6, erfolgreich:   630, gesamt:   636 (net9.0)
  AvailabilityIsAnsweredPerCallerTests.OnlyTheRowsOnThePageAreLookedUp
  ListRequestsTests.EachFilterNarrowsToWhatItNames
  ListRequestsTests.EachOrderIsAnsweredAndItsReverseIsTheSameOrderBackwards
  ListRequestsTests.PagingWalksEveryMatchExactlyOnceAndTheCountIsTheSameOnEveryPage
```

The third is the one worth reading: resolving before the paging is the natural way to write it, and it is caught by legs that are not about availability at all.

## Choosing the means

C#, in this plugin and its suite, because what is being built is a query into the server's own library and there is nothing else it could be written in. The decision with an alternative was where the narrowing happens. It is a second member on `ILibrary` rather than a filter applied after an unrestricted lookup, because a filter written here would be this plugin deciding what a rating means, and the server already decides that; handing it the user record keeps the rule in one place. `ServerLibrary` grows a reference to the server's user manager, which the tree already carries for the seam.

## The suite

```
dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
Bestanden!   : Fehler:     0, erfolgreich:   636, übersprungen:     0, gesamt:   636 (net9.0)
Bestanden!   : Fehler:     0, erfolgreich:   636, übersprungen:     0, gesamt:   636 (net10.0)
```

631 before this change and 636 after it, which is the five legs above.

```
npx --yes prettier@3.6.2 --check "CHANGELOG.md" "docs/api.md" "docs/surface.md"
Checking formatting...
All matched files use Prettier code style!
```

## The size, and why it is one change

544 lines added across 22 files. Thirteen of those files carry one added argument each, which is the constructor gaining a dependency, and one more carries that dependency's name in the list `CatalogueSplitTests` compares against. The part to read is four files: the interface, its two implementations and the endpoint, with the new test file beside them.

## What is not claimed

No server ran. Which items a user record narrows the server's query to is the server's own rule, and `ServerLibrary` is the one part of this path nothing in this repository runs, for the reason `ILibrary` already gives: the server's library interface is not the same interface on the two claimed lines, so a double for it would prove a different thing on each. What is held by the suite is that the question is asked as the reader and that the answer is believed. `docs/api.md` says that in those words rather than leaving it to be inferred.

No rating was exercised. The double keeps a title from one person as a list, because what this plugin has to get right is asking on the caller's behalf, and which of the server's rules produced the narrower answer is not reachable from here.

The endpoint does not catch a library failure. It is not swallowed into `Absent`, which would tell somebody the server does not have a title it may well hold, and there is no leg for a branch that is not there.

This change has had no second reader. The evidence above stands in place of one.
