### PR TITLE
Say what a server has been watched answering on the request API

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -658,10 +658,40 @@ this table names, the default included.
 
 What none of that holds is the server turning a caller away, which is the server's own evaluation of
 the policy and needs a running one. `docs/testing.md` carries that as a refused test with what
-replaces it. **That applies to the repair above as well: no run on a server records these endpoints
-answering anything other than 500.** What is measured is that the name they used exists on neither
-line and that the name they use now exists on both. The first-load procedure in `docs/testing.md` is
-where a run against a server would go, and it has not been made since this changed.
+replaces it, and what replaces it there is a run rather than a plan.
+
+**This paragraph said that no run on a server records these endpoints answering anything other than
+500, and that has stopped being true.** Two checks ask a real Jellyfin of each claimed line, on every
+pull request and nightly. `One person's requests on a real server` asks the queue as a signed-in
+person who is not an administrator. Read at `0a78ab5`, in job `97088428212` on the 10.11 line:
+
+    gh api repos/Flowfin/jellyfin-plugin-requests/actions/jobs/97088428212/logs \
+      | grep -oa 'the queue answered.*\|the queue refused.*\|the administrator is served.*'
+    the queue answered 403
+    the queue refused with 403 and carried nothing that belongs to anybody.
+    the administrator is served 3 rows and all three titles are among them.
+
+The same command against job `97088428126`, which is the 12.0 line of the same run, returns the same
+three lines. So the elevation policy on that action is evaluated by the server and the caller is
+turned away, on both lines, and the third line is what makes the first two say anything: the same
+call as an administrator is served, so a queue broken for everybody cannot pass as a refusal.
+
+**Six of the ten rows above have been answered by a server, and four have not.** The check quoted
+above makes `POST Requests`, `GET Requests`, `GET Requests/Queue` and `GET Page`. `Activity entries
+on a real server` makes `POST Requests/{id}/Approve` and `POST Requests/{id}/Decline`, and the
+entries the server wrote afterwards are what says both were carried out rather than refused:
+
+    gh api repos/Flowfin/jellyfin-plugin-requests/actions/jobs/97088428729/logs \
+      | grep -oa 'Type=MediaRequest[A-Za-z]*'
+    Type=MediaRequestDeclined
+    Type=MediaRequestApproved
+
+Job `97088428783` is the 12.0 line of that run and returns the same two lines. `GET Capabilities`,
+`GET Strings`, `POST Requests/Approve` and `POST Requests/Decline` have not been asked of a server at
+all, so what is held of those four is the assembly reading above and nothing more.
+
+What is measured about the constant is unchanged and is the other half of this: the name they used
+exists on neither line and the name they use now exists on both.
 
 The rule underneath the table is narrower than the table. **A user sees their own requests in full
 and learns nothing at all about anybody else's**, which is what `GET Requests` returns and why its


### PR DESCRIPTION
Closes #6.

`docs/api.md` said, under the table of who may reach what, that no run on a server records these
endpoints answering anything other than 500, and that the first-load procedure was where such a run
would go and had not been made since the policy names changed. Neither is true any more. This
replaces that paragraph with what has been watched, and with the part of the table no server has been
asked about.

## What the runs show

Read at `0a78ab5`, the head of the last change to land, in job `97088428212` on the 10.11 line:

    gh api repos/Flowfin/jellyfin-plugin-requests/actions/jobs/97088428212/logs \
      | grep -oa 'the queue answered.*\|the queue refused.*\|the administrator is served.*'
    the queue answered 403
    the queue refused with 403 and carried nothing that belongs to anybody.
    the administrator is served 3 rows and all three titles are among them.

Job `97088428126` is the 12.0 line of the same run and returns the same three lines. Both jobs
succeeded:

    gh api repos/Flowfin/jellyfin-plugin-requests/actions/runs/32596581422/jobs \
      --jq '.jobs[] | "\(.id)\t\(.name)\t\(.conclusion)"'
    97088428126	isolation 12.0	success
    97088428212	isolation 10.11	success

The two decision endpoints were carried out on a real server by the activity check of the same head,
and the entries the server wrote afterwards are what says so:

    gh api repos/Flowfin/jellyfin-plugin-requests/actions/jobs/97088428729/logs \
      | grep -oa 'Type=MediaRequest[A-Za-z]*'
    Type=MediaRequestDeclined
    Type=MediaRequestApproved

Job `97088428783` is the 12.0 line of that run and returns the same two lines.

## What the paragraph now refuses to round up

Six of the ten rows in that table have been answered by a server. `GET Capabilities`,
`GET Strings`, `POST Requests/Approve` and `POST Requests/Decline` have not been asked of one at all,
and the paragraph names them, so the reading that used to cover all ten now covers four and says
which.

## That the guard behind it bites

The refusal is not asserted by this change, it is asserted by a check that has been watched failing.
`proof/67-the-queue-is-not-closed-to-everybody` takes the elevation off the queue action, which is
one word, and both lines go red at that step:

    gh api repos/Flowfin/jellyfin-plugin-requests/actions/runs/32560880189/jobs \
      --jq '.jobs[] | "\(.name)\t\(.conclusion)"'
    isolation 10.11	failure
    isolation 12.0	failure

That branch is not for merging and has no pull request.

## Why this closes the milestone

The three conditions on #6, read at `e07571c`:

**Every issue in this milestone is closed.** This one is the last:

    gh issue list --repo Flowfin/jellyfin-plugin-requests --state open \
      --milestone "M6 The request API" --json number --jq '[.[].number]|sort'
    [6]

**Every endpoint carries an explicit authorisation policy, and a test asserts the refusal for a
caller who should not reach it.** Eleven endpoints, eleven attributes, and four legs hold the
declarations, one of which is the method that inherits its policy from the controller rather than
carrying one:

    git grep -c 'Http\(Get\|Post\|Put\|Delete\|Patch\)' origin/master -- Jellyfin.Plugin.Requests/Api/ \
      | awk -F: '{s+=$NF} END {print s}'
    11

    git grep -n 'public void ' origin/master -- Jellyfin.Plugin.Requests.Tests/Api/EndpointPolicyTests.cs
    origin/master:Jellyfin.Plugin.Requests.Tests/Api/EndpointPolicyTests.cs:121:    public void EveryEndpointCarriesThePolicyWrittenDownForIt()
    origin/master:Jellyfin.Plugin.Requests.Tests/Api/EndpointPolicyTests.cs:148:    public void NoEndpointInheritsItsPolicyFromTheControllerItSitsOn()
    origin/master:Jellyfin.Plugin.Requests.Tests/Api/EndpointPolicyTests.cs:165:    public void NoEndpointIsReachableWithoutASession()
    origin/master:Jellyfin.Plugin.Requests.Tests/Api/EndpointPolicyTests.cs:183:    public void TheControllerItselfCarriesAPolicy()

The refusal half is the run quoted above. That is a caller who should not reach an endpoint being
turned away by a real server of each claimed line, which is what a suite here cannot do and what the
condition asks for.

**The route prefix and the version rule are written down, and a change that breaks a caller is a
version change rather than a silent edit.**

    git grep -n '^## The prefix$\|^## The version rule$\|^## Who may reach what$' origin/master -- docs/api.md
    origin/master:docs/api.md:3:## The prefix
    origin/master:docs/api.md:23:## The version rule
    origin/master:docs/api.md:586:## Who may reach what

The published document is compared against a written-down set of operations and separately against
the assembly, so an endpoint removed, moved, hidden or answering with a different type reds the
suite.

## What is still not covered, and it is not this issue's

An unauthenticated caller has never been turned away by a server here. Nothing in
`scripts/verify-user-isolation.sh` makes a call without a token, so
`NoEndpointIsReachableWithoutASession` is a declaration read off the assembly and not a run. The
condition asks for a caller who should not reach an endpoint, and the one that was refused is a
signed-in person without elevation.

A field renamed or retyped inside one of the answer shapes is not caught by the document comparison,
because the written-down set carries the name of the type and not its properties. That is on the
page's own list of breaking changes and is caught by a reader.

## The suite

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    0 Warnung(en)
    0 Fehler

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler:     0, erfolgreich:   646, uebersprungen:     0, gesamt:   646 (net9.0)
    Bestanden!   : Fehler:     0, erfolgreich:   646, uebersprungen:     0, gesamt:   646 (net10.0)

The two lines above are the summary of a run whose output is in German, which is the language this
machine is set to. Nothing else was elided.

**Nothing here was run against a server by me.** Every server statement in this change quotes a
recorded run of a check that already exists. **This change has no second reader**, and the evidence
above stands in place of one.
