### PR TITLE
Throwaway: watch the full disk check red when the mount is not small enough to fill

### DIFF
--- a/.github/workflows/full-disk.yaml
+++ b/.github/workflows/full-disk.yaml
@@ -1,0 +1,83 @@
+# What a caller sees when the volume the store writes to runs out of room.
+#
+# #46 asks for three things and the suite holds two of them. A write stopped in the middle, and
+# persisted bytes cut short at every offset, are both cheap to produce on any machine and both run
+# under `dotnet test`. The third is a full disk, and it is listed separately because it is the one
+# failure of the three where the wrong outcome looks exactly like the right one: a request that was
+# never written, on a call that returned normally.
+#
+# It cannot run in the suite. Filling a filesystem means having one to fill, and the headless rule
+# in `docs/testing.md` refuses a test that needs a container engine. So it runs here, on a mount
+# with a hard size, and nothing outside that mount is written to.
+#
+# The probe refuses to report a measurement it did not make. If every addition succeeds it exits 2
+# saying nothing was measured, which is what a mount that was never size limited produces, so a
+# green run on this job is a run in which the filesystem actually filled.
+#
+# Both claimed lines, because a store that reports a full disk on one runtime and swallows it on the
+# other is a difference between the two server lines, and running one of them would find it on
+# whichever line nobody ran.
+#
+# It runs on pull requests as well as on a schedule, for the reason the activity check gives: a
+# check of this shape that only runs nightly reports a defect after it has landed.
+name: A full disk reaches the caller
+
+on:
+  pull_request:
+    branches: ["**"]
+  schedule:
+    - cron: "23 5 * * *"
+  workflow_dispatch:
+
+# Explicit deny-all at workflow level; the job grants what it needs.
+permissions: {}
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  full-disk:
+    name: full disk ${{ matrix.line }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    strategy:
+      # Both lines run whatever the other one does. A failure on one is a fact about that line, and
+      # cancelling the other would leave nobody knowing whether it is a fact about both.
+      fail-fast: false
+      matrix:
+        include:
+          - line: "10.11"
+            framework: "net9.0"
+          - line: "12.0"
+            framework: "net10.0"
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Nothing here pushes, so do not leave the token in .git/config.
+          persist-credentials: false
+
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: |
+            9.0.x
+            10.0.x
+
+      - name: Does a full disk reach the caller
+        # The matrix value arrives as an environment variable rather than as an expression inside
+        # the script, for the reason the isolation check gives: it is written in this file and is
+        # not somebody's input, and the shape is what keeps that true when a later matrix takes a
+        # value from somewhere else.
+        env:
+          FRAMEWORK: ${{ matrix.framework }}
+        run: |
+          set -euo pipefail
+          ./scripts/verify-full-disk.sh "$FRAMEWORK"

--- a/Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj
+++ b/Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj
@@ -70,6 +70,7 @@
          server and a container engine, which is the refusal they are the replacement for. -->
     <None Include="../scripts/verify-plugin-loads.sh" Link="scripts/verify-plugin-loads.sh" CopyToOutputDirectory="PreserveNewest" />
     <None Include="../scripts/verify-user-isolation.sh" Link="scripts/verify-user-isolation.sh" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="../scripts/verify-full-disk.sh" Link="scripts/verify-full-disk.sh" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.Requests.Tests/RepositoryDocumentsTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/RepositoryDocumentsTests.cs
@@ -232,7 +232,7 @@ public sealed class RepositoryDocumentsTests
     /// </summary>
     /// <returns>One path in the tree per case.</returns>
     public static TheoryData<string> ProceduresTheRefusalListNames()
-        => new TheoryData<string> { "scripts/verify-plugin-loads.sh", "scripts/verify-user-isolation.sh" };
+        => new TheoryData<string> { "scripts/verify-plugin-loads.sh", "scripts/verify-user-isolation.sh", "scripts/verify-full-disk.sh" };
 
     /// <summary>
     /// The refusal list names a procedure for each refusal a running server answers instead of the

--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -291,12 +291,12 @@ produce several.
 Twelve files here map onto a file there and are placed by the table above:
 `dco.yml`, `dependency-review.yml`, `invariant-lint.yaml`, `mutation.yaml`,
 `package.yaml`, `prettier.yml`, `pr-hygiene.yaml`, `publish.yaml`,
-`scan-codeql.yaml`, `scorecard.yml`, `unicode-guard.yml` and `zizmor.yml`. Seven
-of the rows below name a file that is present, and twelve plus seven is what the
+`scan-codeql.yaml`, `scorecard.yml`, `unicode-guard.yml` and `zizmor.yml`. Eight
+of the rows below name a file that is present, and twelve plus eight is what the
 directory holds:
 
     $ ls .github/workflows/ | wc -l
-    19
+    20
 
 This paragraph said eleven and three and pasted 14, and the three numbers were
 wrong in one way: `package.yaml`, `seam-probe.yaml` and `user-isolation.yaml` had
@@ -317,19 +317,20 @@ vanishes without one is a question somebody asks again. `Disposition` says which
 of the two a row is, so no reader has to infer presence from a table that no
 longer tracks it.
 
-| File here               | Disposition       | Reasoning                                                                                                                                                                                                                                                                  |
-| ----------------------- | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `abi-floor.yaml`        | adopted, landed   | The floor leg, split out because the lines and their floors are read out of the packaging files rather than listed in a job, so adding a line is adding a file.                                                                                                            |
-| `activity-entries.yaml` | adopted, landed   | A request walked through its life on a real server of each line, with the activity entries read back out of the endpoint the dashboard draws. It reports and holds no merge; #107 is where required contexts are decided.                                                  |
-| `sibling-set.yaml`      | adopted, landed   | This plugin alone and beside the supported sibling set, on a real server of each line, with a collision scan over routes, scheduled task names and plugin configuration. #119.                                                                                             |
-| `build.yaml`            | adopted, landed   | The trigger surface and the two check names the ruleset matches literally; the legs themselves moved into `gate.yaml`.                                                                                                                                                     |
-| `gate.yaml`             | adopted, landed   | The build and test legs, in this repository rather than called from another organisation, because a called workflow knows nothing about this tree's lockfiles.                                                                                                             |
-| `seam-probe.yaml`       | adopted, landed   | What a second plugin in the same server process can see of this one, measured on a real server of each line with `tools/seam-probe` as the second plugin. It records an answer rather than holding a merge, so what reds it is a run that produced no answer at all. #117. |
-| `user-isolation.yaml`   | adopted, landed   | Two ordinary accounts on a real server of each line, each asking for something and reading back what they are given, with the queue asked as somebody who is not an administrator. The server's own evaluation of a policy is the half no double here reaches. #67.        |
-| `changelog.yaml`        | declined, deleted | It drafts a release changelog against a version scheme this repository has not fixed, and nothing covers that risk here because there is nothing to release yet; #107.                                                                                                     |
-| `command-dispatch.yaml` | declined, deleted | It turns issue comments into workflow runs, which is a surface this repository does not use, and nothing here needs covering because nothing depends on it.                                                                                                                |
-| `command-rebase.yaml`   | declined, deleted | Same comment-driven surface, the half that rewrites pull request branches on command, and the same absence.                                                                                                                                                                |
-| `sync-labels.yaml`      | declined, deleted | It overwrites the label vocabulary from a file in another organisation, and the vocabulary here is this board's own, so adopting it would delete what it is meant to keep.                                                                                                 |
+| File here               | Disposition       | Reasoning                                                                                                                                                                                                                                                                    |
+| ----------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `abi-floor.yaml`        | adopted, landed   | The floor leg, split out because the lines and their floors are read out of the packaging files rather than listed in a job, so adding a line is adding a file.                                                                                                              |
+| `activity-entries.yaml` | adopted, landed   | A request walked through its life on a real server of each line, with the activity entries read back out of the endpoint the dashboard draws. It reports and holds no merge; #107 is where required contexts are decided.                                                    |
+| `sibling-set.yaml`      | adopted, landed   | This plugin alone and beside the supported sibling set, on a real server of each line, with a collision scan over routes, scheduled task names and plugin configuration. #119.                                                                                               |
+| `build.yaml`            | adopted, landed   | The trigger surface and the two check names the ruleset matches literally; the legs themselves moved into `gate.yaml`.                                                                                                                                                       |
+| `gate.yaml`             | adopted, landed   | The build and test legs, in this repository rather than called from another organisation, because a called workflow knows nothing about this tree's lockfiles.                                                                                                               |
+| `seam-probe.yaml`       | adopted, landed   | What a second plugin in the same server process can see of this one, measured on a real server of each line with `tools/seam-probe` as the second plugin. It records an answer rather than holding a merge, so what reds it is a run that produced no answer at all. #117.   |
+| `user-isolation.yaml`   | adopted, landed   | Two ordinary accounts on a real server of each line, each asking for something and reading back what they are given, with the queue asked as somebody who is not an administrator. The server's own evaluation of a policy is the half no double here reaches. #67.          |
+| `full-disk.yaml`        | adopted, landed   | What a caller sees when the volume the store writes to runs out of room, on a mount with a hard size, on the runtime of each line. The suite cannot ask it: filling a filesystem needs one to fill, and the headless rule refuses a test that needs a container engine. #46. |
+| `changelog.yaml`        | declined, deleted | It drafts a release changelog against a version scheme this repository has not fixed, and nothing covers that risk here because there is nothing to release yet; #107.                                                                                                       |
+| `command-dispatch.yaml` | declined, deleted | It turns issue comments into workflow runs, which is a surface this repository does not use, and nothing here needs covering because nothing depends on it.                                                                                                                  |
+| `command-rebase.yaml`   | declined, deleted | Same comment-driven surface, the half that rewrites pull request branches on command, and the same absence.                                                                                                                                                                  |
+| `sync-labels.yaml`      | declined, deleted | It overwrites the label vocabulary from a file in another organisation, and the vocabulary here is this board's own, so adopting it would delete what it is meant to keep.                                                                                                   |
 
 ## Mutation testing is adopted, fuzzing is declined
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -164,6 +164,29 @@ what an endpoint carries and never what a server does with it. The procedure run
 and on a schedule, so a mainline commit that no pull request carried has no reading of its own
 until the next nightly run.
 
+**Filling the volume the store writes to, as part of the ordinary suite.** Refused: there has to
+be a volume that may be filled, and making one means a container engine, which is the fourth
+condition. Filling the volume the checkout is on is worse than refused: it is a machine somebody
+else is using.
+
+What replaces it is `scripts/verify-full-disk.sh` and `tools/full-disk-probe`, run by
+`.github/workflows/full-disk.yaml` on every pull request and nightly, once per claimed line. The
+mount is `--tmpfs /data:size=256k`, so what fills is a filesystem of a fixed size that lives in
+memory and is discarded with the container, and nothing outside it is written to. The probe drives
+the store this repository ships, adds requests until one is refused, and asks four things: that a
+write failed at all, that the caller was told and what it was told, that the store it was told
+through still reports the set it held before, and that a store opened fresh over the same directory
+loads and holds that same set.
+
+**A run in which nothing filled is a refusal rather than a pass.** That is the mistake this shape
+exists against: a mount that is not size limited produces a job where every step succeeds and
+nothing was measured. The probe bounds the additions it will attempt and exits saying so, and the
+refusal is watched rather than assumed, below.
+
+What it does not do is prove anything about a disk that is full for a different reason. A tmpfs at
+its size limit is one way a write runs out of room; a quota, a full physical device and a
+filesystem out of inodes are others, and none of them was produced here.
+
 Every replacement named above exists, either as something already in the tree or as an issue on
 this board. The states move, and a paste taken once reads afterwards as a claim about today, so
 this one carries the commit it was read at, `ffa28c1`:

--- a/scripts/verify-full-disk.sh
+++ b/scripts/verify-full-disk.sh
@@ -19,7 +19,7 @@
 #
 # The runtime image is derived from the target framework rather than read out of
 # scripts/server-lines.tsv. That file pairs a framework with the Jellyfin server image that runs
-# the plugin, and no server is started here: what this needs is the bare .NET runtime the line
+# the plugin, and no server is started here: what this needs is the .NET runtime the line
 # provides, which is a different fact about the same framework.
 #
 # usage: scripts/verify-full-disk.sh <target-framework> [size]
@@ -31,9 +31,14 @@ set -euo pipefail
 framework=${1:?target framework, for example net9.0}
 size=${2:-64m}
 
+# The ASP.NET Core image rather than the bare runtime one. The plugin compiles against
+# Jellyfin.Controller, which carries a framework reference to Microsoft.AspNetCore.App, and that
+# reference is recorded in the probe's runtime configuration whether or not the store touches a
+# type from it. The bare runtime image refuses to start such an application, which is how this was
+# found: `No frameworks were found.` on both lines.
 case "$framework" in
-    net9.0) runtime=mcr.microsoft.com/dotnet/runtime:9.0 ;;
-    net10.0) runtime=mcr.microsoft.com/dotnet/runtime:10.0 ;;
+    net9.0) runtime=mcr.microsoft.com/dotnet/aspnet:9.0 ;;
+    net10.0) runtime=mcr.microsoft.com/dotnet/aspnet:10.0 ;;
     *)
         echo "no .NET runtime image for $framework. The claimed lines are:" >&2
         grep -v '^#' "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/server-lines.tsv" >&2

--- a/scripts/verify-full-disk.sh
+++ b/scripts/verify-full-disk.sh
@@ -29,7 +29,7 @@
 set -euo pipefail
 
 framework=${1:?target framework, for example net9.0}
-size=${2:-256k}
+size=${2:-64m}
 
 case "$framework" in
     net9.0) runtime=mcr.microsoft.com/dotnet/runtime:9.0 ;;

--- a/scripts/verify-full-disk.sh
+++ b/scripts/verify-full-disk.sh
@@ -55,16 +55,24 @@ dotnet publish "$root/tools/full-disk-probe/FullDiskProbe.csproj" \
     --framework "$framework" \
     --output "$out"
 
+# `mktemp -d` makes a directory only its owner may enter, and the runtime image runs as a user
+# that is not that owner, so without this the container cannot see the published probe at all.
+# It failed that way the first time this ran, with `realpath(/probe/...) failed: Permission
+# denied`, which reads as a missing file rather than as a permission.
+chmod -R a+rX "$out"
+
 echo "== running the probe on a $size filesystem under $runtime"
 
 # --network none because nothing here talks to anything, --cap-drop ALL and no-new-privileges
 # because a probe needs none of it, and the published output goes in read-only: the only thing this
 # container may write to is the mount it is here to fill.
+# mode=1777 on that mount for the same reason as the chmod above: the container is not root, and
+# the mount is the one place it has to be able to write.
 docker run --rm \
     --network none \
     --cap-drop ALL \
     --security-opt no-new-privileges \
     --volume "$out:/probe:ro" \
-    --tmpfs "/data:size=$size" \
+    --tmpfs "/data:rw,size=$size,mode=1777" \
     "$runtime" \
     dotnet /probe/Jellyfin.Plugin.Requests.FullDiskProbe.dll /data

--- a/scripts/verify-full-disk.sh
+++ b/scripts/verify-full-disk.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Ask the shipped store what a caller sees when the volume it writes to runs out of room.
+#
+# This is the third condition of #46. The other two are met by tests in the ordinary suite, which
+# truncate the persisted bytes at every offset and stop a write in the middle. Neither of those
+# needs anything the machine does not already have. Filling a disk does, and the headless rule in
+# docs/testing.md refuses a suite that needs a container engine, so the measurement is made here
+# rather than under `dotnet test`.
+#
+# WHAT IS FILLED IS A MOUNT WITH A HARD SIZE AND NOTHING ELSE. `--tmpfs /data:size=...` gives the
+# container a filesystem of exactly that size, in memory, discarded when the container exits.
+# Nothing outside it is written to, so the objection to filling a disk on somebody's machine does
+# not apply to filling this one.
+#
+# The probe is tools/full-disk-probe. It drives the store this repository ships, not a copy of it,
+# and it refuses to report a measurement it did not make: if every addition succeeds it exits 2
+# saying so, which is what a mount that was never size limited produces. A missing or mistyped size
+# is the mistake that would otherwise leave a green check that measured nothing.
+#
+# The runtime image is derived from the target framework rather than read out of
+# scripts/server-lines.tsv. That file pairs a framework with the Jellyfin server image that runs
+# the plugin, and no server is started here: what this needs is the bare .NET runtime the line
+# provides, which is a different fact about the same framework.
+#
+# usage: scripts/verify-full-disk.sh <target-framework> [size]
+#   scripts/verify-full-disk.sh net9.0
+#   scripts/verify-full-disk.sh net10.0 256k
+
+set -euo pipefail
+
+framework=${1:?target framework, for example net9.0}
+size=${2:-256k}
+
+case "$framework" in
+    net9.0) runtime=mcr.microsoft.com/dotnet/runtime:9.0 ;;
+    net10.0) runtime=mcr.microsoft.com/dotnet/runtime:10.0 ;;
+    *)
+        echo "no .NET runtime image for $framework. The claimed lines are:" >&2
+        grep -v '^#' "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/server-lines.tsv" >&2
+        exit 1
+        ;;
+esac
+
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+out=$(mktemp -d)
+trap 'rm -rf "$out"' EXIT
+
+echo "== publishing the probe for $framework"
+
+# Framework-dependent on purpose. The runtime under the measurement is then the one the image
+# carries and named in this file, rather than one bundled at publish time, so a run on the wrong
+# image fails to start instead of quietly measuring the other line.
+dotnet publish "$root/tools/full-disk-probe/FullDiskProbe.csproj" \
+    --configuration Release \
+    --framework "$framework" \
+    --output "$out"
+
+echo "== running the probe on a $size filesystem under $runtime"
+
+# --network none because nothing here talks to anything, --cap-drop ALL and no-new-privileges
+# because a probe needs none of it, and the published output goes in read-only: the only thing this
+# container may write to is the mount it is here to fill.
+docker run --rm \
+    --network none \
+    --cap-drop ALL \
+    --security-opt no-new-privileges \
+    --volume "$out:/probe:ro" \
+    --tmpfs "/data:size=$size" \
+    "$runtime" \
+    dotnet /probe/Jellyfin.Plugin.Requests.FullDiskProbe.dll /data

--- a/tools/full-disk-probe/Directory.Build.props
+++ b/tools/full-disk-probe/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+    <!-- INHERITANCE STOPS HERE, DELIBERATELY, for the reason the seam probe's copy of this file
+         gives: MSBuild walks up until it finds one of these, and the repository root's properties
+         belong to the artefact somebody installs. The probe is an instrument. It is built only by
+         the job that runs the measurement, it ships to nobody, and inheriting the plugin's version
+         number would make a second thing claim to be that version. -->
+
+</Project>

--- a/tools/full-disk-probe/FullDiskProbe.csproj
+++ b/tools/full-disk-probe/FullDiskProbe.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <!-- The same two targets the plugin claims. A store that reports a full disk on one runtime and
+         swallows it on the other is a difference between the two server lines, which is exactly the
+         kind of thing a probe run on one line only would miss. -->
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <RootNamespace>Jellyfin.Plugin.Requests.FullDiskProbe</RootNamespace>
+    <AssemblyName>Jellyfin.Plugin.Requests.FullDiskProbe</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <JellyfinVersion Condition="'$(JellyfinVersion)' == '' and '$(TargetFramework)' == 'net9.0'">10.11.11</JellyfinVersion>
+    <JellyfinVersion Condition="'$(JellyfinVersion)' == '' and '$(TargetFramework)' == 'net10.0'">12.0.0-rc4</JellyfinVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Without ExcludeAssets, unlike the plugin. The plugin leaves these out because a running
+         server supplies them and a package carrying a second copy is how a plugin breaks on the
+         server it was built for. Nothing supplies them to a probe running on its own, so the
+         runtime assets have to be here or the store cannot be constructed at all. This is the same
+         reason the test project references them this way. -->
+    <PackageReference Include="Jellyfin.Controller" Version="$(JellyfinVersion)" />
+    <PackageReference Include="Jellyfin.Model" Version="$(JellyfinVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- The project rather than a built assembly, so the store under measurement is the one in this
+         checkout and never a stale copy in a bin directory. -->
+    <ProjectReference Include="..\..\Jellyfin.Plugin.Requests\Jellyfin.Plugin.Requests.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/full-disk-probe/Program.cs
+++ b/tools/full-disk-probe/Program.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Time;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.Requests.FullDiskProbe;
+
+/// <summary>
+/// Asks the shipped store what a caller sees when the volume it writes to runs out of room.
+///
+/// The third condition of issue #46 is the one of the three where the wrong outcome looks exactly
+/// like the right one: a request that was never written, on a call that returned normally. The
+/// other two conditions are met by tests that truncate and interrupt, and both of those run in the
+/// ordinary suite. This one cannot, because a suite that needs a volume it may fill is a suite that
+/// needs a container engine, which the headless rule in docs/testing.md refuses.
+///
+/// So the measurement is made here, against the store this repository ships, on a filesystem whose
+/// size is fixed by whoever starts the container. Nothing outside that mount is touched.
+///
+/// What it reports:
+///
+///   - a write eventually failed, rather than the filesystem turning out to be large enough that
+///     nothing was measured
+///   - the caller was told, and what it was told
+///   - the store still answers with the set it held before the failed write
+///   - a store opened fresh over the same directory loads, and holds that same set
+///
+/// Exit codes: 0 all four hold, 1 one of them does not, 2 no write ever failed.
+/// </summary>
+internal static class Program
+{
+    /// <summary>
+    /// How many additions are attempted before the run is abandoned. It is a bound rather than a
+    /// loop that never ends, and it is what turns "the mount was not size limited" into a refusal
+    /// instead of a green run that measured nothing. A missing or mistyped size argument is the
+    /// one-character mistake this exists against.
+    /// </summary>
+    private const int Bound = 200;
+
+    /// <summary>
+    /// Characters of display title per request. Large so the document outgrows a small mount in a
+    /// few writes: the store serialises the whole set on every write, so a record small enough to
+    /// need thousands of them turns this into a long run rather than a better one.
+    /// </summary>
+    private const int TitleLength = 8192;
+
+    private static async Task<int> Main(string[] args)
+    {
+        if (args.Length != 1)
+        {
+            await Console.Error.WriteLineAsync("usage: Jellyfin.Plugin.Requests.FullDiskProbe <directory on a size limited filesystem>").ConfigureAwait(false);
+            return 1;
+        }
+
+        var directory = args[0];
+        var logger = new ConsoleLogger();
+        var clock = new SystemClock();
+
+        Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "== the store writes into {0}", directory));
+        Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "== running on {0}", Environment.Version));
+
+        var store = new FileRequestStore(directory, logger, clock);
+        var accepted = new List<Guid>();
+        Exception? refusal = null;
+
+        for (var ordinal = 0; ordinal < Bound; ordinal++)
+        {
+            var request = ARequest(ordinal);
+
+            try
+            {
+                await store.AddAsync(request, CancellationToken.None).ConfigureAwait(false);
+                accepted.Add(request.Id);
+            }
+            catch (Exception reason) when (reason is not OutOfMemoryException)
+            {
+                refusal = reason;
+                break;
+            }
+        }
+
+        Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "== {0} of at most {1} additions were accepted", accepted.Count, Bound));
+
+        if (refusal is null)
+        {
+            await Console.Error.WriteLineAsync(string.Format(
+                CultureInfo.InvariantCulture,
+                "NOTHING WAS MEASURED. {0} additions all succeeded, so the filesystem under {1} never ran out of room. This run says nothing about what a caller sees on a full disk. Check that the mount is size limited.",
+                Bound,
+                directory)).ConfigureAwait(false);
+            return 2;
+        }
+
+        Console.WriteLine("== what the caller was told");
+        Console.WriteLine(refusal.GetType().FullName);
+        Console.WriteLine(refusal.Message);
+
+        var wrong = new List<string>();
+
+        if (refusal is not IOException)
+        {
+            wrong.Add(string.Format(
+                CultureInfo.InvariantCulture,
+                "the caller was told {0}, which is not the IOException a filesystem raises when it is out of room",
+                refusal.GetType().FullName));
+        }
+
+        var stillHeld = await store.GetAllAsync(CancellationToken.None).ConfigureAwait(false);
+        Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "== the store that saw the failure now reports {0}", stillHeld.Count));
+
+        if (!SameSet(stillHeld, accepted))
+        {
+            wrong.Add("the store that saw the failure does not report the set it held before the write that failed");
+        }
+
+        IReadOnlyList<StoredRequest> reopened;
+
+        try
+        {
+            reopened = await new FileRequestStore(directory, logger, clock).GetAllAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (RequestStoreLoadException reason)
+        {
+            Console.WriteLine("== a store opened fresh over the same directory refused to load");
+            Console.WriteLine(reason.Message);
+            wrong.Add("a store opened fresh over the same directory does not load");
+            reopened = Array.Empty<StoredRequest>();
+        }
+
+        Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "== a store opened fresh over the same directory reports {0}", reopened.Count));
+
+        if (!SameSet(reopened, accepted))
+        {
+            wrong.Add("a store opened fresh over the same directory does not hold the set that was accepted before the write that failed");
+        }
+
+        Console.WriteLine("== what is left on the mount");
+
+        foreach (var file in new DirectoryInfo(directory).EnumerateFiles().OrderBy(file => file.Name, StringComparer.Ordinal))
+        {
+            Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "{0}\t{1}", file.Length, file.Name));
+        }
+
+        if (wrong.Count > 0)
+        {
+            foreach (var line in wrong)
+            {
+                await Console.Error.WriteLineAsync(line).ConfigureAwait(false);
+            }
+
+            return 1;
+        }
+
+        Console.WriteLine("== the caller was told, and nothing that was accepted was lost");
+        return 0;
+    }
+
+    private static bool SameSet(IReadOnlyList<StoredRequest> held, IReadOnlyList<Guid> accepted)
+        => held.Select(stored => stored.Request.Id).OrderBy(id => id).SequenceEqual(accepted.OrderBy(id => id));
+
+    private static MediaRequest ARequest(int ordinal)
+    {
+        var asked = new DateTimeOffset(2026, 8, 8, 8, 0, 0, TimeSpan.Zero);
+
+        return new MediaRequest
+        {
+            Id = new Guid(string.Format(CultureInfo.InvariantCulture, "00000000-0000-0000-0000-{0:D12}", ordinal)),
+            RequestedByUserId = new Guid("b31d0f9a-5c2e-4a71-8f6b-0d4c3e2a1b58"),
+            RequestedAt = asked,
+            StateChangedAt = asked,
+            Kind = RequestedItemKind.Movie,
+            DisplayTitle = new string('t', TitleLength)
+        };
+    }
+
+    /// <summary>
+    /// The store writes to a log before it throws, and on this run that log is evidence rather than
+    /// noise, so it goes to the output the job records instead of being dropped.
+    /// </summary>
+    private sealed class ConsoleLogger : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+            => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            ArgumentNullException.ThrowIfNull(formatter);
+
+            Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "[{0}] {1}", logLevel, formatter(state, exception)));
+        }
+    }
+}


### PR DESCRIPTION
Not for merging, and it will be closed as soon as the run it exists for has been read.

Part of #46. It exists to watch the full disk check in #276 go red for the reason it names. That check refuses a run in which nothing was measured, and until that refusal has been seen happening it is a claim rather than a guard.

The change is one token. `scripts/verify-full-disk.sh` raises the mount from `256k` to `64m`, which is the mistake it is written against: a size argument dropped, mistyped, or set to whatever was lying around. Every addition the probe is bounded at then succeeds, no write ever runs out of room, and the probe exits saying nothing was measured instead of reporting a pass.

Everything else on the branch is #276 unchanged.
