### PR TITLE
Record what reds the mutation run, and what does not

### DIFF
--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -587,7 +587,7 @@ added, and #2 asks the same of them: a run in which the guard went red for the r
 a run in which the tree passes it. Nothing in this tree recorded either, so what follows is that
 record rather than a claim that it already existed.
 
-Eleven of the thirteen have both. Two do not, and the table says which rather than leaving a
+Twelve of the thirteen have both. One does not, and the table says which rather than leaving a
 reader to take a full-looking column for a full one.
 
 **Two of those cells said the guard had no red run of this kind and both were wrong.** They were
@@ -631,7 +631,7 @@ arrived after that head, so their green runs are their own and carry their own h
 | `activity-entries.yaml`       | 32490301669, `notify/75-activity-entries-on-a-real-server`, job `entries 10.11` red at `Does an operator see the moves`                               | 32603611247               |
 | `build.yaml` with `gate.yaml` | 31083336296, `proof/22-gate-bites`, jobs `call / build` and `call / test` red at `Build every claimed target framework`                               | 32603611416               |
 | `invariant-lint.yaml`         | 31265005320, `proof/28-invariants-refuse`, red at `Refuse an invariant broken anywhere in the tree`                                                   | 32603611261               |
-| `mutation.yaml`               | none at all, below                                                                                                                                    | 31996260260, at `0482b29` |
+| `mutation.yaml`               | 32659524696, `proof/2-a-mutation-run-that-breaks`, red at `Mutate the plugin project` with no report produced, below                                  | 31996260260, at `0482b29` |
 | `package.yaml`                | 32554832287, `proof/1-a-version-the-tree-does-not-hold-is-refused`, both lines red at `Install this package on a server of the line it was built for` | 32603611237               |
 | `pr-hygiene.yaml`             | 31258955738, `proof/26-hygiene-refuses`, red at `Run the hygiene checks`                                                                              | 32603611353               |
 | `prettier.yml`                | 31258897067, `proof/26-hygiene-annotates`, red at `Check formatting of the embedded web assets and the markdown`                                      | 32603611279               |
@@ -729,16 +729,41 @@ no answer at all, and that is what happened, so its cell is the reason the guard
 than an approximation of it. The cause was read rather than assumed, out of the server's own log
 on `throwaway/66-what-the-server-said`, and `docs/surface.md` carries it.
 
-### The two empty cells, one reason each
+### The cell that filled, and what the first attempt at it found instead
 
-**`mutation.yaml`.** No red run at all, and `sibling-set.yaml` is beside it in this command
-because the count it returns is the one that moved.
+**A red suite does not stop the weekly mutation run, and that was measured rather than assumed.**
+The near-miss written first for this cell was one failing test, on the reasoning that the runner
+begins by running the suite unmutated and that a run which cannot start is what `mutation.yaml` says
+reds it. The run went green. What the runner does with a red suite is warn and carry on:
 
-    $ for w in mutation.yaml sibling-set.yaml; do printf '%s: ' "$w"; \
-        gh run list --repo Flowfin/jellyfin-plugin-requests --workflow $w \
-          --status failure --limit 1 --json databaseId --jq 'length'; done
-    mutation.yaml: 0
-    sibling-set.yaml: 1
+    $ gh run view 32658416123 --repo Flowfin/jellyfin-plugin-requests --json conclusion,headSha --jq '.conclusion + "  " + .headSha[0:7]'
+    success  22ebc87
+
+    $ gh api repos/Flowfin/jellyfin-plugin-requests/actions/jobs/97240739544/logs | grep -a 'tests are failing'
+    2026-08-23T18:34:39.0695831Z [18:34:39 WRN] 1 tests are failing. Stryker will continue but outcome will be impacted.
+
+So the weekly report is published from a red suite, with a score that is impacted and a run that
+looks like every other one. Nothing else watches that, because this workflow is off the merge path
+on purpose and what it produces is a report somebody reads.
+
+**What does red it is the run not happening**, which is the sentence the file makes about itself.
+The second head of the same branch names a project the tree does not hold, which is the mistake that
+produces one and the one no other gate here can see: the project is renamed and this file still says
+the old name.
+
+    $ gh api repos/Flowfin/jellyfin-plugin-requests/actions/jobs/97243454378/logs \
+        | grep -a -E 'No project found|Stryker cannot continue|##\[error\]' | sed 's/\x1b\[[0-9;]*m//g'
+    2026-08-23T18:54:50.5204519Z [18:54:50 WRN] No project found, check settings and ensure project file is not corrupted.
+    2026-08-23T18:54:50.5246963Z Failed to analyze project builds. Stryker cannot continue.
+    2026-08-23T18:54:50.5402698Z ##[error]Process completed with exit code 1.
+
+**The bound on that cell is that the near-miss is in the workflow's own argument and not in the
+tree.** Every breakage of the tree that would stop this run, source that does not compile or a target
+framework the test project no longer builds, reds the ordinary gate first, so a reader who takes this
+cell for "a change was refused here" is reading it wrong. What it records is that the step reds when
+the run does not happen rather than reporting a score nobody produced.
+
+### The one cell that is still empty
 
 **`scan-codeql.yaml`.** Five red runs, and none of them is the analysis refusing code. Four are red
 at `Build for the analysis`, which is a change that did not compile rather than anything the scan


### PR DESCRIPTION
Part of #2.

#2's third condition asks that every guard shipping here have a recorded run in which it went red for the reason it names and a recorded run in which the tree passes it. Two cells in the ledger were empty. One of them fills here, and the attempt that failed to fill it is the part worth reading.

## The near-miss that did not bite

`mutation.yaml` passes `--break-at 0` and says of itself that the step reds only when the run itself breaks. The runner begins by running the suite unmutated, so a failing test looked like the way to break it. `proof/2-a-mutation-run-that-breaks` carries one, and the run went green:

    gh run view 32658416123 --repo Flowfin/jellyfin-plugin-requests --json conclusion,headSha --jq '.conclusion + "  " + .headSha[0:7]'
    success  22ebc87

    gh api repos/Flowfin/jellyfin-plugin-requests/actions/jobs/97240739544/logs | grep -a 'tests are failing'
    2026-08-23T18:34:39.0695831Z [18:34:39 WRN] 1 tests are failing. Stryker will continue but outcome will be impacted.

So the weekly report is published from a red suite, with a score that is impacted and a run that looks like every other one. That is a fact about this guard which nothing in the tree recorded, and it is the reason this branch exists rather than a detail of it.

## What does red it

The second head of the same branch names a project the tree does not hold, which is the mistake that stops the run and the one no other gate here can see: the project is renamed and this file still says the old name.

    gh api repos/Flowfin/jellyfin-plugin-requests/actions/jobs/97243454378/logs \
      | grep -a -E 'No project found|Stryker cannot continue|##\[error\]' | sed 's/\x1b\[[0-9;]*m//g'
    2026-08-23T18:54:50.5204519Z [18:54:50 WRN] No project found, check settings and ensure project file is not corrupted.
    2026-08-23T18:54:50.5246963Z Failed to analyze project builds. Stryker cannot continue.
    2026-08-23T18:54:50.5402698Z ##[error]Process completed with exit code 1.

    gh api repos/Flowfin/jellyfin-plugin-requests/actions/runs/32659524696/jobs --jq '.jobs[] | select(.conclusion=="failure") | .name + "  |  " + ([.steps[]|select(.conclusion=="failure")|.name]|join("; "))'
    mutate  |  Mutate the plugin project

## The bound, which is written beside the cell rather than left to be discovered

The near-miss is in the workflow's own argument and not in the tree. Every breakage of the tree that would stop this run, source that does not compile or a target framework the test project no longer builds, reds the ordinary gate first, so a reader who takes this cell for a change that was refused here is reading it wrong. What the cell records is that the step reds when the run does not happen rather than reporting a score nobody produced.

## What this does not do

**It does not close #2.** The fourth condition is the ruleset on `master`, which is a repository setting rather than a file in this tree and is #30's, and one cell of the third condition is still empty: `scan-codeql.yaml` has five red runs and none of them is the analysis refusing something it found. That paragraph is unchanged and its heading now says one cell rather than two.

**Nothing in the tree changes.** This is `docs/quality-parity.md` and nothing else:

    git diff --name-only origin/master...HEAD
    docs/quality-parity.md

**The proof branch is not merged and is not deleted.** `proof/2-a-mutation-run-that-breaks` is the evidence the two runs above point at, and both of its heads are near-misses rather than work: the first breaks the suite, the second points the workflow at a project that does not exist.

**No second reader has read this.** The runs above stand in place of one rather than beside one.

The suite passes on both server lines. The runner reports in the language this machine is set to, and its output is pasted rather than translated:

```
dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror

Bestanden!   : Fehler:     0, erfolgreich:   665, übersprungen:     0, gesamt:   665, Dauer: 23 s - Jellyfin.Plugin.Requests.Tests.dll (net9.0)
Bestanden!   : Fehler:     0, erfolgreich:   665, übersprungen:     0, gesamt:   665, Dauer: 23 s - Jellyfin.Plugin.Requests.Tests.dll (net10.0)
```
