### PR TITLE
Print the configuration page out of a file rather than a pipe

### DIFF
--- a/scripts/verify-plugin-loads.sh
+++ b/scripts/verify-plugin-loads.sh
@@ -37,7 +37,9 @@ port=${3:-18096}
 # The answer the server gives after the save is read twice, once by a person reading this output and
 # once by the check under it, so it is kept in a file rather than in a variable a pipeline would eat.
 stored_configuration=$(mktemp)
-trap 'server_stop; rm -f "$stored_configuration"' EXIT
+# The configuration page's own bytes, for the same reason and read once.
+page_body=$(mktemp)
+trap 'server_stop; rm -f "$stored_configuration" "$page_body"' EXIT
 
 server_start "$image" "$framework" "$port" "jellyfin-plugin-load-check-$framework"
 
@@ -48,7 +50,17 @@ page_status=$(curl --silent --output /dev/null --write-out '%{http_code}' --max-
     "$BASE/web/ConfigurationPage?name=$PLUGIN_NAME")
 echo "GET /web/ConfigurationPage?name=$PLUGIN_NAME -> $page_status"
 test "$page_status" = "200"
-curl --silent --fail --max-time 30 "$BASE/web/ConfigurationPage?name=$PLUGIN_NAME" | head -5
+# THE HEAD IS PRINTED OUT OF A FILE AND NEVER OUT OF A PIPE, and it is the same reason the stored
+# configuration above is kept in one. `head` closes the pipe after five lines, and where the body is
+# still being written at that moment curl cannot finish writing it, exits 23, and `pipefail` ends a
+# check whose subject answered 200 one line earlier. Which of the two happens is a race between two
+# processes and says nothing about the plugin, the server or the page. It was watched happening,
+# once, on a head carrying two markdown files and nothing this script reads; the same head passed on
+# a second attempt with nothing changed between them (#263). Out of a file there is no pipe to close,
+# and curl failing to fetch at all still ends the check, which is what --fail is here for.
+curl --silent --fail --max-time 30 --output "$page_body" \
+    "$BASE/web/ConfigurationPage?name=$PLUGIN_NAME"
+head -5 "$page_body"
 
 step "the configuration the page reads and writes"
 api GET "/Plugins/$PLUGIN_ID/Configuration"

--- a/scripts/verify-sibling-set.sh
+++ b/scripts/verify-sibling-set.sh
@@ -129,6 +129,11 @@ while read -r board directory; do
     rm -rf "$work/package"
     mkdir -p "$work/package"
     gh release download "$found" --repo "$board" --pattern '*.zip' --dir "$work/package" >/dev/null
+    # The other pipeline of this shape in scripts/, and it is safe where the one in
+    # verify-plugin-loads.sh was not (#263). What writes into head here is find over a directory
+    # this loop empties and refills with one release download, so the whole output is a path or
+    # two and fits in the pipe before head can close it. The unsafe case is a producer still
+    # writing when the reader leaves, which a release full of zip files is not.
     zip=$(find "$work/package" -name '*.zip' | head -1)
     test -n "$zip"
     rm -rf "$work/unpacked"


### PR DESCRIPTION
Closes #263.

The real-server check reddened on the line that only prints the head of the configuration page, one line after asserting a 200 for it. `head` closes the pipe after five lines, curl fails to write the rest of the body, exits 23, and `pipefail` ends the run. Which of the two happens is a race between two processes.

Printing out of a file removes the pipe. It is the idiom the stored configuration a few lines above already uses, for the same class and with the reason written at it.

## The failure, watched

One head, two attempts, nothing changed between them. Head `037cf140e8001111c13cb4748936165178521c1f` carried two markdown files under `docs/` and nothing this script reads:

    gh api repos/Flowfin/jellyfin-plugin-requests/actions/runs/32547140022/attempts/1 --jq '.conclusion'
    failure

    gh api repos/Flowfin/jellyfin-plugin-requests/actions/runs/32547140022 --jq '{conclusion, run_attempt}'
    {"conclusion":"success","run_attempt":2}

The failed attempt reported the plugin healthy immediately before it died:

    Requests is Active, id 0f9c9107b31b459e81fa6d35dac25e79
    == the configuration page the dashboard would fetch
    GET /web/ConfigurationPage?name=Requests -> 200
    <!doctype html>
    ...
    ##[error]Process completed with exit code 23.

## The mechanism, reproduced

The same command against a body big enough that curl is certainly still writing when `head` leaves. Exit 23 is the same code the job died with:

    $ cat race.sh
    set -euo pipefail
    curl --silent --fail --max-time 30 "file://$1" | head -5
    $ bash race.sh /tmp/big.html > /dev/null 2>&1; echo "exit=$?"
    exit=23

The shape this change lands, against the same body:

    $ cat fixed.sh
    set -euo pipefail
    out=$(mktemp)
    trap 'rm -f "$out"' EXIT
    curl --silent --fail --max-time 30 --output "$out" "file://$1"
    head -5 "$out"
    $ bash fixed.sh /tmp/big.html > /dev/null 2>&1; echo "exit=$?"
    exit=0

And a fetch that genuinely fails still ends the check, so `--fail` is not being traded away for this:

    $ bash fixed.sh /tmp/does-not-exist.html > /dev/null 2>&1; echo "exit=$?"
    exit=37

## The assertion that carries the step, watched failing

The near-miss is the one somebody would actually make: the step still has to red when the server does not serve the page. Watched, on a running server of each claimed line. #264 is a throwaway head that asks the same server for a page name no plugin has, which is one half of a rename carried through in one place and not the other. It is closed rather than merged and its branch is deleted:

    gh api repos/Flowfin/jellyfin-plugin-requests/actions/runs/32547852608 --jq '.conclusion'
    failure

    entries 10.11 | Requests is Active, id 0f9c9107b31b459e81fa6d35dac25e79
    entries 10.11 | GET /web/ConfigurationPage?name=Requests -> 404
    entries 10.11 | ##[error]Process completed with exit code 1.

    entries 12.0  | Requests is Active, id 0f9c9107b31b459e81fa6d35dac25e79
    entries 12.0  | GET /web/ConfigurationPage?name=Requests -> 404
    entries 12.0  | ##[error]Process completed with exit code 1.

Both red on the assertion, each reporting the plugin healthy one line earlier. Exit code 1 there is the `test`; the failure this change removes is exit code 23 from a pipeline, and the two stay distinguishable in the log.

    git grep -n 'test "$page_status" = "200"' -- scripts/verify-plugin-loads.sh
    scripts/verify-plugin-loads.sh:50:test "$page_status" = "200"

## The other pipeline of this shape

`scripts/verify-sibling-set.sh` has one and it is safe, so it is named with why rather than changed. What writes into `head` there is `find` over a directory the loop empties and refills with one release download, so the producer finishes before the reader leaves.

## What is not claimed

**No server was started here.** No container engine answers on the machine this was written on, so the reproduction above is of the pipeline, over `file://`, and not of this script against a Jellyfin server. What runs it against two real servers is this pull request's own `entries 10.11` and `entries 12.0` jobs.

    docker version --format '{{.Server.Version}}'
    failed to connect to the docker API at npipe:////./pipe/dockerDesktopLinuxEngine; check if the path is correct and if the daemon is running: open //./pipe/dockerDesktopLinuxEngine: Das System kann die angegebene Datei nicht finden.

The last clause is the operating system saying the pipe is not there.

**This does not make the check less likely to red for a real defect.** It removes one failure mode that is not a defect, and the status assertion above it is unchanged.

**This has had no second reader.** The evidence above stands in place of one.
