### PR TITLE
Ask a real server of each line what one person's list holds

### DIFF
--- a/.github/workflows/user-isolation.yaml
+++ b/.github/workflows/user-isolation.yaml
@@ -1,0 +1,90 @@
+# Does one person's request reach another person, on a real server of each claimed line.
+#
+# #67 asks for this and says why a suite cannot answer it. The suite runs the controller over a
+# double: there is no session, no authorisation pipeline and no cache, so what it holds is that the
+# action reading a person's own list reads the store for that person, and that the queue action
+# carries the elevation attribute. Whether the server enforces that attribute, and whether a second
+# caller arriving after the first is handed the first one's answer, are properties of the server.
+#
+# So this job starts a Jellyfin of each line, installs the plugin, creates two ordinary accounts,
+# has each of them ask for something, and reads back what each of them is given. One of the three
+# requests is a title both of them asked for, which the plugin joins into a single row: that row is
+# the one two people are both entitled to see, and the notes written on it are not.
+#
+# What it does not do is render a page. Nothing here opens a browser, which is the headless rule in
+# `docs/testing.md`, so what this proves is what the server hands back, not what a client draws.
+#
+# It runs on pull requests as well as on a schedule, for the reason the activity check gives: a
+# check of this shape that only runs nightly reports a defect after it has landed. The cost is one
+# container per line.
+name: One person's requests on a real server
+
+on:
+  pull_request:
+    branches: ["**"]
+  schedule:
+    - cron: "47 4 * * *"
+  workflow_dispatch:
+
+# Explicit deny-all at workflow level; the job grants what it needs.
+permissions: {}
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  isolation:
+    name: isolation ${{ matrix.line }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+
+    strategy:
+      # Both lines run whatever the other one does. A failure on one is a fact about that line, and
+      # cancelling the other would leave nobody knowing whether it is a fact about both.
+      fail-fast: false
+      matrix:
+        include:
+          # The image is not written here. It is one half of a pair several checks need, and two
+          # copies of that pair disagree the first time a line moves, so it lives in
+          # `scripts/server-lines.tsv` and the steps below ask for it by framework.
+          - line: "10.11"
+            framework: "net9.0"
+            port: "18100"
+          - line: "12.0"
+            framework: "net10.0"
+            port: "18101"
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Nothing here pushes, so do not leave the token in .git/config.
+          persist-credentials: false
+
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: |
+            9.0.x
+            10.0.x
+
+      - name: Restore in locked mode
+        run: dotnet restore Jellyfin.Plugin.Requests.sln --locked-mode
+
+      - name: Is one person's list that person's alone
+        # The matrix values arrive as environment variables rather than as expressions inside the
+        # script. They are written in this file and are not somebody's input, so nothing here is
+        # injectable today; what the shape buys is that it stays that way when a later matrix takes
+        # a value from somewhere else.
+        env:
+          FRAMEWORK: ${{ matrix.framework }}
+          PORT: ${{ matrix.port }}
+        run: |
+          set -euo pipefail
+          IMAGE=$(./scripts/server-image-for.sh "$FRAMEWORK")
+          ./scripts/verify-user-isolation.sh "$IMAGE" "$FRAMEWORK" "$PORT"

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -120,6 +120,78 @@ are reachable only under a name registered as a plugin page, and those are serve
 administrator, so a user asking for one would meet a refusal instead of a stylesheet. The page
 carries its own.
 
+## Whether one person's requests reach another, asked of a running server
+
+The suite runs the controller over a double. What it holds is that the action serving a person's own
+list reads the store for that person and nothing wider, and that the queue action carries the
+elevation attribute:
+
+    git grep -n "public async Task NothingButTheCallersOwnRequestsComesBackWhateverIsAskedFor" -- Jellyfin.Plugin.Requests.Tests/Api/ListRequestsTests.cs
+    Jellyfin.Plugin.Requests.Tests/Api/ListRequestsTests.cs:61:    public async Task NothingButTheCallersOwnRequestsComesBackWhateverIsAskedFor()
+
+A double has no session, no authorisation pipeline and no cache, so two things it cannot answer are
+whether the server enforces an attribute written on an action and whether an answer stays one
+person's after the server has handed it out. `scripts/verify-user-isolation.sh` asks a running
+server of each claimed line instead, and `.github/workflows/user-isolation.yaml` runs it on every
+pull request and nightly.
+
+It creates two ordinary accounts, has each of them ask for a title of its own and both of them ask
+for a third, which is joined into a single row rather than asked for twice. That row is the one two
+people are both entitled to see and the notes written on it are not, which is why it is there.
+
+**The order of the three list calls is the part that is about caching.** One call as one person and
+one as another says nothing: an answer cached against the route rather than against the caller only
+comes back to the wrong person when the second caller arrives after the first. So the second
+person's list is read immediately after the first person's, and the first person's is read again
+once the server has answered both. Every assertion reads the raw bytes as well as the parsed rows,
+because a leak arriving in a field the script does not name is the one worth catching.
+
+Taken at `c9dd8d2` on the 10.11 line, job `97001703609`:
+
+    the first person was given ['A film both of them asked for', 'A film only the first person asked for']
+    the second person was given ['A film both of them asked for', 'A film only the second person asked for']
+    the first person, asking again was given ['A film both of them asked for', 'A film only the first person asked for']
+    the queue answered 403
+    the queue refused with 403 and carried nothing that belongs to anybody.
+    the administrator is served 3 rows and all three titles are among them.
+    the page served to the first person carries no title and no note.
+    the page served to the second person carries no title and no note.
+
+The 12.0 line is job `97001703695` and returns the same eight lines.
+
+The queue is asked for twice on purpose. A queue that is broken for everybody would satisfy the
+refusal on its own, so it is asked again as the administrator and has to answer with all three
+titles; the refusal above means the endpoint is closed to that person rather than closed.
+
+### That the check bites
+
+Two branches carry the mistakes it exists to catch. Neither is for merging and neither has a pull
+request.
+
+`proof/67-one-persons-list-is-not-everybodys` replaces `FindForUserAsync` with `GetAllAsync` in the
+action serving a person's own list, which compiles and passes every suite leg that runs the
+controller over a double. Run `32560869939`, both lines red at the first list:
+
+    the first person was given ['A film both of them asked for', 'A film only the first person asked for', 'A film only the second person asked for'] and what belongs to that caller is ['A film both of them asked for', 'A film only the first person asked for'].
+
+`proof/67-the-queue-is-not-closed-to-everybody` takes the elevation off the queue action and leaves
+the authorisation attribute, which is one word. Run `32560880189`, both lines red at the queue and
+green at everything before it:
+
+    the queue answered 200
+    the queue was served to somebody who is not an administrator.
+
+### What this does not reach
+
+It is the API and the page. The channel is not in the tree, and the leak #67 is written about is a
+property of that surface specifically: the server materialising what a channel returns into its
+library database, where an item is ordinarily visible to whoever can see the folder holding it.
+Nothing above says anything about that, and the fallback stated under what the channel costs is
+unchanged.
+
+Nothing here opens a browser. What is measured is what the server hands back, including the bytes of
+the page itself, and not what a client draws from them.
+
 ## What is not reached
 
 Nothing here is softened, and the parts that are claims rather than measurements say so.

--- a/scripts/verify-user-isolation.sh
+++ b/scripts/verify-user-isolation.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+# Ask a running Jellyfin of one claimed line whether one person's requests reach another person.
+#
+# The suite already asserts that the endpoint serving a person's own list reads the store for that
+# person and nothing wider, and that the queue endpoint carries the elevation policy. Neither of
+# those is the question #67 asks. A double has no session, no authorisation pipeline and no cache,
+# so what a double cannot say is whether the server hands the same answer to a second caller, or
+# whether a policy written on an action is a policy the server enforces.
+#
+# So this creates two ordinary accounts on a real server, has each of them ask for something, and
+# reads back what each of them is given.
+#
+# THE ORDER OF THE CALLS IS PART OF THE CHECK. Asking once as one person and once as another says
+# nothing about a cached answer, because an answer cached against the route rather than against the
+# caller only comes back to the wrong person when a second caller arrives after the first. So the
+# second person's list is asked for immediately after the first person's, and the first person's is
+# asked for again after the server has answered both.
+#
+# What it does not do is render anything. Nothing here opens a browser, which is the headless rule
+# in docs/testing.md, so what is checked is the answer the page draws from and the bytes of the page
+# itself, not the markup a browser would make of them.
+#
+# The server, the install, the wizard and the administrator account are scripts/server-under-test.sh,
+# which the plugin-load check and the activity check also source. The two ordinary accounts are this
+# script's own. They live for the length of that container and are reachable only from a loopback
+# port.
+#
+# usage: scripts/verify-user-isolation.sh <image> <target-framework> [host-port]
+#   scripts/verify-user-isolation.sh jellyfin/jellyfin:10.11.11 net9.0  18100
+#   scripts/verify-user-isolation.sh jellyfin/jellyfin:12.0-rc4  net10.0 18101
+
+set -euo pipefail
+
+image=${1:?server image, for example jellyfin/jellyfin:10.11.11}
+framework=${2:?target framework, for example net9.0}
+port=${3:-18100}
+
+# shellcheck source=scripts/server-under-test.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/server-under-test.sh"
+
+trap server_stop EXIT
+
+server_start "$image" "$framework" "$port" "jellyfin-isolation-check-$framework"
+
+prefix=/MediaRequests/v1
+
+# The titles are distinctive so that finding one in an answer cannot be some other row that happened
+# to be there, and so that a leak can be looked for in the raw bytes rather than only in the fields
+# this script knows the names of.
+first_title="A film only the first person asked for"
+second_title="A film only the second person asked for"
+shared_title="A film both of them asked for"
+first_note="The first person typed this and nobody else may read it."
+second_note="The second person typed this and nobody else may read it."
+
+# One authenticated call as somebody other than the administrator. The token is the first argument
+# and everything after it is the call. `--fail-with-body` for the reason the shared `api` uses it: a
+# refusal from this plugin names the field that was wrong, and a check that threw the body away
+# would print a status code and nothing to act on.
+as() {
+    local token=${1:?token} method=${2:?method} path=${3:?path} body=${4:-}
+
+    if [ -n "$body" ]; then
+        curl --silent --fail-with-body --max-time 30 -X "$method" "$BASE$path" \
+            -H 'Content-Type: application/json' \
+            -H "Authorization: $AUTH_HEADER, Token=\"$token\"" \
+            -d "$body"
+    else
+        curl --silent --fail-with-body --max-time 30 -X "$method" "$BASE$path" \
+            -H "Authorization: $AUTH_HEADER, Token=\"$token\""
+    fi
+}
+
+# The same call, writing the body to a file and printing the status code, for the two places where a
+# refusal is the thing being checked and a non-zero exit would end the run before it is read.
+status_as() {
+    local token=${1:?token} method=${2:?method} path=${3:?path} out=${4:?body file}
+
+    curl --silent --max-time 30 -X "$method" "$BASE$path" \
+        -H "Authorization: $AUTH_HEADER, Token=\"$token\"" \
+        --output "$out" --write-out '%{http_code}'
+}
+
+# An ordinary account, created by the administrator and authenticated as itself. Prints the
+# identifier and the token, separated by a space.
+#
+# The account is refused if the server made it an administrator, because every refusal below would
+# then be a refusal this check did not test. The password is generated rather than written here: it
+# exists for the length of one container on a loopback port, and a literal in a script is a literal
+# somebody copies into a server that is neither.
+ordinary_account() {
+    local name=${1:?account name} password created authenticated
+    password=$(python3 -c 'import secrets; print(secrets.token_urlsafe(24))')
+
+    created=$(api POST /Users/New "$(printf '{"Name": "%s", "Password": "%s"}' "$name" "$password")")
+    printf '%s' "$created" | python3 -c '
+import json, sys
+
+user = json.load(sys.stdin)
+policy = user.get("Policy") or {}
+if policy.get("IsAdministrator"):
+    sys.exit("{0} was created as an administrator, which is not the account this check needs.".format(user.get("Name")))
+' >&2
+
+    authenticated=$(curl --silent --fail --max-time 30 -X POST "$BASE/Users/AuthenticateByName" \
+        -H 'Content-Type: application/json' \
+        -H "Authorization: $AUTH_HEADER" \
+        -d "$(printf '{"Username": "%s", "Pw": "%s"}' "$name" "$password")")
+
+    printf '%s' "$authenticated" | python3 -c '
+import json, sys
+
+answer = json.load(sys.stdin)
+token = answer.get("AccessToken")
+identifier = (answer.get("User") or {}).get("Id")
+if not token or not identifier:
+    sys.exit("the server authenticated that account and named no token or no user.")
+print(identifier, token)
+'
+}
+
+# Refuses unless an answer holds exactly the titles named for that caller, and unless none of the
+# strings that belong to somebody else appears anywhere in it.
+#
+# THE RAW BYTES ARE READ AND NOT ONLY THE FIELDS. A leak arriving in a field this script does not
+# know the name of is the leak worth catching, and a reader walking a list of field names would hand
+# it back green.
+VERDICT='
+import json, sys
+
+label = sys.argv[1]
+expected = sorted(line for line in sys.argv[2].splitlines() if line)
+forbidden = [line for line in sys.argv[3].splitlines() if line]
+
+raw = sys.stdin.read()
+answer = json.loads(raw)
+
+rows = answer["Requests"] if "Requests" in answer else answer["requests"]
+titles = sorted(row.get("DisplayTitle", row.get("displayTitle")) for row in rows)
+
+if titles != expected:
+    sys.exit("{0} was given {1} and what belongs to that caller is {2}.".format(label, titles, expected))
+
+for secret in forbidden:
+    if secret in raw:
+        sys.exit("{0} was given {1!r}, which belongs to somebody else.".format(label, secret))
+
+print("{0} was given {1}".format(label, titles))
+'
+
+step "make two ordinary accounts"
+read -r FIRST_ID FIRST_TOKEN <<<"$(ordinary_account isolation-check-one)"
+read -r SECOND_ID SECOND_TOKEN <<<"$(ordinary_account isolation-check-two)"
+test -n "$FIRST_ID"
+test -n "$SECOND_ID"
+test "$FIRST_ID" != "$SECOND_ID"
+test "$FIRST_ID" != "$ADMIN_ID"
+test "$SECOND_ID" != "$ADMIN_ID"
+echo "first $FIRST_ID, second $SECOND_ID, administrator $ADMIN_ID"
+
+step "the first person asks for something"
+as "$FIRST_TOKEN" POST "$prefix/Requests" "$(printf '{
+  "kind": "Movie",
+  "title": "%s",
+  "year": 1999,
+  "providerIds": { "Tmdb": "isolation-check-first" },
+  "note": "%s"
+}' "$first_title" "$first_note")"
+echo
+
+step "the second person asks for something else"
+as "$SECOND_TOKEN" POST "$prefix/Requests" "$(printf '{
+  "kind": "Movie",
+  "title": "%s",
+  "year": 2001,
+  "providerIds": { "Tmdb": "isolation-check-second" },
+  "note": "%s"
+}' "$second_title" "$second_note")"
+echo
+
+step "both of them ask for one and the same thing"
+# A title somebody has already asked for is joined rather than asked for twice, so this is the one
+# row on the server both people are entitled to see. It is the sharpest case here: the row is
+# legitimately shared and the note written on it is not.
+as "$FIRST_TOKEN" POST "$prefix/Requests" "$(printf '{
+  "kind": "Movie",
+  "title": "%s",
+  "year": 1975,
+  "providerIds": { "Tmdb": "isolation-check-shared" },
+  "note": "%s"
+}' "$shared_title" "$first_note")"
+echo
+as "$SECOND_TOKEN" POST "$prefix/Requests" "$(printf '{
+  "kind": "Movie",
+  "title": "%s",
+  "year": 1975,
+  "providerIds": { "Tmdb": "isolation-check-shared" },
+  "note": "%s"
+}' "$shared_title" "$second_note")"
+echo
+
+step "what the first person is given"
+as "$FIRST_TOKEN" GET "$prefix/Requests?take=200" | python3 -c "$VERDICT" \
+    "the first person" \
+    "$first_title
+$shared_title" \
+    "$second_title
+$second_note
+$SECOND_ID"
+
+step "what the second person is given, immediately after"
+# Immediately after the call above, because that is when an answer cached against the route rather
+# than against the caller comes back to the wrong person.
+as "$SECOND_TOKEN" GET "$prefix/Requests?take=200" | python3 -c "$VERDICT" \
+    "the second person" \
+    "$second_title
+$shared_title" \
+    "$first_title
+$first_note
+$FIRST_ID"
+
+step "what the first person is given once the server has answered both"
+as "$FIRST_TOKEN" GET "$prefix/Requests?take=200" | python3 -c "$VERDICT" \
+    "the first person, asking again" \
+    "$first_title
+$shared_title" \
+    "$second_title
+$second_note
+$SECOND_ID"
+
+step "the queue is refused to somebody who is not an administrator"
+# The elevation on that action is asserted in the suite as an attribute on a method. Whether the
+# server enforces it is a property of the server, and nothing on this board has asked one until now.
+queue_body=$(mktemp)
+queue_status=$(status_as "$FIRST_TOKEN" GET "$prefix/Requests/Queue?take=200" "$queue_body")
+echo "the queue answered $queue_status"
+cat "$queue_body"
+echo
+python3 -c '
+import sys
+
+status = sys.argv[1]
+body = open(sys.argv[2], encoding="utf-8", errors="replace").read()
+forbidden = sys.argv[3:]
+
+if status == "200":
+    sys.exit("the queue was served to somebody who is not an administrator.")
+if status not in ("401", "403"):
+    sys.exit("the queue answered {0}, which is neither the refusal this looks for nor a serving.".format(status))
+for secret in forbidden:
+    if secret in body:
+        sys.exit("the refusal carried {0!r}, which belongs to somebody else.".format(secret))
+print("the queue refused with {0} and carried nothing that belongs to anybody.".format(status))
+' "$queue_status" "$queue_body" "$second_title" "$second_note" "$SECOND_ID"
+rm -f "$queue_body"
+
+step "the administrator is not refused the same call"
+# Without this, the step above would pass on a server where the queue is broken for everybody, which
+# is a different thing from a queue closed to a person who may not read it.
+api GET "$prefix/Requests/Queue?take=200" | python3 -c '
+import json, sys
+
+wanted = sys.argv[1:]
+answer = json.load(sys.stdin)
+rows = answer["Requests"] if "Requests" in answer else answer["requests"]
+titles = [row.get("DisplayTitle", row.get("displayTitle")) for row in rows]
+for title in wanted:
+    if title not in titles:
+        sys.exit("the queue does not hold {0!r}, so the refusal above says nothing.".format(title))
+print("the administrator is served {0} rows and all three titles are among them.".format(len(rows)))
+' "$first_title" "$second_title" "$shared_title"
+
+step "the page a person opens carries no row of anybody's"
+# The page draws its rows from the call already checked above rather than carrying them, and this is
+# where that stops being an assumption about the served bytes. A page that ever did carry them would
+# be a second copy of the answer, on a route where nothing above would look.
+page_body=$(mktemp)
+for who in first second; do
+    case $who in
+        first) token=$FIRST_TOKEN ;;
+        second) token=$SECOND_TOKEN ;;
+    esac
+    page_status=$(status_as "$token" GET "$prefix/Page" "$page_body")
+    echo "the page answered the $who person with $page_status, $(wc -c <"$page_body") bytes"
+    python3 -c '
+import sys
+
+who, status = sys.argv[1], sys.argv[2]
+body = open(sys.argv[3], encoding="utf-8", errors="replace").read()
+forbidden = sys.argv[4:]
+
+if status != "200":
+    sys.exit("the page answered the {0} person with {1} rather than serving it.".format(who, status))
+for secret in forbidden:
+    if secret in body:
+        sys.exit("the page served to the {0} person carries {1!r}.".format(who, secret))
+print("the page served to the {0} person carries no title and no note.".format(who))
+' "$who" "$page_status" "$page_body" "$first_title" "$second_title" "$shared_title" "$first_note" "$second_note"
+done
+rm -f "$page_body"
+
+step "done"
+echo "two people and three requests, one of them shared, on $image ($framework): neither was given the other's"


### PR DESCRIPTION
Part of #67. It answers that issue's second condition for the two surfaces that exist, and leaves the third surface where it was.

## Why a suite could not answer this

The suite runs the controller over a double. What it holds is that the action serving a person's own list reads the store for that person and nothing wider, and that the queue action carries the elevation attribute:

    git grep -n "public async Task NothingButTheCallersOwnRequestsComesBackWhateverIsAskedFor\|public void TheQueueEndpointCarriesTheElevationPolicyAndTheOwnRequestsEndpointDoesNot" -- Jellyfin.Plugin.Requests.Tests/Api/ListRequestsTests.cs
    Jellyfin.Plugin.Requests.Tests/Api/ListRequestsTests.cs:61:    public async Task NothingButTheCallersOwnRequestsComesBackWhateverIsAskedFor()
    Jellyfin.Plugin.Requests.Tests/Api/ListRequestsTests.cs:428:    public void TheQueueEndpointCarriesTheElevationPolicyAndTheOwnRequestsEndpointDoesNot()

A double has no session, no authorisation pipeline and no cache. The controller says the same thing about itself, in the documentation on the queue action:

    git grep -n "no test on this board exercises it" -- Jellyfin.Plugin.Requests/Api/RequestsController.cs
    Jellyfin.Plugin.Requests/Api/RequestsController.cs:406:    /// What the server does with that policy is the server's, and no test on this board exercises it:

So two things were unmeasured: whether the server enforces an attribute written on an action, and whether an answer stays one person's after the server has handed it out.

## What the check does

`scripts/verify-user-isolation.sh` sources `scripts/server-under-test.sh`, which is the same server, install, wizard and account the plugin-load check and the activity check already use. On top of that it creates two ordinary accounts, refuses either of them if the server made it an administrator, and then:

- the first person asks for one title and the second person asks for another;
- both of them ask for a third title, which the plugin joins into one row, so there is one row on the server that two people are legitimately entitled to see and two notes on it that they are not;
- the first person's list is read, then the second person's immediately after it, then the first person's again once the server has answered both;
- the queue endpoint is called by somebody who is not an administrator and a serving is refused;
- the queue endpoint is then called by the administrator, so that a queue broken for everybody cannot pass as a queue that is closed to the person who may not read it;
- the page each of them opens is read and asserted to carry no title and no note at all.

The order of the three list calls is the part that is about caching rather than about filtering. One call as one person and one as another says nothing: an answer cached against the route rather than against the caller only reaches the wrong person when the second caller arrives after the first.

Every assertion reads the raw bytes as well as the parsed rows. A leak arriving in a field the script does not know the name of is the leak worth catching, and a reader walking a list of field names hands it back green.

`.github/workflows/user-isolation.yaml` runs it against a server of each claimed line, on pull requests and nightly, with the image taken from `scripts/server-lines.tsv` rather than written into the workflow.

## The answer, on both lines

Taken at `c9dd8d2`, the 10.11 line, job `97001703609`:

    gh api repos/Flowfin/jellyfin-plugin-requests/actions/jobs/97001703609/logs | grep -a "was given\|the queue \|the page served\|the administrator is served"
    the first person was given ['A film both of them asked for', 'A film only the first person asked for']
    the second person was given ['A film both of them asked for', 'A film only the second person asked for']
    the first person, asking again was given ['A film both of them asked for', 'A film only the first person asked for']
    the queue answered 403
    the queue refused with 403 and carried nothing that belongs to anybody.
    the administrator is served 3 rows and all three titles are among them.
    the page served to the first person carries no title and no note.
    the page served to the second person carries no title and no note.

The 12.0 line is job `97001703695` and the same command returns the same eight lines.

## That it bites

Two branches carry the mistakes it exists to catch. Neither is for merging and neither has a pull request.

`proof/67-one-persons-list-is-not-everybodys` replaces `FindForUserAsync` with `GetAllAsync` in the action serving a person's own list. It compiles and passes every suite leg that runs the controller over a double. Run `32560869939`, both lines red at the first list:

    gh run view 32560869939 --repo Flowfin/jellyfin-plugin-requests --json conclusion,jobs --jq '.conclusion, (.jobs[] | "\(.name)  \(.conclusion)")'
    failure
    isolation 10.11  failure
    isolation 12.0  failure

    the first person was given ['A film both of them asked for', 'A film only the first person asked for', 'A film only the second person asked for'] and what belongs to that caller is ['A film both of them asked for', 'A film only the first person asked for'].

`proof/67-the-queue-is-not-closed-to-everybody` takes the elevation off the queue action and leaves the authorisation attribute, which is one word. Run `32560880189`, both lines red at the queue and green at every step before it:

    the queue answered 200
    the queue was served to somebody who is not an administrator.

## The means

Bash driving a container, with `python3` for the readings, and no browser. That is the means every server check in this tree already uses, it is what `scripts/server-under-test.sh` is written in, and a second language here would be a second procedure for booting the same server. The headless rule in `docs/testing.md` is what rules out driving a client instead.

## What this does not cover

The channel is not in the tree, and #67's body is written about the channel specifically: the server materialising what a channel returns into its library database. Nothing here says anything about that surface, and this change does not finish that issue.

Nothing here opens a browser, so what is proven is what the server hands back, including the bytes of the page itself, and not what a client draws from them.

There was no second reader for this change. The runs on both claimed lines, and the two red runs above, stand in place of one.
