### PR TITLE
Install the package the gate builds on a server of its line

### DIFF
--- a/.github/workflows/activity-entries.yaml
+++ b/.github/workflows/activity-entries.yaml
@@ -49,14 +49,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # The images and frameworks are the pairs `docs/testing.md` records its runs against. The
-          # 12.0 line is a release candidate, which `docs/compatibility.md` says in its own words.
+          # The image is not written here. It is one half of a pair the package check needs too,
+          # and two copies of that pair disagree the first time a line moves, so it lives in
+          # `scripts/server-lines.tsv` and the steps below ask for it by framework.
           - line: '10.11'
-            image: 'jellyfin/jellyfin:10.11.11'
             framework: 'net9.0'
             port: '18098'
           - line: '12.0'
-            image: 'jellyfin/jellyfin:12.0-rc4'
             framework: 'net10.0'
             port: '18099'
 
@@ -85,19 +84,19 @@ jobs:
         # injectable today; what the shape buys is that it stays that way when a later matrix takes
         # a value from somewhere else.
         env:
-          IMAGE: ${{ matrix.image }}
           FRAMEWORK: ${{ matrix.framework }}
           PORT: ${{ matrix.port }}
         run: |
           set -euo pipefail
+          IMAGE=$(./scripts/server-image-for.sh "$FRAMEWORK")
           ./scripts/verify-plugin-loads.sh "$IMAGE" "$FRAMEWORK" "$PORT"
 
       - name: Does an operator see the moves
         env:
-          IMAGE: ${{ matrix.image }}
           FRAMEWORK: ${{ matrix.framework }}
           PORT: ${{ matrix.port }}
         run: |
           set -euo pipefail
+          IMAGE=$(./scripts/server-image-for.sh "$FRAMEWORK")
           ./scripts/verify-activity-entries.sh "$IMAGE" "$FRAMEWORK" "$PORT"
 

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -22,9 +22,11 @@
 # than a file in this tree, #30 is where it is written down and applied, so a
 # red job here does not by itself hold a merge today.
 #
-# What this does not do is install the package on a server. That needs a
-# container engine, which docs/testing.md keeps out of the ordinary suite, and
-# it is a deliberate run whose output goes in that document beside the others.
+# WHAT IT ALSO DOES IS INSTALL WHAT IT BUILT. The last step of each line puts
+# the archive it just produced on a server of that line, in a container, and
+# asks the server what it has. That closes the gap between a package that builds
+# and a package that loads, which is where an artifact list missing a dependency
+# the host does not provide shows up and nowhere earlier.
 name: Package
 
 on:
@@ -214,3 +216,31 @@ jobs:
           path: |
             ${{ steps.jprm.outputs.artifact }}
             ${{ steps.jprm.outputs.artifact }}.meta.json
+
+      - name: Install this package on a server of the line it was built for
+        # THE ARCHIVE, NOT A PUBLISH. Everything above this step reasons about
+        # what the package contains; this one starts a server of the line the
+        # package declares, puts the package's own bytes in its plugin directory
+        # and asks the server what it has. An artifact list missing a dependency
+        # the host does not provide produces a plugin that installs and throws on
+        # first use, and only a server that started with it says so.
+        #
+        # The image is read out of scripts/server-lines.tsv rather than written
+        # here, because the container check beside this one needs the same pair
+        # and two copies of it disagree the first time a line moves.
+        #
+        # It ends non-zero unless the server reports the plugin Active, fetches
+        # the configuration page and takes a setting back, which is the procedure
+        # docs/testing.md records rather than a second one written here.
+        env:
+          ARTIFACT: ${{ steps.jprm.outputs.artifact }}
+          FRAMEWORK: ${{ matrix.framework }}
+        run: |
+          set -euo pipefail
+          staged="${RUNNER_TEMP}/packaged-plugin"
+          rm -rf "${staged}"
+          mkdir -p "${staged}"
+          unzip -o "${ARTIFACT}" -d "${staged}"
+          ls -1 "${staged}"
+          image=$(./scripts/server-image-for.sh "${FRAMEWORK}")
+          PLUGIN_FROM_DIRECTORY="${staged}" ./scripts/verify-plugin-loads.sh "${image}" "${FRAMEWORK}" 18096

--- a/.github/workflows/sibling-set.yaml
+++ b/.github/workflows/sibling-set.yaml
@@ -70,13 +70,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # The image is not written here. It is one half of a pair three checks need, and copies
+          # of it disagree the first time a line moves, so it lives in `scripts/server-lines.tsv`
+          # and the step below asks for it by the framework it already carries.
           - line: '10.11'
-            image: 'jellyfin/jellyfin:10.11.11'
             framework: 'net9.0'
             abi: '10.11.0.0'
             port: '18100'
           - line: '12.0'
-            image: 'jellyfin/jellyfin:12.0-rc4'
             framework: 'net10.0'
             abi: '12.0.0.0'
             port: '18101'
@@ -104,11 +105,11 @@ jobs:
         # The token reads the sibling boards' public releases to find the package for this line. It
         # is the job's own read-only token and it writes nothing anywhere.
         env:
-          IMAGE: ${{ matrix.image }}
           FRAMEWORK: ${{ matrix.framework }}
           ABI: ${{ matrix.abi }}
           PORT: ${{ matrix.port }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          IMAGE=$(./scripts/server-image-for.sh "$FRAMEWORK")
           ./scripts/verify-sibling-set.sh "$IMAGE" "$FRAMEWORK" "$ABI" "$PORT"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -420,9 +420,13 @@ ruleset setting and is #107.
 
 The 12.0 line is a release candidate. `12.0-rc4` is what exists today and the tag will move.
 
-The packages are not what a catalogue would serve. This installs the assembly the build produces
-into the plugin directory; it does not build the zip, publish a manifest, or exercise the install
-path an operator uses. Those are M14.
+What this check installs is the assembly the build produces, put into the plugin directory. The
+archive an operator would download is installed by the package job instead, which unzips what it
+just built into a server of that line and runs this same procedure over it, so the two differ in
+the bytes they install and not in what they then ask the server.
+
+Neither is the install path an operator uses. Nothing here publishes a manifest or asks a server to
+fetch and install from one, which is M14.
 
 Nothing here plays media, so the container's transcoding dependencies are never touched, and a
 failure that needs a real library to show would not show here.

--- a/scripts/server-image-for.sh
+++ b/scripts/server-image-for.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# The server image for one target framework, read out of scripts/server-lines.tsv.
+#
+# Every check that starts a container needs the pair, and the checks arrive at it from different
+# directions: the activity check is handed a line, the package check is handed the framework the
+# packaging metadata declares. So the pair lives in one file and this is how it is asked for.
+#
+# An unknown framework is refused rather than answered with an empty string, because an empty image
+# reaches `docker run` as a missing argument and fails several steps later with an error about
+# something else.
+#
+# usage: scripts/server-image-for.sh net9.0
+set -euo pipefail
+
+framework=${1:?target framework, for example net9.0}
+table="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/server-lines.tsv"
+
+image=$(awk -F '\t' -v want="$framework" '$1 == want { print $2; found = 1 } END { exit !found }' "$table") || {
+    echo "no server image for $framework in $table. The claimed lines are:" >&2
+    grep -v '^#' "$table" >&2
+    exit 1
+}
+
+printf '%s\n' "$image"

--- a/scripts/server-lines.tsv
+++ b/scripts/server-lines.tsv
@@ -1,0 +1,13 @@
+# The claimed server lines, one row per line, as the pair every container check needs: the target
+# framework this plugin is built for and the server image that runs it.
+#
+# It is a file rather than a list inside each workflow because more than one check needs the pair,
+# and two copies of it disagree the first time a line moves. What a workflow holds instead is the
+# framework it is already working from, and it asks here for the rest.
+#
+# The 12.0 entry is a release candidate. docs/compatibility.md says so in its own words and this
+# file does not repeat the argument.
+#
+# framework	image
+net9.0	jellyfin/jellyfin:10.11.11
+net10.0	jellyfin/jellyfin:12.0-rc4

--- a/scripts/server-under-test.sh
+++ b/scripts/server-under-test.sh
@@ -11,6 +11,12 @@
 # container, is reached over plain HTTP on the loopback interface, and is removed by the caller's
 # trap when the run ends. The one credential it creates lives for the length of that container.
 #
+# WHAT IS INSTALLED IS A PUBLISH BY DEFAULT AND A DIRECTORY WHERE ONE IS NAMED. Setting
+# `PLUGIN_FROM_DIRECTORY` to a directory makes `server_start` install what is in it rather than
+# publishing the project, and copy all of it rather than the assembly alone. That is how a package
+# built by the gate is put on a server: the bytes a person would install are the ones under test,
+# and a publish is a different set of files from a package.
+#
 # What a caller gets, after `server_start`:
 #
 #   $BASE       the address to call, on the loopback interface
@@ -54,7 +60,7 @@ server_start() {
     CONTAINER="$name"
     BASE="http://127.0.0.1:$port"
 
-    local repo_root project publish_dir host_dll plugin_dir
+    local repo_root project publish_dir host_dll host_dir plugin_dir
     repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
     project="$repo_root/$ASSEMBLY/$ASSEMBLY.csproj"
     plugin_dir="/config/plugins/$ASSEMBLY"
@@ -66,14 +72,25 @@ server_start() {
 
     AUTH_HEADER='MediaBrowser Client="plugin-load-check", Device="load-check", DeviceId="plugin-load-check", Version="1.0.0.0"'
 
-    step "publish $ASSEMBLY for $framework"
-    # Under the repository rather than in the temporary directory, because this path is handed to
-    # both dotnet and docker and those two disagree about what an absolute path looks like on this
-    # platform.
-    publish_dir="$repo_root/artifacts/load-check/$framework"
-    rm -rf "$publish_dir"
-    dotnet publish "$project" -c Release -f "$framework" -o "$publish_dir" --nologo -v quiet
-    ls -1 "$publish_dir"
+    if [ -n "${PLUGIN_FROM_DIRECTORY:-}" ]; then
+        step "take the plugin from $PLUGIN_FROM_DIRECTORY instead of building one"
+        # WHAT IS INSTALLED IS WHAT WOULD BE SHIPPED, WHICH IS THE POINT OF THIS MODE. A publish and
+        # a package are two different sets of bytes: the package carries the files the artifact list
+        # names and nothing else, so a dependency the host does not provide is absent from it and
+        # present in a publish. Installing the publish would answer a question nobody asked.
+        publish_dir=$PLUGIN_FROM_DIRECTORY
+        test -d "$publish_dir"
+        ls -1 "$publish_dir"
+    else
+        step "publish $ASSEMBLY for $framework"
+        # Under the repository rather than in the temporary directory, because this path is handed to
+        # both dotnet and docker and those two disagree about what an absolute path looks like on this
+        # platform.
+        publish_dir="$repo_root/artifacts/load-check/$framework"
+        rm -rf "$publish_dir"
+        dotnet publish "$project" -c Release -f "$framework" -o "$publish_dir" --nologo -v quiet
+        ls -1 "$publish_dir"
+    fi
     host_dll=$(cygpath --windows "$publish_dir/$ASSEMBLY.dll" 2>/dev/null || printf '%s' "$publish_dir/$ASSEMBLY.dll")
 
     step "start a server from $image"
@@ -91,9 +108,16 @@ server_start() {
         sleep 1
     done
     dk exec "$CONTAINER" mkdir -p "$plugin_dir"
-    # Only the assembly. The rest of the publish output is a symbol file and a documentation file,
-    # and a package shipping those would be shipping what a server has no use for.
-    dk cp "$host_dll" "$CONTAINER:$plugin_dir/$ASSEMBLY.dll"
+    if [ -n "${PLUGIN_FROM_DIRECTORY:-}" ]; then
+        # Everything the package holds, because leaving a file out here would be this check deciding
+        # what a server gets rather than the artifact list deciding it.
+        host_dir=$(cygpath --windows "$publish_dir" 2>/dev/null || printf '%s' "$publish_dir")
+        dk cp "$host_dir/." "$CONTAINER:$plugin_dir"
+    else
+        # Only the assembly. The rest of the publish output is a symbol file and a documentation file,
+        # and a package shipping those would be shipping what a server has no use for.
+        dk cp "$host_dll" "$CONTAINER:$plugin_dir/$ASSEMBLY.dll"
+    fi
     # Plugins are read at start, so the server has to come up again with the plugin already in place.
     dk restart "$CONTAINER" >/dev/null
     dk exec "$CONTAINER" ls -1 "$plugin_dir"


### PR DESCRIPTION
The third condition of #108, taken the way it was decided: in the gate rather than
by hand on a machine with an engine.

## What changed

The package job reasoned about what the archive contains and stopped there. It
now unzips the archive it just produced, puts it in a container server's plugin
directory and asks the server what it has. It is the archive rather than a
publish, because those are different sets of files and installing the publish
would answer a question nobody asked: a dependency the host does not provide is
absent from the package and present in a publish, and that is the failure this
issue names.

The load check learns one mode for it, an install from a named directory rather
than from a publish, and everything after that is the check it already was: the
server reports the plugin Active, the configuration page answers, and a setting
written through the endpoint comes back.

The image the container runs is one half of a pair the activity check already
needed. It was written inside that workflow, and two copies of it disagree the
first time a line moves, so it is a file now, `scripts/server-lines.tsv`, with a
lookup that refuses an unknown framework rather than answering with an empty
string that reaches docker as a missing argument.

## Evidence

The archive layout the install step relies on is read off a run rather than
assumed. From the package job on `b0d0b89`:

    unzip -l ./artifacts/requests_0.1.0.0.zip
      Length      Date    Time    Name
    ---------  ---------- -----   ----
          900  2026-08-21 19:11   meta.json
       329216  2026-08-21 19:11   Jellyfin.Plugin.Requests.dll

The lookup answers both claimed lines and refuses anything else:

    scripts/server-image-for.sh net9.0
    jellyfin/jellyfin:10.11.11

    scripts/server-image-for.sh net10.0
    jellyfin/jellyfin:12.0-rc4

    scripts/server-image-for.sh net8.0 ; echo "exit=$?"
    no server image for net8.0 in .../scripts/server-lines.tsv. The claimed lines are:
    net9.0	jellyfin/jellyfin:10.11.11
    net10.0	jellyfin/jellyfin:12.0-rc4
    exit=1

The image is gone from every workflow matrix that carried it, so the pair is
written once:

    git grep -c 'matrix.image' -- .github/workflows/ ; echo "exit=$?"
    exit=1

Corrected after posting. That command was first quoted here under a sentence
saying two workflows carried the pair. Running it returned a third, in the
sibling-set check, and the count was written from the two I had edited rather
than from the tree. The third is in the table now, which is what makes the
output above the output it is.

## Means

Bash and the container engine the runner already has, called from the workflow
that already builds the package, because the question is about a running server
and no suite in this repository can reach one. Nothing new is added to hold it:
the server, the wizard and the account are the helper both container checks
already source.

## The run

The package jobs of this pull request installed what they built. Run
`32518167762`, jobs `96884396892` and `96884396806`:

    Archive:  ./artifacts/requests_0.1.0.0.zip
      inflating: /home/runner/work/_temp/packaged-plugin/meta.json
      inflating: /home/runner/work/_temp/packaged-plugin/Jellyfin.Plugin.Requests.dll

    == take the plugin from /home/runner/work/_temp/packaged-plugin instead of building one
    Jellyfin.Plugin.Requests.dll
    meta.json

    == start a server from jellyfin/jellyfin:10.11.11

    == verdict
    Requests is Active, id 0f9c9107b31b459e81fa6d35dac25e79

and the same on the other line, from `jellyfin/jellyfin:12.0-rc4`. Each run ends
non-zero unless the server reports the plugin Active, so the verdict above is a
refusal that did not happen rather than a line somebody read.

## What this does not do

It does not publish a manifest or ask a server to fetch and install from one.
That is the install path an operator uses and it is M14. `docs/testing.md` said
the container check does not install what a catalogue would serve, which is half
stale after this change, so that paragraph now says which check installs which
bytes.

**Nothing here was run on this machine.** There is no container engine answering
on it, and the run that matters is this pull request's own package jobs. The
result of those runs is read off the checks rather than predicted here.

It does not make the package job a required check. What holds a merge is a
repository setting rather than a file in this tree, and that is #30.

Nobody but me has read this change. There is no second reader on it, and the
commands above stand in place of one rather than beside one.

Closes #108
