### PR TITLE
Put a person's own requests in front of a client nobody here can change

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Localisation/PageWordsTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Localisation/PageWordsTests.cs
@@ -160,6 +160,11 @@ public sealed class PageWordsTests
     /// covered the first time the suite runs.
     /// </para>
     /// <para>
+    /// <see cref="ChannelWords"/> is the third, and it is here because the channel draws nothing
+    /// itself: it hands the server a folder tree and the server renders it, so a key it names is
+    /// invisible to the reading of the assets above.
+    /// </para>
+    /// <para>
     /// <see cref="LiveSentences"/> is the second such class and is here for a stronger version of
     /// the same reason. No page draws any of those at all: they are pushed to a person's client
     /// when their request moves, so there is no asset for the first leg to find them in, and
@@ -169,7 +174,7 @@ public sealed class PageWordsTests
     /// <returns>The keys.</returns>
     private static string[] Declared()
     {
-        var declared = new[] { typeof(Sentences), typeof(LiveSentences) }
+        var declared = new[] { typeof(Sentences), typeof(LiveSentences), typeof(ChannelWords) }
             .SelectMany(declaring => declaring.GetFields(BindingFlags.Public | BindingFlags.Static))
             .Where(field => field.IsLiteral && field.FieldType == typeof(string))
             .Select(field => (string?)field.GetRawConstantValue())

--- a/Jellyfin.Plugin.Requests.Tests/Surface/TheChannelAPersonBrowsesTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Surface/TheChannelAPersonBrowsesTests.cs
@@ -1,0 +1,411 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Localisation;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Surface;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using MediaBrowser.Controller.Channels;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Surface;
+
+/// <summary>
+/// The view a person gets of their own requests on a client this project has never touched.
+/// <para>
+/// The page reaches a browser and nothing else. The channel is the surface that reaches a
+/// television client and a set-top box, which on a media server is most of the people using it, and
+/// <c>docs/surface.md</c> is where that was decided. What this holds is what the channel answers:
+/// one folder per state the person has something in, the titles inside them, the reason a decline
+/// was given, and a sentence rather than an empty tree for somebody who has asked for nothing.
+/// </para>
+/// <para>
+/// <b>What the catalogue legs cannot see.</b> Every sentence below is compared against the value
+/// the catalogue holds rather than against a word typed here, which catches a channel that stops
+/// looking a key up and catches a key that is missing. It does not catch a copy: the same sentence
+/// written into the channel by hand passes, because the two strings are then equal. That near-miss
+/// was executed rather than reasoned about, with the catalogue's own words for a declined reason
+/// written straight into the channel, and the suite stayed green. What the assets have for this,
+/// <c>NoAssetCarriesOneOfTheseSentencesItself</c>, reads the shipped resources, and there is no
+/// resource here to read: the channel is code. So this is a bound on the legs below rather than a
+/// gap somebody has not noticed.
+/// </para>
+/// <para>
+/// <b>The bound, and it is the same one every check over this surface carries.</b> Nothing here
+/// runs a server and nothing renders anything, which the headless rule in <c>docs/testing.md</c>
+/// settles. So what is held is the answer this plugin hands the server, never what the server does
+/// with it afterwards and never what a client draws. What a running server does with two callers in
+/// turn is #67, and it is measured on a real server rather than argued here.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class TheChannelAPersonBrowsesTests
+{
+    private static readonly Guid Asker = new Guid("70000000-0000-0000-0000-000000000001");
+    private static readonly Guid Somebody = new Guid("70000000-0000-0000-0000-000000000002");
+    private static readonly DateTimeOffset Asked = new DateTimeOffset(2026, 8, 8, 8, 0, 0, TimeSpan.Zero);
+
+    /// <summary>
+    /// The root is one folder per state this person actually has something in, in the order
+    /// somebody reads rather than in the order the states are stored.
+    /// <para>
+    /// Grouping is the whole shape of this view: a flat list with a state column is what the page
+    /// draws, and a folder tree that repeats it says nothing a person can navigate. A state they
+    /// have nothing in is not a folder, because an empty folder in a tree is a thing somebody opens
+    /// for no reason.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task TheRootIsOneFolderPerStateTheyHaveSomethingIn()
+    {
+        var store = new InMemoryRequestStore();
+        await store.AddAsync(ARequest(1, Asker), CancellationToken.None).ConfigureAwait(true);
+        await store.AddAsync(ARequest(2, Asker) with { State = RequestState.Fulfilled }, CancellationToken.None).ConfigureAwait(true);
+        await store.AddAsync(ARequest(3, Asker) with { State = RequestState.Fulfilled }, CancellationToken.None).ConfigureAwait(true);
+
+        var answer = await Channel(store).GetChannelItems(Browsing(Asker, null), CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Equal(
+            [
+                RequestsChannel.StateFolderPrefix + nameof(RequestState.Open),
+                RequestsChannel.StateFolderPrefix + nameof(RequestState.Fulfilled)
+            ],
+            answer.Items.Select(item => item.Id));
+
+        Assert.All(answer.Items, item => Assert.Equal(ChannelItemType.Folder, item.Type));
+        Assert.Equal(2, answer.TotalRecordCount);
+    }
+
+    /// <summary>
+    /// Every folder name is the catalogue's word for that state, compared against the catalogue
+    /// rather than against a word typed into this test.
+    /// <para>
+    /// A leg asserting the wording would go red the day somebody improves a sentence, which teaches
+    /// whoever meets it to change the test. What matters is that the channel and the page say the
+    /// same thing, and they do that by both looking the same key up.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task EveryFolderIsNamedByTheCatalogueRatherThanBySomethingWrittenHere()
+    {
+        var store = new InMemoryRequestStore();
+        await store.AddAsync(ARequest(1, Asker), CancellationToken.None).ConfigureAwait(true);
+        await store.AddAsync(ARequest(2, Asker) with { State = RequestState.Declined, DeclineReason = DeclineReason.NoRoomForIt }, CancellationToken.None).ConfigureAwait(true);
+
+        var answer = await Channel(store).GetChannelItems(Browsing(Asker, null), CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Equal(
+            [
+                StringCatalogue.Shipped.Get("mine.state." + nameof(RequestState.Open), null),
+                StringCatalogue.Shipped.Get("mine.state." + nameof(RequestState.Declined), null)
+            ],
+            answer.Items.Select(item => item.Name));
+    }
+
+    /// <summary>
+    /// A folder holds the requests in its own state and no others.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AFolderHoldsTheRequestsInThatStateAndNoOthers()
+    {
+        var store = new InMemoryRequestStore();
+        await store.AddAsync(ARequest(1, Asker), CancellationToken.None).ConfigureAwait(true);
+        await store.AddAsync(ARequest(2, Asker) with { State = RequestState.Fulfilled }, CancellationToken.None).ConfigureAwait(true);
+
+        var answer = await Channel(store)
+            .GetChannelItems(Browsing(Asker, RequestsChannel.StateFolderPrefix + nameof(RequestState.Fulfilled)), CancellationToken.None)
+            .ConfigureAwait(true);
+
+        var row = Assert.Single(answer.Items);
+
+        Assert.Equal(Identifier(2).ToString("D", CultureInfo.InvariantCulture), row.Id);
+        Assert.Equal(ChannelItemType.Media, row.Type);
+    }
+
+    /// <summary>
+    /// Nothing but this person's own requests reaches the answer, whichever folder is opened.
+    /// <para>
+    /// The store is asked for one person's requests rather than for everything and filtered
+    /// afterwards, and this is what holds that: a second person's request in the same state as the
+    /// first person's is in the store while the folder is opened, and it is not in the answer.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task NothingButTheirOwnRequestsReachesTheAnswer()
+    {
+        var store = new InMemoryRequestStore();
+        await store.AddAsync(ARequest(1, Asker), CancellationToken.None).ConfigureAwait(true);
+        await store.AddAsync(ARequest(2, Somebody), CancellationToken.None).ConfigureAwait(true);
+
+        var inside = await Channel(store)
+            .GetChannelItems(Browsing(Asker, RequestsChannel.StateFolderPrefix + nameof(RequestState.Open)), CancellationToken.None)
+            .ConfigureAwait(true);
+
+        var row = Assert.Single(inside.Items);
+        Assert.Equal(Identifier(1).ToString("D", CultureInfo.InvariantCulture), row.Id);
+    }
+
+    /// <summary>
+    /// No row names anybody, including the person reading it.
+    /// <para>
+    /// This is the leg that goes past the obvious reading of the one above. It is not enough that
+    /// somebody sees only their own rows: a row that carries a user identifier is a way to learn
+    /// one, and a channel's rows are written into the server's own library database where this
+    /// plugin no longer decides who reads them. Everything the answer carries is searched rather
+    /// than the fields this test happens to know the names of.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task NoRowNamesAnybodyIncludingThePersonReadingIt()
+    {
+        var store = new InMemoryRequestStore();
+        await store.AddAsync(
+            ARequest(1, Asker) with
+            {
+                JoinedByUserIds = [Somebody],
+                State = RequestState.Declined,
+                DeclineReason = DeclineReason.NoRoomForIt,
+                DeclineNote = "There is no room for it this month.",
+                StateChangedByUserId = Somebody
+            },
+            CancellationToken.None).ConfigureAwait(true);
+
+        var channel = Channel(store);
+        var root = await channel.GetChannelItems(Browsing(Asker, null), CancellationToken.None).ConfigureAwait(true);
+        var inside = await channel
+            .GetChannelItems(Browsing(Asker, RequestsChannel.StateFolderPrefix + nameof(RequestState.Declined)), CancellationToken.None)
+            .ConfigureAwait(true);
+
+        var written = string.Join(
+            "\n",
+            root.Items.Concat(inside.Items).Select(item => string.Join("\n", item.Id, item.Name, item.Overview)));
+
+        Assert.DoesNotContain(Asker.ToString("D", CultureInfo.InvariantCulture), written, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(Somebody.ToString("D", CultureInfo.InvariantCulture), written, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// A declined request carries the reason it was declined, and the note beside it where one was
+    /// given.
+    /// <para>
+    /// It is the second condition of #66 and it is the one thing a person cannot get anywhere else:
+    /// a state name says the answer was no, and the reason is what stops them asking again for the
+    /// same thing or going and asking the operator why.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ADeclinedRequestCarriesTheReasonAndTheNoteWhereOneWasGiven()
+    {
+        const string Note = "There is no room for it this month.";
+
+        var store = new InMemoryRequestStore();
+        await store.AddAsync(
+            ARequest(1, Asker) with
+            {
+                State = RequestState.Declined,
+                DeclineReason = DeclineReason.NoRoomForIt,
+                DeclineNote = Note
+            },
+            CancellationToken.None).ConfigureAwait(true);
+
+        var answer = await Channel(store)
+            .GetChannelItems(Browsing(Asker, RequestsChannel.StateFolderPrefix + nameof(RequestState.Declined)), CancellationToken.None)
+            .ConfigureAwait(true);
+
+        var said = Assert.Single(answer.Items).Overview;
+
+        // Composed out of the catalogue rather than typed, and compared whole rather than by
+        // containment, so a channel that drops the note or joins the two with wording of its own
+        // reds here instead of passing on a substring.
+        var why = string.Format(
+            CultureInfo.InvariantCulture,
+            StringCatalogue.Shipped.Get("declineReason.withNote", null),
+            StringCatalogue.Shipped.Get("declineReason." + nameof(DeclineReason.NoRoomForIt), null),
+            Note);
+
+        Assert.Equal(
+            string.Format(
+                CultureInfo.InvariantCulture,
+                StringCatalogue.Shipped.Get("queue.askedBefore.withReason", null),
+                StringCatalogue.Shipped.Get("outcome.declined", null),
+                why),
+            said);
+    }
+
+    /// <summary>
+    /// A request nobody has answered says what is happening and that asking again does not move it,
+    /// rather than repeating a state name.
+    /// <para>
+    /// The waiting case is where somebody goes and asks the operator, which is the message this
+    /// plugin exists to remove, and the sentence is the catalogue's own so that this surface and
+    /// the page say one thing rather than two.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task SomethingNobodyHasAnsweredCarriesTheWaitingSentence()
+    {
+        var store = new InMemoryRequestStore();
+        await store.AddAsync(ARequest(1, Asker), CancellationToken.None).ConfigureAwait(true);
+
+        var answer = await Channel(store)
+            .GetChannelItems(Browsing(Asker, RequestsChannel.StateFolderPrefix + nameof(RequestState.Open)), CancellationToken.None)
+            .ConfigureAwait(true);
+
+        Assert.Equal(StringCatalogue.Shipped.Get(Sentences.Waiting, null), Assert.Single(answer.Items).Overview);
+    }
+
+    /// <summary>
+    /// Somebody who has never asked for anything is told so, and opening what they are shown is
+    /// answered with nothing rather than with a failure.
+    /// <para>
+    /// This is the third condition of #66 and it is the cheap one that gets skipped. A tree with
+    /// nothing in it is indistinguishable from a plugin that is broken, and a folder that raises
+    /// when it is opened is worse than either.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task SomebodyWhoHasAskedForNothingIsToldSoAndOpeningItIsHarmless()
+    {
+        var channel = Channel(new InMemoryRequestStore());
+
+        var root = await channel.GetChannelItems(Browsing(Asker, null), CancellationToken.None).ConfigureAwait(true);
+
+        var shown = Assert.Single(root.Items);
+        Assert.Equal(StringCatalogue.Shipped.Get("mine.empty", null), shown.Name);
+
+        var inside = await channel.GetChannelItems(Browsing(Asker, shown.Id), CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Empty(inside.Items);
+        Assert.Equal(0, inside.TotalRecordCount);
+    }
+
+    /// <summary>
+    /// A folder identifier this channel did not write is answered with nothing rather than with a
+    /// failure.
+    /// <para>
+    /// The server keeps the identifiers it was handed earlier, so one arriving after this channel
+    /// has stopped writing it is a stale caller rather than a fault, and a channel that raises on
+    /// one is a folder tree that breaks for everybody after a rename.
+    /// </para>
+    /// </summary>
+    /// <param name="folderId">The identifier the server hands back.</param>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Theory]
+    [InlineData("state:Whatever")]
+    [InlineData("state:")]
+    [InlineData("something-else")]
+    public async Task AFolderIdentifierThisChannelDidNotWriteIsAnsweredWithNothing(string folderId)
+    {
+        var store = new InMemoryRequestStore();
+        await store.AddAsync(ARequest(1, Asker), CancellationToken.None).ConfigureAwait(true);
+
+        var answer = await Channel(store).GetChannelItems(Browsing(Asker, folderId), CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Empty(answer.Items);
+    }
+
+    /// <summary>
+    /// A store that cannot be read is a sentence and a line in the log, not an exception thrown at
+    /// whoever opened the folder.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AStoreThatCannotBeReadIsASentenceRatherThanAFailure()
+    {
+        var log = new RecordingLogger();
+
+        var answer = await new RequestsChannel(new StoreThatCannotBeRead(), StringCatalogue.Shipped, log)
+            .GetChannelItems(Browsing(Asker, null), CancellationToken.None)
+            .ConfigureAwait(true);
+
+        Assert.Equal(StringCatalogue.Shipped.Get("mine.notRead", null), Assert.Single(answer.Items).Name);
+        Assert.NotEmpty(log.At(LogLevel.Warning));
+    }
+
+    /// <summary>
+    /// Two people are never handed one another's copy of this answer, and neither is handed one
+    /// from before the store moved.
+    /// <para>
+    /// A channel that does not carry a cache key derives one path for every user on the server, and
+    /// this channel's answer is one person's requests. That measurement is on #66 and it is read off
+    /// the server's own source; what is held here is the half this plugin decides, which is that
+    /// the key it hands over separates two people and moves when the store does.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void TheCacheKeySeparatesTwoPeopleAndMovesWhenTheStoreDoes()
+    {
+        var store = new InMemoryRequestStore();
+        var channel = Channel(store);
+
+        var first = channel.GetCacheKey(Asker.ToString("D", CultureInfo.InvariantCulture));
+        var second = channel.GetCacheKey(Somebody.ToString("D", CultureInfo.InvariantCulture));
+
+        Assert.NotEqual(first, second);
+
+        store.LastWrittenAt = Asked;
+
+        Assert.NotEqual(first, channel.GetCacheKey(Asker.ToString("D", CultureInfo.InvariantCulture)));
+    }
+
+    /// <summary>
+    /// No row carries a provider identifier.
+    /// <para>
+    /// A channel item with one is a row the server can match against real media, and these rows are
+    /// not media: each is a record that somebody asked for something. This is the leg that keeps the
+    /// awkwardness <c>docs/surface.md</c> accepts from turning into the thing it rejected outright,
+    /// which is rows that are not media appearing as if they were.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task NoRowCarriesAProviderIdentifier()
+    {
+        var store = new InMemoryRequestStore();
+        await store.AddAsync(
+            ARequest(1, Asker) with { ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tmdb"] = "603" } },
+            CancellationToken.None).ConfigureAwait(true);
+
+        var answer = await Channel(store)
+            .GetChannelItems(Browsing(Asker, RequestsChannel.StateFolderPrefix + nameof(RequestState.Open)), CancellationToken.None)
+            .ConfigureAwait(true);
+
+        Assert.Empty(Assert.Single(answer.Items).ProviderIds);
+    }
+
+    private static RequestsChannel Channel(IRequestStore store)
+        => new RequestsChannel(store, StringCatalogue.Shipped, new RecordingLogger());
+
+    private static InternalChannelItemQuery Browsing(Guid who, string? folderId)
+        => new InternalChannelItemQuery { UserId = who, FolderId = folderId };
+
+    private static Guid Identifier(int ordinal)
+        => new Guid(string.Format(CultureInfo.InvariantCulture, "00000000-0000-0000-0000-{0:D12}", ordinal));
+
+    private static MediaRequest ARequest(int ordinal, Guid who) => new MediaRequest
+    {
+        Id = Identifier(ordinal),
+        RequestedByUserId = who,
+        RequestedAt = Asked,
+        StateChangedAt = Asked.AddMinutes(ordinal),
+        Kind = RequestedItemKind.Movie,
+        DisplayTitle = string.Format(CultureInfo.InvariantCulture, "The Conversation {0}", ordinal)
+    };
+}

--- a/Jellyfin.Plugin.Requests.Tests/Surface/TheChannelAPersonBrowsesTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Surface/TheChannelAPersonBrowsesTests.cs
@@ -331,7 +331,7 @@ public sealed class TheChannelAPersonBrowsesTests
     {
         var log = new RecordingLogger();
 
-        var answer = await new RequestsChannel(new StoreThatCannotBeRead(), StringCatalogue.Shipped, log)
+        var answer = await new RequestsChannel(() => new StoreThatCannotBeRead(), StringCatalogue.Shipped, log)
             .GetChannelItems(Browsing(Asker, null), CancellationToken.None)
             .ConfigureAwait(true);
 
@@ -390,8 +390,41 @@ public sealed class TheChannelAPersonBrowsesTests
         Assert.Empty(Assert.Single(answer.Items).ProviderIds);
     }
 
+    /// <summary>
+    /// The channel is built without the store being reached for, and it says nothing about the
+    /// store until somebody browses.
+    /// <para>
+    /// <b>This is the leg for a defect that had already reached a real server.</b> The channel took
+    /// the store, so building the channel built the store, and the store this plugin registers is
+    /// built out of the plugin's own data directory, which exists only once the host has
+    /// constructed the plugin. The server resolves its channels out of the container while it is
+    /// still starting, so on a real server of each claimed line the plugin took the startup wizard
+    /// down with it and every check that needs a running server went red at the same step.
+    /// </para>
+    /// <para>
+    /// So the store is asked for rather than held, and this holds that: a factory that raises
+    /// stands in for the one that raises on a starting server, and constructing the channel and
+    /// reading what a client shows under its name both have to survive it.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void BuildingTheChannelDoesNotBuildTheStore()
+    {
+        var channel = new RequestsChannel(
+            () => throw new InvalidOperationException("The request store was asked for before this plugin was loaded."),
+            StringCatalogue.Shipped,
+            new RecordingLogger());
+
+        Assert.Equal(StringCatalogue.Shipped.Get("mine.title", null), channel.Name);
+        Assert.Equal(StringCatalogue.Shipped.Get(ChannelWords.Description, null), channel.Description);
+        Assert.NotNull(channel.GetChannelFeatures());
+        Assert.True(channel.IsEnabledFor(Asker.ToString("D", CultureInfo.InvariantCulture)));
+        Assert.Equal("0", channel.DataVersion);
+        Assert.NotEmpty(channel.GetCacheKey(Asker.ToString("D", CultureInfo.InvariantCulture)));
+    }
+
     private static RequestsChannel Channel(IRequestStore store)
-        => new RequestsChannel(store, StringCatalogue.Shipped, new RecordingLogger());
+        => new RequestsChannel(() => store, StringCatalogue.Shipped, new RecordingLogger());
 
     private static InternalChannelItemQuery Browsing(Guid who, string? folderId)
         => new InternalChannelItemQuery { UserId = who, FolderId = folderId };

--- a/Jellyfin.Plugin.Requests/Localisation/ChannelWords.cs
+++ b/Jellyfin.Plugin.Requests/Localisation/ChannelWords.cs
@@ -1,0 +1,30 @@
+namespace Jellyfin.Plugin.Requests.Localisation;
+
+/// <summary>
+/// The words the channel names that no asset draws, named by the key each one is under in the
+/// catalogue.
+/// <para>
+/// <b>Why a class and not a literal at the call site.</b> Everything else this plugin shows a
+/// person is drawn by a page, and a page names its keys as literals because it is markup with
+/// nothing else to name them with, so <c>PageWordsTests</c> finds them by reading the assets. The
+/// channel draws nothing: it hands the server a folder tree and the server renders it on whatever
+/// client somebody is holding. A key it names is therefore invisible to that reading, and a key
+/// invisible to that reading is one nobody notices has been left behind after the sentence that
+/// used it is gone.
+/// </para>
+/// <para>
+/// So the keys the channel names and no page draws are declared here, the same way
+/// <see cref="Sentences"/> declares the one outcome that is met while asking rather than while
+/// reading. The rest of what the channel says is already named by a page and is looked up by the
+/// same key on both surfaces on purpose, so the two cannot drift into two answers.
+/// </para>
+/// </summary>
+public static class ChannelWords
+{
+    /// <summary>
+    /// What the channel is, in the one line a client shows under its name. It says that nothing
+    /// here plays, because a folder tree beside somebody's libraries looks like media and the rows
+    /// in it are records that somebody asked for something.
+    /// </summary>
+    public const string Description = "mine.channel.description";
+}

--- a/Jellyfin.Plugin.Requests/Localisation/Strings/en.json
+++ b/Jellyfin.Plugin.Requests/Localisation/Strings/en.json
@@ -35,6 +35,7 @@
   "live.declined": "Your request for {0} was declined: {1}",
   "live.fulfilled": "{0} is in the library now.",
   "live.header": "Requests",
+  "mine.channel.description": "What you asked for and what happened to it. Nothing here plays.",
   "mine.column.availability": "In the library",
   "mine.column.kind": "Kind",
   "mine.column.requestedAt": "Asked for",

--- a/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
@@ -200,7 +200,7 @@ public sealed class PluginServiceRegistrator : IPluginServiceRegistrator
         // clients this project will never change. It is a singleton for the same reason the store
         // is: it holds nothing per call and a second one would be a second reader of one file.
         serviceCollection.AddSingleton<IChannel>(provider => new RequestsChannel(
-            provider.GetRequiredService<IRequestStore>(),
+            provider.GetRequiredService<IRequestStore>,
             provider.GetRequiredService<StringCatalogue>(),
             provider.GetRequiredService<ILogger<RequestsChannel>>()));
     }

--- a/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
@@ -9,8 +9,10 @@ using Jellyfin.Plugin.Requests.Localisation;
 using Jellyfin.Plugin.Requests.Notify;
 using Jellyfin.Plugin.Requests.Seam;
 using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Surface;
 using Jellyfin.Plugin.Requests.Time;
 using MediaBrowser.Controller;
+using MediaBrowser.Controller.Channels;
 using MediaBrowser.Controller.Plugins;
 using MediaBrowser.Controller.Session;
 using MediaBrowser.Model.Activity;
@@ -192,5 +194,14 @@ public sealed class PluginServiceRegistrator : IPluginServiceRegistrator
             provider.GetRequiredService<ILogger<RetentionSweep>>()));
 
         serviceCollection.AddSingleton<IScheduledTask, RetentionTask>();
+
+        // The surface every client can reach. The server resolves its channels out of this
+        // container, so this registration is what puts a folder tree beside a person's libraries on
+        // clients this project will never change. It is a singleton for the same reason the store
+        // is: it holds nothing per call and a second one would be a second reader of one file.
+        serviceCollection.AddSingleton<IChannel>(provider => new RequestsChannel(
+            provider.GetRequiredService<IRequestStore>(),
+            provider.GetRequiredService<StringCatalogue>(),
+            provider.GetRequiredService<ILogger<RequestsChannel>>()));
     }
 }

--- a/Jellyfin.Plugin.Requests/Surface/RequestsChannel.cs
+++ b/Jellyfin.Plugin.Requests/Surface/RequestsChannel.cs
@@ -77,17 +77,23 @@ public sealed class RequestsChannel : IChannel, IHasCacheKey
         RequestState.Failed
     ];
 
-    private readonly IRequestStore _store;
+    private readonly Func<IRequestStore> _store;
     private readonly StringCatalogue _words;
     private readonly ILogger _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RequestsChannel"/> class.
     /// </summary>
-    /// <param name="store">Where the requests are kept.</param>
+    /// <param name="store">
+    /// Where the requests are kept, asked for rather than held. The server resolves its channels
+    /// out of the container while it is still starting, and the store this plugin registers is
+    /// built out of the plugin's own data directory, which exists only once the host has
+    /// constructed the plugin. A channel holding the store would therefore be a channel that has to
+    /// be built before there is one, so it asks for it when somebody browses instead.
+    /// </param>
     /// <param name="words">The catalogue every sentence is looked up in.</param>
     /// <param name="logger">Where a store that cannot be read is reported.</param>
-    public RequestsChannel(IRequestStore store, StringCatalogue words, ILogger logger)
+    public RequestsChannel(Func<IRequestStore> store, StringCatalogue words, ILogger logger)
     {
         ArgumentNullException.ThrowIfNull(store);
         ArgumentNullException.ThrowIfNull(words);
@@ -119,11 +125,34 @@ public sealed class RequestsChannel : IChannel, IHasCacheKey
     /// restarted server starts from the same value again and asks once.
     /// </para>
     /// </summary>
-    public string DataVersion =>
-        _store.LastWrittenAt?.UtcTicks.ToString(CultureInfo.InvariantCulture) ?? "0";
+    public string DataVersion => WhenTheStoreLastMoved();
 
     /// <inheritdoc />
     public bool IsEnabledFor(string userId) => true;
+
+    /// <summary>
+    /// When the store last accepted a write, as the token the two properties above are built from.
+    /// <para>
+    /// <b>A store that cannot be built yet answers the same as one nothing has been written to.</b>
+    /// The store is the plugin's own data directory and there is none until the host has
+    /// constructed the plugin, while the server reads a channel's properties as it starts. There is
+    /// nothing cached at that moment either, so the honest answer and the safe one are the same,
+    /// and the alternative is a plugin that takes the server's startup down with it. The refusal
+    /// caught here is the one the registration raises by name and nothing wider.
+    /// </para>
+    /// </summary>
+    /// <returns>The token.</returns>
+    private string WhenTheStoreLastMoved()
+    {
+        try
+        {
+            return _store().LastWrittenAt?.UtcTicks.ToString(CultureInfo.InvariantCulture) ?? "0";
+        }
+        catch (InvalidOperationException)
+        {
+            return "0";
+        }
+    }
 
     /// <summary>
     /// Gets what the server keys its copy of this channel's answer on, per person.
@@ -171,7 +200,7 @@ public sealed class RequestsChannel : IChannel, IHasCacheKey
 
         try
         {
-            theirs = await _store.FindForUserAsync(query.UserId, cancellationToken).ConfigureAwait(false);
+            theirs = await _store().FindForUserAsync(query.UserId, cancellationToken).ConfigureAwait(false);
         }
         catch (RequestStoreLoadException reason)
         {

--- a/Jellyfin.Plugin.Requests/Surface/RequestsChannel.cs
+++ b/Jellyfin.Plugin.Requests/Surface/RequestsChannel.cs
@@ -1,0 +1,353 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Localisation;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+using MediaBrowser.Controller.Channels;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Channels;
+using MediaBrowser.Model.Entities;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.Requests.Surface;
+
+/// <summary>
+/// What a person asked for and what happened to it, as a folder tree the server puts beside their
+/// libraries.
+/// <para>
+/// <b>Why this and not a page.</b> A page reaches a browser. Most people using a media server are
+/// on a television client or a set-top box this project will never change, and a feature that needs
+/// a client change does not exist for them. A channel is the one extension point that reaches an
+/// unmodified client, and <c>docs/surface.md</c> is where that was decided together with the three
+/// shapes it was decided against.
+/// </para>
+/// <para>
+/// <b>What it renders.</b> One folder per state the person actually has something in, named by the
+/// same words the page uses, and inside each folder the titles they asked for. Nothing else. It is
+/// a status view rather than a second dashboard, and it says nothing about anybody but the person
+/// asking: no row carries a user identifier, a requester name or a note somebody else typed.
+/// </para>
+/// <para>
+/// <b>Somebody who has asked for nothing gets a sentence rather than nothing.</b> An empty tree is
+/// indistinguishable from a plugin that is broken, so the root answers with one folder carrying the
+/// catalogue's own sentence for that case. It is the same sentence the page shows, looked up by key
+/// rather than written here twice.
+/// </para>
+/// <para>
+/// <b>What this type does not settle.</b> A channel's answer is written into the server's library
+/// database under a parent that belongs to the channel rather than to the caller, and the server
+/// removes everything under that parent which the current caller's answer did not contain.
+/// <see cref="IHasCacheKey"/> repairs the cache path, so one person's answer is not handed to the
+/// next caller out of a cache keyed on the channel alone. It does not repair the parent, and
+/// nothing in this repository can say what a running server does with two callers arriving in turn.
+/// That is #67, it is measured on a real server of each claimed line rather than argued here, and
+/// <c>docs/surface.md</c> carries the fallback that applies if it cannot be shown.
+/// </para>
+/// </summary>
+public sealed class RequestsChannel : IChannel, IHasCacheKey
+{
+    /// <summary>
+    /// What a folder identifier starts with. A folder is a state and its identifier says which,
+    /// because the server hands back the identifier and nothing else when somebody opens one.
+    /// </summary>
+    public const string StateFolderPrefix = "state:";
+
+    /// <summary>
+    /// The identifier of the folder shown to somebody who has asked for nothing. It is a folder
+    /// rather than an absence for the reason the type's own documentation gives, and opening it is
+    /// answered with no items rather than with an error.
+    /// </summary>
+    public const string NothingYetFolderId = "nothing-yet";
+
+    /// <summary>
+    /// The order the states are shown in. It is written out rather than taken from the enum's own
+    /// numbering, because that numbering is a storage detail and this is the order somebody reads:
+    /// what is still waiting first, then what was answered, then what arrived.
+    /// </summary>
+    private static readonly RequestState[] _readingOrder =
+    [
+        RequestState.Open,
+        RequestState.Approved,
+        RequestState.Fulfilled,
+        RequestState.Declined,
+        RequestState.Failed
+    ];
+
+    private readonly IRequestStore _store;
+    private readonly StringCatalogue _words;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequestsChannel"/> class.
+    /// </summary>
+    /// <param name="store">Where the requests are kept.</param>
+    /// <param name="words">The catalogue every sentence is looked up in.</param>
+    /// <param name="logger">Where a store that cannot be read is reported.</param>
+    public RequestsChannel(IRequestStore store, StringCatalogue words, ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(words);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _store = store;
+        _words = words;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public string Name => _words.Get("mine.title", null);
+
+    /// <inheritdoc />
+    public string Description => _words.Get(ChannelWords.Description, null);
+
+    /// <inheritdoc />
+    public string HomePageUrl => string.Empty;
+
+    /// <inheritdoc />
+    public ChannelParentalRating ParentalRating => ChannelParentalRating.GeneralAudience;
+
+    /// <summary>
+    /// Gets what the server compares to decide whether it already has this channel's answer.
+    /// <para>
+    /// It moves when the store is written to, so a decision an operator has just taken is not
+    /// hidden behind an answer the server kept. It is a fact about this process rather than about
+    /// the data, which is what <see cref="IRequestStore.LastWrittenAt"/> says about itself, so a
+    /// restarted server starts from the same value again and asks once.
+    /// </para>
+    /// </summary>
+    public string DataVersion =>
+        _store.LastWrittenAt?.UtcTicks.ToString(CultureInfo.InvariantCulture) ?? "0";
+
+    /// <inheritdoc />
+    public bool IsEnabledFor(string userId) => true;
+
+    /// <summary>
+    /// Gets what the server keys its copy of this channel's answer on, per person.
+    /// <para>
+    /// <b>This is the whole reason the interface is implemented.</b> A channel that does not
+    /// implement it derives one cache path for every user on the server, and this channel's answer
+    /// is one person's requests. The key carries the person and the moment the store last moved, so
+    /// two people never share an entry and neither of them is served an answer from before a
+    /// decision.
+    /// </para>
+    /// </summary>
+    /// <param name="userId">The person the answer would be for.</param>
+    /// <returns>The key that answer is kept under.</returns>
+    public string GetCacheKey(string? userId) => userId + "-" + DataVersion;
+
+    /// <inheritdoc />
+    public InternalChannelFeatures GetChannelFeatures() => new()
+    {
+        // Nothing here is downloadable and nothing is sortable by the server: the order is the
+        // reading order above and the rows inside a folder are ordered by when they last moved.
+        ContentTypes = new List<ChannelMediaContentType> { ChannelMediaContentType.Clip },
+        MediaTypes = new List<ChannelMediaType> { ChannelMediaType.Video },
+        SupportsContentDownloading = false,
+        SupportsSortOrderToggle = false
+    };
+
+    /// <inheritdoc />
+    public IEnumerable<ImageType> GetSupportedChannelImages() => Array.Empty<ImageType>();
+
+    /// <inheritdoc />
+    public Task<DynamicImageResponse> GetChannelImage(ImageType type, CancellationToken cancellationToken)
+        // Nothing above declares an image, so the server never asks. Answering with an empty
+        // response rather than raising keeps a host that asks anyway from failing the whole channel
+        // over a picture.
+        => Task.FromResult(new DynamicImageResponse { HasImage = false });
+
+    /// <inheritdoc />
+    public async Task<ChannelItemResult> GetChannelItems(
+        InternalChannelItemQuery query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        IReadOnlyList<StoredRequest> theirs;
+
+        try
+        {
+            theirs = await _store.FindForUserAsync(query.UserId, cancellationToken).ConfigureAwait(false);
+        }
+        catch (RequestStoreLoadException reason)
+        {
+            // The store says why in the log it wrote before throwing. What a person browsing gets
+            // is a sentence rather than a client-side error, for the same reason the page carries
+            // one: a folder that fails to open is indistinguishable from a plugin that is gone.
+            _logger.LogWarning(
+                reason,
+                "The requests could not be read, so the channel answered with the sentence that says so instead of a list.");
+
+            return OneFolder(NothingYetFolderId, _words.Get("mine.notRead", null));
+        }
+
+        if (query.FolderId is null or "")
+        {
+            return Root(theirs);
+        }
+
+        if (string.Equals(query.FolderId, NothingYetFolderId, StringComparison.Ordinal))
+        {
+            return Nothing();
+        }
+
+        return InsideAState(query.FolderId, theirs);
+    }
+
+    private static ChannelItemResult Nothing() => new()
+    {
+        Items = Array.Empty<ChannelItemInfo>(),
+        TotalRecordCount = 0
+    };
+
+    private static ChannelItemResult OneFolder(string id, string name) => new()
+    {
+        Items = new[]
+        {
+            new ChannelItemInfo
+            {
+                Id = id,
+                Name = name,
+                Type = ChannelItemType.Folder,
+                FolderType = ChannelFolderType.Container
+            }
+        },
+        TotalRecordCount = 1
+    };
+
+    /// <summary>
+    /// The folder for a state, as the server hands it back.
+    /// </summary>
+    /// <param name="state">The state the folder holds.</param>
+    /// <returns>That state's identifier.</returns>
+    private static string FolderIdOf(RequestState state) =>
+        StateFolderPrefix + state.ToString();
+
+    private ChannelItemResult Root(IReadOnlyList<StoredRequest> theirs)
+    {
+        if (theirs.Count == 0)
+        {
+            return OneFolder(NothingYetFolderId, _words.Get("mine.empty", null));
+        }
+
+        var held = theirs.Select(stored => stored.Request.State).ToHashSet();
+
+        var folders = _readingOrder
+            .Where(held.Contains)
+            .Select(state => new ChannelItemInfo
+            {
+                Id = FolderIdOf(state),
+                Name = _words.Get("mine.state." + state.ToString(), null),
+                Type = ChannelItemType.Folder,
+                FolderType = ChannelFolderType.Container
+            })
+            .ToArray();
+
+        return new ChannelItemResult
+        {
+            Items = folders,
+            TotalRecordCount = folders.Length
+        };
+    }
+
+    private ChannelItemResult InsideAState(string folderId, IReadOnlyList<StoredRequest> theirs)
+    {
+        if (!folderId.StartsWith(StateFolderPrefix, StringComparison.Ordinal)
+            || !Enum.TryParse<RequestState>(folderId[StateFolderPrefix.Length..], out var state)
+            || !_readingOrder.Contains(state))
+        {
+            // A folder identifier this channel did not write. Answering with nothing rather than
+            // raising, because the server keeps identifiers it was handed earlier and an older one
+            // arriving after a rename is a stale client rather than a fault.
+            return Nothing();
+        }
+
+        var rows = theirs
+            .Select(stored => stored.Request)
+            .Where(request => request.State == state)
+            .OrderByDescending(request => request.StateChangedAt)
+            .ThenBy(request => request.DisplayTitle, StringComparer.Ordinal)
+            .Select(Row)
+            .ToArray();
+
+        return new ChannelItemResult
+        {
+            Items = rows,
+            TotalRecordCount = rows.Length
+        };
+    }
+
+    /// <summary>
+    /// One request, as a row somebody reads.
+    /// <para>
+    /// <b>No provider identifier is carried.</b> A channel item with one is a row the server can
+    /// match against real media, and this row is not media: it is a record that somebody asked for
+    /// something. Pressing play on it does nothing, which is the awkwardness
+    /// <c>docs/surface.md</c> accepts as the price of reaching a client nobody here can change.
+    /// </para>
+    /// </summary>
+    /// <param name="request">The request being shown.</param>
+    /// <returns>The row.</returns>
+    private ChannelItemInfo Row(MediaRequest request) => new()
+    {
+        Id = request.Id.ToString("D", CultureInfo.InvariantCulture),
+        Name = request.DisplayYear is int year
+            ? string.Format(CultureInfo.InvariantCulture, _words.Get("title.withYear", null), request.DisplayTitle, year)
+            : request.DisplayTitle,
+        Type = ChannelItemType.Media,
+        ContentType = ChannelMediaContentType.Clip,
+        MediaType = ChannelMediaType.Video,
+        Overview = WhatHappenedTo(request),
+        DateModified = request.StateChangedAt.UtcDateTime,
+        DateCreated = request.RequestedAt.UtcDateTime,
+        ProductionYear = request.DisplayYear
+    };
+
+    /// <summary>
+    /// The sentence beside a row, which is the one thing this view exists to say.
+    /// <para>
+    /// Every sentence comes out of the catalogue by key. A declined request carries the reason it
+    /// was declined and the note beside it where one was given, and a request nobody has answered
+    /// carries the sentence that says asking again does not move it, which is the message this
+    /// plugin exists to stop somebody taking to the operator.
+    /// </para>
+    /// </summary>
+    /// <param name="request">The request being shown.</param>
+    /// <returns>What a person is told about it.</returns>
+    private string WhatHappenedTo(MediaRequest request)
+    {
+        if (request.State == RequestState.Open)
+        {
+            return _words.Get(Sentences.Waiting, null);
+        }
+
+        if (request.State != RequestState.Declined)
+        {
+            return _words.Get("mine.state." + request.State.ToString(), null);
+        }
+
+        var said = _words.Get(Sentences.Declined, null);
+
+        if (request.DeclineReason is not DeclineReason reason)
+        {
+            return said;
+        }
+
+        var why = _words.Get("declineReason." + reason.ToString(), null);
+
+        if (!string.IsNullOrEmpty(request.DeclineNote))
+        {
+            why = string.Format(
+                CultureInfo.InvariantCulture,
+                _words.Get("declineReason.withNote", null),
+                why,
+                request.DeclineNote);
+        }
+
+        return string.Format(CultureInfo.InvariantCulture, _words.Get("queue.askedBefore.withReason", null), said, why);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -103,8 +103,7 @@ the requests a server already holds are in
 ## Which clients this reaches
 
 No cell of the reach matrix in docs/surface.md has been checked against a real
-client, and the page now on the mainline is not a measurement of one; the
-channel it describes is still not built.
+client, and the channel now on the mainline has not been browsed from one.
 
 That sentence is the whole claim this file makes about client reach, and it is
 the sentence the matrix opens with. The matrix itself, a row per client family

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -67,10 +67,50 @@ and it is the price of reaching a client nobody here can change. It is not the s
 placeholders into a real library, because a channel's folder is the plugin's own and disappears with
 it.
 
+## The channel, as it is built
+
+`Jellyfin.Plugin.Requests/Surface/RequestsChannel.cs`. The server resolves its channels out of the
+container this plugin registers into, so the registration is what puts a folder tree beside a
+person's libraries on a client nobody here can change.
+
+The root is one folder per state that person actually has something in, in the order somebody reads
+rather than the order the states are stored in: what is waiting, then what was approved, then what
+arrived, then what was refused, then what could not be obtained. A state they hold nothing in is not
+a folder, because an empty folder in a tree is a thing somebody opens for no reason. Inside a folder
+are the titles, newest movement first.
+
+Every word comes out of the same catalogue the page reads, by the same key, so the two surfaces
+cannot drift into two answers. A row that is waiting carries the sentence that says nobody has
+answered it yet and that asking again does not move it, which is the message this plugin exists to
+remove. A row that was refused carries the reason and whatever the operator wrote beside it.
+
+Somebody who has never asked for anything gets one folder carrying the sentence that says so, and
+opening it is answered with nothing rather than with an error. An empty tree is indistinguishable
+from a plugin that has stopped working, and a folder that raises when it is opened is worse than
+either.
+
+**No row names anybody, including the person reading it**, and no row carries a provider
+identifier. The first is the same rule the endpoint underneath keeps, one layer further out: these
+rows are written into the server's own library database, where this plugin no longer decides who
+reads them. The second is what keeps a record that somebody asked for something from being matched
+against real media by the server, which is the awkwardness this page accepts rather than the
+placeholder rows it rejected outright.
+
+**What the channel implements for the cache and what that does not buy.** It carries
+`IHasCacheKey`, and the key is the person plus the moment the store last moved. A channel without
+one derives a single cache path for every user on the server, which for a view of one person's
+requests is the failure this milestone cares about most. That repairs the cache path and nothing
+else: the items a channel returns are written under a parent belonging to the channel rather than to
+the caller, and the server removes everything under that parent which the current caller's answer
+did not contain. Whether two callers arriving in turn can see each other's rows is a property of a
+running server, it is #67, and nothing in this repository answers it.
+
+**Nothing here has been browsed from a client and nothing has been run against a server.** What is
+held is the answer this plugin hands the server, which is what the suite asserts.
+
 ## The page, as it is built
 
-The page is on the mainline and the channel is not, so this section is about the one of the three
-surfaces that exists beyond the API.
+Both are on the mainline now, and this section is about the browser one.
 
 It is served by this plugin rather than registered with the dashboard:
 
@@ -227,8 +267,8 @@ nothing to ask with. The gesture that creates a request arrives from the sibling
 
 ## The reach matrix
 
-No cell of the reach matrix in docs/surface.md has been checked against a real client, and the page
-now on the mainline is not a measurement of one; the channel it describes is still not built.
+No cell of the reach matrix in docs/surface.md has been checked against a real client, and the
+channel now on the mainline has not been browsed from one.
 
 That sentence is the first thing in this section because the table under it looks like a
 capability list and is not one. It is what the decision above would reach if it were built, written
@@ -239,7 +279,7 @@ before it looks. Each file becomes one line, so the count is 1 where the sentenc
 where a word of it has moved:
 
     for f in README.md docs/surface.md; do printf '%s: ' "$f"; tr -s '[:space:]' ' ' < "$f" \
-      | grep -c 'No cell of the reach matrix in docs/surface.md has been checked against a real client, and the page now on the mainline is not a measurement of one; the channel it describes is still not built.'; done
+      | grep -c 'No cell of the reach matrix in docs/surface.md has been checked against a real client, and the channel now on the mainline has not been browsed from one.'; done
     README.md: 1
     docs/surface.md: 1
 
@@ -341,7 +381,8 @@ inside the pages, not the entry in the dashboard's own menu.
 Every issue after #65 in milestone 8 is read against the decision above.
 
 - #66, the user's view of their own requests on a client this project has never touched, is the
-  channel rendering.
+  channel rendering, and it is built. The section above says what it answers and what it does not
+  settle.
 - #67, proving one user cannot see another's requests through the surface, is the channel's
   per-user rendering, with the fallback stated above.
 - #68, what gesture creates a request from this side, is unchanged: the gesture arrives through the

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -105,8 +105,29 @@ the caller, and the server removes everything under that parent which the curren
 did not contain. Whether two callers arriving in turn can see each other's rows is a property of a
 running server, it is #67, and nothing in this repository answers it.
 
+**The channel is built before this plugin is, and that is measured rather than supposed.** It is
+worth writing down because it is a trap for anything else this plugin registers. The host resolves a
+channel while it is still starting, from `ApplicationHost.SetStaticProperties`, and at that moment
+the plugin instance the store's data directory comes from does not exist. A channel that took the
+store therefore took the server down with it, on both claimed lines, at the startup wizard. Read out
+of the server's own log on a run made to print it:
+
+    System.InvalidOperationException: The request store was asked for before this plugin was loaded, so there is no data directory to keep requests in.
+       at Jellyfin.Plugin.Requests.PluginServiceRegistrator.<>c.<RegisterServices>b__0_0(IServiceProvider provider)
+       ...
+       at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitIEnumerable(IEnumerableCallSite enumerableCallSite, RuntimeResolverContext context)
+       ...
+       at Emby.Server.Implementations.ApplicationHost.SetStaticProperties()
+       at Emby.Server.Implementations.ApplicationHost.InitializeServices(IConfiguration startupConfig)
+
+The elisions are the container's own frames and are marked. So the channel asks for the store when
+somebody browses rather than holding one, and the token the server caches on answers the same as a
+store nothing has been written to where there is no store to build yet.
+
 **Nothing here has been browsed from a client and nothing has been run against a server.** What is
-held is the answer this plugin hands the server, which is what the suite asserts.
+held is the answer this plugin hands the server, which is what the suite asserts. That the plugin
+still loads at all, with this channel registered, is watched on a real server of each line by the
+checks that install it.
 
 ## The page, as it is built
 


### PR DESCRIPTION
Part of #66. It builds the surface that milestone decided on, and it does not close the issue: the first condition asks that a person see this on a client this project has never touched, and nothing here has been browsed from one.

## What is built

`Jellyfin.Plugin.Requests/Surface/RequestsChannel.cs`, registered into the container the server resolves its channels from.

The root is one folder per state that person actually has something in, in the order somebody reads rather than the order the states are stored in: waiting, approved, in the library, refused, could not be obtained. A state they hold nothing in is not a folder, because an empty folder in a tree is a thing somebody opens for no reason. Inside a folder are the titles, newest movement first.

Every word comes out of the catalogue the page already reads, by the same key. A row nobody has answered carries the sentence saying so and saying that asking again does not move it; a row that was refused carries the reason and whatever the operator wrote beside it. Somebody who has never asked for anything gets one folder carrying the sentence that says so, and opening it answers with nothing rather than raising.

## The two properties that are not about rendering

**No row names anybody, including the person reading it, and no row carries a provider identifier.** These rows are written into the server's own library database, where this plugin no longer decides who reads them, so a user identifier in one is a way to learn a user identifier. A provider identifier would let the server match a record of an ask against real media, which is the shape `docs/surface.md` rejected outright.

**`IHasCacheKey` is implemented and the key is the person plus the moment the store last moved.** A channel without one derives a single cache path for every user on the server. That repairs the cache path and not the parent the items are written under. Whether two callers arriving in turn can see each other's rows is a property of a running server, it is #67, and nothing in this tree answers it.

## That the guards bite

Five near-misses executed against the new legs, each one edit, with the tree restored after each:

| What was changed | What went red |
| --- | --- |
| `GetCacheKey` returns the data version and forgets who is asking | `TheCacheKeySeparatesTwoPeopleAndMovesWhenTheStoreDoes` |
| the root lists every state whether or not they hold one | `TheRootIsOneFolderPerStateTheyHaveSomethingIn`, `EveryFolderIsNamedByTheCatalogueRatherThanBySomethingWrittenHere` |
| somebody who has asked for nothing gets an empty tree | `SomebodyWhoHasAskedForNothingIsToldSoAndOpeningItIsHarmless` |
| a row carries the provider identifiers it was asked for by | `NoRowCarriesAProviderIdentifier` |
| the two halves of a decline are joined with wording of the channel's own | `ADeclinedRequestCarriesTheReasonAndTheNoteWhereOneWasGiven` |

**One near-miss stayed green and it is disclosed rather than dropped.** Writing the catalogue's own words for a decline reason straight into the channel, `var why = "No room for it";`, passed, because the two strings are then equal. The leg was strengthened from containment to whole-string equality afterwards, which is what caught the fifth row above, and the copy case still passes. `NoAssetCarriesOneOfTheseSentencesItself` covers this for the pages by reading the shipped resources; there is no resource to read here, because the channel is code. The bound is written into the test class rather than only here.

## It took the server down first, and that is measured

The first head of this branch, `7deb240`, registered a channel that took the store. Eight jobs across four runs went red at the same step on both claimed lines, the startup wizard, while the same eight were green twenty-two minutes earlier at `b92f1ef`:

    gh api "repos/Flowfin/jellyfin-plugin-requests/actions/runs?per_page=80" --jq '.workflow_runs[] | select(.head_sha=="7deb2408119353f65ac5fbf5c1d68035d706e63c") | "\(.id)  \(.conclusion)  \(.name)"' | sort -k2
    32624752429  failure  Activity entries on a real server
    32624752482  failure  One person's requests on a real server
    32624752432  failure  Package
    32624752477  failure  Works alone, works with the sibling set

The runs said `exit code 22` and nothing else, because the wizard calls use `--fail` and nothing prints the server's log. #279 was opened to print both and is closed; job `97160850799` carries it:

    [FTL] [9] Main: Error while starting server
    System.InvalidOperationException: The request store was asked for before this plugin was loaded, so there is no data directory to keep requests in.
       at Jellyfin.Plugin.Requests.PluginServiceRegistrator.<>c.<RegisterServices>b__0_0(IServiceProvider provider)
       ...
       at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitIEnumerable(IEnumerableCallSite enumerableCallSite, RuntimeResolverContext context)
       ...
       at Emby.Server.Implementations.ApplicationHost.SetStaticProperties()
       at Emby.Server.Implementations.ApplicationHost.InitializeServices(IConfiguration startupConfig)

The elisions are the container's own frames and are marked. The host resolves a channel while it is still starting, before the plugin instance the store's data directory comes from exists, so a channel that holds the store is a plugin that cannot be loaded at all.

The repair is that the channel asks for the store when somebody browses, and the token the server caches on answers the same as a store nothing has been written to where there is no store to build yet. `BuildingTheChannelDoesNotBuildTheStore` holds it and was watched red with the channel holding the store again. `docs/surface.md` carries the log, because this is a trap for anything else this plugin registers rather than a fact about the channel.

One commit on this branch corrects the one before it: the repair commit named a run identifier that belongs to nothing on this board, written from memory instead of from the listing above.

## What was run

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Der Buildvorgang wurde erfolgreich ausgefuehrt.
        0 Warnung(en)
        0 Fehler

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler:     0, erfolgreich:   663, uebersprungen:     0, gesamt:   663 (net9.0)
    Bestanden!   : Fehler:     0, erfolgreich:   663, uebersprungen:     0, gesamt:   663 (net10.0)

Two existing legs refused this change before it was finished, and both were repairs rather than exemptions. `EveryKeyTheCatalogueCarriesIsOneSomethingNames` named the new catalogue key as one nothing draws, because the channel draws nothing itself and that reading looks in the assets; the key is now declared in `ChannelWords`, the way `Sentences` declares the one outcome no page shows. `ThePluginReferencesExactlyTheAssembliesWrittenDown` named `System.Runtime.InteropServices`, which a collection expression targeting `List<T>` brings in, so the two features lists are ordinary constructions and the plugin asks the server for nothing new.

## The means

C# in the plugin, against the same two target frameworks. It is forced: a channel is an interface the server resolves out of this plugin's own assembly, and there is no second way to be one.

## The size

Under one topic and over the length one change usually is. It is one new type and its tests: 353 lines of the type, of which most is the documentation the tree asks for, and 411 lines of test. Splitting it would produce a channel with no legs and legs with no channel, neither of which is reviewable alone.

## What this does not do, and what it leaves open

**Nothing here has been browsed from a client and nothing has been run against a server.** #66's first condition asks for a person on a client this project has never touched, and what the suite holds is the answer this plugin hands the server. The reach matrix in `docs/surface.md` and its copy of the same sentence in `README.md` both now say the channel is on the mainline and has not been browsed from one, which is a narrower claim than the one they carried and is the one that is true.

#67 is where the per-user question is answered on a running server of each claimed line, and `docs/surface.md` carries the fallback that applies if it cannot be shown. #70's first condition, that every surface renders the same message, gains its third surface here.

Nothing is owed to `docs/personal-data.md` by this: a channel row carries a title, a date and a sentence, and no field that names a person, which is what the test above holds rather than what this sentence claims.

**This has no second reader tonight.** The evidence above stands in place of one: six near-misses executed rather than described, the one that stayed green disclosed with what it means, and the two existing legs that refused this change named with how each was repaired.
