### PR TITLE
Throwaway: watch the page assertion red when no page is served

### DIFF
--- a/scripts/verify-plugin-loads.sh
+++ b/scripts/verify-plugin-loads.sh
@@ -37,7 +37,9 @@ port=${3:-18096}
 # The answer the server gives after the save is read twice, once by a person reading this output and
 # once by the check under it, so it is kept in a file rather than in a variable a pipeline would eat.
 stored_configuration=$(mktemp)
-trap 'server_stop; rm -f "$stored_configuration"' EXIT
+# The configuration page's own bytes, for the same reason and read once.
+page_body=$(mktemp)
+trap 'server_stop; rm -f "$stored_configuration" "$page_body"' EXIT
 
 server_start "$image" "$framework" "$port" "jellyfin-plugin-load-check-$framework"
 
@@ -48,7 +50,17 @@ page_status=$(curl --silent --output /dev/null --write-out '%{http_code}' --max-
     "$BASE/web/ConfigurationPage?name=$PLUGIN_NAME")
 echo "GET /web/ConfigurationPage?name=$PLUGIN_NAME -> $page_status"
 test "$page_status" = "200"
-curl --silent --fail --max-time 30 "$BASE/web/ConfigurationPage?name=$PLUGIN_NAME" | head -5
+# THE HEAD IS PRINTED OUT OF A FILE AND NEVER OUT OF A PIPE, and it is the same reason the stored
+# configuration above is kept in one. `head` closes the pipe after five lines, and where the body is
+# still being written at that moment curl cannot finish writing it, exits 23, and `pipefail` ends a
+# check whose subject answered 200 one line earlier. Which of the two happens is a race between two
+# processes and says nothing about the plugin, the server or the page. It was watched happening,
+# once, on a head carrying two markdown files and nothing this script reads; the same head passed on
+# a second attempt with nothing changed between them (#263). Out of a file there is no pipe to close,
+# and curl failing to fetch at all still ends the check, which is what --fail is here for.
+curl --silent --fail --max-time 30 --output "$page_body" \
+    "$BASE/web/ConfigurationPage?name=$PLUGIN_NAME"
+head -5 "$page_body"
 
 step "the configuration the page reads and writes"
 api GET "/Plugins/$PLUGIN_ID/Configuration"

--- a/scripts/verify-plugin-loads.sh
+++ b/scripts/verify-plugin-loads.sh
@@ -47,7 +47,7 @@ step "the configuration page the dashboard would fetch"
 # The embedded resource path is built at run time from the plugin's namespace. A half rename leaves
 # a build that is green and a page that is empty, and this is where that shows.
 page_status=$(curl --silent --output /dev/null --write-out '%{http_code}' --max-time 30 \
-    "$BASE/web/ConfigurationPage?name=$PLUGIN_NAME")
+    "$BASE/web/ConfigurationPage?name=${PLUGIN_NAME}s")
 echo "GET /web/ConfigurationPage?name=$PLUGIN_NAME -> $page_status"
 test "$page_status" = "200"
 # THE HEAD IS PRINTED OUT OF A FILE AND NEVER OUT OF A PIPE, and it is the same reason the stored

--- a/scripts/verify-sibling-set.sh
+++ b/scripts/verify-sibling-set.sh
@@ -129,6 +129,11 @@ while read -r board directory; do
     rm -rf "$work/package"
     mkdir -p "$work/package"
     gh release download "$found" --repo "$board" --pattern '*.zip' --dir "$work/package" >/dev/null
+    # The other pipeline of this shape in scripts/, and it is safe where the one in
+    # verify-plugin-loads.sh was not (#263). What writes into head here is find over a directory
+    # this loop empties and refills with one release download, so the whole output is a path or
+    # two and fits in the pipe before head can close it. The unsafe case is a producer still
+    # writing when the reader leaves, which a release full of zip files is not.
     zip=$(find "$work/package" -name '*.zip' | head -1)
     test -n "$zip"
     rm -rf "$work/unpacked"


### PR DESCRIPTION
Part of #263.

**Not for merge, and it will be closed rather than merged.** This head carries a defect on purpose: `scripts/verify-plugin-loads.sh` asks the server for a configuration page under a name no plugin has, which is one half of a rename that was not carried through.

What it is for is the near-miss #263 owes. The change that issue asks for removes a pipeline from the line below the assertion, and a reader is entitled to ask whether the assertion that carries the step still bites afterwards. This head answers that by making the server serve no page under the name asked for, and the expected result is that `entries 10.11` and `entries 12.0` red on

    test "$page_status" = "200"

rather than passing quietly.

The verdict of the run is quoted on #263 and the branch is deleted once it is read. Nothing here is proposed for the mainline.
