### PR TITLE
Say what the quota, the withdrawal and the seam caller actually do

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,8 +69,20 @@ front of them, which is why it ships from the start rather than later. Ten is a 
 to be trying to reach. It counts what is open rather than what was ever asked, so a person whose
 requests are answered can keep asking.
 
-Where the quota is enforced is #114, and that is not built yet either. **Nothing refuses an
-eleventh open request today.**
+The quota is enforced where a request is created, in
+[`RequestIntake`](../Jellyfin.Plugin.Requests/Intake/RequestIntake.cs), which is the one path both
+the HTTP endpoint and the seam take, so a surface cannot get past it by forgetting to ask. An
+administrator and the plugin itself are not counted against it.
+
+**There is no off switch.** A quota is always set, and a value below 1 is refused rather than read
+as unlimited: by the settings page, and again by the server on a save and on a read. An operator
+whose users are their own household sets a number above anything anybody will reach, and that
+number is a limit rather than an absence.
+
+Naming that workaround is not the same as offering the setting, and the difference is why there is
+no empty field here. A field that means no limit when it is empty is a field whose meaning has to
+be known, and one cleared by accident removes the limit silently. A quota that fails open on a typo
+is worse than a quota somebody has to work around.
 
 **OutboundNoticeAddress** is empty, and empty is the whole of how the outbound notification path is
 turned off. It is the only setting on this page that causes anything to leave this server, and it is

--- a/docs/seam.md
+++ b/docs/seam.md
@@ -230,13 +230,23 @@ nobody agreed. Adding it would also be an argument rather than a field: a want u
 it was expressed and one undone a week after an operator has already acted on it are not the same
 event, and the second is not something a gesture on a browsing surface can decide alone.
 
-Taking back an ask on this side's own surfaces is a separate thing and is not covered by this
-document. It is #68, it needs a state a request can be withdrawn into, and the model records that
-there is none:
+Taking back an ask on this side's own surfaces is a separate thing, and the answer is that a user
+cannot. There is no state a request can be withdrawn into, and the model records why:
 
     git grep -n 'Cancelled' -- Jellyfin.Plugin.Requests/Model/
     Jellyfin.Plugin.Requests/Model/RequestActor.cs:43:    /// is no state for a user withdrawing, refused with the <c>Cancelled</c> state on #113. The
     Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs:69:/// user withdrawing has no state to move to because <c>Cancelled</c> was refused on #113. An
+
+**What a person does instead is ask an operator, who declines the request.** That is written here
+rather than left to be found, because it is the one errand this plugin exists to remove, and an
+absence a user meets without warning is worse than one they were told about.
+
+The cheaper-looking alternative is worse than the absence. Routing a withdrawal through
+`Open -> Declined` would leave the history saying an operator declined a request the person
+withdrew, which is false about both of them. Giving a user a state of their own costs rows in the
+transition table, cells in the mapping table and a case on every surface, and it reopens a decision
+already taken on #113. So the absence stands, and it is the first thing to revisit if the state set
+is ever reopened for another reason rather than a reason to reopen it.
 
 ## What happens to the wants recorded before this plugin was installed
 
@@ -353,6 +363,3 @@ the closing condition of the issue beside it.
 - What a request records about having arrived over the seam, and which caller handed it over. The
   contract carries no field naming the caller, so the second half of that is a question for the
   contract rather than for this side. #118.
-- What a person taking back their own ask does on this side's own surfaces. That an undone gesture
-  does not cross the seam is above; what this document still does not hold is the other half, which
-  needs a state a request can be withdrawn into and has none. #68.

--- a/docs/seam.md
+++ b/docs/seam.md
@@ -360,6 +360,10 @@ install is refusing and why is the diagnostics view in #63.
 Named here so the absence is read as absence rather than as a decision nobody wrote down. Each is
 the closing condition of the issue beside it.
 
-- What a request records about having arrived over the seam, and which caller handed it over. The
-  contract carries no field naming the caller, so the second half of that is a question for the
-  contract rather than for this side. #118.
+- What a request records about having arrived over the seam. Which caller handed it over is settled
+  and is not part of it: the contract grows no field naming the caller, decided on #118, because a
+  field carrying it would be the sender saying who they are, and a history that records an
+  unverified self-declaration as fact is worse than one that records less. That cost is permanent in
+  one direction. If a second handing sibling ever ships, the rows written before it do not carry the
+  distinction and cannot be backfilled, so the question becomes unanswerable for everything already
+  landed. What is still owed here is the history itself, which does not exist yet. #118.


### PR DESCRIPTION
Three documentation changes that record decisions already taken, in one pull
request because all three are documents and separate landings would move the
mainline under each other.

## What changed

`docs/configuration.md`, for #114. The page said "Nothing refuses an eleventh
open request today". That has been false since intake started refusing at the
quota, so the page told an operator the limit was inert while it was enforcing.
It now names where the refusal happens and states that there is no off switch,
with the workaround a household operator actually has: a number above anything
anybody will reach, described as a limit rather than as an absence.

`docs/seam.md`, for #68. The document said there is no state a request can be
withdrawn into and left it there, and listed the absence as still owed. It says
what a person does instead, which is ask an operator to decline it, and it says
why the two cheaper shapes are worse rather than only that they were refused.

`docs/seam.md`, for #118. The caller's identity was listed as an open question
for the contract. It is answered, so the entry carries the answer and the cost
that comes with it, which is that a second handing sibling could never be told
apart from the first in rows written before it.

## Evidence

Both files are unchanged in meaning for every other reader: the diff is 34 added
and 11 removed lines across two documents.

    git diff --stat origin/master...HEAD
     docs/configuration.md | 16 ++++++++++++++--
     docs/seam.md          | 29 ++++++++++++++++++++---------
     2 files changed, 34 insertions(+), 11 deletions(-)

The claim the configuration page now makes about enforcement is the tree's:

    git grep -n 'RefuseWhereTheyAreAtTheirQuotaAsync' -- Jellyfin.Plugin.Requests/
    Jellyfin.Plugin.Requests/Intake/RequestIntake.cs:131:                await RefuseWhereTheyAreAtTheirQuotaAsync(ask, caller, cancellationToken)
    Jellyfin.Plugin.Requests/Intake/RequestIntake.cs:159:                await RefuseWhereTheyAreAtTheirQuotaAsync(ask, caller, cancellationToken)
    Jellyfin.Plugin.Requests/Intake/RequestIntake.cs:219:    private async Task RefuseWhereTheyAreAtTheirQuotaAsync(

and the two callers are the only two paths that create a request:

    git grep -n '_intake.AskAsync' -- Jellyfin.Plugin.Requests/
    Jellyfin.Plugin.Requests/Api/RequestsController.cs:1385:        var intake = await _intake.AskAsync(incoming, caller, cancellationToken).ConfigureAwait(false);
    Jellyfin.Plugin.Requests/Seam/WantHandover.cs:291:                _intake.AskAsync(incoming, RequestCaller.User(want.RequestedByUserId), cancellationToken)).ConfigureAwait(false);

The claim that a quota below 1 is refused on a save and on a read is the two
call sites of the rule list:

    git grep -n 'ConfigurationRules.RefuseWhatCannotWork' -- Jellyfin.Plugin.Requests/
    Jellyfin.Plugin.Requests/Configuration/ServerInstallSettings.cs:76:            ConfigurationRules.RefuseWhatCannotWork(configuration);
    Jellyfin.Plugin.Requests/Plugin.cs:67:            ConfigurationRules.RefuseWhatCannotWork(settings);

The build and the suite were run at the head of this branch, on both target
frameworks:

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    0 Warnung(en)
    0 Fehler

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler: 0, erfolgreich: 636, übersprungen: 0, gesamt: 636 (net9.0)
    Bestanden!   : Fehler: 0, erfolgreich: 636, übersprungen: 0, gesamt: 636 (net10.0)

Prettier was run against these two files with line endings normalised to what a
checkout on the runner has, because the working copy here is CRLF and the check
would otherwise refuse every document in the tree rather than these two:

    npx --yes prettier@3.6.2 --check "*.md"
    All matched files use Prettier code style!

## Means

Markdown in `docs/`, which is where every other page a reader of this plugin
opens already lives, and it adds no format and no tool the tree does not carry.
Nothing here is a claim a test could hold instead: what changed is what a person
is told, and the facts underneath it are quoted from the code above.

## What this does not do

No guard was added and none was deleted, so there is no red run to record. The
three sentences added are prose, and no check on this board reads prose.

Nobody but me has read this change. There is no second reader on it, and the
commands above stand in place of one rather than beside one.

Closes #114
Closes #68
Part of #118
