### PR TITLE
Refuse the three template leftovers, and prove a setting saves on a real server

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -307,6 +307,82 @@ The 12.0 line, `scripts/verify-plugin-loads.sh jellyfin/jellyfin:12.0-rc4 net10.
     == done
     Requests loaded and answered on jellyfin/jellyfin:12.0-rc4 (net10.0)
 
+### The recorded run after the check learned to save a setting
+
+The run above predates two things and reads as though neither had happened. It was made before this
+plugin minted its own identifier, so the plugin it reports is carrying the template's, and before
+the configuration surface had a single setting, so the configuration it reads and writes is `{}`. It
+is kept rather than replaced, because it is what was seen on the day it was made.
+
+What the check does now is write two settings whose values are neither field's default and read the
+configuration back out of the server, which is the difference between an endpoint that answers a
+write and a setting that survives one. This run is from the gate rather than from a machine: the job
+that has to know the plugin loaded before it asks anything else runs the same script on every pull
+request.
+
+Run on `ca059d2`, 2026-08-21, in run `32516343601`, jobs `96878727285` and `96878727539`.
+
+The 10.11 line, `scripts/verify-plugin-loads.sh jellyfin/jellyfin:10.11.11 net9.0 18098`:
+
+    == what the server says about its plugins
+    Name=AudioDB  Version=10.11.11.0  Status=Active  Id=a629c0dafac54c7e931a7174223f14c8
+    Name=MusicBrainz  Version=10.11.11.0  Status=Active  Id=8c95c4d2e50c4fb0a4f36c06ff0f9a1a
+    Name=OMDb  Version=10.11.11.0  Status=Active  Id=a628c0dafac54c7e9d1a7134223f14c8
+    Name=Requests  Version=0.1.0.0  Status=Active  Id=0f9c9107b31b459e81fa6d35dac25e79
+    Name=Studio Images  Version=10.11.11.0  Status=Active  Id=872a78491171458da6fb3de3d442ad30
+    Name=TMDb  Version=10.11.11.0  Status=Active  Id=b8715ed16c4745289ad3f72deb539cd4
+
+    == verdict
+    Requests is Active, id 0f9c9107b31b459e81fa6d35dac25e79
+
+    == the configuration page the dashboard would fetch
+    GET /web/ConfigurationPage?name=Requests -> 200
+    <!doctype html>
+    <html lang="en">
+        <head>
+            <meta charset="utf-8" />
+            <title data-i18n="config.title"></title>
+
+    == the configuration the page reads and writes
+    {"OpenRequestsPerUser":10,"AcceptsMovies":true,"AcceptsSeries":true,"FinishedRequestRetentionDays":365,"OutboundNoticeAddress":"","AnnouncesApprovals":true,"AnnouncesDeclines":true,"AnnouncesFulfilments":true}
+    POST /Plugins/<id>/Configuration -> 204
+
+    == what the server hands back after the save
+    {"OpenRequestsPerUser":7,"AcceptsMovies":true,"AcceptsSeries":true,"FinishedRequestRetentionDays":90,"OutboundNoticeAddress":"","AnnouncesApprovals":true,"AnnouncesDeclines":true,"AnnouncesFulfilments":true}
+    OpenRequestsPerUser=7 and FinishedRequestRetentionDays=90 read back after the save
+
+    == done
+    Requests loaded and answered on jellyfin/jellyfin:10.11.11 (net9.0)
+
+The 12.0 line, `scripts/verify-plugin-loads.sh jellyfin/jellyfin:12.0-rc4 net10.0 18099`:
+
+    == what the server says about its plugins
+    Name=AudioDB  Version=12.0.0.0  Status=Active  Id=a629c0dafac54c7e931a7174223f14c8
+    Name=ListenBrainz Similarity Provider  Version=12.0.0.0  Status=Active  Id=a5b2e8c19d4f4a3b8c7e6f1a2b3c4d5e
+    Name=MusicBrainz  Version=12.0.0.0  Status=Active  Id=8c95c4d2e50c4fb0a4f36c06ff0f9a1a
+    Name=OMDb  Version=12.0.0.0  Status=Active  Id=a628c0dafac54c7e9d1a7134223f14c8
+    Name=Requests  Version=0.1.0.0  Status=Active  Id=0f9c9107b31b459e81fa6d35dac25e79
+    Name=Studio Images  Version=12.0.0.0  Status=Active  Id=872a78491171458da6fb3de3d442ad30
+    Name=TMDb  Version=12.0.0.0  Status=Active  Id=b8715ed16c4745289ad3f72deb539cd4
+
+    == verdict
+    Requests is Active, id 0f9c9107b31b459e81fa6d35dac25e79
+
+    == the configuration the page reads and writes
+    {"OpenRequestsPerUser":10,"AcceptsMovies":true,"AcceptsSeries":true,"FinishedRequestRetentionDays":365,"OutboundNoticeAddress":"","AnnouncesApprovals":true,"AnnouncesDeclines":true,"AnnouncesFulfilments":true}
+    POST /Plugins/<id>/Configuration -> 204
+
+    == what the server hands back after the save
+    {"OpenRequestsPerUser":7,"AcceptsMovies":true,"AcceptsSeries":true,"FinishedRequestRetentionDays":90,"OutboundNoticeAddress":"","AnnouncesApprovals":true,"AnnouncesDeclines":true,"AnnouncesFulfilments":true}
+    OpenRequestsPerUser=7 and FinishedRequestRetentionDays=90 read back after the save
+
+    == done
+    Requests loaded and answered on jellyfin/jellyfin:12.0-rc4 (net10.0)
+
+**The values written back are left on that server and nowhere else.** Each run is a container of its
+own, removed when the run ends, so the setting saved here is not a setting anybody's install now
+carries.
+
 ### That the check bites
 
 A procedure that cannot fail proves nothing, so the mismatch it exists to catch was fed to it. The

--- a/scripts/verify-plugin-loads.sh
+++ b/scripts/verify-plugin-loads.sh
@@ -10,7 +10,12 @@
 #
 # The server, the install, the wizard and the account are `scripts/server-under-test.sh`, which this
 # and the activity check beside it both source. What is left here is what this check is about: the
-# configuration page the dashboard fetches, and the configuration it reads and writes.
+# configuration page the dashboard fetches, and a setting written through the endpoint the page
+# writes to and read back out of the server afterwards.
+#
+# THE READ BACK IS THE HALF THAT IS EASY TO LEAVE OUT. A server that stored nothing answers a write
+# 204 all the same, so a check that stops at the status code says the endpoint exists and nothing
+# about whether a setting survives being saved.
 #
 # This needs no display, no administrator rights and no trusted certificate. The server runs in a
 # container, is reached over plain HTTP on the loopback interface, and is removed when the run
@@ -29,7 +34,10 @@ port=${3:-18096}
 # shellcheck source=scripts/server-under-test.sh
 . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/server-under-test.sh"
 
-trap server_stop EXIT
+# The answer the server gives after the save is read twice, once by a person reading this output and
+# once by the check under it, so it is kept in a file rather than in a variable a pipeline would eat.
+stored_configuration=$(mktemp)
+trap 'server_stop; rm -f "$stored_configuration"' EXIT
 
 server_start "$image" "$framework" "$port" "jellyfin-plugin-load-check-$framework"
 
@@ -45,13 +53,41 @@ curl --silent --fail --max-time 30 "$BASE/web/ConfigurationPage?name=$PLUGIN_NAM
 step "the configuration the page reads and writes"
 api GET "/Plugins/$PLUGIN_ID/Configuration"
 printf '\n'
+
+# A SETTING WITH A VALUE IN IT, RATHER THAN AN EMPTY DOCUMENT. Writing `{}` is answered 204 by a
+# server that stored nothing, so it says the endpoint is there and not that a setting survives being
+# saved. Neither number below is that field's default, so a server that ignored the write and
+# answered with what it already held is refused instead of agreeing with itself. Both are inside what
+# `ConfigurationRules` accepts, because a refused write would be this plugin working correctly rather
+# than the round trip being shown.
+saved_quota=7
+saved_retention=90
 write_status=$(curl --silent --output /dev/null --write-out '%{http_code}' --max-time 30 \
     -X POST "$BASE/Plugins/$PLUGIN_ID/Configuration" \
     -H 'Content-Type: application/json' \
     -H "Authorization: $AUTH_HEADER, Token=\"$TOKEN\"" \
-    --data '{}')
+    --data "{\"OpenRequestsPerUser\":$saved_quota,\"AcceptsMovies\":true,\"AcceptsSeries\":true,\"FinishedRequestRetentionDays\":$saved_retention,\"OutboundNoticeAddress\":\"\",\"AnnouncesApprovals\":true,\"AnnouncesDeclines\":true,\"AnnouncesFulfilments\":true}")
 echo "POST /Plugins/<id>/Configuration -> $write_status"
 test "$write_status" = "204"
+
+step "what the server hands back after the save"
+# Read out of the server rather than out of the request that was just sent. What this condition is
+# about is that the value left the page and came back, and a check comparing the body it posted
+# against itself would pass on a server that dropped it.
+api GET "/Plugins/$PLUGIN_ID/Configuration" | tee "$stored_configuration"
+printf '\n'
+python3 -c '
+import json, sys
+wanted = {"OpenRequestsPerUser": int(sys.argv[2]), "FinishedRequestRetentionDays": int(sys.argv[3])}
+with open(sys.argv[1], encoding="utf-8") as handle:
+    stored = json.load(handle)
+for field, value in wanted.items():
+    if stored.get(field) != value:
+        sys.exit("{0} came back as {1!r} rather than {2}: the save did not survive.".format(
+            field, stored.get(field), value))
+print("OpenRequestsPerUser={0} and FinishedRequestRetentionDays={1} read back after the save".format(
+    wanted["OpenRequestsPerUser"], wanted["FinishedRequestRetentionDays"]))
+' "$stored_configuration" "$saved_quota" "$saved_retention"
 
 step "done"
 echo "$PLUGIN_NAME loaded and answered on $image ($framework)"

--- a/tools/opengrep/fixtures/template/APageScriptObjectLeftBehind.html
+++ b/tools/opengrep/fixtures/template/APageScriptObjectLeftBehind.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<!--
+    Fixture for no-template-config-object-left. This file is embedded in nothing
+    and served to nobody; it exists so the rule can be watched refusing the
+    mistake it names.
+
+    The near-miss is the one a half rename leaves behind. The markup and the
+    script have to agree on the object the page hangs its state on, and a page
+    where one of the two still carries the old name loads, draws, and does
+    nothing when somebody presses save.
+-->
+<html lang="en">
+  <head>
+    <title data-i18n="config.title"></title>
+  </head>
+  <body>
+    <!-- Legal neighbour, left here on purpose: the rule has to stay quiet on the name this page actually uses. -->
+    <div id="RequestsConfigPage">
+      <form id="RequestsConfigForm"></form>
+    </div>
+
+    <script type="text/javascript">
+      (function () {
+        // The regression.
+        var TemplateConfig = {
+          uniqueId: "0f9c9107-b31b-459e-81fa-6d35dac25e79",
+        };
+
+        return TemplateConfig;
+      })();
+    </script>
+  </body>
+</html>

--- a/tools/opengrep/fixtures/template/APageScriptObjectLeftBehind.html
+++ b/tools/opengrep/fixtures/template/APageScriptObjectLeftBehind.html
@@ -10,24 +10,24 @@
     nothing when somebody presses save.
 -->
 <html lang="en">
-  <head>
-    <title data-i18n="config.title"></title>
-  </head>
-  <body>
-    <!-- Legal neighbour, left here on purpose: the rule has to stay quiet on the name this page actually uses. -->
-    <div id="RequestsConfigPage">
-      <form id="RequestsConfigForm"></form>
-    </div>
+    <head>
+        <title data-i18n="config.title"></title>
+    </head>
+    <body>
+        <!-- Legal neighbour, left here on purpose: the rule has to stay quiet on the name this page actually uses. -->
+        <div id="RequestsConfigPage">
+            <form id="RequestsConfigForm"></form>
+        </div>
 
-    <script type="text/javascript">
-      (function () {
-        // The regression.
-        var TemplateConfig = {
-          uniqueId: "0f9c9107-b31b-459e-81fa-6d35dac25e79",
-        };
+        <script type="text/javascript">
+            (function () {
+                // The regression.
+                var TemplateConfig = {
+                    uniqueId: "0f9c9107-b31b-459e-81fa-6d35dac25e79",
+                };
 
-        return TemplateConfig;
-      })();
-    </script>
-  </body>
+                return TemplateConfig;
+            })();
+        </script>
+    </body>
 </html>

--- a/tools/opengrep/fixtures/template/ARootNamespaceLeftBehind.csproj
+++ b/tools/opengrep/fixtures/template/ARootNamespaceLeftBehind.csproj
@@ -1,0 +1,19 @@
+<!--
+    Fixture for no-template-namespace-left. Nothing builds this file; it exists
+    so the rule can be watched refusing the mistake it names.
+
+    The near-miss is the one the rename actually leaves. Every other name in the
+    project file moves in one pass, and this one sits inside an element a reader
+    skims past because it looks like it follows the assembly name. It does not:
+    it is what the embedded configuration page's resource path is built from at
+    run time, so the build stays green and the page is empty on a server.
+-->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Legal neighbour, left here on purpose: the rule has to stay quiet on the name this plugin actually uses. -->
+    <AssemblyName>Jellyfin.Plugin.Requests</AssemblyName>
+
+    <!-- The regression. -->
+    <RootNamespace>Jellyfin.Plugin.Template</RootNamespace>
+  </PropertyGroup>
+</Project>

--- a/tools/opengrep/fixtures/template/TheIdentifierBeforeItWasMinted.yaml
+++ b/tools/opengrep/fixtures/template/TheIdentifierBeforeItWasMinted.yaml
@@ -1,0 +1,16 @@
+# Fixture for no-template-identifier-left. Nothing packages this file; it exists
+# so the rule can be watched refusing the mistake it names.
+#
+# The near-miss is a second packaging file added for another server line and
+# started from a copy of something older than the mint. The server and the
+# packaging metadata have to agree on one identifier, and a page asking the
+# server about the old one is handed no configuration back, which looks like a
+# page that lost its settings rather than like an identifier that is wrong.
+name: "Requests"
+
+# Legal neighbour, left here on purpose: this is the identifier this plugin
+# minted for itself and the rule has to stay quiet on it.
+guid: "0f9c9107-b31b-459e-81fa-6d35dac25e79"
+
+# The regression.
+oldGuid: "eb5d7894-8eef-4b36-aa6f-5d124e828ce1"

--- a/tools/opengrep/rules.yaml
+++ b/tools/opengrep/rules.yaml
@@ -645,3 +645,121 @@ rules:
         - "Jellyfin.Plugin.Requests/**/*.js"
         - "tools/opengrep/fixtures/words/**/*.html"
         - "tools/opengrep/fixtures/words/**/*.js"
+
+  # Invariant (identity, #16): three named leftovers of the plugin template, each
+  # refused by the expression that names it. The rename moved three separate
+  # things, and a leftover of any one of them is a different failure: the root
+  # namespace is what the embedded configuration page's resource path is built
+  # from at run time, the page's script object is what the markup and the script
+  # agree on, and the identifier is what the server and the packaging metadata
+  # agree on. Each was put back on its own and watched being refused, and the
+  # tree was restored after each.
+  #
+  # WHY THREE NAMED EXPRESSIONS RATHER THAN THE WORD. A tree-wide search for
+  # `template` matches the name of a zizmor audit, the description analyzer rule
+  # CA2254 gives of itself, a changelog paragraph saying what a version number
+  # replaced, and the ordinary vocabulary of ASP.NET routing, where a route
+  # template is what the path an endpoint answers under is called. Every one of
+  # those is correct text, and a rule carrying an exception for each is a rule
+  # whose exception list is where somebody eventually puts the real leftover to
+  # make the build pass.
+  #
+  # WHAT THIS DOES NOT REACH, AND IT IS WRITTEN HERE RATHER THAN LEFT TO BE
+  # ASSUMED. These three check three known things rather than a class, so a
+  # fourth kind of leftover that none of them names passes. When a fourth is
+  # found it becomes a fourth rule with its own fixture and its own
+  # put-it-back demonstration, so the set grows by proof rather than by guess.
+  - id: no-template-namespace-left
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      This names the template's root namespace. The embedded configuration
+      page's resource path is built from the namespace at run time, so a
+      leftover here is a page that is empty on a server rather than a build that
+      fails (#16).
+    patterns:
+      - pattern-regex: 'Jellyfin\.Plugin\.Template'
+    paths:
+      include:
+        - "**/*.cs"
+        - "**/*.csproj"
+        - "**/*.css"
+        - "**/*.html"
+        - "**/*.js"
+        - "**/*.json"
+        - "**/*.md"
+        - "**/*.props"
+        - "**/*.py"
+        - "**/*.ruleset"
+        - "**/*.sh"
+        - "**/*.sln"
+        - "**/*.txt"
+        - "**/*.xml"
+        - "**/*.yaml"
+        - "**/*.yml"
+
+  # Invariant (identity, #16), the second of the three. See the block above for
+  # why the set is three expressions and what it does not reach.
+  - id: no-template-config-object-left
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      This names the template's configuration page script object. The markup and
+      the script have to agree on it, and a half rename leaves a page that loads
+      and does nothing (#16).
+    patterns:
+      # The character class is what stops this expression from matching the line it is written on.
+      # This file is inside the paths below, the repository scan excludes only the fixture
+      # directory, and a rule that refuses its own text refuses the tree forever.
+      - pattern-regex: 'Template[C]onfig'
+    paths:
+      include:
+        - "**/*.cs"
+        - "**/*.csproj"
+        - "**/*.css"
+        - "**/*.html"
+        - "**/*.js"
+        - "**/*.json"
+        - "**/*.md"
+        - "**/*.props"
+        - "**/*.py"
+        - "**/*.ruleset"
+        - "**/*.sh"
+        - "**/*.sln"
+        - "**/*.txt"
+        - "**/*.xml"
+        - "**/*.yaml"
+        - "**/*.yml"
+
+  # Invariant (identity, #16), the third of the three. See the block above for
+  # why the set is three expressions and what it does not reach.
+  - id: no-template-identifier-left
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      This is the identifier that was in use before this plugin minted its own.
+      The server and the packaging metadata have to agree on one identifier, and
+      a page asking the server about the old one gets no configuration back
+      (#16).
+    patterns:
+      # Broken by a character class for the reason given at the rule above: written out, this
+      # expression would match itself and red the gate on the file that declares it.
+      - pattern-regex: 'eb5d7894[-]8eef-4b36-aa6f-5d124e828ce1'
+    paths:
+      include:
+        - "**/*.cs"
+        - "**/*.csproj"
+        - "**/*.css"
+        - "**/*.html"
+        - "**/*.js"
+        - "**/*.json"
+        - "**/*.md"
+        - "**/*.props"
+        - "**/*.py"
+        - "**/*.ruleset"
+        - "**/*.sh"
+        - "**/*.sln"
+        - "**/*.txt"
+        - "**/*.xml"
+        - "**/*.yaml"
+        - "**/*.yml"


### PR DESCRIPTION
#16's two open conditions, both taken as decided.

Corrected after posting. Three of the commands below were quoted with line
numbers and one with indentation they do not produce. Each was re-run against
this branch and what stands beside it now is its own output.

## The first condition: three named expressions instead of the word

The condition was a tree-wide search for the word `template` printing nothing,
and no state of this tree satisfies it. The word is the name of a zizmor audit,
the description analyzer rule CA2254 gives of itself, a changelog paragraph
saying what a version number replaced, and the ordinary vocabulary of ASP.NET
routing, where a route template is what the path an endpoint answers under is
called. A condition phrased over it is one whose exception list grows with every
harmless match, and that is the shape where somebody eventually adds the real
leftover to the exceptions to make the build pass.

Three expressions name the three things the rename moved, and each is a rule with
its own fixture:

    sed -n 's/^  - id: \(no-template.*\)$/\1/p' tools/opengrep/rules.yaml
    no-template-namespace-left
    no-template-config-object-left
    no-template-identifier-left

    ls -1 tools/opengrep/fixtures/template/
    APageScriptObjectLeftBehind.html
    ARootNamespaceLeftBehind.csproj
    TheIdentifierBeforeItWasMinted.yaml

The gate's second step is what makes a fixture a proof rather than a file: it
scans the fixture directory and fails unless every declared rule fired on one, so
a rule whose pattern stopped matching reds instead of reporting the same green as
a clean tree.

    git grep -n 'these rules fired on no fixture' -- tools/opengrep/prove-rules-fire.sh
    tools/opengrep/prove-rules-fire.sh:74:    echo "these rules fired on no fixture, so nothing proves they still bite:" >&2

Two of the three expressions carry a character class that breaks the literal.
The rule file is inside the paths the rules cover, and the repository scan
excludes only the fixture directory, so an expression written out in full would
match the line declaring it and red the gate permanently. With the class in, the
three expressions appear nowhere in the tree outside the fixtures:

    git grep -nE 'Jellyfin\.Plugin\.Template|TemplateConfig|eb5d7894-8eef-4b36-aa6f-5d124e828ce1' -- . ':(exclude)LICENSE' ':(exclude)tools/opengrep/fixtures' ; echo "exit=$?"
    exit=1

**What this does not reach is written at the rules rather than left to be
assumed.** Three known things are not a class, so a fourth kind of leftover that
none of the three names passes. When a fourth is found it becomes a fourth rule
with its own fixture and its own put-it-back demonstration, so the set grows by
proof rather than by guess.

## The second condition: a setting that is actually saved

The load check posted an empty configuration document and asserted 204. A server
that stored nothing answers that write the same way, so what it held was that the
endpoint is there, not that a setting survives being saved. The recorded runs in
`docs/testing.md` show an empty configuration for that reason.

It now writes two settings whose values are neither field's default, reads the
configuration back out of the server, and refuses unless both come back as they
were written. Reading the answer out of the server rather than comparing against
the body that was posted is the half that matters: the second passes on a server
that dropped the write.

    git grep -n 'read back after the save' -- scripts/verify-plugin-loads.sh
    scripts/verify-plugin-loads.sh:88:print("OpenRequestsPerUser={0} and FinishedRequestRetentionDays={1} read back after the save".format(

That check runs on a real server of each claimed line on every pull request, in
the job that has to know the plugin loaded before it asks anything else:

    git grep -n 'verify-plugin-loads.sh' -- .github/workflows/
    .github/workflows/activity-entries.yaml:93:          ./scripts/verify-plugin-loads.sh "$IMAGE" "$FRAMEWORK" "$PORT"

## Means

The rules are patterns in the set this repository already keeps for invariants a
compiler cannot refuse, in the file and the fixture layout that set already uses,
so nothing new is introduced to hold them. The round trip is bash and curl inside
the container check that already exists, because what it asks is a question about
a running server and no suite in this repository can reach one.

## The recorded run

`docs/testing.md` now carries a second recorded run beside the one from 2026-08-06.
The old one is kept rather than written over, and the page says what it predates:
it was made before this plugin minted its own identifier and before the
configuration surface had a single setting, so it reports the template's
identifier and an empty configuration.

The new one is this pull request's own checks, run `32516343601`, jobs
`96878727285` and `96878727539`. On both claimed lines:

    == verdict
    Requests is Active, id 0f9c9107b31b459e81fa6d35dac25e79

    == what the server hands back after the save
    {"OpenRequestsPerUser":7,"AcceptsMovies":true,"AcceptsSeries":true,"FinishedRequestRetentionDays":90,"OutboundNoticeAddress":"","AnnouncesApprovals":true,"AnnouncesDeclines":true,"AnnouncesFulfilments":true}
    OpenRequestsPerUser=7 and FinishedRequestRetentionDays=90 read back after the save

That run is against `ca059d2`, which is this branch one commit before the record
of it was added, so the record is of a run that happened rather than of one
expected to.

## What this does not do

It does not make the invariant lint a required check. What holds a merge is a
repository setting rather than a file in this tree, and that is #30.

**Nothing here was run on a machine somebody sat at.** The container runs are the
gate's, on a hosted runner, and no server on this machine was started.

Nobody but me has read this change. There is no second reader on it, and the
commands above stand in place of one rather than beside one.

Closes #16
