### PR TITLE
Ask a full disk what the caller is told

### DIFF
--- a/.github/workflows/full-disk.yaml
+++ b/.github/workflows/full-disk.yaml
@@ -1,0 +1,83 @@
+# What a caller sees when the volume the store writes to runs out of room.
+#
+# #46 asks for three things and the suite holds two of them. A write stopped in the middle, and
+# persisted bytes cut short at every offset, are both cheap to produce on any machine and both run
+# under `dotnet test`. The third is a full disk, and it is listed separately because it is the one
+# failure of the three where the wrong outcome looks exactly like the right one: a request that was
+# never written, on a call that returned normally.
+#
+# It cannot run in the suite. Filling a filesystem means having one to fill, and the headless rule
+# in `docs/testing.md` refuses a test that needs a container engine. So it runs here, on a mount
+# with a hard size, and nothing outside that mount is written to.
+#
+# The probe refuses to report a measurement it did not make. If every addition succeeds it exits 2
+# saying nothing was measured, which is what a mount that was never size limited produces, so a
+# green run on this job is a run in which the filesystem actually filled.
+#
+# Both claimed lines, because a store that reports a full disk on one runtime and swallows it on the
+# other is a difference between the two server lines, and running one of them would find it on
+# whichever line nobody ran.
+#
+# It runs on pull requests as well as on a schedule, for the reason the activity check gives: a
+# check of this shape that only runs nightly reports a defect after it has landed.
+name: A full disk reaches the caller
+
+on:
+  pull_request:
+    branches: ["**"]
+  schedule:
+    - cron: "23 5 * * *"
+  workflow_dispatch:
+
+# Explicit deny-all at workflow level; the job grants what it needs.
+permissions: {}
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  full-disk:
+    name: full disk ${{ matrix.line }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    strategy:
+      # Both lines run whatever the other one does. A failure on one is a fact about that line, and
+      # cancelling the other would leave nobody knowing whether it is a fact about both.
+      fail-fast: false
+      matrix:
+        include:
+          - line: "10.11"
+            framework: "net9.0"
+          - line: "12.0"
+            framework: "net10.0"
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Nothing here pushes, so do not leave the token in .git/config.
+          persist-credentials: false
+
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: |
+            9.0.x
+            10.0.x
+
+      - name: Does a full disk reach the caller
+        # The matrix value arrives as an environment variable rather than as an expression inside
+        # the script, for the reason the isolation check gives: it is written in this file and is
+        # not somebody's input, and the shape is what keeps that true when a later matrix takes a
+        # value from somewhere else.
+        env:
+          FRAMEWORK: ${{ matrix.framework }}
+        run: |
+          set -euo pipefail
+          ./scripts/verify-full-disk.sh "$FRAMEWORK"

--- a/Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj
+++ b/Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj
@@ -70,6 +70,7 @@
          server and a container engine, which is the refusal they are the replacement for. -->
     <None Include="../scripts/verify-plugin-loads.sh" Link="scripts/verify-plugin-loads.sh" CopyToOutputDirectory="PreserveNewest" />
     <None Include="../scripts/verify-user-isolation.sh" Link="scripts/verify-user-isolation.sh" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="../scripts/verify-full-disk.sh" Link="scripts/verify-full-disk.sh" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.Requests.Tests/RepositoryDocumentsTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/RepositoryDocumentsTests.cs
@@ -232,7 +232,7 @@ public sealed class RepositoryDocumentsTests
     /// </summary>
     /// <returns>One path in the tree per case.</returns>
     public static TheoryData<string> ProceduresTheRefusalListNames()
-        => new TheoryData<string> { "scripts/verify-plugin-loads.sh", "scripts/verify-user-isolation.sh" };
+        => new TheoryData<string> { "scripts/verify-plugin-loads.sh", "scripts/verify-user-isolation.sh", "scripts/verify-full-disk.sh" };
 
     /// <summary>
     /// The refusal list names a procedure for each refusal a running server answers instead of the

--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -291,12 +291,12 @@ produce several.
 Twelve files here map onto a file there and are placed by the table above:
 `dco.yml`, `dependency-review.yml`, `invariant-lint.yaml`, `mutation.yaml`,
 `package.yaml`, `prettier.yml`, `pr-hygiene.yaml`, `publish.yaml`,
-`scan-codeql.yaml`, `scorecard.yml`, `unicode-guard.yml` and `zizmor.yml`. Seven
-of the rows below name a file that is present, and twelve plus seven is what the
+`scan-codeql.yaml`, `scorecard.yml`, `unicode-guard.yml` and `zizmor.yml`. Eight
+of the rows below name a file that is present, and twelve plus eight is what the
 directory holds:
 
     $ ls .github/workflows/ | wc -l
-    19
+    20
 
 This paragraph said eleven and three and pasted 14, and the three numbers were
 wrong in one way: `package.yaml`, `seam-probe.yaml` and `user-isolation.yaml` had
@@ -317,19 +317,20 @@ vanishes without one is a question somebody asks again. `Disposition` says which
 of the two a row is, so no reader has to infer presence from a table that no
 longer tracks it.
 
-| File here               | Disposition       | Reasoning                                                                                                                                                                                                                                                                  |
-| ----------------------- | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `abi-floor.yaml`        | adopted, landed   | The floor leg, split out because the lines and their floors are read out of the packaging files rather than listed in a job, so adding a line is adding a file.                                                                                                            |
-| `activity-entries.yaml` | adopted, landed   | A request walked through its life on a real server of each line, with the activity entries read back out of the endpoint the dashboard draws. It reports and holds no merge; #107 is where required contexts are decided.                                                  |
-| `sibling-set.yaml`      | adopted, landed   | This plugin alone and beside the supported sibling set, on a real server of each line, with a collision scan over routes, scheduled task names and plugin configuration. #119.                                                                                             |
-| `build.yaml`            | adopted, landed   | The trigger surface and the two check names the ruleset matches literally; the legs themselves moved into `gate.yaml`.                                                                                                                                                     |
-| `gate.yaml`             | adopted, landed   | The build and test legs, in this repository rather than called from another organisation, because a called workflow knows nothing about this tree's lockfiles.                                                                                                             |
-| `seam-probe.yaml`       | adopted, landed   | What a second plugin in the same server process can see of this one, measured on a real server of each line with `tools/seam-probe` as the second plugin. It records an answer rather than holding a merge, so what reds it is a run that produced no answer at all. #117. |
-| `user-isolation.yaml`   | adopted, landed   | Two ordinary accounts on a real server of each line, each asking for something and reading back what they are given, with the queue asked as somebody who is not an administrator. The server's own evaluation of a policy is the half no double here reaches. #67.        |
-| `changelog.yaml`        | declined, deleted | It drafts a release changelog against a version scheme this repository has not fixed, and nothing covers that risk here because there is nothing to release yet; #107.                                                                                                     |
-| `command-dispatch.yaml` | declined, deleted | It turns issue comments into workflow runs, which is a surface this repository does not use, and nothing here needs covering because nothing depends on it.                                                                                                                |
-| `command-rebase.yaml`   | declined, deleted | Same comment-driven surface, the half that rewrites pull request branches on command, and the same absence.                                                                                                                                                                |
-| `sync-labels.yaml`      | declined, deleted | It overwrites the label vocabulary from a file in another organisation, and the vocabulary here is this board's own, so adopting it would delete what it is meant to keep.                                                                                                 |
+| File here               | Disposition       | Reasoning                                                                                                                                                                                                                                                                    |
+| ----------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `abi-floor.yaml`        | adopted, landed   | The floor leg, split out because the lines and their floors are read out of the packaging files rather than listed in a job, so adding a line is adding a file.                                                                                                              |
+| `activity-entries.yaml` | adopted, landed   | A request walked through its life on a real server of each line, with the activity entries read back out of the endpoint the dashboard draws. It reports and holds no merge; #107 is where required contexts are decided.                                                    |
+| `sibling-set.yaml`      | adopted, landed   | This plugin alone and beside the supported sibling set, on a real server of each line, with a collision scan over routes, scheduled task names and plugin configuration. #119.                                                                                               |
+| `build.yaml`            | adopted, landed   | The trigger surface and the two check names the ruleset matches literally; the legs themselves moved into `gate.yaml`.                                                                                                                                                       |
+| `gate.yaml`             | adopted, landed   | The build and test legs, in this repository rather than called from another organisation, because a called workflow knows nothing about this tree's lockfiles.                                                                                                               |
+| `seam-probe.yaml`       | adopted, landed   | What a second plugin in the same server process can see of this one, measured on a real server of each line with `tools/seam-probe` as the second plugin. It records an answer rather than holding a merge, so what reds it is a run that produced no answer at all. #117.   |
+| `user-isolation.yaml`   | adopted, landed   | Two ordinary accounts on a real server of each line, each asking for something and reading back what they are given, with the queue asked as somebody who is not an administrator. The server's own evaluation of a policy is the half no double here reaches. #67.          |
+| `full-disk.yaml`        | adopted, landed   | What a caller sees when the volume the store writes to runs out of room, on a mount with a hard size, on the runtime of each line. The suite cannot ask it: filling a filesystem needs one to fill, and the headless rule refuses a test that needs a container engine. #46. |
+| `changelog.yaml`        | declined, deleted | It drafts a release changelog against a version scheme this repository has not fixed, and nothing covers that risk here because there is nothing to release yet; #107.                                                                                                       |
+| `command-dispatch.yaml` | declined, deleted | It turns issue comments into workflow runs, which is a surface this repository does not use, and nothing here needs covering because nothing depends on it.                                                                                                                  |
+| `command-rebase.yaml`   | declined, deleted | Same comment-driven surface, the half that rewrites pull request branches on command, and the same absence.                                                                                                                                                                  |
+| `sync-labels.yaml`      | declined, deleted | It overwrites the label vocabulary from a file in another organisation, and the vocabulary here is this board's own, so adopting it would delete what it is meant to keep.                                                                                                   |
 
 ## Mutation testing is adopted, fuzzing is declined
 

--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -587,8 +587,8 @@ added, and #2 asks the same of them: a run in which the guard went red for the r
 a run in which the tree passes it. Nothing in this tree recorded either, so what follows is that
 record rather than a claim that it already existed.
 
-Eight of the twelve have both. Four do not, and the table says which rather than leaving a reader to
-take a full-looking column for a full one.
+Nine of the thirteen have both. Four do not, and the table says which rather than leaving a reader
+to take a full-looking column for a full one.
 
 **Two of those cells said the guard had no red run of this kind and both were wrong.** They were
 filled from the three most recent failures of each workflow rather than from its whole history, which
@@ -621,9 +621,9 @@ workflow that ran on it succeeded:
     32603611353  success  110abde  🧾 PR hygiene
 
 Two names appear twice because two triggers fired on one head, and two of the sixteen belong to the
-inherited section above rather than to this one. Two workflows do not appear at all: `mutation.yaml`
-runs on a schedule and `seam-probe.yaml` on a push that touches the probe, so their green runs are
-their own and carry their own head.
+inherited section above rather than to this one. Three workflows do not appear at all: `mutation.yaml`
+runs on a schedule, `seam-probe.yaml` on a push that touches the probe, and `full-disk.yaml`
+arrived after that head, so their green runs are their own and carry their own head.
 
 | Workflow                      | Red run                                                                                                                                               | Green run                 |
 | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
@@ -639,6 +639,7 @@ their own and carry their own head.
 | `seam-probe.yaml`             | 32555537635, cause unproven, below                                                                                                                    | 32555794613, at `5b96f57` |
 | `sibling-set.yaml`            | none at all, below                                                                                                                                    | 32603611260               |
 | `user-isolation.yaml`         | 32560880189, `proof/67-the-queue-is-not-closed-to-everybody`, both lines red at the queue step                                                        | 32603611273               |
+| `full-disk.yaml`              | 32623464033, `throwaway/46-a-mount-nobody-limited`, both lines red at `Does a full disk reach the caller` with nothing measured                       | 32623457801, at `d154ab3` |
 
 The job and step of each red run are read off the run rather than off a log:
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -164,6 +164,29 @@ what an endpoint carries and never what a server does with it. The procedure run
 and on a schedule, so a mainline commit that no pull request carried has no reading of its own
 until the next nightly run.
 
+**Filling the volume the store writes to, as part of the ordinary suite.** Refused: there has to
+be a volume that may be filled, and making one means a container engine, which is the fourth
+condition. Filling the volume the checkout is on is worse than refused: it is a machine somebody
+else is using.
+
+What replaces it is `scripts/verify-full-disk.sh` and `tools/full-disk-probe`, run by
+`.github/workflows/full-disk.yaml` on every pull request and nightly, once per claimed line. The
+mount is `--tmpfs /data:size=256k`, so what fills is a filesystem of a fixed size that lives in
+memory and is discarded with the container, and nothing outside it is written to. The probe drives
+the store this repository ships, adds requests until one is refused, and asks four things: that a
+write failed at all, that the caller was told and what it was told, that the store it was told
+through still reports the set it held before, and that a store opened fresh over the same directory
+loads and holds that same set.
+
+**A run in which nothing filled is a refusal rather than a pass.** That is the mistake this shape
+exists against: a mount that is not size limited produces a job where every step succeeds and
+nothing was measured. The probe bounds the additions it will attempt and exits saying so, and the
+refusal is watched rather than assumed, below.
+
+What it does not do is prove anything about a disk that is full for a different reason. A tmpfs at
+its size limit is one way a write runs out of room; a quota, a full physical device and a
+filesystem out of inodes are others, and none of them was produced here.
+
 Every replacement named above exists, either as something already in the tree or as an issue on
 this board. The states move, and a paste taken once reads afterwards as a claim about today, so
 this one carries the commit it was read at, `ffa28c1`:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -178,10 +178,43 @@ write failed at all, that the caller was told and what it was told, that the sto
 through still reports the set it held before, and that a store opened fresh over the same directory
 loads and holds that same set.
 
+Read at `d154ab3`, the head that landed it, on the 10.11 line in job `97155092294` and on the 12.0
+line in job `97155092318`:
+
+    gh api repos/Flowfin/jellyfin-plugin-requests/actions/jobs/97155092294/logs | grep -a "== \|No space left" | sed 's/^[0-9T:.Z-]*Z //'
+    == publishing the probe for net9.0
+    == running the probe on a 256k filesystem under mcr.microsoft.com/dotnet/aspnet:9.0
+    == the store writes into /data
+    == running on 9.0.19
+    == 15 of at most 200 additions were accepted
+    == what the caller was told
+    No space left on device : '/data/requests.json.writing'
+    == the store that saw the failure now reports 15
+    == a store opened fresh over the same directory reports 15
+    == what is left on the mount
+    == the caller was told, and nothing that was accepted was lost
+
+The `sed` drops the timestamp the runner puts in front of every line. The same command against `97155092318` returns the same lines with `net10.0`, `aspnet:10.0` and
+`10.0.11` in the three that name the line. The
+fifteenth addition is the one the mount had no room for; the fourteen before it are still there,
+still readable, and still there after the store is opened again.
+
 **A run in which nothing filled is a refusal rather than a pass.** That is the mistake this shape
 exists against: a mount that is not size limited produces a job where every step succeeds and
-nothing was measured. The probe bounds the additions it will attempt and exits saying so, and the
-refusal is watched rather than assumed, below.
+nothing was measured. The probe bounds the additions it will attempt and exits saying so, and that
+refusal is watched rather than assumed. `throwaway/46-a-mount-nobody-limited` raises the mount from
+`256k` to `64m`, which is one token, and both lines go red at the step the measurement is made in:
+
+    gh run view 32623464033 --repo Flowfin/jellyfin-plugin-requests --json headBranch,conclusion,jobs --jq '.headBranch, .conclusion, (.jobs[] | "\(.name)  \(.conclusion)")'
+    throwaway/46-a-mount-nobody-limited
+    failure
+    full disk 10.11  failure
+    full disk 12.0  failure
+
+    == 200 of at most 200 additions were accepted
+    NOTHING WAS MEASURED. 200 additions all succeeded, so the filesystem under /data never ran out of room. This run says nothing about what a caller sees on a full disk. Check that the mount is size limited.
+
+That branch is not for merging.
 
 What it does not do is prove anything about a disk that is full for a different reason. A tmpfs at
 its size limit is one way a write runs out of room; a quota, a full physical device and a

--- a/scripts/verify-full-disk.sh
+++ b/scripts/verify-full-disk.sh
@@ -19,7 +19,7 @@
 #
 # The runtime image is derived from the target framework rather than read out of
 # scripts/server-lines.tsv. That file pairs a framework with the Jellyfin server image that runs
-# the plugin, and no server is started here: what this needs is the bare .NET runtime the line
+# the plugin, and no server is started here: what this needs is the .NET runtime the line
 # provides, which is a different fact about the same framework.
 #
 # usage: scripts/verify-full-disk.sh <target-framework> [size]
@@ -31,9 +31,14 @@ set -euo pipefail
 framework=${1:?target framework, for example net9.0}
 size=${2:-256k}
 
+# The ASP.NET Core image rather than the bare runtime one. The plugin compiles against
+# Jellyfin.Controller, which carries a framework reference to Microsoft.AspNetCore.App, and that
+# reference is recorded in the probe's runtime configuration whether or not the store touches a
+# type from it. The bare runtime image refuses to start such an application, which is how this was
+# found: `No frameworks were found.` on both lines.
 case "$framework" in
-    net9.0) runtime=mcr.microsoft.com/dotnet/runtime:9.0 ;;
-    net10.0) runtime=mcr.microsoft.com/dotnet/runtime:10.0 ;;
+    net9.0) runtime=mcr.microsoft.com/dotnet/aspnet:9.0 ;;
+    net10.0) runtime=mcr.microsoft.com/dotnet/aspnet:10.0 ;;
     *)
         echo "no .NET runtime image for $framework. The claimed lines are:" >&2
         grep -v '^#' "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/server-lines.tsv" >&2

--- a/scripts/verify-full-disk.sh
+++ b/scripts/verify-full-disk.sh
@@ -55,16 +55,24 @@ dotnet publish "$root/tools/full-disk-probe/FullDiskProbe.csproj" \
     --framework "$framework" \
     --output "$out"
 
+# `mktemp -d` makes a directory only its owner may enter, and the runtime image runs as a user
+# that is not that owner, so without this the container cannot see the published probe at all.
+# It failed that way the first time this ran, with `realpath(/probe/...) failed: Permission
+# denied`, which reads as a missing file rather than as a permission.
+chmod -R a+rX "$out"
+
 echo "== running the probe on a $size filesystem under $runtime"
 
 # --network none because nothing here talks to anything, --cap-drop ALL and no-new-privileges
 # because a probe needs none of it, and the published output goes in read-only: the only thing this
 # container may write to is the mount it is here to fill.
+# mode=1777 on that mount for the same reason as the chmod above: the container is not root, and
+# the mount is the one place it has to be able to write.
 docker run --rm \
     --network none \
     --cap-drop ALL \
     --security-opt no-new-privileges \
     --volume "$out:/probe:ro" \
-    --tmpfs "/data:size=$size" \
+    --tmpfs "/data:rw,size=$size,mode=1777" \
     "$runtime" \
     dotnet /probe/Jellyfin.Plugin.Requests.FullDiskProbe.dll /data

--- a/scripts/verify-full-disk.sh
+++ b/scripts/verify-full-disk.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Ask the shipped store what a caller sees when the volume it writes to runs out of room.
+#
+# This is the third condition of #46. The other two are met by tests in the ordinary suite, which
+# truncate the persisted bytes at every offset and stop a write in the middle. Neither of those
+# needs anything the machine does not already have. Filling a disk does, and the headless rule in
+# docs/testing.md refuses a suite that needs a container engine, so the measurement is made here
+# rather than under `dotnet test`.
+#
+# WHAT IS FILLED IS A MOUNT WITH A HARD SIZE AND NOTHING ELSE. `--tmpfs /data:size=...` gives the
+# container a filesystem of exactly that size, in memory, discarded when the container exits.
+# Nothing outside it is written to, so the objection to filling a disk on somebody's machine does
+# not apply to filling this one.
+#
+# The probe is tools/full-disk-probe. It drives the store this repository ships, not a copy of it,
+# and it refuses to report a measurement it did not make: if every addition succeeds it exits 2
+# saying so, which is what a mount that was never size limited produces. A missing or mistyped size
+# is the mistake that would otherwise leave a green check that measured nothing.
+#
+# The runtime image is derived from the target framework rather than read out of
+# scripts/server-lines.tsv. That file pairs a framework with the Jellyfin server image that runs
+# the plugin, and no server is started here: what this needs is the bare .NET runtime the line
+# provides, which is a different fact about the same framework.
+#
+# usage: scripts/verify-full-disk.sh <target-framework> [size]
+#   scripts/verify-full-disk.sh net9.0
+#   scripts/verify-full-disk.sh net10.0 256k
+
+set -euo pipefail
+
+framework=${1:?target framework, for example net9.0}
+size=${2:-256k}
+
+case "$framework" in
+    net9.0) runtime=mcr.microsoft.com/dotnet/runtime:9.0 ;;
+    net10.0) runtime=mcr.microsoft.com/dotnet/runtime:10.0 ;;
+    *)
+        echo "no .NET runtime image for $framework. The claimed lines are:" >&2
+        grep -v '^#' "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/server-lines.tsv" >&2
+        exit 1
+        ;;
+esac
+
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+out=$(mktemp -d)
+trap 'rm -rf "$out"' EXIT
+
+echo "== publishing the probe for $framework"
+
+# Framework-dependent on purpose. The runtime under the measurement is then the one the image
+# carries and named in this file, rather than one bundled at publish time, so a run on the wrong
+# image fails to start instead of quietly measuring the other line.
+dotnet publish "$root/tools/full-disk-probe/FullDiskProbe.csproj" \
+    --configuration Release \
+    --framework "$framework" \
+    --output "$out"
+
+echo "== running the probe on a $size filesystem under $runtime"
+
+# --network none because nothing here talks to anything, --cap-drop ALL and no-new-privileges
+# because a probe needs none of it, and the published output goes in read-only: the only thing this
+# container may write to is the mount it is here to fill.
+docker run --rm \
+    --network none \
+    --cap-drop ALL \
+    --security-opt no-new-privileges \
+    --volume "$out:/probe:ro" \
+    --tmpfs "/data:size=$size" \
+    "$runtime" \
+    dotnet /probe/Jellyfin.Plugin.Requests.FullDiskProbe.dll /data

--- a/tools/full-disk-probe/Directory.Build.props
+++ b/tools/full-disk-probe/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+    <!-- INHERITANCE STOPS HERE, DELIBERATELY, for the reason the seam probe's copy of this file
+         gives: MSBuild walks up until it finds one of these, and the repository root's properties
+         belong to the artefact somebody installs. The probe is an instrument. It is built only by
+         the job that runs the measurement, it ships to nobody, and inheriting the plugin's version
+         number would make a second thing claim to be that version. -->
+
+</Project>

--- a/tools/full-disk-probe/FullDiskProbe.csproj
+++ b/tools/full-disk-probe/FullDiskProbe.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <!-- The same two targets the plugin claims. A store that reports a full disk on one runtime and
+         swallows it on the other is a difference between the two server lines, which is exactly the
+         kind of thing a probe run on one line only would miss. -->
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <RootNamespace>Jellyfin.Plugin.Requests.FullDiskProbe</RootNamespace>
+    <AssemblyName>Jellyfin.Plugin.Requests.FullDiskProbe</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <JellyfinVersion Condition="'$(JellyfinVersion)' == '' and '$(TargetFramework)' == 'net9.0'">10.11.11</JellyfinVersion>
+    <JellyfinVersion Condition="'$(JellyfinVersion)' == '' and '$(TargetFramework)' == 'net10.0'">12.0.0-rc4</JellyfinVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Without ExcludeAssets, unlike the plugin. The plugin leaves these out because a running
+         server supplies them and a package carrying a second copy is how a plugin breaks on the
+         server it was built for. Nothing supplies them to a probe running on its own, so the
+         runtime assets have to be here or the store cannot be constructed at all. This is the same
+         reason the test project references them this way. -->
+    <PackageReference Include="Jellyfin.Controller" Version="$(JellyfinVersion)" />
+    <PackageReference Include="Jellyfin.Model" Version="$(JellyfinVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- The project rather than a built assembly, so the store under measurement is the one in this
+         checkout and never a stale copy in a bin directory. -->
+    <ProjectReference Include="..\..\Jellyfin.Plugin.Requests\Jellyfin.Plugin.Requests.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/full-disk-probe/Program.cs
+++ b/tools/full-disk-probe/Program.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Time;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.Requests.FullDiskProbe;
+
+/// <summary>
+/// Asks the shipped store what a caller sees when the volume it writes to runs out of room.
+///
+/// The third condition of issue #46 is the one of the three where the wrong outcome looks exactly
+/// like the right one: a request that was never written, on a call that returned normally. The
+/// other two conditions are met by tests that truncate and interrupt, and both of those run in the
+/// ordinary suite. This one cannot, because a suite that needs a volume it may fill is a suite that
+/// needs a container engine, which the headless rule in docs/testing.md refuses.
+///
+/// So the measurement is made here, against the store this repository ships, on a filesystem whose
+/// size is fixed by whoever starts the container. Nothing outside that mount is touched.
+///
+/// What it reports:
+///
+///   - a write eventually failed, rather than the filesystem turning out to be large enough that
+///     nothing was measured
+///   - the caller was told, and what it was told
+///   - the store still answers with the set it held before the failed write
+///   - a store opened fresh over the same directory loads, and holds that same set
+///
+/// Exit codes: 0 all four hold, 1 one of them does not, 2 no write ever failed.
+/// </summary>
+internal static class Program
+{
+    /// <summary>
+    /// How many additions are attempted before the run is abandoned. It is a bound rather than a
+    /// loop that never ends, and it is what turns "the mount was not size limited" into a refusal
+    /// instead of a green run that measured nothing. A missing or mistyped size argument is the
+    /// one-character mistake this exists against.
+    /// </summary>
+    private const int Bound = 200;
+
+    /// <summary>
+    /// Characters of display title per request. Large so the document outgrows a small mount in a
+    /// few writes: the store serialises the whole set on every write, so a record small enough to
+    /// need thousands of them turns this into a long run rather than a better one.
+    /// </summary>
+    private const int TitleLength = 8192;
+
+    private static async Task<int> Main(string[] args)
+    {
+        if (args.Length != 1)
+        {
+            await Console.Error.WriteLineAsync("usage: Jellyfin.Plugin.Requests.FullDiskProbe <directory on a size limited filesystem>").ConfigureAwait(false);
+            return 1;
+        }
+
+        var directory = args[0];
+        var logger = new ConsoleLogger();
+        var clock = new SystemClock();
+
+        Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "== the store writes into {0}", directory));
+        Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "== running on {0}", Environment.Version));
+
+        var store = new FileRequestStore(directory, logger, clock);
+        var accepted = new List<Guid>();
+        Exception? refusal = null;
+
+        for (var ordinal = 0; ordinal < Bound; ordinal++)
+        {
+            var request = ARequest(ordinal);
+
+            try
+            {
+                await store.AddAsync(request, CancellationToken.None).ConfigureAwait(false);
+                accepted.Add(request.Id);
+            }
+            catch (Exception reason) when (reason is not OutOfMemoryException)
+            {
+                refusal = reason;
+                break;
+            }
+        }
+
+        Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "== {0} of at most {1} additions were accepted", accepted.Count, Bound));
+
+        if (refusal is null)
+        {
+            await Console.Error.WriteLineAsync(string.Format(
+                CultureInfo.InvariantCulture,
+                "NOTHING WAS MEASURED. {0} additions all succeeded, so the filesystem under {1} never ran out of room. This run says nothing about what a caller sees on a full disk. Check that the mount is size limited.",
+                Bound,
+                directory)).ConfigureAwait(false);
+            return 2;
+        }
+
+        Console.WriteLine("== what the caller was told");
+        Console.WriteLine(refusal.GetType().FullName);
+        Console.WriteLine(refusal.Message);
+
+        var wrong = new List<string>();
+
+        if (refusal is not IOException)
+        {
+            wrong.Add(string.Format(
+                CultureInfo.InvariantCulture,
+                "the caller was told {0}, which is not the IOException a filesystem raises when it is out of room",
+                refusal.GetType().FullName));
+        }
+
+        var stillHeld = await store.GetAllAsync(CancellationToken.None).ConfigureAwait(false);
+        Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "== the store that saw the failure now reports {0}", stillHeld.Count));
+
+        if (!SameSet(stillHeld, accepted))
+        {
+            wrong.Add("the store that saw the failure does not report the set it held before the write that failed");
+        }
+
+        IReadOnlyList<StoredRequest> reopened;
+
+        try
+        {
+            reopened = await new FileRequestStore(directory, logger, clock).GetAllAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (RequestStoreLoadException reason)
+        {
+            Console.WriteLine("== a store opened fresh over the same directory refused to load");
+            Console.WriteLine(reason.Message);
+            wrong.Add("a store opened fresh over the same directory does not load");
+            reopened = Array.Empty<StoredRequest>();
+        }
+
+        Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "== a store opened fresh over the same directory reports {0}", reopened.Count));
+
+        if (!SameSet(reopened, accepted))
+        {
+            wrong.Add("a store opened fresh over the same directory does not hold the set that was accepted before the write that failed");
+        }
+
+        Console.WriteLine("== what is left on the mount");
+
+        foreach (var file in new DirectoryInfo(directory).EnumerateFiles().OrderBy(file => file.Name, StringComparer.Ordinal))
+        {
+            Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "{0}\t{1}", file.Length, file.Name));
+        }
+
+        if (wrong.Count > 0)
+        {
+            foreach (var line in wrong)
+            {
+                await Console.Error.WriteLineAsync(line).ConfigureAwait(false);
+            }
+
+            return 1;
+        }
+
+        Console.WriteLine("== the caller was told, and nothing that was accepted was lost");
+        return 0;
+    }
+
+    private static bool SameSet(IReadOnlyList<StoredRequest> held, IReadOnlyList<Guid> accepted)
+        => held.Select(stored => stored.Request.Id).OrderBy(id => id).SequenceEqual(accepted.OrderBy(id => id));
+
+    private static MediaRequest ARequest(int ordinal)
+    {
+        var asked = new DateTimeOffset(2026, 8, 8, 8, 0, 0, TimeSpan.Zero);
+
+        return new MediaRequest
+        {
+            Id = new Guid(string.Format(CultureInfo.InvariantCulture, "00000000-0000-0000-0000-{0:D12}", ordinal)),
+            RequestedByUserId = new Guid("b31d0f9a-5c2e-4a71-8f6b-0d4c3e2a1b58"),
+            RequestedAt = asked,
+            StateChangedAt = asked,
+            Kind = RequestedItemKind.Movie,
+            DisplayTitle = new string('t', TitleLength)
+        };
+    }
+
+    /// <summary>
+    /// The store writes to a log before it throws, and on this run that log is evidence rather than
+    /// noise, so it goes to the output the job records instead of being dropped.
+    /// </summary>
+    private sealed class ConsoleLogger : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+            => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            ArgumentNullException.ThrowIfNull(formatter);
+
+            Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "[{0}] {1}", logLevel, formatter(state, exception)));
+        }
+    }
+}


### PR DESCRIPTION
Closes #46. That issue's third condition asks that a full disk produce an error the caller sees rather than a silently dropped request. The other two conditions were met when the store landed. This one had never been executed, and it is listed separately because it is the one failure of the three where the wrong outcome looks exactly like the right one.

## What this adds

`tools/full-disk-probe` drives the store this repository ships against a directory, adds requests until one is refused, and reports four things: that a write failed at all, what the caller was told, whether the store that saw the failure still reports the set it held before it, and whether a store opened fresh over the same directory loads and holds that same set.

`scripts/verify-full-disk.sh` publishes the probe framework-dependent and runs it under the ASP.NET Core image for one claimed line, on `--tmpfs /data:rw,size=256k,mode=1777`. What fills is a filesystem with a hard size that lives in memory and is discarded with the container, so nothing outside that mount is written to.

`.github/workflows/full-disk.yaml` runs it on every pull request and nightly, once per claimed line.

## What a caller is told

Green run 32623457801, at `d154ab3`, both lines:

    gh api repos/Flowfin/jellyfin-plugin-requests/actions/jobs/97155092294/logs | grep -a "== \|No space left" | sed 's/^[0-9T:.Z-]*Z //'
    == publishing the probe for net9.0
    == running the probe on a 256k filesystem under mcr.microsoft.com/dotnet/aspnet:9.0
    == the store writes into /data
    == running on 9.0.19
    == 15 of at most 200 additions were accepted
    == what the caller was told
    No space left on device : '/data/requests.json.writing'
    == the store that saw the failure now reports 15
    == a store opened fresh over the same directory reports 15
    == what is left on the mount
    == the caller was told, and nothing that was accepted was lost

The same command against job `97155092318` returns the same lines with `net10.0`, `aspnet:10.0` and `10.0.11` in the three that name the line. The sixteenth addition is the one the mount had no room for. It reached the caller as `System.IO.IOException` naming the file the write was building, the fifteen before it were still readable through the store that saw the refusal, and still readable through a store opened again over the same directory.

## That it bites

Red run 32623464033, on `throwaway/46-a-mount-nobody-limited` in #277, which raises the mount from `256k` to `64m` and changes nothing else:

    gh run view 32623464033 --repo Flowfin/jellyfin-plugin-requests --json headBranch,conclusion,jobs --jq '.headBranch, .conclusion, (.jobs[] | "\(.name)  \(.conclusion)")'
    throwaway/46-a-mount-nobody-limited
    failure
    full disk 10.11  failure
    full disk 12.0  failure

    == 200 of at most 200 additions were accepted
    NOTHING WAS MEASURED. 200 additions all succeeded, so the filesystem under /data never ran out of room. This run says nothing about what a caller sees on a full disk. Check that the mount is size limited.

That is the mistake this shape exists against: a mount that is not size limited otherwise produces a job in which every step succeeds and nothing was measured. The probe bounds the additions it will attempt and refuses rather than reporting a pass. The throwaway branch is not for merging.

## Why it is not a test

The headless rule in `docs/testing.md` refuses a test that needs a container engine, and filling a filesystem means having one to fill. Filling the volume the checkout sits on is worse than refused: it is a machine somebody else is using. So this is the same shape as the first-load procedure and the isolation procedure, and the refusal list now carries it with what replaces it.

## Two things this got wrong on the way, both recorded in the commits

The publish output goes to a directory `mktemp` makes readable only by its owner, and the image runs as a user that is not that owner, so the first run reported `realpath(/probe/...) failed: Permission denied` and the runtime turned that into an application that does not exist. The second run reached the runtime and found no `Microsoft.AspNetCore.App`, which the plugin's framework reference asks for whether or not the store touches a type from it.

## The means

Bash and a container for the harness, C# on the plugin's own two target frameworks for the probe. The harness is forced: a size-limited filesystem is a property of a mount and no .NET API creates one. The probe is C# because the subject is this plugin's own store, and reimplementing its write path in another language would measure a copy. Both are what this tree already carries for the two procedures beside them.

## What was run here

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Der Buildvorgang wurde erfolgreich ausgefuehrt.
        0 Warnung(en)
        0 Fehler

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler:     0, erfolgreich:   648, uebersprungen:     0, gesamt:   648 (net9.0)
    Bestanden!   : Fehler:     0, erfolgreich:   648, uebersprungen:     0, gesamt:   648 (net10.0)

The 648th is the new case of `TheRefusalListNamesAProcedureThatIsThere`, which reaches the new procedure because the test project copies it beside the two it already held.

## What this does not cover

A tmpfs at its size limit is one way a write runs out of room. A quota, a full physical device and a filesystem out of inodes are others, and none of them was produced here. That is written into `docs/testing.md` rather than only here.

**No disk on this machine was filled and no Jellyfin server was started.** The container engine on this machine does not connect, which is why the measurement is made on the runner and read back rather than watched locally.

**This has no second reader tonight.** The evidence above stands in place of one: both runs quoted with the commands that produced them, the near-miss executed rather than described, and the bound of the measurement stated rather than left to be inferred.
