### PR TITLE
Say what a real server now answers about the queue in the refusal list

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj
+++ b/Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj
@@ -65,6 +65,11 @@
          one of those replacements is a type in this project. A document naming an issue number goes
          stale silently; a document naming a type can be read against the type. -->
     <None Include="../docs/testing.md" Link="docs/testing.md" CopyToOutputDirectory="PreserveNewest" />
+    <!-- The two procedures that refusal list names as replacements, so a leg can open what the
+         document points at. They are read for their existence and never run: running one needs a
+         server and a container engine, which is the refusal they are the replacement for. -->
+    <None Include="../scripts/verify-plugin-loads.sh" Link="scripts/verify-plugin-loads.sh" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="../scripts/verify-user-isolation.sh" Link="scripts/verify-user-isolation.sh" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.Requests.Tests/RepositoryDocumentsTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/RepositoryDocumentsTests.cs
@@ -191,6 +191,65 @@ public sealed class RepositoryDocumentsTests
     }
 
     /// <summary>
+    /// The procedures the refusal list names as replacements, each beside the sentence that points
+    /// at it.
+    /// </summary>
+    /// <returns>One path in the tree per case.</returns>
+    public static TheoryData<string> ProceduresTheRefusalListNames()
+        => new TheoryData<string> { "scripts/verify-plugin-loads.sh", "scripts/verify-user-isolation.sh" };
+
+    /// <summary>
+    /// The refusal list names a procedure for each refusal a running server answers instead of the
+    /// suite.
+    /// <para>
+    /// The same guard as the two doubles above and for the same reason, one register wider. A
+    /// refused test is only refused honestly while what replaces it can be found, and both of these
+    /// replacements are shell scripts rather than types, so no rename follows them. A document that
+    /// has stopped naming one leaves a reader looking for the replacement and finding prose.
+    /// </para>
+    /// <para>
+    /// The other direction, a script moved while the document goes on naming it, is refused before
+    /// this runs: the test project copies both paths beside the suite, so a missing one is a build
+    /// that does not produce a test assembly rather than a leg that reds. That is why nothing here
+    /// asserts the file exists. An assertion that cannot fail proves nothing, and the copy is what
+    /// bites.
+    /// </para>
+    /// <para>
+    /// It matches the whole path rather than a substring of one. A plain containment leg passes on
+    /// a document naming <c>scripts/verify-user-isolation.sh.moved</c>, which is a reader sent to a
+    /// path that is not there while the leg stays green, and that near-miss was watched passing
+    /// before this was written.
+    /// </para>
+    /// <para>
+    /// It asks whether the document names the path anywhere in it, not whether the paragraph about
+    /// that refusal does. The evidence block closing the list names both paths as well, so a
+    /// paragraph rewritten to stop naming its own replacement stays green here. That is the same
+    /// bound as the two legs above, which read a name and not the sentence around it, and it is
+    /// stated rather than hidden.
+    /// </para>
+    /// <para>
+    /// It reads the path and never runs the script. Running one needs a server and a container
+    /// engine, which is the refusal these are the replacement for, so a leg that ran them would be
+    /// the test this document refuses.
+    /// </para>
+    /// </summary>
+    /// <param name="procedure">The path the document names, relative to the repository root.</param>
+    [Theory]
+    [MemberData(nameof(ProceduresTheRefusalListNames))]
+    public void TheRefusalListNamesAProcedureThatIsThere(string procedure)
+    {
+        const string Testing = "docs/testing.md";
+
+        var document = File.ReadAllText(Beside(Testing.Replace('/', Path.DirectorySeparatorChar)));
+        var whole = new Regex(
+            @"(?<![\w./-])" + Regex.Escape(procedure) + @"(?![\w.-])",
+            RegexOptions.None,
+            TimeSpan.FromSeconds(2));
+
+        Assert.Matches(whole, document);
+    }
+
+    /// <summary>
     /// One file as it sits next to the suite.
     /// </summary>
     /// <param name="name">Its path, relative to the repository root.</param>

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -125,18 +125,54 @@ taken from the constant the server registers it under. That is the half about wh
 endpoint is under. The other half is that the endpoint a caller without elevation can reach has
 nothing wider than that caller's own requests to return, which `ListRequestsTests` asks under every
 combination of filter, order and page. Neither is the server turning somebody away, and neither
-claims to be: what they leave open is that the server evaluates `RequiresElevation` the way its own
-endpoints are evaluated under it. That is #51.
+claims to be.
+
+The server turning somebody away is watched outside the suite, which is the same shape as the
+first-load procedure above rather than a second kind of thing. `scripts/verify-user-isolation.sh`
+signs two ordinary accounts in to a running Jellyfin and asks the queue endpoint as one of them,
+and `.github/workflows/user-isolation.yaml` runs it on every pull request and nightly, once per
+claimed line. Read at `e51942b`, the head of the change that landed it, on the 10.11 line in job
+`97002549666` and on the 12.0 line in job `97002549757`:
+
+    gh api repos/Flowfin/jellyfin-plugin-requests/actions/jobs/97002549666/logs | grep -a "the queue \|the administrator is served"
+    == the queue is refused to somebody who is not an administrator
+    the queue answered 403
+    the queue refused with 403 and carried nothing that belongs to anybody.
+    the administrator is served 3 rows and all three titles are among them.
+
+The same command against `97002549757` returns the same four lines. The queue is asked a second
+time as an administrator because a queue broken for everybody would satisfy the refusal on its own.
+
+That it can fail is watched rather than assumed. `proof/67-the-queue-is-not-closed-to-everybody`
+takes the elevation off the queue action and leaves the authorisation attribute, which is one word,
+and both lines go red at that step and green at every step before it:
+
+    gh run view 32560880189 --repo Flowfin/jellyfin-plugin-requests --json headBranch,conclusion,jobs --jq '.headBranch, .conclusion, (.jobs[] | "\(.name)  \(.conclusion)")'
+    proof/67-the-queue-is-not-closed-to-everybody
+    failure
+    isolation 12.0  failure
+    isolation 10.11  failure
+
+    the queue answered 200
+    the queue was served to somebody who is not an administrator.
+
+That branch is not for merging and has no pull request.
+
+What this does not do is lift the refusal above. A test inside the ordinary suite still needs a
+running Jellyfin holding a session for a person, and still may not have one, so the suite asserts
+what an endpoint carries and never what a server does with it. The procedure runs on a pull request
+and on a schedule, so a mainline commit that no pull request carried has no reading of its own
+until the next nightly run.
 
 Every replacement named above exists, either as something already in the tree or as an issue on
 this board. The states move, and a paste taken once reads afterwards as a claim about today, so
-this one carries the commit it was read at, `1f5ad56`:
+this one carries the commit it was read at, `ffa28c1`:
 
-    for n in 20 35 50 51 52 54 56 61 64 115; do gh issue view $n --json number,state,title --jq '"\(.number)  \(.state)  \(.title)"'; done
+    for n in 20 35 50 51 52 54 56 61 64 115; do gh issue view $n --repo Flowfin/jellyfin-plugin-requests --json number,state,title --jq '"\(.number)  \(.state)  \(.title)"'; done
     20  CLOSED  Prove the built plugin loads on a server of each claimed line
     35  OPEN  Provide an in-process HTTP double for the outbound calls
     50  CLOSED  Lay out the controller, the route prefix and the version rule
-    51  OPEN  Decide the authorisation policy for every endpoint
+    51  CLOSED  Decide the authorisation policy for every endpoint
     52  CLOSED  Create a request over the API
     54  CLOSED  Act on a request over the API
     56  CLOSED  Fix the error shape and the status codes
@@ -144,8 +180,14 @@ this one carries the commit it was read at, `1f5ad56`:
     64  CLOSED  Hold the page to the same rules as the rest of the tree
     115  CLOSED  Make the headless rule refusable rather than written down
 
-    git ls-files scripts/
+    git ls-tree --name-only origin/master scripts/verify-plugin-loads.sh scripts/verify-user-isolation.sh
     scripts/verify-plugin-loads.sh
+    scripts/verify-user-isolation.sh
+
+The two lines above replace a `git ls-files scripts/` whose pasted output was one file. That did
+not reproduce at the commit it was stamped with either, where the directory already held two, and
+it drifts every time anything unrelated is added beside them. Naming the two files this list points
+at is what a reader wants from it and is what stays true.
 
 `Check formatting` is the name the check reports rather than the name of its file, read off a run
 rather than off the workflow:


### PR DESCRIPTION
Part of #3. The refusal list in `docs/testing.md` is M3's third done-condition, and two things in it had stopped being true of the tree.

## What was wrong

The fifth refusal says a test that a signed-in caller who is not an administrator is turned away from the queue endpoint needs a running Jellyfin, names what replaces it inside the suite, and ended with the sentence that what those replacements leave open is the server evaluating `RequiresElevation`, "That is #51."

#51 closed on 21 August, and its closing note names that same gap as what it does not claim. Then a procedure landed that answers it. So the one sentence in this document that tells a reader where the remaining question lives sent them to a closed issue, which is exactly the failure the list already learned once: it went on saying the outbound double did not exist because it named the issue that would build it rather than the file that had been built.

The evidence block closing the list carried this:

    git ls-files scripts/
    scripts/verify-plugin-loads.sh

That output did not reproduce at the commit the block is stamped with. At `1f5ad56` the directory held two tracked files:

    git ls-tree --name-only -r 1f5ad56 -- scripts/
    scripts/bill-of-materials.sh
    scripts/verify-plugin-loads.sh

and at `ffa28c1` it holds eighty-four, most of them collision-scan fixtures, so the command drifts on anything added beside the scripts the list is about.

## What the document says now

The fifth refusal keeps its refusal and gains what a running server answers. `scripts/verify-user-isolation.sh` signs two ordinary accounts in and asks the queue endpoint as one of them, and `.github/workflows/user-isolation.yaml` runs it on every pull request and nightly, once per claimed line. Read at `e51942b`, on the 10.11 line in job `97002549666`:

    gh api repos/Flowfin/jellyfin-plugin-requests/actions/jobs/97002549666/logs | grep -a "the queue \|the administrator is served"
    == the queue is refused to somebody who is not an administrator
    the queue answered 403
    the queue refused with 403 and carried nothing that belongs to anybody.
    the administrator is served 3 rows and all three titles are among them.

The same command against `97002549757`, which is the 12.0 line, returns the same four lines.

That it can fail is watched rather than assumed:

    gh run view 32560880189 --repo Flowfin/jellyfin-plugin-requests --json headBranch,conclusion,jobs --jq '.headBranch, .conclusion, (.jobs[] | "\(.name)  \(.conclusion)")'
    proof/67-the-queue-is-not-closed-to-everybody
    failure
    isolation 12.0  failure
    isolation 10.11  failure

    the queue answered 200
    the queue was served to somebody who is not an administrator.

Two negatives are written into the paragraph rather than dropped. The refusal above is unchanged, because a test inside the ordinary suite still needs a running Jellyfin holding a session for a person and still may not have one. And that workflow runs on a pull request and on a schedule, so a mainline commit no pull request carried has no reading of its own until the next nightly run.

The evidence block names the two paths the list points at instead of listing a directory, and its issue states are re-read at `ffa28c1`:

    for n in 20 35 50 51 52 54 56 61 64 115; do gh issue view $n --repo Flowfin/jellyfin-plugin-requests --json number,state,title --jq '"\(.number)  \(.state)  \(.title)"'; done

`51` comes back `CLOSED` there, which is the line that moved.

## The guard, and it was watched biting

`TheRefusalListNamesAProcedureThatIsThere` is a theory over `scripts/verify-plugin-loads.sh` and `scripts/verify-user-isolation.sh`. It is the same shape as the two legs beside it that hold the names of the doubles, one register wider: those replacements are types and a rename follows them, these are shell scripts and nothing follows them.

The suite, on both claimed target frameworks. The runner prints in the machine's language and this is its output rather than a translation of it:

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler:     0, erfolgreich:   638, übersprungen:     0, gesamt:   638 - Jellyfin.Plugin.Requests.Tests.dll (net9.0)
    Bestanden!   : Fehler:     0, erfolgreich:   638, übersprungen:     0, gesamt:   638 - Jellyfin.Plugin.Requests.Tests.dll (net10.0)

Three near-misses, one at a time.

The document stops naming the path at all. Every mention of `scripts/verify-user-isolation.sh` replaced by prose:

    [xUnit.net]     ...TheRefusalListNamesAProcedureThatIsThere(procedure: "scripts/verify-user-isolation.sh") [FAIL]
    Fehler!      : Fehler:     1, erfolgreich:     1, übersprungen:     0, gesamt:     2

One of the two cases red and the other green, which is the leg answering for its own path rather than for the file.

The document names the path with something after it. Every mention replaced by `scripts/verify-user-isolation.sh.moved`, which is what a reader follows to nothing:

    [xUnit.net]     ...TheRefusalListNamesAProcedureThatIsThere(procedure: "scripts/verify-user-isolation.sh") [FAIL]
    Fehler!      : Fehler:     1, erfolgreich:     1, übersprungen:     0, gesamt:     2

This one is why the leg matches a whole path rather than a substring. Written first as `Assert.Contains`, it passed this mutation, and the pass was watched before the leg was tightened.

The script is moved and the document goes on naming it. `git mv scripts/verify-user-isolation.sh scripts/verify-user-isolation-moved.sh`:

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release
    error MSB3030: Datei ".../scripts/verify-user-isolation.sh" konnte nicht kopiert werden, da die Datei nicht gefunden wurde.

Red on both target frameworks. This direction is refused by the copy in the test project rather than by the leg, and that is why the leg asserts nothing about the file existing: an assertion that cannot fail proves nothing, so it is not written.

## What the guard cannot do, stated rather than hidden

It asks whether the document names the path anywhere in it, not whether the paragraph about that refusal does. The evidence block names both paths as well, so a paragraph rewritten to stop naming its own replacement stays green here. That is the same bound the two legs beside it carry, and it is written in the leg's own documentation.

It also says nothing about whether the prose around the path is correct. A document naming the script and describing it wrongly passes.

## The means

Markdown for the document, because that is what this tree's documents are, and a leg in the existing xUnit suite for the guard, because `RepositoryDocumentsTests` already reads documents copied beside the suite and holds two names true this way. Nothing new was added to the dependency graph and no second apparatus was introduced.

## Not covered

Nobody has run `scripts/verify-user-isolation.sh` from this branch. What stands behind the four log lines is the run at `e51942b` and the two proof runs, which are readings of a server rather than of this change. This branch touches no shell script and no workflow.

Nobody else has read this. The transcripts above stand in place of a second reader.
