### PR TITLE
Write down the shared seam type decision and start the user guide

### DIFF
--- a/docs/seam.md
+++ b/docs/seam.md
@@ -88,6 +88,67 @@ Giving up is safe here for the same reason a repeat is safe. The want carries an
 other side hands it over again, and a request the abandoned call still managed to write is
 recognised as the repeat it is rather than made twice.
 
+## Where the shared type comes from
+
+Implementing somebody's interface means having the type, so the type has to arrive from somewhere,
+and where it arrives from is the whole of whether this seam works at all. The failure is quiet:
+two assemblies of the same simple name in one process can declare two different types with the same
+full name, nothing fails at build time, and what happens instead is that the container returns no
+implementations, which looks exactly like the sibling not being installed and is a supported state.
+
+**The choice is a contract-only package both sides compile against, with exactly one copy shipped.**
+Taken on #117 on 2026-08-21, and taken before the sibling writes its half, because once the other
+side has written against a type declared in this assembly, moving it is a migration across two
+boards rather than a choice on one.
+
+What it costs, stated rather than implied. It is another artefact with its own version and its own
+publishing route, on a board that does not yet publish a manifest for the plugin itself, so the
+package's release path has to be settled as part of building this and not assumed to follow the
+plugin's. It is versioned independently and changed rarely: a contract package that moves often is
+two plugins that have to be upgraded together, which is the thing a shared type was meant to avoid.
+
+### The two that were rejected
+
+**A contract-only package both sides compile against and both ship, with the loader deduplicating
+it.** Rejected. It rests on the loader actually merging two copies, and that is the assumption the
+entire handover would then depend on. Nobody has measured it on either claimed line, so the cost of
+this option is an unmeasured premise underneath every call that crosses. One shipped copy removes
+the question instead of answering it.
+
+**No shared type at all, with the handover taken by name through reflection.** Rejected, and it is
+the honest fallback if the package turns out to be impractical rather than a bad idea. It is immune
+to this whole error class, because there is no second type to be a different type. What it costs is
+the thing #117's fourth condition is about: a mismatch stops being a compile error and becomes a
+runtime one, so "no sibling installed" and "sibling installed, type did not match" collapse back
+into the same silence. A compile-time contract is what keeps those two states different.
+
+### What the tree does today is not yet the choice above
+
+The type the sibling would name is declared in this plugin's own assembly, and this project
+references no contract package:
+
+    git grep -n 'public interface IWantHandover' -- Jellyfin.Plugin.Requests/Seam/IWantHandover.cs
+    Jellyfin.Plugin.Requests/Seam/IWantHandover.cs:30:public interface IWantHandover
+
+    git grep -n 'PackageReference Include\|ProjectReference' -- Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.csproj
+    Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.csproj:23:    <PackageReference Include="Jellyfin.Controller" Version="$(JellyfinVersion)">
+    Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.csproj:26:    <PackageReference Include="Jellyfin.Model" Version="$(JellyfinVersion)">
+
+Two references and both are the host's. So the registration landed before the question was decided,
+and the decision above is a thing to build rather than a description of what ships. Reading this
+section as the arrangement being in place is the one misreading it could produce, which is why the
+commands are here.
+
+**Three things #117 asks for are still not done, and none of them is softened by the choice being
+taken.** What the server's loader does with two plugin directories each carrying an assembly of one
+simple name is unmeasured on both claimed lines; a run needs a container engine, an image per line,
+and two throwaway plugins built for the purpose, and none of that has been done from this tree.
+Nothing proves that the sibling's container lookup finds this plugin's implementation, in the shape
+that will actually ship, on either line; what the suite resolves is this assembly's own
+registration, which is a different claim and is written as one above. And nothing separates a
+container that found no implementation from one that found none because the type did not match, so
+an operator meeting either one meets the same silence.
+
 ## Both sides watch the library, and neither tells the other
 
 This plugin decides that a request is fulfilled by watching the server's library for the thing

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,124 @@
+# Asking for something, from the client you actually use
+
+This is the document for somebody who uses this server rather than runs it. It answers one question
+per client family: what you can do here from the thing in front of you, and where the answer is that
+this client cannot, what can instead.
+
+If you run the server, [operating.md](operating.md) is yours and this one is not. It is the document
+to hand to the people on your server, and it does not repeat what that one says.
+
+## Two answers that are the same on every client
+
+Both are decided rather than missing, so no client and no update changes them.
+
+**There is no way to search for a title here.** This plugin holds requests; it does not hold a
+catalogue and it asks nothing about films or series anywhere. So there is no box to type a title
+into, on any client. A request reaches this server either from a browsing plugin your operator has
+installed beside this one, or from something driving the server's own interface, and if neither of
+those is set up on your server then there is no way to ask and asking your operator directly is the
+answer.
+
+**There is no way to take an ask back.** A request has no withdrawn state, deliberately, so nothing
+on any client can cancel one. What to do instead is ask whoever runs the server to decline it, which
+is one action on their side and reads correctly in the history afterwards.
+
+## What each family gets
+
+Each section says what is there today, and carries the line saying whether anybody has opened that
+client and looked. The wording is the same as the reach matrix in [surface.md](surface.md) uses, and
+it means the same thing:
+
+- **not checked** means nobody has opened that client and looked. It is not a prediction that it
+  works. It is the admission that it has not been tried.
+- A section that has been checked names the client and the version it was checked on, in place of
+  those two words, so a checked section and an unchecked one can never be read as the same thing.
+
+Nothing in this document says a client does something on the strength of a plan. Where the thing
+itself is not built yet, the section says that instead, and no observation can change it until it is.
+
+### Browser
+
+Open the address your operator gives you and you see your own requests: what you asked for, what
+sort of thing it is, where it stands, when you asked, when it last moved, whether the server has it
+now, the note you wrote, and the reason and the sentence your operator gave if the answer was no.
+
+The address carries your credential in it, which is how a browser tab reaches an authenticated page
+on this server at all. Treat the link the way you would treat a password: it lands in your browser
+history, and anybody you send it to is being sent your session rather than a page.
+
+There is nothing to press on that page. It shows and it does not decide, because approving and
+declining are the operator's and cancelling does not exist.
+
+Not checked.
+
+### Desktop client that wraps the web interface
+
+The same page as the browser row, opened the same way, because this family draws the web interface.
+
+Not checked.
+
+### Android phone and tablet
+
+Nothing from this plugin yet. The surface meant for a client that draws its own interface is a
+folder that appears beside your libraries, and it is not built, so today there is nothing to open on
+this family and nothing to look for.
+
+Reading your own requests works from a browser on the same device, with the address above.
+
+### Android TV and Fire TV
+
+Nothing from this plugin yet, for the same reason as the row above.
+
+This is the family the absence costs most, because a television is where somebody is least able to
+go and open a browser instead. Reading your own requests means finding a browser somewhere else,
+which is a real answer and not a good one.
+
+### iPhone and iPad
+
+Nothing from this plugin yet, for the same reason.
+
+Reading your own requests works from a browser on the same device.
+
+### Apple TV
+
+Nothing from this plugin yet, for the same reason, and the same cost as the other television
+families.
+
+### Roku
+
+Nothing from this plugin yet, for the same reason, and the same cost as the other television
+families.
+
+### LG webOS television
+
+Nothing from this plugin yet, for the same reason, and the same cost as the other television
+families.
+
+### Samsung Tizen television
+
+Nothing from this plugin yet, for the same reason, and the same cost as the other television
+families.
+
+### Kodi
+
+Nothing from this plugin yet, for the same reason.
+
+### A script, or another program
+
+Everything this plugin does is reachable over the server's own interface, and that is the floor the
+rest of this document is built on. What the routes are, what they take and what they answer is in
+[api.md](api.md).
+
+Taking an ask back is the one thing that is not there either, for the reason at the top: there is no
+state to move a request into.
+
+## What this document does not tell you
+
+**Whether any of the sections above is true of your client.** Every one of them carries its own
+answer to that, and today none of them has been checked against a real client of that family. A
+section that says nothing is built is certain, because that is a fact about this plugin rather than
+about your client. A section that says something works is not, until it names the client and the
+version somebody saw it on.
+
+**Anything about running the server.** Settings, the queue, retention and what is stored about a
+person are the operator's documents, and they are linked from [operating.md](operating.md).


### PR DESCRIPTION
Two documents, no code. They land together because each is a document and a separate landing would move the mainline under the other for no reason.

Part of #117.
Part of #103.

## What is in it

**`docs/seam.md` gains a section saying where the shared type comes from.** The chosen shape is a contract-only package both sides compile against with exactly one copy shipped, and the two rejected shapes are written down with what each costs: two shipped copies deduplicated by the loader rest on a merge nobody has measured, and reflection by name is immune to the whole error class at the price of turning a type mismatch back into the same silence as no sibling being installed. That is the second condition of #117.

**`docs/user-guide.md` is new.** A section per family of the reach matrix, the two answers that are certain on every client, and the same two wordings the matrix uses for a section nobody has checked.

## What this does not claim

**The tree does not do what the seam section decides, and the section says so with the commands.** The interface the sibling would name is declared in this plugin's own assembly and the project references only the host's two packages:

    git grep -n 'public interface IWantHandover' -- Jellyfin.Plugin.Requests/Seam/IWantHandover.cs
    Jellyfin.Plugin.Requests/Seam/IWantHandover.cs:30:public interface IWantHandover

    git grep -n 'PackageReference Include\|ProjectReference' -- Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.csproj
    Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.csproj:23:    <PackageReference Include="Jellyfin.Controller" Version="$(JellyfinVersion)">
    Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.csproj:26:    <PackageReference Include="Jellyfin.Model" Version="$(JellyfinVersion)">

**No measurement of the loader was made and none is claimed.** What the server does with two plugin directories each carrying an assembly of one simple name is untested on both claimed lines. The paragraph in `docs/seam.md` that already refuses the reachability claim is untouched and still refuses it.

**No client was opened.** Every section of the user guide that could carry a client observation carries the words saying nobody has looked. The sections that say a surface is not built are certain instead, because that is a fact about this plugin rather than about a client.

**Neither issue closes.** #117 still owes the loader measurement, the proof that the sibling's lookup finds this implementation in the shape that ships, and the separation of a type mismatch from an absent sibling. #103 still owes a section per family that has been checked, and the pointer from the operator guide, which is a line in `docs/operating.md` and I did not take a second hand to that file.

## Evidence

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    0 Warnung(en)
    0 Fehler

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler:     0, erfolgreich:   636, übersprungen:     0, gesamt:   636 (net9.0)
    Bestanden!   : Fehler:     0, erfolgreich:   636, übersprungen:     0, gesamt:   636 (net10.0)

    npx --yes prettier@3.6.2 --check "docs/seam.md" "docs/user-guide.md"
    All matched files use Prettier code style!

The suite output is the German of the local runtime. It reports zero failures and 636 passes on each claimed target framework.

No guard is added here, so there is nothing to delete and watch go red. The change is prose in `docs/`, and both files are inside the scope the two issues declare.

**This has had no second reader.** The evidence above stands in place of one.
