### PR TITLE
Ask the server which version it loaded rather than printing it

### DIFF
--- a/scripts/server-under-test.sh
+++ b/scripts/server-under-test.sh
@@ -26,8 +26,9 @@
 #   api ...     curl with the address, the authorisation header and the failure flags already on it
 #   dk ...      docker with the path rewriting Git Bash does turned off
 #
-# It decides nothing and asserts nothing beyond the server answering and the plugin being active,
-# which is the precondition of every check that sources it rather than a check of its own.
+# It decides nothing and asserts nothing beyond the server answering, the plugin being active, and
+# the version the server reports for it being the one this tree holds. That set is the precondition
+# of every check that sources it rather than a check of its own.
 
 # The assembly and the name the server lists it under. Both are read by every caller.
 ASSEMBLY=Jellyfin.Plugin.Requests
@@ -184,9 +185,22 @@ for plugin in json.load(sys.stdin):
 '
 
     step "verdict"
+    # THE VERSION IS COMPARED HERE AND WAS ONLY PRINTED BEFORE. Everything else this repository knows
+    # about its own version is one file of its own read against another: the suite refuses
+    # Directory.Build.props disagreeing with either packaging file. None of that says what a server
+    # hands back for the plugin it actually loaded, and the number travels through the packaging
+    # tool, an archive and an install before it gets there.
+    #
+    # The number is read out of the one place that holds it rather than written here, so this adds no
+    # copy of it. Exactly one value, or the test below ends the run: two would make which one is
+    # meant a guess, and none would compare against the empty string and pass on any server at all.
+    local expected_version
+    expected_version=$(grep -o '<PluginVersion>[^<]*' "$repo_root/Directory.Build.props" | cut -d'>' -f2)
+    test "$(printf '%s' "$expected_version" | grep -c '^')" = "1"
+
     PLUGIN_ID=$(printf '%s' "$plugins" | python3 -c '
 import json, sys
-name = sys.argv[1]
+name, expected = sys.argv[1], sys.argv[2]
 mine = [p for p in json.load(sys.stdin) if p.get("Name") == name]
 if not mine:
     sys.exit("{0} is not in the plugin list: the server did not load it.".format(name))
@@ -195,9 +209,13 @@ if len(mine) != 1:
 status = mine[0].get("Status")
 if status != "Active":
     sys.exit("{0} is {1} rather than Active.".format(name, status))
+reported = mine[0].get("Version")
+if reported != expected:
+    sys.exit("{0} reports {1!r} and this tree holds {2!r}: the server did not load what was built.".format(
+        name, reported, expected))
 print(mine[0]["Id"])
-' "$PLUGIN_NAME")
-    echo "$PLUGIN_NAME is Active, id $PLUGIN_ID"
+' "$PLUGIN_NAME" "$expected_version")
+    echo "$PLUGIN_NAME is Active at $expected_version, id $PLUGIN_ID"
 }
 
 # One authenticated call. The body is read from the third argument where there is one.


### PR DESCRIPTION
The plugin-load check lists the plugin, refuses a status other than `Active`, and printed the version beside it without comparing it with anything. This compares it.

## What was green before, and should not have been

Every version claim this repository makes is one of its own files read against another. `PluginVersionMatchesThePackagingMetadata` refuses `Directory.Build.props` disagreeing with either packaging file, and `BothPackagesClaimTheSameIdentity` refuses the two packages diverging. None of that says anything about the number a running server hands back for the plugin it loaded, and that number travels through the packaging tool, an archive and an install on the way there.

Measured on `master` as `ead7b2c`, at the head of #265. Both lines report a version and nothing reads it:

    gh api repos/Flowfin/jellyfin-plugin-requests/actions/jobs/96969550136/logs | grep -aE "Name=Requests"
    Name=Requests  Version=0.1.0.0  Status=Active  Id=0f9c9107b31b459e81fa6d35dac25e79

    gh api repos/Flowfin/jellyfin-plugin-requests/actions/jobs/96969550154/logs | grep -aE "Name=Requests"
    Name=Requests  Version=0.1.0.0  Status=Active  Id=0f9c9107b31b459e81fa6d35dac25e79

## What this changes

`server_start` reads the expected number out of `Directory.Build.props`, which is the one place that holds it, so this adds no copy of it. The run ends unless that file holds exactly one such value: two would make which one is meant a guess, and none would compare against the empty string and pass on any server at all.

The comparison sits in the block that already refuses a plugin that is missing or not `Active`, so all three checks that source this file get it: the load check, the activity-entries check and the sibling-set check.

## That it bites

`proof/1-a-version-the-tree-does-not-hold-is-refused` carries the same change with the packaging metadata raised to `0.1.0.1` and `Directory.Build.props` left at `0.1.0.0`, which is the one-character mistake somebody makes when a version is raised in one place. That branch is not for merging and has no pull request.

The Package workflow was dispatched on that head and both of its matrix legs went red, at the step this change touches:

    gh run view 32554832287 --repo Flowfin/jellyfin-plugin-requests --json conclusion,jobs --jq '.conclusion, (.jobs[] | "\(.name)  \(.conclusion)")'
    failure
    package-lines  success
    package 12.0.0.0  failure
    package 10.11.0.0  failure

    gh api repos/Flowfin/jellyfin-plugin-requests/actions/jobs/96987258511/logs | grep -aE "Name=Requests|reports"
    Name=Requests  Version=0.1.0.1  Status=Active  Id=0f9c9107b31b459e81fa6d35dac25e79
    Requests reports '0.1.0.1' and this tree holds '0.1.0.0': the server did not load what was built.

The same two lines on the line above the refusal are the reason this is worth having. The server came up, loaded the package, listed it and reported it `Active` while carrying a version this tree does not hold, which is exactly the run that was green before. What the server reports is the package's own `meta.json`, so the drift is visible there and nowhere else in this repository.

No workflow other than Package was run on that head, so nothing is claimed about the other two checks that source the same file there.

## The means

Bash and Python 3, because both are what `scripts/server-under-test.sh` already is and what a hosted runner already has. A refusal here has to happen where the server is answering, and adding a language or a runtime for four lines of comparison would be paid on every run of three checks.

## What this does not claim

Nothing here was run against a container on the machine it was written on; the container engine is not answering there, so every reading above and below comes from a hosted runner. The comparison and the extraction were exercised locally against a captured answer and against `Directory.Build.props`, which is the part that needs no server.

This had no second reader. The evidence above stands in place of one.

Part of #1.

