### PR TITLE
Tell a live administrator that a request arrived

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Api/ActOnARequestTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/ActOnARequestTests.cs
@@ -521,7 +521,7 @@ public sealed class ActOnARequestTests
     /// <param name="caller">Who the server says is calling.</param>
     /// <returns>The controller under test.</returns>
     private RequestsController ControllerFor(IRequestStore store, Guid? caller)
-        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), new FakeInstallSettings(), new RecordingJournal(), new RecordingSink(), new RecordingRequesterNotice(), new FakeLibrary());
+        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), new FakeInstallSettings(), new RecordingJournal(), new RecordingSink(), new RecordingRequesterNotice(), new RecordingArrivalNotice(), new FakeLibrary());
 
     /// <summary>
     /// The row a successful decision handed back, with the status code checked.

--- a/Jellyfin.Plugin.Requests.Tests/Api/ActOnManyRequestsTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/ActOnManyRequestsTests.cs
@@ -619,7 +619,7 @@ public sealed class ActOnManyRequestsTests
     /// <param name="caller">Who the server says is calling.</param>
     /// <returns>The controller under test.</returns>
     private RequestsController ControllerFor(IRequestStore store, Guid? caller)
-        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), new FakeInstallSettings(), new RecordingJournal(), new RecordingSink(), new RecordingRequesterNotice(), new FakeLibrary());
+        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), new FakeInstallSettings(), new RecordingJournal(), new RecordingSink(), new RecordingRequesterNotice(), new RecordingArrivalNotice(), new FakeLibrary());
 
     /// <summary>
     /// The entries an action came back with, with the status code checked.

--- a/Jellyfin.Plugin.Requests.Tests/Api/CreateRequestTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/CreateRequestTests.cs
@@ -369,6 +369,7 @@ public sealed class CreateRequestTests
             new RecordingJournal(),
             new RecordingSink(),
             new RecordingRequesterNotice(),
+            new RecordingArrivalNotice(),
             new FakeLibrary());
 
     /// <summary>

--- a/Jellyfin.Plugin.Requests.Tests/Api/ErrorSurfaceTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/ErrorSurfaceTests.cs
@@ -391,7 +391,7 @@ public sealed class ErrorSurfaceTests
     /// <param name="settings">What this install is set to.</param>
     /// <returns>The controller under test.</returns>
     private RequestsController ControllerFor(IRequestStore store, Guid? caller, IInstallSettings settings)
-        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), settings, new RecordingJournal(), new RecordingSink(), new RecordingRequesterNotice(), new FakeLibrary());
+        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), settings, new RecordingJournal(), new RecordingSink(), new RecordingRequesterNotice(), new RecordingArrivalNotice(), new FakeLibrary());
 
     /// <summary>
     /// A second request in the store, so one of them can be moved out of the way.

--- a/Jellyfin.Plugin.Requests.Tests/Api/ListRequestsTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/ListRequestsTests.cs
@@ -624,5 +624,6 @@ public sealed class ListRequestsTests
             new RecordingJournal(),
             new RecordingSink(),
             new RecordingRequesterNotice(),
+            new RecordingArrivalNotice(),
             new FakeLibrary());
 }

--- a/Jellyfin.Plugin.Requests.Tests/Api/PublishedApiDocumentTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/PublishedApiDocumentTests.cs
@@ -552,7 +552,7 @@ public sealed class PublishedApiDocumentTests
     /// <param name="settings">What this install is set to.</param>
     /// <returns>The controller under test.</returns>
     private RequestsController ControllerFor(IRequestStore store, Guid? caller, IInstallSettings settings)
-        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), settings, new RecordingJournal(), new RecordingSink(), new RecordingRequesterNotice(), new FakeLibrary());
+        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), settings, new RecordingJournal(), new RecordingSink(), new RecordingRequesterNotice(), new RecordingArrivalNotice(), new FakeLibrary());
 
     /// <summary>
     /// The health endpoint over one store, with nothing behind the bridge and no sweep having run,

--- a/Jellyfin.Plugin.Requests.Tests/Api/QueueContextTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/QueueContextTests.cs
@@ -437,5 +437,6 @@ public sealed class QueueContextTests
             new RecordingJournal(),
             new RecordingSink(),
             new RecordingRequesterNotice(),
+            new RecordingArrivalNotice(),
             new FakeLibrary());
 }

--- a/Jellyfin.Plugin.Requests.Tests/CatalogueSplitTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/CatalogueSplitTests.cs
@@ -86,9 +86,9 @@ public sealed class CatalogueSplitTests
     }
 
     /// <summary>
-    /// The controller takes eight things and none of them can fetch anything. A metadata source
-    /// arrives as something injected, so the constructor is where one would appear first, and a
-    /// ninth parameter fails here before anybody writes the call.
+    /// The controller takes a fixed list of things and none of them can fetch anything. A metadata
+    /// source arrives as something injected, so the constructor is where one would appear first, and
+    /// one more parameter fails here before anybody writes the call.
     /// <para>
     /// Written as the exact list rather than as "nothing called a provider". A name test would pass
     /// the day somebody injects a fetcher under a name nobody predicted, which is the shape this
@@ -115,6 +115,7 @@ public sealed class CatalogueSplitTests
                 nameof(IActivityJournal),
                 nameof(IOutboundSink),
                 nameof(IRequesterNotice),
+                nameof(IArrivalNotice),
                 nameof(ILibrary)),
             string.Join(" | ", taken),
             StringComparer.Ordinal);
@@ -153,5 +154,6 @@ public sealed class CatalogueSplitTests
             new RecordingJournal(),
             new RecordingSink(),
             new RecordingRequesterNotice(),
+            new RecordingArrivalNotice(),
             new FakeLibrary());
 }

--- a/Jellyfin.Plugin.Requests.Tests/Configuration/ConfigurationRulesTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Configuration/ConfigurationRulesTests.cs
@@ -25,6 +25,24 @@ public class ConfigurationRulesTests
     private const string SomewhereToPostTo = "https://example.invalid/hook";
 
     /// <summary>
+    /// The settings no value of which can be refused, written out by hand.
+    /// <para>
+    /// A rule refuses a configuration this plugin cannot run on. A switch over a path that does
+    /// nothing but the thing it names has no such value: on is a working install and off is a
+    /// working install, and a rule invented for it would be a refusal with no failure behind it,
+    /// which is worse than an absence because a reader takes it for one that bites.
+    /// </para>
+    /// <para>
+    /// The list is here rather than nowhere so that the leg below still catches the case it exists
+    /// for. A setting added later is a name in the class that is neither refused by a rule nor on
+    /// this list, and whoever adds it has to say which of the two it is. Both directions are closed:
+    /// a name here that no longer exists fails as well, so the exemption cannot outlive the setting.
+    /// </para>
+    /// </summary>
+    private static readonly string[] SettingsNoValueOfWhichCanBeRefused =
+        ["TellsAdministratorsAboutArrivals"];
+
+    /// <summary>
     /// The last value each rule accepts, and the first one it refuses, with the setting the refusal
     /// has to name. One row per rule, and the row for the accepted kinds names both switches because
     /// either of them fixes it.
@@ -144,13 +162,14 @@ public class ConfigurationRulesTests
     }
 
     /// <summary>
-    /// Every setting is reached by a rule. This is the leg that catches a setting added later with
-    /// nothing judging it: the hostile configuration below is written by hand, so a new setting is a
-    /// name in the class that is not in the answer, and whoever adds it has to say what value of it
-    /// cannot work.
+    /// Every setting is reached by a rule, or is named above as one no value of which can be
+    /// refused. This is the leg that catches a setting added later with nothing judging it: the
+    /// hostile configuration below is written by hand, so a new setting is a name in the class that
+    /// is in neither answer, and whoever adds it has to say what value of it cannot work or why
+    /// none can.
     /// </summary>
     [Fact]
-    public void EverySettingIsNamedByARule()
+    public void EverySettingIsNamedByARuleOrDeclaredUnrefusable()
     {
         var hostile = new PluginConfiguration
         {
@@ -172,7 +191,18 @@ public class ConfigurationRulesTests
 
         var named = Settings(ConfigurationRules.Problems(hostile).Select(problem => problem.Setting));
 
-        Assert.Equal(declared, named);
+        // The exemption cannot outlive the setting it exempts, so it is checked against the class
+        // before it is allowed to make up the difference.
+        Assert.Equal(
+            SettingsNoValueOfWhichCanBeRefused.OrderBy(name => name, StringComparer.Ordinal).ToArray(),
+            SettingsNoValueOfWhichCanBeRefused
+                .Where(declared.Contains)
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToArray());
+
+        Assert.Equal(
+            declared,
+            Settings(named.Concat(SettingsNoValueOfWhichCanBeRefused)));
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Requests.Tests/Configuration/PluginConfigurationTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Configuration/PluginConfigurationTests.cs
@@ -41,7 +41,8 @@ public class PluginConfigurationTests
             { "AnnouncesFulfilments", "true" },
             { "FinishedRequestRetentionDays", "365" },
             { "OpenRequestsPerUser", "10" },
-            { "OutboundNoticeAddress", string.Empty }
+            { "OutboundNoticeAddress", string.Empty },
+            { "TellsAdministratorsAboutArrivals", "false" }
         };
 
     /// <summary>

--- a/Jellyfin.Plugin.Requests.Tests/Doubles/ASessionManagerThatOnlyDelivers.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/ASessionManagerThatOnlyDelivers.cs
@@ -14,15 +14,24 @@ using MediaBrowser.Model.SyncPlay;
 namespace Jellyfin.Plugin.Requests.Tests.Doubles;
 
 /// <summary>
-/// The server's session manager with exactly one method that works.
+/// The server's session manager with exactly two methods that work.
 /// <para>
 /// <b>Every other way of sending anything raises, and that is what this double is for.</b> The
-/// interface offers eleven ways to push something at somebody, and three of them reach people the
-/// plugin was not talking about: an administrator broadcast, a device broadcast, and the two
-/// remote-control commands that take a session identifier rather than a user. A double that
-/// answered all of them politely could not tell a test that only the requester was reached from one
-/// where everybody was. So the only member with a body is the one this plugin is allowed to call,
-/// and a change that reaches for another one fails as a raised exception naming the member.
+/// interface offers eleven ways to push something at somebody, and most of them reach people the
+/// plugin was not talking about: a device broadcast, and the remote-control commands that take a
+/// session identifier rather than a user. A double that answered all of them politely could not
+/// tell a test that only the requester was reached from one where everybody was. So the only
+/// members with a body are the two this plugin is allowed to call, and a change that reaches for
+/// another one fails as a raised exception naming the member.
+/// </para>
+/// <para>
+/// <b>The two are kept in separate lists on purpose.</b> Naming one person and naming an audience
+/// are the two different things this plugin does with sessions, and the guard that matters most
+/// here is that neither path drifts into the other: a message about one person's request must not
+/// go to an audience, and an arrival must not go to a person. A single list would make both claims
+/// unaskable. <see cref="Delivered"/> is what was sent to named people and <see cref="Broadcasts"/>
+/// is what was sent to whoever administers the server, and a test asserts the list it is not about
+/// is empty rather than relying on this double to raise.
 /// </para>
 /// <para>
 /// The recorded call keeps the arguments as they were passed, the user list included, because the
@@ -33,6 +42,7 @@ namespace Jellyfin.Plugin.Requests.Tests.Doubles;
 internal sealed class ASessionManagerThatOnlyDelivers : ISessionManager
 {
     private readonly List<Delivery> _delivered = [];
+    private readonly List<Broadcast> _broadcast = [];
 
     /// <inheritdoc />
     public event EventHandler<PlaybackProgressEventArgs>? PlaybackStart;
@@ -62,9 +72,15 @@ internal sealed class ASessionManagerThatOnlyDelivers : ISessionManager
     public IEnumerable<SessionInfo> Sessions => [];
 
     /// <summary>
-    /// Gets every push this double was asked to make, in order.
+    /// Gets every push at a named person this double was asked to make, in order.
     /// </summary>
     public IReadOnlyList<Delivery> Delivered => _delivered;
+
+    /// <summary>
+    /// Gets every push at whoever administers the server, in order. The server decides which
+    /// sessions those are, so there is no list of people to record and the audience is the fact.
+    /// </summary>
+    public IReadOnlyList<Broadcast> Broadcasts => _broadcast;
 
     /// <summary>
     /// Gets a value indicating whether the one usable call fails instead of delivering.
@@ -96,7 +112,16 @@ internal sealed class ASessionManagerThatOnlyDelivers : ISessionManager
 
     /// <inheritdoc />
     public Task SendMessageToAdminSessions<T>(SessionMessageType name, T data, CancellationToken cancellationToken)
-        => throw Refused(nameof(SendMessageToAdminSessions));
+    {
+        if (Refuses)
+        {
+            throw new InvalidOperationException("This session manager was told to fail the push.");
+        }
+
+        _broadcast.Add(new Broadcast(name, data));
+
+        return Task.CompletedTask;
+    }
 
     /// <inheritdoc />
     public Task SendMessageToUserDeviceSessions<T>(string deviceId, SessionMessageType name, T data, CancellationToken cancellationToken)
@@ -224,7 +249,7 @@ internal sealed class ASessionManagerThatOnlyDelivers : ISessionManager
     /// <returns>The exception to raise, so every call site is one line.</returns>
     private static NotSupportedException Refused(string member)
         => new NotSupportedException(
-            "This plugin reached ISessionManager." + member + ". The only call it is allowed to make is SendMessageToUserSessions, which names the one person a message is about; everything else here reaches somebody the message was not about.");
+            "This plugin reached ISessionManager." + member + ". The only calls it is allowed to make are SendMessageToUserSessions, which names the one person a message is about, and SendMessageToAdminSessions, which names whoever administers the server; everything else here reaches somebody neither message was about.");
 
     /// <summary>
     /// One push, as it was asked for.
@@ -233,5 +258,12 @@ internal sealed class ASessionManagerThatOnlyDelivers : ISessionManager
     /// <param name="Name">The name it went out under.</param>
     /// <param name="Payload">What was sent.</param>
     internal sealed record Delivery(IReadOnlyList<Guid> UserIds, SessionMessageType Name, object? Payload);
+
+    /// <summary>
+    /// One push at whoever administers the server, as it was asked for.
+    /// </summary>
+    /// <param name="Name">The name it went out under.</param>
+    /// <param name="Payload">What was sent.</param>
+    internal sealed record Broadcast(SessionMessageType Name, object? Payload);
 }
 #pragma warning restore CS0067

--- a/Jellyfin.Plugin.Requests.Tests/Doubles/RecordingArrivalNotice.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/RecordingArrivalNotice.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Notify;
+
+namespace Jellyfin.Plugin.Requests.Tests.Doubles;
+
+/// <summary>
+/// A path to the administrators that keeps what it was told instead of pushing it anywhere.
+/// <para>
+/// It is the double for every test whose subject is a path rather than the pushing, which is most of
+/// them: what a test of an endpoint or of the seam can assert is how many arrivals were announced
+/// and what each document said. Whether a message actually reaches a client is
+/// <c>ServerArrivalNotice</c>'s own, tested against the session manager double in
+/// <see cref="ASessionManagerThatOnlyDelivers"/>.
+/// </para>
+/// <para>
+/// <b>It keeps everything it is given and drops nothing, and it reads no setting.</b> Whether an
+/// install says anything at all is <c>ServerArrivalNotice</c>'s decision, and a double that repeated
+/// that rule would let the rule pass a test while being absent from the thing that ships.
+/// </para>
+/// </summary>
+internal sealed class RecordingArrivalNotice : IArrivalNotice
+{
+    private readonly List<OutboundNotice> _told = [];
+
+    /// <summary>
+    /// Gets every document, in the order it was given.
+    /// </summary>
+    public IReadOnlyList<OutboundNotice> Told => _told;
+
+    /// <inheritdoc />
+    public void Tell(OutboundNotice notice) => _told.Add(notice);
+
+    /// <inheritdoc />
+    public Task QuietAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/Jellyfin.Plugin.Requests.Tests/Notify/ActivityJournalTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Notify/ActivityJournalTests.cs
@@ -272,6 +272,7 @@ public sealed class ActivityJournalTests
             journal,
             new RecordingSink(),
             new RecordingRequesterNotice(),
+            new RecordingArrivalNotice(),
             new FakeLibrary());
 
     /// <summary>

--- a/Jellyfin.Plugin.Requests.Tests/Notify/QuietByDefaultTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Notify/QuietByDefaultTests.cs
@@ -332,6 +332,7 @@ public sealed class QuietByDefaultTests
             journal,
             sink,
             new RecordingRequesterNotice(),
+            new RecordingArrivalNotice(),
             new FakeLibrary());
 
     /// <summary>

--- a/Jellyfin.Plugin.Requests.Tests/Notify/TellingAdministratorsTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Notify/TellingAdministratorsTests.cs
@@ -1,0 +1,339 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Api;
+using Jellyfin.Plugin.Requests.Configuration;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Notify;
+using Jellyfin.Plugin.Requests.Seam;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using MediaBrowser.Model.Session;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Notify;
+
+/// <summary>
+/// What a live administrator is told when something arrives, which is #76.
+/// <para>
+/// The delivery is a websocket to a client on a running server, and the headless rule in
+/// <c>docs/testing.md</c> refuses one, so what is asserted here stops at the server's own session
+/// interface: that one document went to the administrators, that nobody was named, that no other
+/// way of reaching anybody was used, and that an install nobody switched on says nothing at all.
+/// Whether a client then does something with it is a different claim, and this plugin makes it about
+/// no client: nothing on either claimed line listens, which <c>docs/notifications.md</c> carries
+/// with the reading behind it.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class TellingAdministratorsTests
+{
+    private static readonly Guid Asker = new Guid("76000000-0000-0000-0000-000000000001");
+    private static readonly Guid SecondPerson = new Guid("76000000-0000-0000-0000-000000000002");
+    private static readonly DateTimeOffset Started = new DateTimeOffset(2026, 8, 22, 9, 0, 0, TimeSpan.Zero);
+
+    private readonly SequentialIdentifierSource _identifiers = new SequentialIdentifierSource();
+
+    /// <summary>
+    /// A request that came into existence is announced once, and one that joined an existing request
+    /// is not announced at all.
+    /// <para>
+    /// This is the first condition of #76 on the surface a person asks over. The second half is what
+    /// a count alone cannot show: a join is a second person on a row an operator has already been
+    /// shown, so announcing it would put the same title in front of them once per person waiting for
+    /// it, and one film six people want would read as six things to work.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AnArrivalOverTheEndpointIsAnnouncedOnceAndAJoinIsNotAnnouncedAtAll()
+    {
+        var store = new InMemoryRequestStore();
+        var arrivals = new RecordingArrivalNotice();
+
+        await Controller(store, Asker, arrivals).CreateAsync(AFilm(), CancellationToken.None).ConfigureAwait(true);
+
+        var announced = Assert.Single(arrivals.Told);
+
+        Assert.Equal(NoticeEvent.Asked, announced.Event);
+        Assert.Equal("The Conversation", announced.Title);
+        Assert.Equal(Asker, announced.RequestedByUserId);
+        Assert.Equal(RequestState.Open, announced.State);
+        Assert.Null(announced.MovedByUserId);
+
+        await Controller(store, SecondPerson, arrivals).CreateAsync(AFilm(), CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Single(arrivals.Told);
+    }
+
+    /// <summary>
+    /// A want handed across the seam is announced the same way, and the same want handed over again
+    /// is not.
+    /// <para>
+    /// This is the first condition of #76 on the other surface an arrival comes in on. It is a leg
+    /// of its own rather than a variation of the one above, because the failure it stands for is the
+    /// one <c>docs/notifications.md</c> already names for the outbound switches: a path wired at the
+    /// endpoint alone carries some arrivals while reading as though it carried all of them, and an
+    /// operator would then hear about what people typed and never about what the sibling handed
+    /// across.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AWantHandedAcrossTheSeamIsAnnouncedOnceAndTheSameWantAgainIsNot()
+    {
+        var store = new InMemoryRequestStore();
+        var arrivals = new RecordingArrivalNotice();
+        var seam = Seam(store, arrivals);
+
+        Assert.True(await seam.AcceptAsync(AWant(), CancellationToken.None).ConfigureAwait(true));
+
+        var announced = Assert.Single(arrivals.Told);
+
+        Assert.Equal(NoticeEvent.Asked, announced.Event);
+        Assert.Equal("Stalker", announced.Title);
+        Assert.Equal(Asker, announced.RequestedByUserId);
+
+        Assert.True(await seam.AcceptAsync(AWant(), CancellationToken.None).ConfigureAwait(true));
+
+        Assert.Single(arrivals.Told);
+    }
+
+    /// <summary>
+    /// The one call this plugin makes to the server addresses whoever administers it, names nobody,
+    /// and carries the document the outbound sink would post.
+    /// <para>
+    /// This is the rest of the first condition, and the part of it about who is reached rather than
+    /// how many times. The double keeps a push at a named person and a push at the administrators in
+    /// separate lists and raises on every other way of sending anything, so the absence asserted here
+    /// is a real one: a device broadcast or a remote-control command would end the test rather than
+    /// pass it, and a document that named the person who asked would land in the list this leg
+    /// requires to be empty.
+    /// </para>
+    /// <para>
+    /// The document is compared against <see cref="OutboundNotice.For"/> rather than against fields
+    /// written out here, because what makes it a contract is that one shape leaves this plugin
+    /// whichever carrier took it.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ThePushReachesTheAdministratorsAndNamesNobody()
+    {
+        var sessions = new ASessionManagerThatOnlyDelivers();
+        var arriving = AnAsk(Asker, "The Conversation");
+        var notice = new ServerArrivalNotice(sessions, SwitchedOn(), new RecordingLogger());
+
+        notice.Tell(OutboundNotice.For(arriving, NoticeEvent.Asked));
+
+        await notice.QuietAsync(CancellationToken.None).ConfigureAwait(true);
+
+        var pushed = Assert.Single(sessions.Broadcasts);
+
+        Assert.Empty(sessions.Delivered);
+        Assert.Equal(SessionMessageType.ActivityLogEntry, pushed.Name);
+        Assert.Equal(OutboundNotice.For(arriving, NoticeEvent.Asked), Assert.IsType<OutboundNotice>(pushed.Payload));
+    }
+
+    /// <summary>
+    /// A fresh install pushes nothing, and turning the switch on is what makes it push.
+    /// <para>
+    /// This is the third condition of #76, and off is the shipping state rather than a degraded one:
+    /// no client on either claimed line reads this document, so an install that sent it by default
+    /// would push a message at every administrator's client on every arrival for nobody to read.
+    /// Both halves are in one leg because either alone passes on a path that is broken the other
+    /// way, and a switch stuck in one position looks exactly like a switch.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AFreshInstallSaysNothingAndAnInstallSwitchedOnSays()
+    {
+        var quiet = new ASessionManagerThatOnlyDelivers();
+        var arriving = AnAsk(Asker, "The Conversation");
+        var off = new ServerArrivalNotice(quiet, new FakeInstallSettings(), new RecordingLogger());
+
+        off.Tell(OutboundNotice.For(arriving, NoticeEvent.Asked));
+
+        await off.QuietAsync(CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Empty(quiet.Broadcasts);
+        Assert.Empty(quiet.Delivered);
+
+        var loud = new ASessionManagerThatOnlyDelivers();
+        var on = new ServerArrivalNotice(loud, SwitchedOn(), new RecordingLogger());
+
+        on.Tell(OutboundNotice.For(arriving, NoticeEvent.Asked));
+
+        await on.QuietAsync(CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Single(loud.Broadcasts);
+    }
+
+    /// <summary>
+    /// The switch is read per arrival rather than when the path was built.
+    /// <para>
+    /// An operator turning this off while the server is running expects the next arrival to be
+    /// silent, not the one after the next restart. The failure this stands for is a value captured
+    /// in a constructor, which passes the leg above and leaves the switch inert on a running server,
+    /// which is the only place anybody ever uses it.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task TurningItOffStopsTheNextArrivalRatherThanTheNextRestart()
+    {
+        var sessions = new ASessionManagerThatOnlyDelivers();
+        var settings = SwitchedOn();
+        var arriving = AnAsk(Asker, "The Conversation");
+        var notice = new ServerArrivalNotice(sessions, settings, new RecordingLogger());
+
+        notice.Tell(OutboundNotice.For(arriving, NoticeEvent.Asked));
+
+        await notice.QuietAsync(CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Single(sessions.Broadcasts);
+
+        settings.Current.TellsAdministratorsAboutArrivals = false;
+
+        notice.Tell(OutboundNotice.For(arriving, NoticeEvent.Asked));
+
+        await notice.QuietAsync(CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Single(sessions.Broadcasts);
+    }
+
+    /// <summary>
+    /// A push nobody could take costs the ask nothing and lands in the log.
+    /// <para>
+    /// This is the second condition of #76. The request is in the store before anybody is told and
+    /// telling hands nothing back for a caller to check, so a client that cannot be reached must not
+    /// be able to undo somebody's ask. The exception is caught by kind rather than by name, because
+    /// the host decides what a push can raise on two server generations, and the one nobody listed
+    /// would otherwise arrive later on a thread nothing is watching.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task APushThatFailsCostsTheAskNothing()
+    {
+        var store = new InMemoryRequestStore();
+        var log = new RecordingLogger();
+        var notice = new ServerArrivalNotice(
+            new ASessionManagerThatOnlyDelivers { Refuses = true },
+            SwitchedOn(),
+            log);
+
+        var answered = await Controller(store, Asker, notice)
+            .CreateAsync(AFilm(), CancellationToken.None)
+            .ConfigureAwait(true);
+
+        // Returns rather than raising, which is the whole promise of the interface.
+        await notice.QuietAsync(CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Equal(201, Assert.IsType<ObjectResult>(answered.Result).StatusCode);
+        Assert.Single(await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true));
+
+        var reported = Assert.Single(log.At(LogLevel.Warning));
+
+        Assert.NotNull(reported.Exception);
+        Assert.Contains("stands", reported.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// One install with the switch on, held so a test can move it.
+    /// </summary>
+    /// <returns>The settings.</returns>
+    private static FakeInstallSettings SwitchedOn()
+        => new FakeInstallSettings(new PluginConfiguration { TellsAdministratorsAboutArrivals = true });
+
+    /// <summary>
+    /// A film, named by one provider.
+    /// </summary>
+    /// <returns>The body.</returns>
+    private static CreateRequestBody AFilm() => new CreateRequestBody
+    {
+        Kind = RequestedItemKind.Movie,
+        Title = "The Conversation",
+        Year = 1974,
+        ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tmdb"] = "603" }
+    };
+
+    /// <summary>
+    /// A want as the sibling hands one across.
+    /// </summary>
+    /// <returns>The want.</returns>
+    private static HandedOverWant AWant()
+        => new HandedOverWant
+        {
+            ContractVersion = WantHandover.KnownContractVersion,
+            WantId = new Guid("76333333-3333-3333-3333-333333333333"),
+            RequestedByUserId = Asker,
+            Kind = RequestedItemKind.Movie,
+            Title = "Stalker",
+            Year = 1979,
+            ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tmdb"] = "1398" }
+        };
+
+    /// <summary>
+    /// A controller announcing arrivals to the path handed in.
+    /// </summary>
+    /// <param name="store">Where requests are kept.</param>
+    /// <param name="caller">Who is asking.</param>
+    /// <param name="arrivals">Where an arrival is announced.</param>
+    /// <returns>The controller.</returns>
+    private RequestsController Controller(InMemoryRequestStore store, Guid caller, IArrivalNotice arrivals)
+        => new RequestsController(
+            store,
+            new TestClock(Started),
+            _identifiers,
+            new FakeCallerIdentity(caller),
+            new FakeInstallSettings(),
+            new RecordingJournal(),
+            new RecordingSink(),
+            new RecordingRequesterNotice(),
+            arrivals,
+            new FakeLibrary());
+
+    /// <summary>
+    /// The seam announcing arrivals to the path handed in.
+    /// </summary>
+    /// <param name="store">Where requests are kept.</param>
+    /// <param name="arrivals">Where an arrival is announced.</param>
+    /// <returns>The seam.</returns>
+    private WantHandover Seam(InMemoryRequestStore store, IArrivalNotice arrivals)
+        => new WantHandover(
+            store,
+            new TestClock(Started),
+            _identifiers,
+            new FakeInstallSettings(),
+            new FakeKnownUsers(Asker, SecondPerson),
+            arrivals,
+            new RecordingLogger(),
+            WantHandover.DefaultAnswerWithin);
+
+    /// <summary>
+    /// One request, from one person, for one title.
+    /// </summary>
+    /// <param name="who">Who asked.</param>
+    /// <param name="title">What they asked for.</param>
+    /// <returns>The request.</returns>
+    private MediaRequest AnAsk(Guid who, string title)
+        => new MediaRequest
+        {
+            Id = _identifiers.NewId(),
+            RequestedByUserId = who,
+            RequestedAt = Started,
+            StateChangedAt = Started,
+            Kind = RequestedItemKind.Movie,
+            DisplayTitle = title,
+            DisplayYear = 1974,
+            ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tmdb"] = "603" }
+        };
+}

--- a/Jellyfin.Plugin.Requests.Tests/Notify/TellingTheRequesterTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Notify/TellingTheRequesterTests.cs
@@ -246,10 +246,13 @@ public sealed class TellingTheRequesterTests
     /// The one call this plugin makes to the server names that one person, goes out under the name a
     /// client acts on, and carries a timeout.
     /// <para>
-    /// The double raises on every other way of sending anything, so this leg also asserts the
-    /// absence: an administrator broadcast, a device broadcast or a remote-control command would end
-    /// the test rather than pass it. The timeout is not decoration - the web client draws a message
-    /// carrying one as a notice that fades and one without as a dialog somebody has to dismiss.
+    /// The double raises on every way of sending anything except the two this plugin is allowed to
+    /// make, so this leg asserts the absence twice over: a device broadcast or a remote-control
+    /// command would end the test rather than pass it, and the one remaining way of reaching
+    /// somebody the message was not about, which is the broadcast to whoever administers the server,
+    /// is asserted here to be empty rather than left to raise. The timeout is not decoration - the
+    /// web client draws a message carrying one as a notice that fades and one without as a dialog
+    /// somebody has to dismiss.
     /// </para>
     /// </summary>
     /// <returns>A task that completes when the assertions have run.</returns>
@@ -265,6 +268,7 @@ public sealed class TellingTheRequesterTests
 
         var pushed = Assert.Single(sessions.Delivered);
 
+        Assert.Empty(sessions.Broadcasts);
         Assert.Equal(new[] { Asker }, pushed.UserIds);
         Assert.Equal(SessionMessageType.GeneralCommand, pushed.Name);
 
@@ -320,6 +324,7 @@ public sealed class TellingTheRequesterTests
             new RecordingJournal(),
             new RecordingSink(),
             told,
+            new RecordingArrivalNotice(),
             new FakeLibrary());
 
     /// <summary>

--- a/Jellyfin.Plugin.Requests.Tests/PluginServiceRegistrationTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/PluginServiceRegistrationTests.cs
@@ -10,6 +10,7 @@ using Jellyfin.Plugin.Requests.Seam;
 using Jellyfin.Plugin.Requests.Storage;
 using Jellyfin.Plugin.Requests.Tests.Doubles;
 using Jellyfin.Plugin.Requests.Time;
+using MediaBrowser.Controller.Session;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -166,16 +167,22 @@ public class PluginServiceRegistrationTests
     }
 
     /// <summary>
-    /// The registration as it ships, with the four things behind it that only a running server has.
+    /// The registration as it ships, with the five things behind it that only a running server has.
     /// <para>
-    /// Each of the four is stood in for because reaching the real one from a test would read
-    /// something other than the registration. The logger factory and the user manager come from the
-    /// server's own container and are not in this collection at all. The store and the settings both
-    /// reach the plugin instance, which is a static the host sets while loading and which any test
-    /// running beside this one replaces, so a test resolving them would fail for a reason nobody
-    /// caused; <c>ServerInstallSettings</c> says so about itself where it takes its second
-    /// constructor. What is left over the four is the seam's own registration, which is what these
-    /// tests are about.
+    /// Each of the five is stood in for because reaching the real one from a test would read
+    /// something other than the registration. The logger factory, the user manager and the session
+    /// manager come from the server's own container and are not in this collection at all. The store
+    /// and the settings both reach the plugin instance, which is a static the host sets while loading
+    /// and which any test running beside this one replaces, so a test resolving them would fail for a
+    /// reason nobody caused; <c>ServerInstallSettings</c> says so about itself where it takes its
+    /// second constructor. What is left over the five is the seam's own registration, which is what
+    /// these tests are about.
+    /// </para>
+    /// <para>
+    /// The session manager arrived with the arrival notice the seam announces through. It is the
+    /// double that raises on every way of reaching somebody this plugin is not allowed to use, so a
+    /// registration that resolved a wider path than the one it declares fails here rather than in
+    /// front of an operator.
     /// </para>
     /// </summary>
     /// <param name="store">The queue the sink writes into.</param>
@@ -190,6 +197,7 @@ public class PluginServiceRegistrationTests
         services.AddSingleton(store);
         services.AddSingleton<IInstallSettings>(new FakeInstallSettings());
         services.AddSingleton<IKnownUsers>(new FakeKnownUsers(Asker));
+        services.AddSingleton<ISessionManager>(new ASessionManagerThatOnlyDelivers());
 
         return services.BuildServiceProvider();
     }

--- a/Jellyfin.Plugin.Requests.Tests/Seam/WantHandoverTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Seam/WantHandoverTests.cs
@@ -99,7 +99,7 @@ public class WantHandoverTests
             .ToArray();
 
         Assert.Equal(
-            ["IRequestStore", "IClock", "IIdentifierSource", "IInstallSettings", "IKnownUsers", "ILogger", "TimeSpan"],
+            ["IRequestStore", "IClock", "IIdentifierSource", "IInstallSettings", "IKnownUsers", "IArrivalNotice", "ILogger", "TimeSpan"],
             taken);
     }
 
@@ -792,6 +792,10 @@ public class WantHandoverTests
     /// <param name="settings">What the install is set to, or a fresh install where not given.</param>
     /// <param name="log">Where refusals are written, or a discarded one where not given.</param>
     /// <param name="users">Who the server has, or both people these tests use where not given.</param>
+    /// <param name="arrivals">
+    /// Where an arrival is announced to the administrators, or one that keeps what it was given
+    /// where not given.
+    /// </param>
     /// <param name="answerWithin">
     /// How long to wait for the queue, or the shipping bound where not given. A test that is not
     /// about waiting takes the shipping one, so nothing here passes for the wrong reason.
@@ -802,6 +806,7 @@ public class WantHandoverTests
         IInstallSettings? settings = null,
         RecordingLogger? log = null,
         IKnownUsers? users = null,
+        RecordingArrivalNotice? arrivals = null,
         TimeSpan? answerWithin = null)
         => new WantHandover(
             store,
@@ -809,6 +814,7 @@ public class WantHandoverTests
             new SequentialIdentifierSource(),
             settings ?? new FakeInstallSettings(),
             users ?? new FakeKnownUsers(Asker, SecondAsker),
+            arrivals ?? new RecordingArrivalNotice(),
             log ?? new RecordingLogger(),
             answerWithin ?? WantHandover.DefaultAnswerWithin);
 
@@ -832,6 +838,7 @@ public class WantHandoverTests
                 new SequentialIdentifierSource(),
                 new FakeInstallSettings(),
                 new FakeKnownUsers(Asker, SecondAsker),
+                new RecordingArrivalNotice(),
                 log,
                 WantHandover.DefaultAnswerWithin),
             "the clock" => new WantHandover(
@@ -840,6 +847,7 @@ public class WantHandoverTests
                 new SequentialIdentifierSource(),
                 new FakeInstallSettings(),
                 new FakeKnownUsers(Asker, SecondAsker),
+                new RecordingArrivalNotice(),
                 log,
                 WantHandover.DefaultAnswerWithin),
             "the identifier source" => new WantHandover(
@@ -848,6 +856,7 @@ public class WantHandoverTests
                 failing,
                 new FakeInstallSettings(),
                 new FakeKnownUsers(Asker, SecondAsker),
+                new RecordingArrivalNotice(),
                 log,
                 WantHandover.DefaultAnswerWithin),
             "the settings" => new WantHandover(
@@ -856,6 +865,7 @@ public class WantHandoverTests
                 new SequentialIdentifierSource(),
                 failing,
                 new FakeKnownUsers(Asker, SecondAsker),
+                new RecordingArrivalNotice(),
                 log,
                 WantHandover.DefaultAnswerWithin),
             "the server's users" => new WantHandover(
@@ -864,6 +874,7 @@ public class WantHandoverTests
                 new SequentialIdentifierSource(),
                 new FakeInstallSettings(),
                 failing,
+                new RecordingArrivalNotice(),
                 log,
                 WantHandover.DefaultAnswerWithin),
 

--- a/Jellyfin.Plugin.Requests.Tests/Surface/AvailabilityIsAnsweredPerCallerTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Surface/AvailabilityIsAnsweredPerCallerTests.cs
@@ -253,5 +253,6 @@ public sealed class AvailabilityIsAnsweredPerCallerTests
             new RecordingJournal(),
             new RecordingSink(),
             new RecordingRequesterNotice(),
+            new RecordingArrivalNotice(),
             library);
 }

--- a/Jellyfin.Plugin.Requests.Tests/Surface/WhatAPersonIsToldTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Surface/WhatAPersonIsToldTests.cs
@@ -233,5 +233,6 @@ public sealed class WhatAPersonIsToldTests
             new RecordingJournal(),
             new RecordingSink(),
             new RecordingRequesterNotice(),
+            new RecordingArrivalNotice(),
             new FakeLibrary());
 }

--- a/Jellyfin.Plugin.Requests.Tests/Web/QueueViewTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Web/QueueViewTests.cs
@@ -227,6 +227,7 @@ public sealed class QueueViewTests
             new RecordingJournal(),
             new RecordingSink(),
             new RecordingRequesterNotice(),
+            new RecordingArrivalNotice(),
             new FakeLibrary());
 
         var answered = await controller.QueueAsync(

--- a/Jellyfin.Plugin.Requests/Api/RequestsController.cs
+++ b/Jellyfin.Plugin.Requests/Api/RequestsController.cs
@@ -102,6 +102,7 @@ public sealed class RequestsController : RequestsControllerBase
     private readonly IActivityJournal _journal;
     private readonly IOutboundSink _sink;
     private readonly IRequesterNotice _told;
+    private readonly IArrivalNotice _arrivals;
     private readonly ILibrary _library;
     private readonly RequestIntake _intake;
 
@@ -132,6 +133,12 @@ public sealed class RequestsController : RequestsControllerBase
     /// endpoint has to be able to see is that exactly one person was told and which one, and that
     /// is not visible through a server nothing here runs.
     /// </param>
+    /// <param name="arrivals">
+    /// Where administrators signed in at that moment are told that somebody has asked for something.
+    /// It is a dependency for the reason the one above it is: what a test of this endpoint has to be
+    /// able to see is that an arrival was announced once and that an ask which joined an existing
+    /// request was not, and neither is visible through a server nothing here runs.
+    /// </param>
     /// <param name="library">
     /// The server's library, asked what one person may see of a title. A request row on somebody's
     /// own page says whether what they asked for has arrived, and that sentence is answered for the
@@ -146,6 +153,7 @@ public sealed class RequestsController : RequestsControllerBase
         IActivityJournal journal,
         IOutboundSink sink,
         IRequesterNotice told,
+        IArrivalNotice arrivals,
         ILibrary library)
     {
         _store = store;
@@ -155,6 +163,7 @@ public sealed class RequestsController : RequestsControllerBase
         _journal = journal;
         _sink = sink;
         _told = told;
+        _arrivals = arrivals;
         _library = library;
 
         // Built here rather than injected, because it is this controller's use of the store rather
@@ -1383,6 +1392,16 @@ public sealed class RequestsController : RequestsControllerBase
         CancellationToken cancellationToken)
     {
         var intake = await _intake.AskAsync(incoming, caller, cancellationToken).ConfigureAwait(false);
+
+        if (intake.Outcome == IntakeOutcome.Created)
+        {
+            // Only a request that came into existence. A join is a second person on a row an
+            // operator has already been shown, and announcing it again would put the same title in
+            // front of them once per person waiting for it. The document is built from the stored
+            // request rather than from what was asked for, so what is announced is what a queue read
+            // a moment later would answer.
+            _arrivals.Tell(OutboundNotice.For(intake.Request.Request, NoticeEvent.Asked));
+        }
 
         return new CreatedRequest
         {

--- a/Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs
@@ -22,9 +22,10 @@ namespace Jellyfin.Plugin.Requests.Configuration;
 /// boolean added now would be the wrong shape rather than an early version of the right one.
 /// </para>
 /// <para>
-/// The notification switches below name the three movements this plugin announces outward and
-/// nothing else. A switch for a path that does not exist is a setting an operator can change with no
-/// effect, so the set grows when a path does rather than ahead of one.
+/// The notification switches below name the three movements this plugin announces outward, and one
+/// more names the arrival this plugin tells a live administrator about. A switch for a path that
+/// does not exist is a setting an operator can change with no effect, so the set grows when a path
+/// does rather than ahead of one, and this is that rule applied rather than an exception to it.
 /// </para>
 /// <para>
 /// There is no bridge address and no credential. The only implementation of the bridge in this tree
@@ -97,6 +98,26 @@ public class PluginConfiguration : BasePluginConfiguration
     /// </para>
     /// </summary>
     public int FinishedRequestRetentionDays { get; set; } = 365;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether administrators signed in at that moment are told that
+    /// somebody has asked for something.
+    /// <para>
+    /// False, and off is the shipping state rather than a degraded one. Nothing on either claimed
+    /// server line listens for this document, which <c>docs/notifications.md</c> measures rather than
+    /// asserts, so an install that sent it by default would push a message at every administrator's
+    /// client on every arrival and no client would do anything with it. An operator running
+    /// something written against the contract turns it on.
+    /// </para>
+    /// <para>
+    /// It is a switch of its own rather than one of the three below it. Those three narrow what
+    /// leaves the machine on the outbound sink, and this leaves nothing: it goes down connections
+    /// the server already holds to clients already signed in. Sharing a switch with the sink would
+    /// make turning off what a chat service receives also turn off what an operator's own dashboard
+    /// is handed, which are different decisions.
+    /// </para>
+    /// </summary>
+    public bool TellsAdministratorsAboutArrivals { get; set; }
 
     /// <summary>
     /// Gets or sets where a notice about a request is posted, or nothing to send none.

--- a/Jellyfin.Plugin.Requests/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Requests/Configuration/configPage.html
@@ -50,6 +50,14 @@
 
                         <div class="checkboxContainer checkboxContainer-withDescription">
                             <label>
+                                <input is="emby-checkbox" type="checkbox" id="RequestsTellsAdministratorsAboutArrivals" />
+                                <span data-i18n="config.tellsAdministratorsAboutArrivals.label"></span>
+                            </label>
+                            <div class="fieldDescription checkboxFieldDescription" data-i18n="config.tellsAdministratorsAboutArrivals.description"></div>
+                        </div>
+
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label>
                                 <input is="emby-checkbox" type="checkbox" id="RequestsAnnouncesApprovals" />
                                 <span data-i18n="config.announcesApprovals.label"></span>
                             </label>
@@ -120,6 +128,7 @@
                         AnnouncesApprovals: "#RequestsAnnouncesApprovals",
                         AnnouncesDeclines: "#RequestsAnnouncesDeclines",
                         AnnouncesFulfilments: "#RequestsAnnouncesFulfilments",
+                        TellsAdministratorsAboutArrivals: "#RequestsTellsAdministratorsAboutArrivals",
                     };
 
                     // Read and written as typed, with no trimming and no default put in its place.

--- a/Jellyfin.Plugin.Requests/Localisation/Strings/en.json
+++ b/Jellyfin.Plugin.Requests/Localisation/Strings/en.json
@@ -19,6 +19,8 @@
   "config.retention.description": "A finished request names a person, a title and a date. After this many days it is removed. Thirty days is the shortest period allowed, so the history cannot be switched off by setting this to nothing.",
   "config.retention.label": "Keep finished requests for, in days",
   "config.save": "Save",
+  "config.tellsAdministratorsAboutArrivals.description": "Off, and off is the ordinary way to run this. With it on, a small JSON document about each new request is pushed down the connections this server already holds to administrators who are signed in at that moment. Nothing leaves the machine and nothing is retried. No Jellyfin client reads it today, so turn it on only if you run something written to listen for it; the queue is where an operator sees what is waiting.",
+  "config.tellsAdministratorsAboutArrivals.label": "Tell signed-in administrators when something is asked for",
   "config.title": "Requests",
   "declineReason.AlreadyInTheLibrary": "Already in the library",
   "declineReason.AlreadyRequested": "Already asked for",

--- a/Jellyfin.Plugin.Requests/Notify/IArrivalNotice.cs
+++ b/Jellyfin.Plugin.Requests/Notify/IArrivalNotice.cs
@@ -1,0 +1,50 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jellyfin.Plugin.Requests.Notify;
+
+/// <summary>
+/// The path that tells whoever administers this server, on the connections the server already holds
+/// to whatever they are signed in on right now, that somebody has asked for something.
+/// <para>
+/// <b>It is a courtesy and never a delivery.</b> Nobody is signed in most of the time, so most
+/// arrivals reach nobody through here and nothing remembers that they did not. What an operator can
+/// rely on is the queue, which holds every open request whenever they next open it. Nothing about a
+/// request depends on a message going out here, and a caller that has just taken one in tells the
+/// administrators and carries on.
+/// </para>
+/// <para>
+/// <b>Nothing on either claimed server line listens for this today.</b> It is a contract for a
+/// client somebody else writes, the same way <see cref="IOutboundSink"/> is a contract for a service
+/// an operator already runs, and <c>docs/notifications.md</c> says so in plain words rather than
+/// describing the mechanism in a way that implies a dashboard reacts to it. That is why an install
+/// says nothing here until an operator turns it on.
+/// </para>
+/// <para>
+/// <b>Telling returns nothing, for the reason <see cref="IRequesterNotice"/> gives.</b> A method
+/// handing back a task is a method somebody awaits, and an arrival that waits on a message is an ask
+/// that can fail because an administrator's socket is slow.
+/// </para>
+/// </summary>
+public interface IArrivalNotice
+{
+    /// <summary>
+    /// Pushes the document at the administrators' sessions, eventually, or does not. Returns as soon
+    /// as the delivery is under way and never raises anything the caller has to handle.
+    /// </summary>
+    /// <param name="notice">The document, which is the same one the outbound sink posts.</param>
+    void Tell(OutboundNotice notice);
+
+    /// <summary>
+    /// Waits until nothing told so far is still in flight.
+    /// <para>
+    /// This exists for two callers and neither is on the path a request takes, which is the same
+    /// division <see cref="IRequesterNotice.QuietAsync"/> is written under: the suite uses it to
+    /// assert what was pushed without waiting on a clock, and a shutdown can use it to let a message
+    /// in flight finish.
+    /// </para>
+    /// </summary>
+    /// <param name="cancellationToken">Gives up waiting.</param>
+    /// <returns>A task that completes when nothing is in flight.</returns>
+    Task QuietAsync(CancellationToken cancellationToken);
+}

--- a/Jellyfin.Plugin.Requests/Notify/ServerArrivalNotice.cs
+++ b/Jellyfin.Plugin.Requests/Notify/ServerArrivalNotice.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Configuration;
+using MediaBrowser.Controller.Session;
+using MediaBrowser.Model.Session;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.Requests.Notify;
+
+/// <summary>
+/// The server's own broadcast to administrator sessions, as the one call this plugin makes to it.
+/// <para>
+/// This is the only place that names <c>SendMessageToAdminSessions</c>, so the reach exists once and
+/// everything above it takes <see cref="IArrivalNotice"/> instead. The shape of the host call is the
+/// same on both claimed lines: a name out of the server's own closed enumeration and a payload, with
+/// the server deciding which sessions administer it.
+/// </para>
+/// <para>
+/// <b>A plugin cannot add a name to that enumeration, and none of its members means "a plugin has
+/// something to say".</b> They are playback commands, server lifecycle, package installation,
+/// scheduled tasks, sessions, sync play and the activity log. So a name has to be borrowed, and the
+/// two kinds of member are not equally safe to borrow: a client obeys a command and merely reads a
+/// notice. <see cref="SessionMessageType.ActivityLogEntry"/> is the notice closest in meaning to
+/// what this sends, which is that something happened an operator's view may want to react to, and
+/// the dashboard subscribes to no such name, so a document under it is ignored there rather than
+/// acted on. <c>docs/notifications.md</c> carries the reading of both sides and the price of the
+/// borrowing.
+/// </para>
+/// <para>
+/// <b>The document is <see cref="OutboundNotice"/> and not a second shape.</b> A reader written
+/// against this plugin gets one set of field names whichever carrier brought them, and a field added
+/// to one carrier cannot be missing from the other. What differs is the carrier and the audience,
+/// which the two interfaces already say.
+/// </para>
+/// <para>
+/// <b>An install says nothing here until an operator turns it on.</b> The switch is read per notice
+/// from the settings rather than captured, so turning it on applies to the next arrival rather than
+/// to the next restart, which is the same reading the outbound sink makes of its own three.
+/// </para>
+/// </summary>
+public sealed class ServerArrivalNotice : IArrivalNotice
+{
+    /// <summary>
+    /// The name the document goes out under, borrowed from the server's closed enumeration for the
+    /// reason above. It is a constant here so that a reader of a test and a reader of the ship both
+    /// find one answer, and so that changing it is one edit rather than two.
+    /// </summary>
+    public const SessionMessageType SentAs = SessionMessageType.ActivityLogEntry;
+
+    private readonly ISessionManager _sessions;
+    private readonly IInstallSettings _settings;
+    private readonly ILogger _logger;
+    private readonly object _gate = new object();
+
+    private Task _inFlight = Task.CompletedTask;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ServerArrivalNotice"/> class.
+    /// </summary>
+    /// <param name="sessions">The server's sessions.</param>
+    /// <param name="settings">What this install is set to, read per notice rather than kept.</param>
+    /// <param name="logger">Where a message that could not be pushed is reported.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Where there is nothing to push through, nothing to read the settings from, or nothing to
+    /// report on.
+    /// </exception>
+    public ServerArrivalNotice(ISessionManager sessions, IInstallSettings settings, ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(sessions);
+        ArgumentNullException.ThrowIfNull(settings);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _sessions = sessions;
+        _settings = settings;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public void Tell(OutboundNotice notice)
+    {
+        ArgumentNullException.ThrowIfNull(notice);
+
+        if (!_settings.Current.TellsAdministratorsAboutArrivals)
+        {
+            return;
+        }
+
+        // Started rather than awaited, and started off this thread, for the reason the requester
+        // path gives: what this interface promises is that telling costs the caller nothing, and
+        // that promise should not depend on how fast the slowest connected administrator is.
+        var delivery = Task.Run(() => PushAsync(notice));
+
+        lock (_gate)
+        {
+            _inFlight = Both(_inFlight, delivery);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task QuietAsync(CancellationToken cancellationToken)
+    {
+        Task waiting;
+
+        lock (_gate)
+        {
+            waiting = _inFlight;
+        }
+
+        return waiting.WaitAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Both pushes, as one thing to wait for. Written out rather than done with <c>Task.WhenAll</c>
+    /// so that a chain of messages does not grow an array per message.
+    /// </summary>
+    /// <param name="earlier">What was already in flight.</param>
+    /// <param name="later">What has just been started.</param>
+    /// <returns>A task that completes when both have.</returns>
+    private static async Task Both(Task earlier, Task later)
+    {
+        await earlier.ConfigureAwait(false);
+        await later.ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// One push, which either happens or is written to the log.
+    /// </summary>
+    /// <param name="notice">The document the administrators' clients are handed.</param>
+    /// <returns>A task that completes when the attempt is over, however it went.</returns>
+    private async Task PushAsync(OutboundNotice notice)
+    {
+        try
+        {
+            await _sessions
+                .SendMessageToAdminSessions(SentAs, notice, CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+        catch (Exception reason)
+#pragma warning restore CA1031
+        {
+            // Every outcome of a push is the same outcome here: nobody was told and the request is
+            // unaffected. Catching by name instead would leave whichever exception nobody listed to
+            // surface out of a task nothing observes, and the failure this path exists to avoid is a
+            // courtesy message deciding what happens to somebody's ask.
+            _logger.LogWarning(
+                reason,
+                "A request arrived and the administrators signed in at that moment could not be told. The request itself was written and stands, and it is in the queue whenever an operator next opens it. Nothing will be retried. {RequestId}",
+                notice.RequestId);
+        }
+    }
+}

--- a/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
@@ -101,6 +101,7 @@ public sealed class PluginServiceRegistrator : IPluginServiceRegistrator
             provider.GetRequiredService<IIdentifierSource>(),
             provider.GetRequiredService<IInstallSettings>(),
             provider.GetRequiredService<IKnownUsers>(),
+            provider.GetRequiredService<IArrivalNotice>(),
             provider.GetRequiredService<ILogger<WantHandover>>(),
             WantHandover.DefaultAnswerWithin));
 
@@ -136,6 +137,17 @@ public sealed class PluginServiceRegistrator : IPluginServiceRegistrator
         serviceCollection.AddSingleton<IRequesterNotice>(provider => new ServerRequesterNotice(
             provider.GetRequiredService<ISessionManager>(),
             provider.GetRequiredService<ILogger<ServerRequesterNotice>>()));
+
+        // The path that tells whoever administers the server that somebody has asked for something,
+        // on whatever they are signed in on right now. It is a fourth registration rather than a
+        // second use of the one above because the audience is different and so is the host call:
+        // that one names one person and this one names none, and the server decides which sessions
+        // administer it. The settings are handed in because an install says nothing here until an
+        // operator turns it on, and the switch is read per notice rather than at startup.
+        serviceCollection.AddSingleton<IArrivalNotice>(provider => new ServerArrivalNotice(
+            provider.GetRequiredService<ISessionManager>(),
+            provider.GetRequiredService<IInstallSettings>(),
+            provider.GetRequiredService<ILogger<ServerArrivalNotice>>()));
 
         // The server's library, as the two questions this plugin asks of it. One per server, because
         // the instance subscribes to the library's own events and a second subscription would look

--- a/Jellyfin.Plugin.Requests/Seam/WantHandover.cs
+++ b/Jellyfin.Plugin.Requests/Seam/WantHandover.cs
@@ -5,6 +5,7 @@ using Jellyfin.Plugin.Requests.Configuration;
 using Jellyfin.Plugin.Requests.Identity;
 using Jellyfin.Plugin.Requests.Intake;
 using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Notify;
 using Jellyfin.Plugin.Requests.Storage;
 using Jellyfin.Plugin.Requests.Time;
 using Microsoft.Extensions.Logging;
@@ -84,6 +85,7 @@ public sealed class WantHandover : IWantHandover
     private readonly IIdentifierSource _identifiers;
     private readonly IInstallSettings _settings;
     private readonly IKnownUsers _users;
+    private readonly IArrivalNotice _arrivals;
     private readonly ILogger _logger;
     private readonly TimeSpan _answerWithin;
 
@@ -95,6 +97,13 @@ public sealed class WantHandover : IWantHandover
     /// <param name="identifiers">Where a new request's identifier comes from.</param>
     /// <param name="settings">What this install is set to.</param>
     /// <param name="users">The server's answer to whether it has the user a want names.</param>
+    /// <param name="arrivals">
+    /// Where administrators signed in at that moment are told that somebody has asked for something.
+    /// This side announces its own arrivals rather than leaving it to the endpoint, because a want
+    /// handed across here is a request an operator has to work exactly like one typed at the API,
+    /// and a path wired at one of the two surfaces would carry some arrivals while reading as though
+    /// it carried all of them.
+    /// </param>
     /// <param name="logger">Where a refusal is written.</param>
     /// <param name="answerWithin">
     /// How long to wait for the queue before answering without it. A server passes
@@ -109,6 +118,7 @@ public sealed class WantHandover : IWantHandover
         IIdentifierSource identifiers,
         IInstallSettings settings,
         IKnownUsers users,
+        IArrivalNotice arrivals,
         ILogger logger,
         TimeSpan answerWithin)
     {
@@ -117,6 +127,7 @@ public sealed class WantHandover : IWantHandover
         ArgumentNullException.ThrowIfNull(identifiers);
         ArgumentNullException.ThrowIfNull(settings);
         ArgumentNullException.ThrowIfNull(users);
+        ArgumentNullException.ThrowIfNull(arrivals);
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentOutOfRangeException.ThrowIfLessThan(answerWithin, TimeSpan.Zero);
 
@@ -126,6 +137,7 @@ public sealed class WantHandover : IWantHandover
         _identifiers = identifiers;
         _settings = settings;
         _users = users;
+        _arrivals = arrivals;
         _logger = logger;
         _answerWithin = answerWithin;
     }
@@ -314,6 +326,15 @@ public sealed class WantHandover : IWantHandover
         if (!intake.InTime)
         {
             return Refused(want, HandoverRefusal.TheStoreDidNotAnswerInTime);
+        }
+
+        if (intake.Value.Outcome == IntakeOutcome.Created)
+        {
+            // Only a request that came into existence, for the reason the endpoint gives at its own
+            // call: a join is a second person on a row an operator has already been shown. What is
+            // announced is the stored request rather than the want, so an administrator's client is
+            // handed the same document whichever surface the ask arrived on.
+            _arrivals.Tell(OutboundNotice.For(intake.Value.Request.Request, NoticeEvent.Asked));
         }
 
         if (_logger.IsEnabled(LogLevel.Debug))

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,16 +14,17 @@ without this page moving with it, and again if the page cannot reach one of them
 
 <!-- settings begins -->
 
-| Setting                      | Default |
-| ---------------------------- | ------- |
-| AcceptsMovies                | true    |
-| AcceptsSeries                | true    |
-| AnnouncesApprovals           | true    |
-| AnnouncesDeclines            | true    |
-| AnnouncesFulfilments         | true    |
-| FinishedRequestRetentionDays | 365     |
-| OpenRequestsPerUser          | 10      |
-| OutboundNoticeAddress        |         |
+| Setting                          | Default |
+| -------------------------------- | ------- |
+| AcceptsMovies                    | true    |
+| AcceptsSeries                    | true    |
+| AnnouncesApprovals               | true    |
+| AnnouncesDeclines                | true    |
+| AnnouncesFulfilments             | true    |
+| FinishedRequestRetentionDays     | 365     |
+| OpenRequestsPerUser              | 10      |
+| OutboundNoticeAddress            |         |
+| TellsAdministratorsAboutArrivals | false   |
 
 <!-- settings ends -->
 
@@ -108,11 +109,27 @@ forwards the yeses and not the noes is an ordinary thing to want, and a fulfilme
 decides, so its volume follows how fast the library is filling rather than how often an operator
 looks at the queue. That is the switch most likely to be turned off first.
 
-**An arrival is not on this list and there is no switch for one.** A request is made over the
-endpoint and also over the seam the sibling plugin hands a want across, and a switch that caught the
-first and not the second would send some arrivals and look like it sent all of them. So nothing is
-announced when a request is made, and what an operator has instead is the queue and, when #76 lands,
-a message to a live administrator session.
+**An arrival is not on that list and is not posted to the address at all.** A request is made over
+the endpoint and also over the seam the sibling plugin hands a want across, and a switch that caught
+the first and not the second would send some arrivals and look like it sent all of them. So the sink
+announces movements and never an arrival, and the setting below is the one that says anything when a
+request is made.
+
+**TellsAdministratorsAboutArrivals** is off, and off is the shipping state rather than a degraded
+one. With it on, a request that has just come into existence is pushed at whoever is signed in as an
+administrator at that moment, on both surfaces an ask arrives over, as the same JSON document the
+sink would post. It leaves nothing on the wire out of this machine: it goes down connections the
+server already holds to clients already signed in.
+
+It is off because no Jellyfin client reads it. The name it goes out under is one a plugin has to
+borrow from the server's own closed list, the dashboard does not subscribe to that name, and
+[notifications.md](notifications.md) carries the measurement and the price of the borrowing. An
+operator running something written against the document turns this on; everybody else leaves it
+alone and reads the queue, which is where what is waiting has always been.
+
+It is a switch of its own rather than a fourth on the list above. Those three narrow what leaves the
+machine, and turning off what a chat service receives should not also turn off what an operator's own
+client is handed.
 
 ## What is refused
 
@@ -152,7 +169,9 @@ other path that could carry anything, since the bridge adapter is #82 and is not
 happen on a fresh install and neither is a path off the machine. Every transition is written to the
 server's own activity log, which is a record rather than a message. And the person who asked is told
 on whatever they are signed in on when their own request is answered, down the connection the server
-already holds to their client. Both are [`notifications.md`](notifications.md).
+already holds to their client. Both are [`notifications.md`](notifications.md). The third session
+path, which tells a live administrator that something arrived, is off on a fresh install and is
+`TellsAdministratorsAboutArrivals` above.
 `NoRequestBackend` is what a server without an external request service runs, and it is what every
 server runs today.
 
@@ -172,8 +191,8 @@ already has somewhere to send to and are not a second way of saying off, which i
 with an address set is refused rather than treated as silence.
 
 **Switches for paths that do not exist.** A setting an operator can change with no effect is worse
-than its absence, so the set above names the three movements the sink announces and grows when a path
-does.
+than its absence, so the set above names the three movements the sink announces plus the one arrival
+path that has a switch, and it grows when a path does rather than ahead of one.
 
 **A switch for the message to the person who asked.** There is none. It reaches only the person the
 request belongs to and only while they are signed in, and whether an operator or that person should

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -69,7 +69,8 @@ stands now rather than where it stood when the measurement above was taken:
     origin/master:MediaBrowser.Controller/Session/ISessionManager.cs:207:        Task SendMessageToUserSessions<T>(List<Guid> userIds, SessionMessageType name, T data, CancellationToken cancellationToken);
 
 Telling the person who asked that their own request moved is built, and the section below is what
-they are told. Telling a live administrator that something arrived is #76 and is not built.
+they are told. Telling a live administrator that something arrived is built too, on the other of the
+two calls above, and the section for it says why an operator sees nothing today.
 
 **One outbound sink.** An operator who wants a request to reach something outside the server points
 this at whatever they already run. It is one sink with a defined payload rather than a service this
@@ -162,7 +163,7 @@ needs to know what happened reads that log.
 One entry per transition and none for anything else. Asking for something is not a transition:
 nothing has been decided, the model appends no history entry for it, and an entry there would be this
 plugin announcing its own arrival in a list an operator reads for what the server did. Telling an
-administrator that something arrived is a live message and is #76. An observation that changed a
+administrator that something arrived is a live message and is the section further down. An observation that changed a
 title's availability without moving the request writes nothing here either, because a line per
 re-observation is the wall of entries this page's own rule refuses.
 
@@ -345,6 +346,109 @@ reaches this, and the activity log has no switch either. Whether an operator or 
 should be the one to turn this off is a question nobody has taken, and it is written here rather than
 answered by adding a field.
 
+## What a live administrator is told when something arrives
+
+The other message this plugin pushes is about a request that has just come into existence, and it
+goes to whoever administers the server rather than to a person this plugin names.
+
+**Nothing on either claimed line reads it, and that is the first thing to know about it.** An
+operator who installs this plugin, switches it on and then watches the dashboard sees nothing,
+because the dashboard is `jellyfin-web` and it does not subscribe to the name this goes out under.
+That is measured in the section below rather than assumed. What this path is for is a client written
+against the document, the same way the outbound sink is for a service an operator already runs. What
+reaches an operator today is the activity entries above, which are in a page the dashboard already
+draws, and the queue, which holds every open request whenever they next open it.
+
+It is off on a fresh install. `TellsAdministratorsAboutArrivals` in the settings is what turns it on,
+and off is a supported way to run rather than a degraded one: a path nothing reads is traffic on
+every administrator's connection for nobody.
+
+### When it is sent, and when it is not
+
+One document per request that came into existence, on both surfaces an ask arrives over: the endpoint
+a person asks through and the seam a sibling plugin hands a want across. A path wired at one of the
+two would carry some arrivals while reading as though it carried all of them, which is the same
+failure the sink's own switches are written against.
+
+A second person joining a request that is already open sends nothing, and neither does somebody
+asking again for their own. A join is another person on a row an operator has already been shown, so
+announcing it would put one title in front of them once per person waiting for it.
+
+### What it sends
+
+The same document the outbound sink posts, with `event` set to `Asked`, which is the word the sink's
+vocabulary has always carried and nothing has ever sent. So there is one shape leaving this plugin
+whichever carrier took it, one version number, and one place a field is added. What it carries and
+what it deliberately does not is the sink's own section above, without exception: neither note, no
+provider identifiers, nobody else waiting, no history, and no user name of any kind.
+
+`state` on an arrival is `Open` and `movedByUserId` is absent, because nobody has moved it. `at` is
+when the request was asked for.
+
+### How it reaches a client, and why nothing acts on it
+
+The server carries one call that addresses administrators rather than named people, and it takes a
+name out of an enumeration a plugin cannot add to. The enumeration is closed and the two claimed
+lines carry the same members, compared rather than assumed:
+
+    for r in release-10.11.z master; do gh api \
+      "repos/jellyfin/jellyfin/contents/MediaBrowser.Model/Session/SessionMessageType.cs?ref=$r" \
+      -H "Accept: application/vnd.github.raw" | grep -oE '^\s{8}[A-Za-z]+,' | tr -d ' ,' ; done \
+      | sort | uniq -c | awk '$1 != 2'
+    (nothing)
+
+Not one of those members means "a plugin has something to say", so a name has to be borrowed, and the
+members are not equally safe to borrow. Some are commands a client is expected to obey and the rest
+are notices it may read. A document sent under a command name is acted on as a command, which is a
+worse outcome than not being read at all. `ActivityLogEntry` is the notice closest in meaning to what
+this sends, which is that something happened a view of the server may want to react to:
+
+    gh api "repos/jellyfin/jellyfin/contents/MediaBrowser.Model/Session/SessionMessageType.cs?ref=release-10.11.z" \
+      -H "Accept: application/vnd.github.raw" | grep -nE '^\s{8}(ActivityLogEntry|GeneralCommand),'
+    12:        GeneralCommand,
+    36:        ActivityLogEntry,
+
+The web client subscribes to five names and that is not one of them. Read at `5389bba` in
+`jellyfin/jellyfin-web`, which is the same commit the section above reads:
+
+    ref=5389bbad37d178ef5ebeaac8860403527c0e4121
+    gh api "repos/jellyfin/jellyfin-web/contents/src/scripts/serverNotifications.js?ref=$ref" \
+      -H "Accept: application/vnd.github.raw" | grep -oE 'OutboundWebSocketMessageType\.[A-Za-z]+' | sort -u
+    OutboundWebSocketMessageType.GeneralCommand
+    OutboundWebSocketMessageType.Play
+    OutboundWebSocketMessageType.Playstate
+    OutboundWebSocketMessageType.SyncPlayCommand
+    OutboundWebSocketMessageType.SyncPlayGroupUpdate
+
+    gh api "repos/jellyfin/jellyfin-web/contents/src/scripts/serverNotifications.js?ref=$ref" \
+      -H "Accept: application/vnd.github.raw" | grep -c 'ActivityLogEntry'
+    0
+
+Three of the five are commands a client obeys and two belong to sync play, so a document sent under
+any of them would be obeyed or discarded rather than read. The name this plugin uses is ignored
+there, which is the outcome to prefer of the two available.
+
+**The price of the borrowing, written down rather than discovered.** A client that subscribes to
+`ActivityLogEntry` expecting the server's own entry shape is handed this plugin's document instead
+and does not recognise it. That is the cost of an enumeration a plugin cannot add to, and it is why
+`version` is on the document: a reader can tell what it is holding without guessing from which fields
+it found.
+
+### What this is not proof of
+
+One file of one client was read, at one commit, and no client was run. It is not a claim about what
+any other Jellyfin client does with the same name, and it is not a claim that anybody saw anything.
+Nothing here was run against a server either: the suite asserts what this plugin asked the server to
+send, that it addressed the administrators, that nobody was named, and that no other way of reaching
+anybody was used, and the headless rule in [testing.md](testing.md) is why it stops there.
+
+### When the push fails
+
+**Nothing that reaches a request.** The request is in the store before anybody is told, telling hands
+nothing back for a caller to check, and every way a push can fail costs the same: a line in the
+server's log and nothing else. Nothing is retried and nothing is queued. An operator who was not
+reached finds the request in the queue, which is where they would look anyway.
+
 ## Why there is no fourth
 
 Because the fourth is the first of six. Growing an integration per messaging service is how a plugin
@@ -361,9 +465,10 @@ design, it is a standing decision recorded on #113, and it has no opt-in.
 
 Nothing leaves the machine until an operator turns it on. The outbound sink is off on a fresh
 install by having nowhere to send to, and what an operator narrows it with once it has somewhere is
-the section below. The other two paths have no switch and neither leaves the machine: the activity
-log is a record in the server's own database, and the message to the person who asked goes down a
-connection that server already holds to their client.
+the section below. The other paths put nothing on a wire out of this machine: the activity log is a
+record in the server's own database, and both session messages go down connections that server
+already holds to clients. The activity log has no switch and the message to the person who asked has
+none either; the message to a live administrator has one, and it is off until somebody sets it.
 
 ## Which movements are announced, and which are not
 
@@ -384,16 +489,12 @@ The vocabulary carries `Asked` because the document's shape is a contract with s
 machine and removing a word from it is a change to that contract; nothing here sends one, and the
 sink refuses any movement it has no switch for rather than sending it under a default.
 
-Telling an administrator that something arrived is #76, on the path that is a message rather than a
-post off the machine. What the person who asked is told when their own request moves is the section
-above, and it is not narrowed by these three either.
+Telling an administrator that something arrived is a message rather than a post off the machine, it
+is `TellsAdministratorsAboutArrivals` rather than one of these three, and the section below it is
+where what it sends and what reads it are written down. What the person who asked is told when their
+own request moves is the section above, and it is not narrowed by these three either.
 
 ## What this page does not do
-
-It does not say what a message to a live administrator would send. That half of the session path is
-#76's and is unbuilt, and its own question, what such a message is for on a dashboard that does not
-listen for one, is open there. The half that is built is the message to the person who asked, and it
-is above.
 
 It does not say what a fourth path would be switched with. The three settings above name the three
 movements the sink announces, and a setting for a path nothing sends on is a field an operator can

--- a/docs/personal-data.md
+++ b/docs/personal-data.md
@@ -211,14 +211,15 @@ rather than a habit:
 And nothing reports anything to this project, at any setting, by design and with no opt-in. That is
 recorded in [notifications.md](notifications.md) with the decision behind it.
 
-Three paths would carry something outward once they are built, and each is named here so that an
+Four paths would carry something outward once they are built, and each is named here so that an
 operator can find out what turning one on would mean before it exists:
 
-| Path                | Issue | What leaves, or would                                                           | Off until         | Built |
-| ------------------- | ----- | ------------------------------------------------------------------------------- | ----------------- | ----- |
-| The outbound sink   | #78   | the identifiers of the asker and the answerer, the title, the year, the request | an address is set | yes   |
-| The bridge          | #82   | a title, and an external account for the person who asked                       | a backend is set  | no    |
-| The session message | #77   | nothing off the machine, a message to the asker's own signed-in clients         | never off         | yes   |
+| Path                  | Issue | What leaves, or would                                                           | Off until          | Built |
+| --------------------- | ----- | ------------------------------------------------------------------------------- | ------------------ | ----- |
+| The outbound sink     | #78   | the identifiers of the asker and the answerer, the title, the year, the request | an address is set  | yes   |
+| The bridge            | #82   | a title, and an external account for the person who asked                       | a backend is set   | no    |
+| The session message   | #77   | nothing off the machine, a message to the asker's own signed-in clients         | never off          | yes   |
+| The arrival to admins | #76   | nothing off the machine, one arrival to whoever administers the server          | a switch is set on | yes   |
 
 The bridge names a person to the external service by an account the operator wrote into a table, and
 never by their name. That is the decision in [bridge.md](bridge.md), and the table is empty on a
@@ -226,10 +227,14 @@ fresh install, so a bridge configured and nothing else sends no attribution at a
 in #75 is the fourth path and it is not in the table because it writes into the server's own log,
 which does not leave the machine.
 
-The session message is in the table for what it is rather than for what it sends off the machine,
-which is nothing: it goes to whatever the person who asked is signed in on, over the connection the
-server already holds, and it carries the title they asked for and what happened to it. The
-administrator half of that path is #76 and is not built.
+The two session rows are in the table for what they are rather than for what they send off the
+machine, which is nothing: both go down connections the server already holds to clients already
+signed in. The one to the person who asked carries the title they asked for and what happened to it.
+The one to the administrators carries the same document the outbound sink would post about an
+arrival, which names the person who asked by the server's own identifier and nobody else, and it
+reaches only sessions the server itself counts as administering it. It is off on a fresh install:
+`TellsAdministratorsAboutArrivals` in [configuration.md](configuration.md) is what turns it on, and
+[notifications.md](notifications.md) says why nothing reads it today.
 
 **The bridge row is the one that is not built.** The other two say what happens today.
 


### PR DESCRIPTION
Closes #76.

The decision on that issue was to build the path as written, for a client somebody else writes, with
`docs/notifications.md` saying in plain words that nothing listens today. That is what this is.

## What it does

A request that has just come into existence is pushed at whoever is signed in as an administrator at
that moment, on both surfaces an ask arrives over. A join announces nothing. The document is the one
the outbound sink posts, with `event` set to `Asked`, which is the word that vocabulary has always
carried and nothing has ever sent, so one shape leaves this plugin whichever carrier took it.

`TellsAdministratorsAboutArrivals` turns it on and it is off on a fresh install.

## The name it is sent under, and why nothing reads it

The call that addresses administrators takes a name out of the server's own closed enumeration and a
plugin cannot add one. Both claimed lines carry the same members, compared rather than assumed:

    for r in release-10.11.z master; do gh api "repos/jellyfin/jellyfin/contents/MediaBrowser.Model/Session/SessionMessageType.cs?ref=$r" -H "Accept: application/vnd.github.raw" | grep -oE '^\s{8}[A-Za-z]+,' | tr -d ' ,' ; done | sort | uniq -c | awk '$1 != 2'
    (nothing)

Not one of them means "a plugin has something to say", so a name has to be borrowed, and the members
are not equally safe to borrow: some are commands a client obeys and the rest are notices it may
read. A document under a command name is acted on as a command, which is a worse outcome than not
being read at all. `ActivityLogEntry` is the notice closest in meaning:

    gh api "repos/jellyfin/jellyfin/contents/MediaBrowser.Model/Session/SessionMessageType.cs?ref=release-10.11.z" -H "Accept: application/vnd.github.raw" | grep -nE '^\s{8}(ActivityLogEntry|GeneralCommand),'
    12:        GeneralCommand,
    36:        ActivityLogEntry,

The web client subscribes to five names and that is not one of them. Read at `5389bba` in
`jellyfin/jellyfin-web`, which is the commit the neighbouring section of that page already reads:

    ref=5389bbad37d178ef5ebeaac8860403527c0e4121
    gh api "repos/jellyfin/jellyfin-web/contents/src/scripts/serverNotifications.js?ref=$ref" -H "Accept: application/vnd.github.raw" | grep -oE 'OutboundWebSocketMessageType\.[A-Za-z]+' | sort -u
    OutboundWebSocketMessageType.GeneralCommand
    OutboundWebSocketMessageType.Play
    OutboundWebSocketMessageType.Playstate
    OutboundWebSocketMessageType.SyncPlayCommand
    OutboundWebSocketMessageType.SyncPlayGroupUpdate

    gh api "repos/jellyfin/jellyfin-web/contents/src/scripts/serverNotifications.js?ref=$ref" -H "Accept: application/vnd.github.raw" | grep -c 'ActivityLogEntry'
    0

So an operator who switches this on and watches the dashboard sees nothing. `docs/notifications.md`
says that, points at the activity entries as what actually reaches them, and writes down the price of
the borrowing: a client subscribing to that name expecting the server's own entry shape is handed a
document it does not recognise, which is why `version` is on it.

## The suite

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler:     0, erfolgreich:   646, übersprungen:     0, gesamt:   646, Dauer: 17 s - Jellyfin.Plugin.Requests.Tests.dll (net9.0)
    Bestanden!   : Fehler:     0, erfolgreich:   646, übersprungen:     0, gesamt:   646, Dauer: 17 s - Jellyfin.Plugin.Requests.Tests.dll (net10.0)

Six hundred and thirty-eight before this, so eight legs are new: six in
`TellingAdministratorsTests` and two theory rows on the settings list.

## Every guard here was watched failing, and the tree restored after each

Each run below is `--filter` over the class named, on `net9.0`, with one thing changed and put back.

**The switch, deleted.** Two legs red:

    AFreshInstallSaysNothingAndAnInstallSwitchedOnSays [FAIL]
    TurningItOffStopsTheNextArrivalRatherThanTheNextRestart [FAIL]
    Fehler!      : Fehler:     2, erfolgreich:     4, übersprungen:     0, gesamt:     6

**The endpoint announcing a join as well**, `== IntakeOutcome.Created` to `!= IntakeOutcome.AlreadyWaiting`:

    AnArrivalOverTheEndpointIsAnnouncedOnceAndAJoinIsNotAnnouncedAtAll [FAIL]
    Fehler!      : Fehler:     1, erfolgreich:     5, übersprungen:     0, gesamt:     6

**The seam announcing the wrong outcome**, one word:

    AWantHandedAcrossTheSeamIsAnnouncedOnceAndTheSameWantAgainIsNot [FAIL]
    Fehler!      : Fehler:     1, erfolgreich:     5, übersprungen:     0, gesamt:     6

**The borrowed name changed to the one a client obeys**, `ActivityLogEntry` to `GeneralCommand`:

    ThePushReachesTheAdministratorsAndNamesNobody [FAIL]
    Fehler!      : Fehler:     1, erfolgreich:     5, übersprungen:     0, gesamt:     6

**The two changed guards, in one run.** The exemption list emptied, and the requester path widened to
also push at the administrators:

    ConfigurationRulesTests.EverySettingIsNamedByARuleOrDeclaredUnrefusable [FAIL]
    TellingTheRequesterTests.ThePushNamesThatOnePersonAndNothingElseIsReachedFor [FAIL]
    Fehler!      : Fehler:     2, erfolgreich:    23, übersprungen:     0, gesamt:    25

## Two existing guards changed rather than added to, and why

**The session-manager double.** It refused `SendMessageToAdminSessions` by raising, which is what
`TellingTheRequesterTests` leaned on to say the requester path reached nobody else. It now records
that call in a list of its own, and that leg asserts the list is empty. The claim is the same claim
and it is now made rather than inherited; every other way of sending anything still raises, and the
run above is that assertion watched failing.

**`EverySettingIsNamedByARule`.** It required every setting to be refusable by some rule. A switch
over a path that does nothing but the thing it names has no value that cannot work, so the honest
choices were to invent a refusal with no failure behind it or to widen the guard. It is widened: a
setting is refused by a rule or is on a written-out list of settings no value of which can be
refused, and both directions stay closed, so a name on that list that no longer exists fails too.

## What was not done

**Nothing was run against a server, and no client was opened.** What the suite holds is what this
plugin asked the server to send, that it addressed the administrators, that nobody was named, and
that no other way of reaching anybody was used. That a message arrives, and that any client does
anything with it, is not shown here and is not claimed anywhere in the change.

**One file of one client was read, at one commit.** The measurement above says what `jellyfin-web`
subscribes to in `serverNotifications.js` at `5389bba`. It is not a claim about any other Jellyfin
client, and not a claim that no file anywhere in that repository reads another name.

**The invariant lint was not run on this machine.** `opengrep` is not on this machine and the
workflow fetches a Linux binary, so that leg is left to the gate here rather than checked before the
push. The rules that could have bitten were read instead: the page rules match text written between
tags and an accessible name written as a literal, and the two controls added carry `data-i18n` keys
and no text.

**Prettier was checked, and not in this working tree.** This checkout has CRLF line endings, which
the repository's `.editorconfig` says are LF, so a local `--check` warns on thirty files including
ones this change does not touch. The four files here that the gate's glob reaches were copied out
with LF beside a copy of `.editorconfig` and checked at the pinned version:

    npx --yes prettier@3.6.2 --check configPage.html docs/configuration.md docs/notifications.md docs/personal-data.md
    All matched files use Prettier code style!

**This change is larger than the inherited four hundred line cap**, at 967 insertions across 32
files. Most of it is the documentation comments this tree asks of every type and the new test class;
the mechanical part is one argument added at fourteen construction sites of the controller and six of
the seam. It is one topic and splitting it would produce two halves neither of which builds.

**There is no second reader on this board tonight.** The runs above are in place of one, and the
near-miss for each guard is the part to read first.
