### PR TITLE
Say here rather than yet where a television family gets nothing

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -34,7 +34,8 @@ it means the same thing:
   those two words, so a checked section and an unchecked one can never be read as the same thing.
 
 Nothing in this document says a client does something on the strength of a plan. Where the thing
-itself is not built yet, the section says that instead, and no observation can change it until it is.
+itself is not there, the section says that instead, and no observation can change it while it is
+absent.
 
 ### Browser
 
@@ -71,7 +72,7 @@ Reading your own requests works from a browser on the same device, with the addr
 
 ### Android TV and Fire TV
 
-Nothing from this plugin yet, for the same reason as the row above.
+Nothing from this plugin here, for the same reason as the row above.
 
 This is the family the absence costs most, because a television is where somebody is least able to
 go and open a browser instead. Reading your own requests means finding a browser somewhere else,
@@ -79,33 +80,33 @@ which is a real answer and not a good one.
 
 ### iPhone and iPad
 
-Nothing from this plugin yet, for the same reason.
+Nothing from this plugin here, for the same reason.
 
 Reading your own requests works from a browser on the same device.
 
 ### Apple TV
 
-Nothing from this plugin yet, for the same reason, and the same cost as the other television
+Nothing from this plugin here, for the same reason, and the same cost as the other television
 families.
 
 ### Roku
 
-Nothing from this plugin yet, for the same reason, and the same cost as the other television
+Nothing from this plugin here, for the same reason, and the same cost as the other television
 families.
 
 ### LG webOS television
 
-Nothing from this plugin yet, for the same reason, and the same cost as the other television
+Nothing from this plugin here, for the same reason, and the same cost as the other television
 families.
 
 ### Samsung Tizen television
 
-Nothing from this plugin yet, for the same reason, and the same cost as the other television
+Nothing from this plugin here, for the same reason, and the same cost as the other television
 families.
 
 ### Kodi
 
-Nothing from this plugin yet, for the same reason.
+Nothing from this plugin here, for the same reason.
 
 ### A script, or another program
 


### PR DESCRIPTION
Part of #103.

## What was wrong

Seven family sections in `docs/user-guide.md` say "Nothing from this plugin yet". The word says the
thing is coming. For those families it is not: the surface meant for a client that draws its own
interface was the channel, and `a5d365b` took the per-user rows off it because on a running server
of each claimed line one person was handed a title only another person had asked for. That reading
and what follows from it are on #67 and in `docs/surface.md`.

So the absence on a television family is a decision with a measurement behind it rather than a gap
somebody has not got to. The sentence above the sections carried the same word for the same reason
and is corrected with them.

The Android phone and tablet section was rewritten in that merge and already says it. This is the
six television families and Kodi, which each point at it with "for the same reason", plus the
framing sentence.

## What it moves on #103

The second condition asks that where a client cannot do something, the guide says so plainly and
names an alternative. That was met for the two answers which are the same on every client, and the
per-family half of it was recorded as moving with an observation of each client. For every family
whose only surface would have been the channel it no longer waits on one: what those families get is
nothing, that is decided rather than untested, and each section names the browser as what to do
instead.

What still waits on somebody opening a client is the browser and desktop rows, which reach the page
and end in the two words saying nobody has looked. The third condition is untouched: the pointer
from the operator guide is a line in `docs/operating.md`, which belongs to #102.

## Evidence

Documents only. Prettier is checked against the pinned version, and the claim about `a5d365b` is the
merge of #281 on this repository's own mainline.

This board has no second reader for this change tonight, and the change is one word in eight places
plus the sentence that explains it.
