### PR TITLE
Record the catalogue decision, and say where the server's data directory is

### DIFF
--- a/docs/catalogue.md
+++ b/docs/catalogue.md
@@ -41,12 +41,12 @@ tooling would be a claim about a process nobody outside it can see.
 
 ## Checked against this repository
 
-| What the route needs                               | Where that is decided                        | Here          |
-| -------------------------------------------------- | -------------------------------------------- | ------------- |
-| A name beginning `jellyfin-plugin-`                | `update_submodules.py:59`, `build_all.sh:18` | met           |
-| A repository in the `jellyfin` organisation        | `update_submodules.py:43`                    | not met, #113 |
-| A `build.yaml` at the root carrying `version`      | `build_plugin.sh`                            | met           |
-| One plugin per repository, built from `build.yaml` | `build_plugin.sh`                            | not met, #110 |
+| What the route needs                               | Where that is decided                        | Here                      |
+| -------------------------------------------------- | -------------------------------------------- | ------------------------- |
+| A name beginning `jellyfin-plugin-`                | `update_submodules.py:59`, `build_all.sh:18` | met                       |
+| A repository in the `jellyfin` organisation        | `update_submodules.py:43`                    | not met, declined on #110 |
+| A `build.yaml` at the root carrying `version`      | `build_plugin.sh`                            | met                       |
+| One plugin per repository, built from `build.yaml` | `build_plugin.sh`                            | not met, #110             |
 
 The name is met, and it is met by accident rather than by decision: this repository is called
 `jellyfin-plugin-requests` because that is what a Jellyfin plugin repository is called.
@@ -132,25 +132,22 @@ than in the table above.
 
 ## The submission decision
 
-**It has not been taken.** It is decision 11 on #113 and no answer to that number has been written
-there.
+**Declined.** This repository does not move into the `jellyfin` organisation, and the plugin is
+distributed from a manifest under Flowfin's control instead. That was settled on #110, together with
+the shape of that manifest, and the two are one answer rather than two: the enumeration above is the
+only route into the official catalogue, so declining the move is declining the catalogue.
 
-The decision is not whether to send an entry somewhere, because there is nowhere to send one. It is
-whether this repository moves into the `jellyfin` organisation, which is the only thing the
-enumeration above reaches. That carries who owns the repository, who can publish a release from it
-and under whose rules it is maintained, and none of those is a packaging question.
+The decision was never whether to send an entry somewhere, because there is nowhere to send one. It
+is whether this repository moves, which carries who owns it, who can publish a release from it and
+under whose rules it is maintained. None of those is a packaging question, which is why the answer
+is recorded here rather than read off the table above.
 
-What each answer costs, so that the decision is made against the costs rather than against a
-preference:
+**What it costs is that most people never find this plugin.** The list every Jellyfin server already
+shows will not carry it, so an operator reaches it only by being told the manifest URL and adding it
+by hand. That price is accepted rather than argued away, and it is the larger half of what the
+decision buys.
 
-**Staying outside.** The plugin is not in the list every server already shows, so an operator finds
-it only by being told the manifest URL and adding it by hand. That is most people never finding it.
-Nothing else changes: the release route in [RELEASING.md](RELEASING.md) already publishes without
-feeding any catalogue, and the two-line packaging problem above stays this board's own.
-
-**Moving in.** The plugin appears wherever a Jellyfin server does. The repository is no longer this
-account's, releases are made under that organisation's process, and the version an operator installs
-is the timestamp the build script writes rather than the one minted here.
-
-This page records that the question is open and what it costs. Answering it is not something a
-document in this repository can do.
+What it keeps is the repository, the release route already in [RELEASING.md](RELEASING.md), and
+version numbers minted here rather than replaced by the timestamp the catalogue's build script
+writes over them. The two-line packaging problem in the table above stays this board's own, which it
+would have been under either answer.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -209,6 +209,13 @@ installation and by operating system, and this document does not name it, for th
 [storage.md](storage.md) gives: the server is the authority for its own paths. Run these from
 inside it, with the server stopped.
 
+An operator who does not know where that directory is on their install should not have to go
+looking. Jellyfin documents it under "Server Paths" in
+[its own configuration page](https://jellyfin.org/docs/general/administration/configuration/), per
+operating system and per installation method, and that is the answer to read rather than anything
+written here. A copy of those paths on this page would be this repository going stale about somebody
+else's program, which is worse than a link because it would be wrong with authority.
+
 On Linux and macOS:
 
     rm -rf ./plugins/Jellyfin.Plugin.Requests


### PR DESCRIPTION
Two documents, in one pull request because both are documents and separate
landings would move the mainline under each other.

`docs/catalogue.md` said the submission decision had not been taken, and set out
what each answer would cost. It has been taken, so the page carries the answer
instead of the question.

## What changed

The submission decision section now records that the official catalogue is
declined: this repository does not move into the `jellyfin` organisation, and
distribution is a manifest under Flowfin's control. The two are one answer rather
than two, because the enumeration this page already documents is the only route
into that catalogue.

The price is kept rather than dropped once it stopped being hypothetical. The
list every Jellyfin server already shows will not carry this plugin, so an
operator reaches it only by being told the manifest URL and adding it by hand.

The requirement table says declined against the organisation row, instead of
pointing a reader at a decision nobody had made.

## Evidence

The three conditions on #112 read against this branch.

Every requirement the route imposes is listed with met or not met, and each
unmet row names an issue:

    git grep -c '^| ' docs/catalogue.md
    docs/catalogue.md:6

    sed -n '44,50p' docs/catalogue.md | grep 'not met'
    | A repository in the `jellyfin` organisation        | `update_submodules.py:43`                    | not met, declined on #110 |
    | One plugin per repository, built from `build.yaml` | `build_plugin.sh`                            | not met, #110             |

The licence position is stated for the compiled result rather than for the
source, and the three facts it rests on are quoted from their own sources rather
than recalled:

    git grep -n '^## The licence position for a compiled plugin' docs/catalogue.md
    docs/catalogue.md:87:## The licence position for a compiled plugin

    gh api repos/jellyfin/jellyfin/license --jq '{spdx: .license.spdx_id, name: .license.name}'
    {"name":"GNU General Public License v2.0","spdx":"GPL-2.0"}

    grep -h '<license type' ~/.nuget/packages/jellyfin.controller/10.11.11/jellyfin.controller.nuspec
        <license type="expression">GPL-3.0-only</license>

The submission decision is recorded, with what it costs:

    git grep -n '^\*\*Declined\.\*\*' docs/catalogue.md
    docs/catalogue.md:135:**Declined.** This repository does not move into the `jellyfin` organisation, and the plugin is

The suite was run at the head of this branch on both target frameworks:

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler: 0, erfolgreich: 636, übersprungen: 0, gesamt: 636 (net9.0)
    Bestanden!   : Fehler: 0, erfolgreich: 636, übersprungen: 0, gesamt: 636 (net10.0)

Prettier realigned the table, which is why the diff is larger than the two
paragraphs that changed. It was run against a copy with line endings normalised
to what a checkout on the runner has:

    npx --yes prettier@3.6.2 --check "catalogue.md"
    All matched files use Prettier code style!

## Means

Markdown in `docs/`, beside every other page this plugin's readers open. The
change adds no format and no tool the tree does not already carry, and what
changed is a recorded answer rather than behaviour a test could hold.

## What this does not do

It publishes nothing and it changes no release route. The manifest this decision
implies is #110's work and is not touched here.

Nobody but me has read this change. There is no second reader on it, and the
commands above stand in place of one rather than beside one.

## The second document, for #98

`docs/configuration.md` writes the removal commands relative to the server's data
directory and deliberately does not name that directory, because it moves with
the installation and with the operating system. It did not say where the answer
is, which leaves an operator holding a command and nowhere to run it from. It now
points at Jellyfin's own configuration page, which documents the paths per
operating system and per installation method:

    git grep -n 'jellyfin.org/docs/general/administration/configuration' -- docs/configuration.md
    docs/configuration.md:214:[its own configuration page](https://jellyfin.org/docs/general/administration/configuration/), per

    curl -s -o /dev/null -w "%{http_code}
" -L https://jellyfin.org/docs/general/administration/configuration/
    200

    curl -s -L https://jellyfin.org/docs/general/administration/configuration/       | grep -oiE 'Server Paths|Data Directory|JELLYFIN_DATA_DIR' | sort | uniq -c
          1 data directory
          7 Data Directory
          1 JELLYFIN_DATA_DIR
          4 Server Paths

A copy of those paths here would be this repository going stale about somebody
else's program, and a stale path is worse than a link because it is wrong with
authority.

The other two conditions on that issue are held by guards rather than by prose,
and neither moved here:

    git grep -n 'public void ' -- Jellyfin.Plugin.Requests.Tests/Configuration/UninstallTests.cs
    Jellyfin.Plugin.Requests.Tests/Configuration/UninstallTests.cs:39:    public void AnUninstallRemovesNothingThisPluginWrote()
    Jellyfin.Plugin.Requests.Tests/Configuration/UninstallTests.cs:71:    public void WhatTheDocumentedCommandRemovesIsWhatIsActuallyLeft()

**Nothing measured what the server itself removes on an uninstall.** No uninstall
was run on a server here. What is held is this plugin's own behaviour when it is
told it is going away, and the document keeps saying so under its own heading
rather than letting a passing test imply somebody looked.

Closes #112
Closes #98
