### PR TITLE
Keep what a service called an approved request

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Api/ActOnARequestTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/ActOnARequestTests.cs
@@ -521,7 +521,7 @@ public sealed class ActOnARequestTests
     /// <param name="caller">Who the server says is calling.</param>
     /// <returns>The controller under test.</returns>
     private RequestsController ControllerFor(IRequestStore store, Guid? caller)
-        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), new FakeInstallSettings(), new RecordingJournal(), new RecordingSink(), new RecordingRequesterNotice(), new RecordingArrivalNotice(), new FakeLibrary());
+        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), new FakeInstallSettings(), new RecordingJournal(), new RecordingSink(), new RecordingRequesterNotice(), new RecordingArrivalNotice(), new FakeLibrary(), ABridgeSubmission.WithNothingBehindIt(store));
 
     /// <summary>
     /// The row a successful decision handed back, with the status code checked.

--- a/Jellyfin.Plugin.Requests.Tests/Api/ActOnManyRequestsTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/ActOnManyRequestsTests.cs
@@ -619,7 +619,7 @@ public sealed class ActOnManyRequestsTests
     /// <param name="caller">Who the server says is calling.</param>
     /// <returns>The controller under test.</returns>
     private RequestsController ControllerFor(IRequestStore store, Guid? caller)
-        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), new FakeInstallSettings(), new RecordingJournal(), new RecordingSink(), new RecordingRequesterNotice(), new RecordingArrivalNotice(), new FakeLibrary());
+        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), new FakeInstallSettings(), new RecordingJournal(), new RecordingSink(), new RecordingRequesterNotice(), new RecordingArrivalNotice(), new FakeLibrary(), ABridgeSubmission.WithNothingBehindIt(store));
 
     /// <summary>
     /// The entries an action came back with, with the status code checked.

--- a/Jellyfin.Plugin.Requests.Tests/Api/CreateRequestTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/CreateRequestTests.cs
@@ -370,7 +370,8 @@ public sealed class CreateRequestTests
             new RecordingSink(),
             new RecordingRequesterNotice(),
             new RecordingArrivalNotice(),
-            new FakeLibrary());
+            new FakeLibrary(),
+            ABridgeSubmission.WithNothingBehindIt(store));
 
     /// <summary>
     /// The answer, with the status code checked, so a leg cannot pass on a body that came back under

--- a/Jellyfin.Plugin.Requests.Tests/Api/ErrorSurfaceTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/ErrorSurfaceTests.cs
@@ -391,7 +391,7 @@ public sealed class ErrorSurfaceTests
     /// <param name="settings">What this install is set to.</param>
     /// <returns>The controller under test.</returns>
     private RequestsController ControllerFor(IRequestStore store, Guid? caller, IInstallSettings settings)
-        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), settings, new RecordingJournal(), new RecordingSink(), new RecordingRequesterNotice(), new RecordingArrivalNotice(), new FakeLibrary());
+        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), settings, new RecordingJournal(), new RecordingSink(), new RecordingRequesterNotice(), new RecordingArrivalNotice(), new FakeLibrary(), ABridgeSubmission.WithNothingBehindIt(store));
 
     /// <summary>
     /// A second request in the store, so one of them can be moved out of the way.

--- a/Jellyfin.Plugin.Requests.Tests/Api/ListRequestsTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/ListRequestsTests.cs
@@ -625,5 +625,6 @@ public sealed class ListRequestsTests
             new RecordingSink(),
             new RecordingRequesterNotice(),
             new RecordingArrivalNotice(),
-            new FakeLibrary());
+            new FakeLibrary(),
+            ABridgeSubmission.WithNothingBehindIt(store));
 }

--- a/Jellyfin.Plugin.Requests.Tests/Api/PublishedApiDocumentTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/PublishedApiDocumentTests.cs
@@ -552,7 +552,7 @@ public sealed class PublishedApiDocumentTests
     /// <param name="settings">What this install is set to.</param>
     /// <returns>The controller under test.</returns>
     private RequestsController ControllerFor(IRequestStore store, Guid? caller, IInstallSettings settings)
-        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), settings, new RecordingJournal(), new RecordingSink(), new RecordingRequesterNotice(), new RecordingArrivalNotice(), new FakeLibrary());
+        => new RequestsController(store, new TestClock(Started), _identifiers, new FakeCallerIdentity(caller), settings, new RecordingJournal(), new RecordingSink(), new RecordingRequesterNotice(), new RecordingArrivalNotice(), new FakeLibrary(), ABridgeSubmission.WithNothingBehindIt(store));
 
     /// <summary>
     /// The health endpoint over one store, with nothing behind the bridge and no sweep having run,

--- a/Jellyfin.Plugin.Requests.Tests/Api/QueueContextTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/QueueContextTests.cs
@@ -438,5 +438,6 @@ public sealed class QueueContextTests
             new RecordingSink(),
             new RecordingRequesterNotice(),
             new RecordingArrivalNotice(),
-            new FakeLibrary());
+            new FakeLibrary(),
+            ABridgeSubmission.WithNothingBehindIt(store));
 }

--- a/Jellyfin.Plugin.Requests.Tests/Bridge/NoBackendCompletenessTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Bridge/NoBackendCompletenessTests.cs
@@ -30,7 +30,7 @@ public class NoBackendCompletenessTests
     /// Everything in the plugin that touches the bridge. Each is a place that has to keep working
     /// on a server with no external service.
     /// </summary>
-    private static readonly string[] Expected = ["CapabilitiesController", "HealthController"];
+    private static readonly string[] Expected = ["BridgeSubmission", "CapabilitiesController", "HealthController"];
 
     /// <summary>
     /// Everything that takes the bridge is named in the register, and nothing is named there that

--- a/Jellyfin.Plugin.Requests.Tests/Bridge/SubmittingAnApprovalTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Bridge/SubmittingAnApprovalTests.cs
@@ -1,0 +1,312 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Api;
+using Jellyfin.Plugin.Requests.Bridge;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Bridge;
+
+/// <summary>
+/// What approving does about an external request service, and what it keeps of the answer.
+/// <para>
+/// Two of these go through the endpoint, because the claim is about approving rather than about a
+/// method: a submission that only happens when something calls it directly is a submission an
+/// operator never triggers. The rest go through <see cref="BridgeSubmission"/> on its own, for the
+/// states the endpoint cannot produce - a request that already carries a reference, and a store that
+/// refuses the second write of one decision.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class SubmittingAnApprovalTests
+{
+    private static readonly Guid Asker = new Guid("c8000000-0000-0000-0000-000000000001");
+    private static readonly Guid Operator = new Guid("c8000000-0000-0000-0000-000000000002");
+    private static readonly DateTimeOffset Started = new DateTimeOffset(2026, 8, 23, 9, 0, 0, TimeSpan.Zero);
+
+    private readonly SequentialIdentifierSource _identifiers = new SequentialIdentifierSource();
+
+    /// <summary>
+    /// Approving with a service configured hands the request over once and keeps what the service
+    /// called it, on the request in the store and on the row the caller is answered with.
+    /// <para>
+    /// The row matters as much as the store. The operator's page holds the revision it was answered
+    /// with and sends it back on the next action, so answering the revision from before the reference
+    /// was written would refuse that action for a conflict this call created itself.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AnApprovalWithAServiceConfiguredIsHandedOverOnceAndTheReferenceIsKept()
+    {
+        var store = new InMemoryRequestStore();
+        var service = new AServiceThatKeepsWhatItIsHanded();
+        var open = await AnOpenRequestAsync(store).ConfigureAwait(true);
+
+        var answered = await ControllerOver(store, service)
+            .ApproveAsync(open.Request.Id, new ApproveRequestBody { Revision = open.Revision }, CancellationToken.None)
+            .ConfigureAwait(true);
+
+        var row = Moved(answered);
+        var held = await Held(store, open.Request.Id).ConfigureAwait(true);
+
+        Assert.Equal(open.Request.Id, Assert.Single(service.Handed).Id);
+        Assert.Equal(AServiceThatKeepsWhatItIsHanded.Name, held.Request.Backend?.Service);
+        Assert.Equal("svc-1", held.Request.Backend?.Id);
+        Assert.Equal(RequestState.Approved, held.Request.State);
+        Assert.Equal(held.Revision, row.Revision);
+    }
+
+    /// <summary>
+    /// A submission that failed leaves the request approved, carrying no reference, and says so in
+    /// the log with the identifier of the request it is about.
+    /// <para>
+    /// The approval standing is the whole rule. An operator decided, and a plugin that undid the
+    /// decision because a service on another machine refused would be overruling a person for a
+    /// reason that has nothing to do with the request. The absent reference is what makes the failure
+    /// recoverable: it is what the refusal to submit twice reads, so a request that has one is done
+    /// and a request that has none can be handed over again.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AFailedSubmissionLeavesTheRequestApprovedAndSaysSoInTheLog()
+    {
+        var store = new InMemoryRequestStore();
+        var log = new RecordingLogger();
+        var open = await AnOpenRequestAsync(store).ConfigureAwait(true);
+
+        var answered = await ControllerOver(store, new AServiceThatWillNotTakeAnything(), log)
+            .ApproveAsync(open.Request.Id, new ApproveRequestBody { Revision = open.Revision }, CancellationToken.None)
+            .ConfigureAwait(true);
+
+        var row = Moved(answered);
+        var held = await Held(store, open.Request.Id).ConfigureAwait(true);
+
+        Assert.Equal(RequestState.Approved, held.Request.State);
+        Assert.Equal(RequestState.Approved, row.State);
+        Assert.Null(held.Request.Backend);
+
+        var reported = Assert.Single(log.At(LogLevel.Error));
+
+        Assert.Contains(open.Request.Id.ToString(), reported.Message, StringComparison.Ordinal);
+        Assert.Equal(AServiceThatWillNotTakeAnything.Complaint, reported.Exception?.Message);
+    }
+
+    /// <summary>
+    /// A request that already carries a reference is not handed over a second time.
+    /// <para>
+    /// This is the answer to what submitting the same request twice does, and it is refused rather
+    /// than harmless. A second submission of something a service already accepted is a second copy of
+    /// the same download over there, and nothing on this side could tell the two apart afterwards.
+    /// </para>
+    /// <para>
+    /// It goes through the submission directly because the endpoint cannot reach this state: the
+    /// transition table refuses approving a request that is already approved. What can reach it is a
+    /// request sent onward again after it failed, and the reference it carries is from the first time.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ARequestThatWasAlreadyHandedOverIsNotHandedOverAgain()
+    {
+        var store = new InMemoryRequestStore();
+        var service = new AServiceThatKeepsWhatItIsHanded();
+        var submission = new BridgeSubmission(service, store, new RecordingLogger());
+        var approved = await AnApprovedRequestAsync(store).ConfigureAwait(true);
+
+        var once = await submission.SubmitAsync(approved, CancellationToken.None).ConfigureAwait(true);
+        var twice = await submission.SubmitAsync(once, CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Single(service.Handed);
+        Assert.Equal("svc-1", twice.Request.Backend?.Id);
+        Assert.Equal(once.Revision, twice.Revision);
+    }
+
+    /// <summary>
+    /// A reference the store would not take is reported with what the service called it, and nothing
+    /// is submitted again.
+    /// <para>
+    /// This is the one case here that needs somebody to look: the service holds the request and this
+    /// queue does not know so. Retrying would be the duplicate the rule above exists against, so the
+    /// log carries the service's own identifier instead and the two can be reconciled by hand.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AReferenceThatCouldNotBeWrittenBackIsReportedWithWhatTheServiceCalledIt()
+    {
+        var store = new InMemoryRequestStore();
+        var log = new RecordingLogger();
+        var service = new AServiceThatKeepsWhatItIsHanded();
+        var approved = await AnApprovedRequestAsync(store).ConfigureAwait(true);
+
+        // Somebody else moves the request in the window between the decision being written and the
+        // reference being written onto it, so the store refuses the second write for a conflict.
+        var contended = new StoreThatMovesARequestUnderTheWrite(
+            store,
+            request => request with { RequesterNote = "moved by somebody else" });
+
+        var after = await new BridgeSubmission(service, contended, log)
+            .SubmitAsync(approved, CancellationToken.None)
+            .ConfigureAwait(true);
+
+        Assert.Single(service.Handed);
+        Assert.Null(after.Request.Backend);
+
+        var reported = Assert.Single(log.At(LogLevel.Error));
+
+        Assert.Contains(AServiceThatKeepsWhatItIsHanded.Name, reported.Message, StringComparison.Ordinal);
+        Assert.Contains("svc-1", reported.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// On a server with no external service an approval keeps nothing and writes no line about it.
+    /// <para>
+    /// That is the shipping install and it is the one this must not become noisy on. The bridge there
+    /// hands back no reference, which is an answer rather than a failure, so an error in the log
+    /// would be an operator being told something went wrong on every decision they make.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AnApprovalOnAServerWithNoServiceKeepsNothingAndSaysNothing()
+    {
+        var store = new InMemoryRequestStore();
+        var log = new RecordingLogger();
+        var approved = await AnApprovedRequestAsync(store).ConfigureAwait(true);
+
+        var after = await new BridgeSubmission(new NoRequestBackend(), store, log)
+            .SubmitAsync(approved, CancellationToken.None)
+            .ConfigureAwait(true);
+
+        Assert.Null(after.Request.Backend);
+        Assert.Equal(approved.Revision, after.Revision);
+        Assert.Empty(log.Lines);
+    }
+
+    /// <summary>
+    /// A move that is not an approval hands nothing over. Declining is a decision that this server
+    /// will not fetch the title, and a service asked to fetch it anyway would be doing the opposite
+    /// of what the operator said.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task DecliningHandsNothingOver()
+    {
+        var store = new InMemoryRequestStore();
+        var service = new AServiceThatKeepsWhatItIsHanded();
+        var open = await AnOpenRequestAsync(store).ConfigureAwait(true);
+
+        await ControllerOver(store, service)
+            .DeclineAsync(
+                open.Request.Id,
+                new DeclineRequestBody { Revision = open.Revision, Reason = DeclineReason.AlreadyInTheLibrary },
+                CancellationToken.None)
+            .ConfigureAwait(true);
+
+        var held = await Held(store, open.Request.Id).ConfigureAwait(true);
+
+        Assert.Equal(RequestState.Declined, held.Request.State);
+        Assert.Empty(service.Handed);
+        Assert.Null(held.Request.Backend);
+    }
+
+    /// <summary>
+    /// An open request in the store, named by one provider so every move is available on it.
+    /// </summary>
+    /// <param name="store">Where it goes.</param>
+    /// <returns>The request and the revision the store holds it at.</returns>
+    private async Task<StoredRequest> AnOpenRequestAsync(InMemoryRequestStore store)
+        => await store.AddAsync(
+            new MediaRequest
+            {
+                Id = _identifiers.NewId(),
+                RequestedByUserId = Asker,
+                RequestedAt = Started,
+                StateChangedAt = Started,
+                Kind = RequestedItemKind.Movie,
+                DisplayTitle = "The Conversation",
+                DisplayYear = 1974,
+                ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tmdb"] = "603" }
+            },
+            CancellationToken.None).ConfigureAwait(true);
+
+    /// <summary>
+    /// A request the store already holds as approved, which is the state the submission is handed.
+    /// </summary>
+    /// <param name="store">Where it goes.</param>
+    /// <returns>The request and the revision the store holds it at.</returns>
+    private async Task<StoredRequest> AnApprovedRequestAsync(InMemoryRequestStore store)
+    {
+        var open = await AnOpenRequestAsync(store).ConfigureAwait(true);
+
+        return await store.ReplaceAsync(
+            RequestLifecycle.Move(open.Request, RequestState.Approved, Started, RequestCaller.Administrator(Operator)),
+            open.Revision,
+            CancellationToken.None).ConfigureAwait(true);
+    }
+
+    /// <summary>
+    /// What the store holds for one request, which is what a leg asserts against rather than the
+    /// answer the endpoint returned.
+    /// </summary>
+    /// <param name="store">The store.</param>
+    /// <param name="id">The request.</param>
+    /// <returns>The request and its revision.</returns>
+    private static async Task<StoredRequest> Held(InMemoryRequestStore store, Guid id)
+    {
+        var stored = await store.GetAsync(id, CancellationToken.None).ConfigureAwait(true);
+
+        return Assert.NotNull(stored);
+    }
+
+    /// <summary>
+    /// A controller whose approval reaches the service handed in.
+    /// </summary>
+    /// <param name="store">Where requests are kept.</param>
+    /// <param name="service">The external request service.</param>
+    /// <param name="log">Where a failed submission is reported.</param>
+    /// <returns>The controller under test.</returns>
+    private RequestsController ControllerOver(
+        InMemoryRequestStore store,
+        IRequestBackend service,
+        ILogger? log = null)
+        => new RequestsController(
+            store,
+            new TestClock(Started),
+            _identifiers,
+            new FakeCallerIdentity(Operator),
+            new FakeInstallSettings(),
+            new RecordingJournal(),
+            new RecordingSink(),
+            new RecordingRequesterNotice(),
+            new RecordingArrivalNotice(),
+            new FakeLibrary(),
+            new BridgeSubmission(service, store, log ?? new RecordingLogger()));
+
+    /// <summary>
+    /// The row a successful decision handed back, with the status code checked.
+    /// </summary>
+    /// <param name="answered">What the action returned.</param>
+    /// <returns>The row.</returns>
+    private static QueuedRequest Moved(ActionResult<QueuedRequest> answered)
+    {
+        var result = Assert.IsAssignableFrom<ObjectResult>(answered.Result);
+
+        Assert.Equal(200, result.StatusCode);
+
+        return Assert.IsType<QueuedRequest>(result.Value);
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/CatalogueSplitTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/CatalogueSplitTests.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.Requests.Api;
+using Jellyfin.Plugin.Requests.Bridge;
 using Jellyfin.Plugin.Requests.Configuration;
 using Jellyfin.Plugin.Requests.Fulfilment;
 using Jellyfin.Plugin.Requests.Identity;
@@ -116,7 +117,8 @@ public sealed class CatalogueSplitTests
                 nameof(IOutboundSink),
                 nameof(IRequesterNotice),
                 nameof(IArrivalNotice),
-                nameof(ILibrary)),
+                nameof(ILibrary),
+                nameof(BridgeSubmission)),
             string.Join(" | ", taken),
             StringComparer.Ordinal);
     }
@@ -155,5 +157,6 @@ public sealed class CatalogueSplitTests
             new RecordingSink(),
             new RecordingRequesterNotice(),
             new RecordingArrivalNotice(),
-            new FakeLibrary());
+            new FakeLibrary(),
+            ABridgeSubmission.WithNothingBehindIt(store));
 }

--- a/Jellyfin.Plugin.Requests.Tests/Doubles/ABridgeSubmission.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/ABridgeSubmission.cs
@@ -1,0 +1,24 @@
+using Jellyfin.Plugin.Requests.Bridge;
+using Jellyfin.Plugin.Requests.Storage;
+
+namespace Jellyfin.Plugin.Requests.Tests.Doubles;
+
+/// <summary>
+/// The submission every test that is not about the bridge is given.
+/// <para>
+/// It is the real thing over the shipping bridge rather than a stand-in, because that is what every
+/// install without an external service runs and a decision on such a server has to behave exactly as
+/// it did before this existed. A double here would let the submission path drift while the tests of
+/// the endpoints around it stayed green.
+/// </para>
+/// </summary>
+internal static class ABridgeSubmission
+{
+    /// <summary>
+    /// A submission with no service behind it, over the store the test is using.
+    /// </summary>
+    /// <param name="store">The store under test, which the submission writes a reference back into.</param>
+    /// <returns>The submission.</returns>
+    public static BridgeSubmission WithNothingBehindIt(IRequestStore store)
+        => new BridgeSubmission(new NoRequestBackend(), store, new RecordingLogger());
+}

--- a/Jellyfin.Plugin.Requests.Tests/Doubles/AServiceThatKeepsWhatItIsHanded.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/AServiceThatKeepsWhatItIsHanded.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Bridge;
+using Jellyfin.Plugin.Requests.Model;
+
+namespace Jellyfin.Plugin.Requests.Tests.Doubles;
+
+/// <summary>
+/// An external request service that accepts what it is handed and gives it a name.
+/// <para>
+/// The two bridges the suite already has answer questions about reachability and hand nothing over,
+/// which is the honest behaviour of a server with no service and useless for watching a submission.
+/// This is the other half: it records every request it was given, in order, and answers with a
+/// reference the way a service does.
+/// </para>
+/// <para>
+/// The names it issues are its own and mean nothing here. They are sequential so a test can say
+/// which submission it is looking at, and they are strings rather than numbers because the shape of
+/// an identifier is the service's business.
+/// </para>
+/// </summary>
+internal sealed class AServiceThatKeepsWhatItIsHanded : IRequestBackend
+{
+    /// <summary>
+    /// What this service calls itself when it issues a reference.
+    /// </summary>
+    public const string Name = "a-service";
+
+    private readonly List<MediaRequest> _handed = [];
+
+    /// <summary>
+    /// Gets every request handed to this service, in the order it arrived.
+    /// </summary>
+    public IReadOnlyList<MediaRequest> Handed => _handed;
+
+    /// <inheritdoc />
+    public Task<BackendReachability> CheckReachableAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return Task.FromResult(BackendReachability.Reachable);
+    }
+
+    /// <inheritdoc />
+    public Task<BackendReference?> SubmitAsync(MediaRequest request, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        _handed.Add(request);
+
+        return Task.FromResult<BackendReference?>(new BackendReference
+        {
+            Service = Name,
+            Id = string.Format(CultureInfo.InvariantCulture, "svc-{0}", _handed.Count)
+        });
+    }
+
+    /// <inheritdoc />
+    public Task<BackendReport?> ReportAsync(BackendReference reference, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return Task.FromResult<BackendReport?>(null);
+    }
+
+    /// <inheritdoc />
+    public Task WithdrawAsync(BackendReference reference, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return Task.CompletedTask;
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/Doubles/AServiceThatWillNotTakeAnything.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/AServiceThatWillNotTakeAnything.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Bridge;
+using Jellyfin.Plugin.Requests.Model;
+
+namespace Jellyfin.Plugin.Requests.Tests.Doubles;
+
+/// <summary>
+/// An external request service that throws when it is handed something.
+/// <para>
+/// It stands for every way a submission can fail from this side of the interface: the service is
+/// down, the credential is refused, the answer cannot be read. Which of those an adapter tells apart
+/// and what each one then does is a separate question; what this is for is the one rule that holds
+/// across all of them, that an approval already written is not taken back.
+/// </para>
+/// <para>
+/// The exception it throws carries no vocabulary of its own on purpose. A double raising a named
+/// bridge failure would be a test of a distinction nothing in this tree makes yet.
+/// </para>
+/// </summary>
+internal sealed class AServiceThatWillNotTakeAnything : IRequestBackend
+{
+    /// <summary>
+    /// What the failure says, so a test can find it again in the log.
+    /// </summary>
+    public const string Complaint = "This service is not taking anything today.";
+
+    /// <inheritdoc />
+    public Task<BackendReachability> CheckReachableAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return Task.FromResult(BackendReachability.Reachable);
+    }
+
+    /// <inheritdoc />
+    public Task<BackendReference?> SubmitAsync(MediaRequest request, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        throw new InvalidOperationException(Complaint);
+    }
+
+    /// <inheritdoc />
+    public Task<BackendReport?> ReportAsync(BackendReference reference, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return Task.FromResult<BackendReport?>(null);
+    }
+
+    /// <inheritdoc />
+    public Task WithdrawAsync(BackendReference reference, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return Task.CompletedTask;
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/Model/MediaRequestTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Model/MediaRequestTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using Jellyfin.Plugin.Requests.Bridge;
 using Jellyfin.Plugin.Requests.Model;
 using Xunit;
 
@@ -24,6 +25,7 @@ public class MediaRequestTests
     [
         "Availability",
         "AvailabilityCheckedAt",
+        "Backend",
         "DeclineNote",
         "DeclineReason",
         "DisplayTitle",
@@ -226,7 +228,30 @@ public class MediaRequestTests
         return underlying == typeof(IReadOnlyDictionary<string, string>)
             || underlying == typeof(IReadOnlyList<int>)
             || underlying == typeof(IReadOnlyList<Guid>)
-            || underlying == typeof(IReadOnlyList<RequestHistoryEntry>);
+            || underlying == typeof(IReadOnlyList<RequestHistoryEntry>)
+            || underlying == typeof(BackendReference);
+    }
+
+    /// <summary>
+    /// The reference an external service issued is held to the same rule as the record that carries
+    /// it, for the reason the history entry is: widening the line above to admit a record admits
+    /// whatever that record's own fields happen to be, and the reader of the widened line does not
+    /// see that. Two strings the service chose, which the record does not read.
+    /// </summary>
+    [Fact]
+    public void TheBackendReferenceIsAPlainValueToo()
+    {
+        var offending = typeof(BackendReference)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(property => !IsAPlainValue(property.PropertyType))
+            .Select(property => string.Format(
+                CultureInfo.InvariantCulture,
+                "{0} is {1}",
+                property.Name,
+                property.PropertyType.Name))
+            .ToArray();
+
+        Assert.Empty(offending);
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Requests.Tests/Notify/ActivityJournalTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Notify/ActivityJournalTests.cs
@@ -273,7 +273,8 @@ public sealed class ActivityJournalTests
             new RecordingSink(),
             new RecordingRequesterNotice(),
             new RecordingArrivalNotice(),
-            new FakeLibrary());
+            new FakeLibrary(),
+            ABridgeSubmission.WithNothingBehindIt(store));
 
     /// <summary>
     /// One open request in the store, with a provider identifier so the library can match it.

--- a/Jellyfin.Plugin.Requests.Tests/Notify/QuietByDefaultTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Notify/QuietByDefaultTests.cs
@@ -333,7 +333,8 @@ public sealed class QuietByDefaultTests
             sink,
             new RecordingRequesterNotice(),
             new RecordingArrivalNotice(),
-            new FakeLibrary());
+            new FakeLibrary(),
+            ABridgeSubmission.WithNothingBehindIt(store));
 
     /// <summary>
     /// One open request, with a provider identifier the library can match.

--- a/Jellyfin.Plugin.Requests.Tests/Notify/TellingAdministratorsTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Notify/TellingAdministratorsTests.cs
@@ -299,7 +299,8 @@ public sealed class TellingAdministratorsTests
             new RecordingSink(),
             new RecordingRequesterNotice(),
             arrivals,
-            new FakeLibrary());
+            new FakeLibrary(),
+            ABridgeSubmission.WithNothingBehindIt(store));
 
     /// <summary>
     /// The seam announcing arrivals to the path handed in.

--- a/Jellyfin.Plugin.Requests.Tests/Notify/TellingTheRequesterTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Notify/TellingTheRequesterTests.cs
@@ -325,7 +325,8 @@ public sealed class TellingTheRequesterTests
             new RecordingSink(),
             told,
             new RecordingArrivalNotice(),
-            new FakeLibrary());
+            new FakeLibrary(),
+            ABridgeSubmission.WithNothingBehindIt(store));
 
     /// <summary>
     /// A sweep telling the path handed in.

--- a/Jellyfin.Plugin.Requests.Tests/Surface/AvailabilityIsAnsweredPerCallerTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Surface/AvailabilityIsAnsweredPerCallerTests.cs
@@ -254,5 +254,6 @@ public sealed class AvailabilityIsAnsweredPerCallerTests
             new RecordingSink(),
             new RecordingRequesterNotice(),
             new RecordingArrivalNotice(),
-            library);
+            library,
+            ABridgeSubmission.WithNothingBehindIt(store));
 }

--- a/Jellyfin.Plugin.Requests.Tests/Surface/WhatAPersonIsToldTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Surface/WhatAPersonIsToldTests.cs
@@ -234,5 +234,6 @@ public sealed class WhatAPersonIsToldTests
             new RecordingSink(),
             new RecordingRequesterNotice(),
             new RecordingArrivalNotice(),
-            new FakeLibrary());
+            new FakeLibrary(),
+            ABridgeSubmission.WithNothingBehindIt(store));
 }

--- a/Jellyfin.Plugin.Requests.Tests/Web/QueueViewTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Web/QueueViewTests.cs
@@ -228,7 +228,8 @@ public sealed class QueueViewTests
             new RecordingSink(),
             new RecordingRequesterNotice(),
             new RecordingArrivalNotice(),
-            new FakeLibrary());
+            new FakeLibrary(),
+            ABridgeSubmission.WithNothingBehindIt(store));
 
         var answered = await controller.QueueAsync(
             [Enum.Parse<RequestState>(SelectedValueOf(body, "RequestsQueueState"), false)],

--- a/Jellyfin.Plugin.Requests/Api/RequestsController.cs
+++ b/Jellyfin.Plugin.Requests/Api/RequestsController.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Bridge;
 using Jellyfin.Plugin.Requests.Configuration;
 using Jellyfin.Plugin.Requests.Fulfilment;
 using Jellyfin.Plugin.Requests.Identity;
@@ -104,6 +105,7 @@ public sealed class RequestsController : RequestsControllerBase
     private readonly IRequesterNotice _told;
     private readonly IArrivalNotice _arrivals;
     private readonly ILibrary _library;
+    private readonly BridgeSubmission _bridge;
     private readonly RequestIntake _intake;
 
     /// <summary>
@@ -144,6 +146,12 @@ public sealed class RequestsController : RequestsControllerBase
     /// own page says whether what they asked for has arrived, and that sentence is answered for the
     /// reader rather than for the server, which is #71.
     /// </param>
+    /// <param name="bridge">
+    /// What an approval hands to an external request service, and what it keeps of the answer. It
+    /// is a dependency rather than something this controller builds, because it takes the bridge and
+    /// the server's log, and because what a test of an approval has to be able to see is whether
+    /// anything was handed over at all, which is not visible through a server nothing here runs.
+    /// </param>
     public RequestsController(
         IRequestStore store,
         IClock clock,
@@ -154,7 +162,8 @@ public sealed class RequestsController : RequestsControllerBase
         IOutboundSink sink,
         IRequesterNotice told,
         IArrivalNotice arrivals,
-        ILibrary library)
+        ILibrary library,
+        BridgeSubmission bridge)
     {
         _store = store;
         _clock = clock;
@@ -165,6 +174,7 @@ public sealed class RequestsController : RequestsControllerBase
         _told = told;
         _arrivals = arrivals;
         _library = library;
+        _bridge = bridge;
 
         // Built here rather than injected, because it is this controller's use of the store rather
         // than one more thing the server has to supply. CatalogueSplitTests reads the list this
@@ -863,6 +873,17 @@ public sealed class RequestsController : RequestsControllerBase
                     _told.Tell(message);
                 }
             }
+
+            // An approval is also the moment something else is asked to fetch the title, and what
+            // comes back is written onto the request. Last of everything here and never in place of
+            // the write above: the decision is the operator's and it stands whatever a service on
+            // another machine does, so this can only add a reference and never take a decision back.
+            //
+            // The row that is answered with is the one this leaves behind, because it is the newer
+            // revision. Answering the earlier one would hand the page a number the store has already
+            // moved past, and the operator's next action on that row would be refused for a conflict
+            // this call created itself.
+            written = await _bridge.SubmitAsync(written, cancellationToken).ConfigureAwait(false);
 
             return new DecidedRequest { Id = id, Request = Queued(written) };
         }

--- a/Jellyfin.Plugin.Requests/Bridge/BridgeSubmission.cs
+++ b/Jellyfin.Plugin.Requests/Bridge/BridgeSubmission.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.Requests.Bridge;
+
+/// <summary>
+/// What an approval does about an external request service, and what it keeps of the answer.
+/// <para>
+/// Approving is the moment something else is asked to fetch the title. What comes back is the
+/// service's own name for the thing it accepted, and losing it means the two systems can never be
+/// reconciled again: this side would hold a request it believes was handed over and no way to ask
+/// anybody about it. So the reference is written back onto the request, and the write is the whole
+/// reason this exists.
+/// </para>
+/// <para>
+/// <b>An approval is never undone by a submission that failed.</b> The operator decided, the store
+/// already holds the decision, and a plugin that rolled it back would be overruling a person because
+/// a service on another machine was down. What a failure produces here is a log line and an approved
+/// request with no reference, which is a state that can be submitted again once the service is back.
+/// Making that failure visible to an operator without reading a log is #283.
+/// </para>
+/// <para>
+/// <b>Submitting the same request twice is refused, and it is refused by looking at the request.</b>
+/// <see cref="MediaRequest.Backend"/> is written only here and only after a service answered, so a
+/// request carrying one has already been handed over and is not handed over again. That is the
+/// answer this issue's third condition asks to be stated: refused rather than harmless, because a
+/// second submission of an accepted request is a second copy of the same download on the service's
+/// side, and nothing on this side could tell the two apart afterwards.
+/// </para>
+/// <para>
+/// On a server with no external service this does nothing at all and says nothing about it. The
+/// shipping bridge hands back no reference, which is not a failure, so a decision on such a server
+/// leaves no log line and no field, and the caller has no branch for the difference.
+/// </para>
+/// </summary>
+public sealed class BridgeSubmission
+{
+    private readonly IRequestBackend _backend;
+    private readonly IRequestStore _store;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BridgeSubmission"/> class.
+    /// </summary>
+    /// <param name="backend">Whatever else on this server fetches media.</param>
+    /// <param name="store">Where requests are kept, for the reference to be written back into.</param>
+    /// <param name="logger">The server's log, which is where a failed submission is reported.</param>
+    public BridgeSubmission(IRequestBackend backend, IRequestStore store, ILogger logger)
+    {
+        _backend = backend;
+        _store = store;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Hands a request that has just been approved to the service, and keeps what it called it.
+    /// <para>
+    /// Called with the request as the store wrote it, and answers with the request as the store
+    /// holds it afterwards. Where nothing was handed over, where the service refused, or where the
+    /// reference could not be written back, that is the same value it was given: the approval stands
+    /// in every one of those cases and the caller has one thing to return either way.
+    /// </para>
+    /// <para>
+    /// Nothing here throws. It runs after a decision has already been written, so an exception
+    /// escaping it would turn a decision that was taken into a call that reports failure, and the
+    /// operator would press the button again against a queue that had already moved.
+    /// </para>
+    /// </summary>
+    /// <param name="written">The request as the store wrote it, at its new revision.</param>
+    /// <param name="cancellationToken">Cancels the submission.</param>
+    /// <returns>The request at the revision the store holds it at now.</returns>
+    public async Task<StoredRequest> SubmitAsync(StoredRequest written, CancellationToken cancellationToken)
+    {
+        if (written.Request.State != RequestState.Approved || written.Request.Backend is not null)
+        {
+            // Not an approval, or one that has already been handed over. Both are ordinary and
+            // neither is worth a line in an operator's log.
+            return written;
+        }
+
+        BackendReference? reference;
+
+        try
+        {
+            reference = await _backend.SubmitAsync(written.Request, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception reason)
+        {
+            // Every failure of the service, including a cancelled call. Cancellation is not rethrown
+            // because the decision is already in the store: the caller asked to stop, and what it
+            // would stop is a submission rather than the approval, so the honest answer is the
+            // approved request with no reference on it.
+            //
+            // Which failures an adapter distinguishes, and what each of them then does, is #86. What
+            // is decided here is only that none of them loses the approval.
+            _logger.LogError(
+                reason,
+                "Request {RequestId} was approved and could not be handed to the external request service. The approval stands and nothing was undone; it carries no reference, so it has not been fetched and can be submitted again.",
+                written.Request.Id);
+
+            return written;
+        }
+
+        if (reference is not BackendReference kept)
+        {
+            // Nothing was handed over. This is what a server with no external service answers on
+            // every approval, and it is not a failure to report.
+            return written;
+        }
+
+        try
+        {
+            return await _store.ReplaceAsync(
+                written.Request with { Backend = kept },
+                written.Revision,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception reason)
+        {
+            // The worst of the three and the reason it is reported loudest: the service has the
+            // request and this side did not keep what it called it. Nothing here retries, because a
+            // second submission against a service that already accepted one is the duplicate the
+            // rule above exists against, and the operator is told the identifier so the two can be
+            // reconciled by hand.
+            _logger.LogError(
+                reason,
+                "Request {RequestId} was handed to {Service}, which called it {Reference}, and that reference could not be written back. The service holds it and this queue does not know so, which is the one case here that needs somebody to look.",
+                written.Request.Id,
+                kept.Service,
+                kept.Id);
+
+            return written;
+        }
+    }
+}

--- a/Jellyfin.Plugin.Requests/Model/MediaRequest.cs
+++ b/Jellyfin.Plugin.Requests/Model/MediaRequest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using Jellyfin.Plugin.Requests.Bridge;
 
 namespace Jellyfin.Plugin.Requests.Model;
 
@@ -276,6 +277,28 @@ public sealed record MediaRequest
     /// operator asking why a request still says absent needs to know whether anything checked.
     /// </summary>
     public DateTimeOffset? AvailabilityCheckedAt { get; init; }
+
+    /// <summary>
+    /// Gets what an external request service called this after it was handed over, or
+    /// <see langword="null"/> where nothing was. Null is the ordinary value: most servers run no
+    /// such service, and on those nothing is ever handed anywhere.
+    /// <para>
+    /// It is kept on the request because losing it means the two systems can never be reconciled
+    /// again. A reference held anywhere else would be a second store to keep in step with this one,
+    /// and the first restore from a backup would separate them.
+    /// </para>
+    /// <para>
+    /// Both halves of it are strings the service chose, unread. Nothing here parses one, which is
+    /// what keeps the record a value with nothing to resolve, and it is why a reference on a plain
+    /// record is not the same kind of field as a client or a manager would be.
+    /// </para>
+    /// <para>
+    /// It is written once. <see cref="Bridge.BridgeSubmission"/> hands a request over only where
+    /// this is null, so a request that already carries one is never submitted a second time, and
+    /// this field is the fact that decides it.
+    /// </para>
+    /// </summary>
+    public BackendReference? Backend { get; init; }
 
     /// <summary>
     /// Whether this person is one of the people waiting for this request, whether they asked first

--- a/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
@@ -87,6 +87,15 @@ public sealed class PluginServiceRegistrator : IPluginServiceRegistrator
         // registration and nothing else.
         serviceCollection.AddSingleton<IRequestBackend, NoRequestBackend>();
 
+        // What an approval hands over and what it keeps of the answer. Registered rather than built
+        // inside the controller, because it takes the bridge and the server's log, and because it
+        // writes to the store: a second construction of it somewhere else would be a second place
+        // that decides whether a request has already been handed over.
+        serviceCollection.AddSingleton<BridgeSubmission>(provider => new BridgeSubmission(
+            provider.GetRequiredService<IRequestBackend>(),
+            provider.GetRequiredService<IRequestStore>(),
+            provider.GetRequiredService<ILogger<BridgeSubmission>>()));
+
         // When the bridge was last seen answering. One per server, because it is a fact about the
         // install and the controller that reads it is built per call: state kept on that controller
         // would be forgotten between two reads of the same page.

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -8,9 +8,9 @@ reconciled: what the service's words mean here.
 It is not the whole of the bridge. The interface is
 [`IRequestBackend`](../Jellyfin.Plugin.Requests/Bridge/IRequestBackend.cs), the implementation every
 server without a service runs is
-[`NoRequestBackend`](../Jellyfin.Plugin.Requests/Bridge/NoRequestBackend.cs), and how a submission is
-made and what happens when the service misbehaves are separate questions this page does not answer.
-Where a credential lives is answered at the end of it.
+[`NoRequestBackend`](../Jellyfin.Plugin.Requests/Bridge/NoRequestBackend.cs), what an approval hands
+over is below, and what happens when the service misbehaves is a separate question this page does not
+answer. Where a credential lives is answered at the end of it.
 
 ## The mapping
 
@@ -76,6 +76,34 @@ history, and the person it belongs to is told something untrue about their own r
 Case is ignored when a word is looked up, because two adapters written against one service will spell
 one word two ways and both mean what the service meant. Nothing else is normalised.
 
+## What an approval hands over
+
+Approving is the moment something else is asked to fetch the title, and
+[`BridgeSubmission`](../Jellyfin.Plugin.Requests/Bridge/BridgeSubmission.cs) is the whole of what this
+side does about it. It runs after the decision has been written and never instead of it.
+
+**A submission that failed never takes an approval back.** The operator decided, the queue already
+holds the decision, and undoing it because a service on another machine was down would be the plugin
+overruling a person. What a failure leaves is an approved request carrying no reference and a line in
+the server log, which is a state that can be handed over again once the service answers. Making that
+failure visible to an operator without reading a log is #283, and until that lands the log is the only
+place it appears.
+
+**Submitting the same request twice is refused, and the request itself is what refuses it.** The
+reference is written only after a service answered, so a request carrying one has already been handed
+over and is not handed over again. Harmless was the other available answer and it is the wrong one: a
+second submission of an accepted request is a second copy of the same download on the service's side,
+and nothing here could tell the two apart afterwards.
+
+The one case that needs somebody to look is the service accepting a request and the reference then
+failing to be written back. The service holds it and this queue does not know so. Nothing retries,
+because retrying is the duplicate the rule above exists against, and the log line carries the
+identifier the service issued so the two can be reconciled by hand.
+
+On a server with no external service none of this happens and none of it is reported. The shipping
+bridge hands back no reference, which is an answer rather than a failure, so an approval there leaves
+no log line and no field.
+
 ## Whose name a request carries over there
 
 The external service has its own users, and something has to decide whose name a submitted request
@@ -136,6 +164,7 @@ cannot arrive quietly: it either gets a line in this table saying so, or the cha
 
 | What                     | Without a bridge                                                          |
 | ------------------------ | ------------------------------------------------------------------------- |
+| `BridgeSubmission`       | Hands nothing over, keeps nothing, and writes no line about it.           |
 | `CapabilitiesController` | Answers, and says that no bridge is configured.                           |
 | `HealthController`       | Answers, and says the bridge is not configured rather than not answering. |
 


### PR DESCRIPTION
Closes #82.

Approving is the moment something else is asked to fetch the title, and nothing asked. Two types took the bridge, one to say whether a service is configured and one to say whether it answered, and neither handed anything over. There was nowhere to keep an answer either: neither the model nor the store carried the word.

    git grep -n 'IRequestBackend' 21c7232 -- Jellyfin.Plugin.Requests/ | grep -v ':Jellyfin.Plugin.Requests/Bridge/'
    21c7232:Jellyfin.Plugin.Requests/Api/CapabilitiesController.cs:37:    private readonly IRequestBackend _backend;
    21c7232:Jellyfin.Plugin.Requests/Api/CapabilitiesController.cs:45:    public CapabilitiesController(IInstallSettings settings, IRequestBackend backend)
    21c7232:Jellyfin.Plugin.Requests/Api/HealthController.cs:39:    private readonly IRequestBackend _backend;
    21c7232:Jellyfin.Plugin.Requests/Api/HealthController.cs:58:        IRequestBackend backend,
    21c7232:Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs:85:        serviceCollection.AddSingleton<IRequestBackend, NoRequestBackend>();

    git grep -in 'backend' 21c7232 -- Jellyfin.Plugin.Requests/Model/ Jellyfin.Plugin.Requests/Storage/ ; echo "exit=$?"
    exit=1

## What is here

`MediaRequest.Backend` carries what a service called the request and which service said so. `BridgeSubmission` is the one place that writes it, and the approval path is the one place that calls it.

It runs after the decision has been written and never instead of it. A submission that failed leaves an approved request carrying no reference and an error in the log, and the approval is not undone: the operator decided, the queue already holds the decision, and rolling it back because a service on another machine was down would be the plugin overruling a person.

**Submitting the same request twice is refused, and the request refuses it.** That is the answer this issue asks to be stated. A reference is written only after a service answered, so a request carrying one has already been handed over. Harmless was the other available answer and it is the wrong one: a second submission of an accepted request is a second copy of the same download over there, and nothing on this side could tell the two apart afterwards.

The one case that needs somebody to look is the service accepting a request and the reference then failing to be written back. Nothing retries, because retrying is the duplicate the rule above exists against, and the log line carries the identifier the service issued so the two can be reconciled by hand.

On a server with no external service none of this happens and none of it is reported. The shipping bridge hands back no reference, which is an answer rather than a failure.

## What was watched failing

Every guard here was watched red for the reason it names, by mutating the tree and running the suite. All of them on `net9.0` at the head of this branch.

The register comparison, run before `BridgeSubmission` had a row in `docs/bridge.md`:

    Assert.Equal() Failure: Values differ
    Expected: CapabilitiesController | HealthController
    Actual:   BridgeSubmission | CapabilitiesController | HealthController

The submission removed from the approval path, leaving the class and its tests in place:

    SubmittingAnApprovalTests.AFailedSubmissionLeavesTheRequestApprovedAndSaysSoInTheLog [FAIL]
    SubmittingAnApprovalTests.AnApprovalWithAServiceConfiguredIsHandedOverOnceAndTheReferenceIsKept [FAIL]
    Assert.Single() Failure: The collection was empty

The refusal to submit twice deleted, so the check is only on the state:

    SubmittingAnApprovalTests.ARequestThatWasAlreadyHandedOverIsNotHandedOverAgain [FAIL]
    Assert.Single() Failure: The collection contained 2 items

A failure rethrown instead of being reported, which is the one-line mistake that turns a decision that was taken into a call that reports failure:

    SubmittingAnApprovalTests.AFailedSubmissionLeavesTheRequestApprovedAndSaysSoInTheLog [FAIL]
    System.InvalidOperationException : This service is not taking anything today.

And the rule that keeps the request a value with nothing to resolve, with the new field taken out of the widened line:

    MediaRequestTests.EveryFieldIsAPlainValueSoTheRecordCannotFetchAnything [FAIL]
    Assert.Empty() Failure: Collection was not empty
    Collection: ["Backend is BackendReference"]

The tree passes, on both server lines. The runner reports in the language this machine is set to, and its output is pasted rather than translated:

```
dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror

Bestanden!   : Fehler:     0, erfolgreich:   665, übersprungen:     0, gesamt:   665, Dauer: 16 s - Jellyfin.Plugin.Requests.Tests.dll (net10.0)
Bestanden!   : Fehler:     0, erfolgreich:   665, übersprungen:     0, gesamt:   665, Dauer: 17 s - Jellyfin.Plugin.Requests.Tests.dll (net9.0)
```

658 on the base and 665 here, which is the seven legs this adds.

## The size, and why it was not split further

    git diff --numstat origin/master...HEAD | awk '{a+=$1;d+=$2} END{print a" added, "d" deleted"}'
    753 added, 22 deleted

That is over the 400-line proxy and it is not claimed as an exception, because none of the declared shapes covers it: nothing here is generated, vendored, moved, imported as evidence, or one substitution rule applied everywhere. What it is instead is a change whose parts only make sense together. A field with nothing writing it, or a submitter with nowhere to keep its answer, is not reviewable alone, and this issue has already been re-planned once for exactly this reason: the operator-facing half was split out and is #283.

Where the size actually is:

    git diff --numstat origin/master...HEAD | sort -rn | head -5
    312     0       Jellyfin.Plugin.Requests.Tests/Bridge/SubmittingAnApprovalTests.cs
    139     0       Jellyfin.Plugin.Requests/Bridge/BridgeSubmission.cs
    76      0       Jellyfin.Plugin.Requests.Tests/Doubles/AServiceThatKeepsWhatItIsHanded.cs
    60      0       Jellyfin.Plugin.Requests.Tests/Doubles/AServiceThatWillNotTakeAnything.cs
    35      1       Jellyfin.Plugin.Requests.Tests/Doubles/ABridgeSubmission.cs

Fifteen of the twenty-six files are one line each: the controller took one more dependency, and every test that builds it hands one in.

## What this does not do

**No adapter is added and nothing leaves any server.** The only implementation of the bridge in this tree is still the one for a server that has no service, and the plugin still holds no HTTP client outside the notification sink:

    git grep -n ': IRequestBackend' -- Jellyfin.Plugin.Requests/
    Jellyfin.Plugin.Requests/Bridge/NoRequestBackend.cs:23:public sealed class NoRequestBackend : IRequestBackend

    git grep -ln 'HttpClient\|IHttpClientFactory\|WebRequest' -- Jellyfin.Plugin.Requests/
    Jellyfin.Plugin.Requests/Notify/OutboundSink.cs

`docs/personal-data.md` was read against this and is unchanged. Its bridge row says the path is not built and is off until a backend is set, and both still hold: what is built is the caller, and there is nothing behind it to call.

**Nothing was run against an external service or against a Jellyfin server.** No such service exists in this tree to run against, and the suite reaches none. What is measured is what this plugin hands the interface and what it keeps of the answer, which is narrower than watching a request arrive in a real service.

**Which failures an adapter tells apart is not decided here.** Unreachable, a refused credential, an unknown title and a version this adapter does not know are #86, and what is settled here is only that none of them loses an approval.

**No second reader has read this.** Nothing on this board tonight is a second pair of eyes, and the evidence above stands in place of one rather than beside one.
