### PR TITLE
Record how an ask reached this server, on the request

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Api/CreateRequestTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/CreateRequestTests.cs
@@ -353,6 +353,58 @@ public sealed class CreateRequestTests
         };
 
     /// <summary>
+    /// A request asked for over the endpoint records that it arrived there. The person named on it
+    /// is the one the server said was calling, so the entry says that a session stood behind the
+    /// name, which is the difference from the seam that an operator answering for a request needs.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ARequestAskedForAtTheEndpointRecordsThatItArrivedThere()
+    {
+        var store = new InMemoryRequestStore();
+
+        _ = Answer(
+            await ControllerFor(store, Asker).CreateAsync(AFilm(), CancellationToken.None).ConfigureAwait(true),
+            expectedStatus: 201);
+
+        var made = Assert.Single(await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true)).Request;
+        var entry = Assert.Single(made.History);
+
+        Assert.Equal(RequestArrival.Endpoint, entry.Arrival);
+        Assert.Equal(Asker, entry.ByUserId);
+        Assert.Equal(made.RequestedAt, entry.At);
+        Assert.Equal(made.State, entry.From);
+        Assert.Equal(made.State, entry.To);
+    }
+
+    /// <summary>
+    /// A second person asking for the same title joins the request that is there and adds no second
+    /// arrival to it. The entry says how the request reached this server, and the request reached it
+    /// once.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task JoiningARequestThatIsAlreadyHereAddsNoSecondArrival()
+    {
+        var store = new InMemoryRequestStore();
+
+        _ = Answer(
+            await ControllerFor(store, Asker).CreateAsync(AFilm(), CancellationToken.None).ConfigureAwait(true),
+            expectedStatus: 201);
+
+        var joined = Answer(
+            await ControllerFor(store, SecondPerson).CreateAsync(AFilm(), CancellationToken.None).ConfigureAwait(true),
+            expectedStatus: 200);
+
+        Assert.Equal(RequestOutcome.Joined, joined.Outcome);
+
+        var made = Assert.Single(await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true)).Request;
+
+        Assert.Equal([SecondPerson], made.JoinedByUserIds);
+        Assert.Equal(Asker, Assert.Single(made.History).ByUserId);
+    }
+
+    /// <summary>
     /// A controller wired to one store and one identity, with a clock and an identifier source the
     /// test controls.
     /// </summary>

--- a/Jellyfin.Plugin.Requests.Tests/Model/RequestHistoryTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Model/RequestHistoryTests.cs
@@ -87,8 +87,7 @@ public class RequestHistoryTests
     [Fact]
     public void AMoveAppendsBeneathAnArrivalAndLeavesItThere()
     {
-        var request = ARequest();
-        var arrived = request with { History = [RequestHistoryEntry.Arriving(RequestArrival.Seam, request)] };
+        var arrived = RequestLifecycle.Arriving(ARequest(), RequestArrival.Seam);
 
         var approved = RequestLifecycle.Move(arrived, RequestState.Approved, At(9), ByFirstOperator);
 
@@ -99,15 +98,34 @@ public class RequestHistoryTests
     }
 
     /// <summary>
-    /// There is no arrival to derive without a request to derive it from. It refuses rather than
+    /// A request that already carries a history has already arrived, and a second arrival on it is
+    /// refused rather than appended. The history is append-only, so a row saying a request arrived
+    /// after somebody decided on it could never be taken back out.
+    /// </summary>
+    [Fact]
+    public void ARequestThatHasAlreadyArrivedCannotArriveAgain()
+    {
+        var arrived = RequestLifecycle.Arriving(ARequest(), RequestArrival.Endpoint);
+        var approved = RequestLifecycle.Move(arrived, RequestState.Approved, At(9), ByFirstOperator);
+
+        Assert.Throws<InvalidOperationException>(
+            () => RequestLifecycle.Arriving(arrived, RequestArrival.Endpoint));
+        Assert.Throws<InvalidOperationException>(
+            () => RequestLifecycle.Arriving(approved, RequestArrival.Seam));
+    }
+
+    /// <summary>
+    /// There is no arrival to record without a request to record it on. It refuses rather than
     /// building an entry out of defaults, because an entry naming nobody at the epoch is a row that
     /// reads as a fact.
     /// </summary>
     [Fact]
-    public void AnArrivalCannotBeDerivedFromNothing()
+    public void AnArrivalCannotBeRecordedOnNothing()
     {
         Assert.Throws<ArgumentNullException>(
             () => RequestHistoryEntry.Arriving(RequestArrival.Endpoint, null!));
+        Assert.Throws<ArgumentNullException>(
+            () => RequestLifecycle.Arriving(null!, RequestArrival.Endpoint));
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Requests.Tests/Model/RequestHistoryTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Model/RequestHistoryTests.cs
@@ -21,14 +21,93 @@ public class RequestHistoryTests
     private static readonly RequestCaller BySecondOperator = RequestCaller.Administrator(SecondOperator);
 
     /// <summary>
-    /// A request nobody has decided has an empty history. Being created is not a move, and an entry
-    /// saying it was created would put a row in every history that says nothing an operator asked
-    /// about.
+    /// A request the model built and nothing has decided has an empty history. Being created is not
+    /// a move, so nothing here appends one.
+    /// <para>
+    /// The head of a real request's history is an arrival rather than a move, and it is written by
+    /// the surface the ask came in on rather than by this type, because only that surface knows
+    /// which of them it was. #118 is where that was decided, and the legs for it are on the two
+    /// surfaces. What this leg holds is that the model itself invents no row.
+    /// </para>
     /// </summary>
     [Fact]
     public void ARequestNothingHasDecidedHasNoHistory()
     {
         Assert.Empty(ARequest().History);
+    }
+
+    /// <summary>
+    /// An arrival entry is derived from the request it goes on, so a surface cannot write one that
+    /// disagrees with the record beneath it. Every field but the arrival itself comes off the
+    /// request, and the arrival is the one thing the record does not already hold.
+    /// </summary>
+    [Fact]
+    public void AnArrivalEntryIsDerivedFromTheRequestItIsOn()
+    {
+        var request = ARequest();
+
+        var entry = RequestHistoryEntry.Arriving(RequestArrival.Seam, request);
+
+        Assert.Equal(RequestArrival.Seam, entry.Arrival);
+        Assert.Equal(request.RequestedAt, entry.At);
+        Assert.Equal(request.RequestedByUserId, entry.ByUserId);
+        Assert.Equal(request.State, entry.From);
+        Assert.Equal(request.State, entry.To);
+        Assert.Null(entry.Reason);
+        Assert.Null(entry.Note);
+    }
+
+    /// <summary>
+    /// An arrival and a move are told apart by the arrival and never by the pair of states. An
+    /// arrival moves nothing, so both its states are the one the request came into existence in, and
+    /// a reader that separated the two rows by comparing <c>From</c> with <c>To</c> would be
+    /// separating them by a coincidence rather than by what they are.
+    /// </summary>
+    [Fact]
+    public void AnArrivalIsToldFromAMoveByTheArrivalRatherThanByItsStates()
+    {
+        var request = ARequest();
+
+        var arrival = RequestHistoryEntry.Arriving(RequestArrival.Endpoint, request);
+        var move = Assert.Single(
+            RequestLifecycle.Move(request, RequestState.Approved, At(9), ByFirstOperator).History);
+
+        Assert.NotNull(arrival.Arrival);
+        Assert.Equal(arrival.From, arrival.To);
+
+        Assert.Null(move.Arrival);
+        Assert.NotEqual(move.From, move.To);
+    }
+
+    /// <summary>
+    /// A move appends beneath an arrival rather than replacing it. The history is append-only, so
+    /// the row saying where the request came from has to survive every decision made on it
+    /// afterwards, which is what makes it worth writing at all.
+    /// </summary>
+    [Fact]
+    public void AMoveAppendsBeneathAnArrivalAndLeavesItThere()
+    {
+        var request = ARequest();
+        var arrived = request with { History = [RequestHistoryEntry.Arriving(RequestArrival.Seam, request)] };
+
+        var approved = RequestLifecycle.Move(arrived, RequestState.Approved, At(9), ByFirstOperator);
+
+        Assert.Equal(2, approved.History.Count);
+        Assert.Equal(RequestArrival.Seam, approved.History[0].Arrival);
+        Assert.Null(approved.History[1].Arrival);
+        Assert.Equal(RequestState.Approved, approved.History[1].To);
+    }
+
+    /// <summary>
+    /// There is no arrival to derive without a request to derive it from. It refuses rather than
+    /// building an entry out of defaults, because an entry naming nobody at the epoch is a row that
+    /// reads as a fact.
+    /// </summary>
+    [Fact]
+    public void AnArrivalCannotBeDerivedFromNothing()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => RequestHistoryEntry.Arriving(RequestArrival.Endpoint, null!));
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Requests.Tests/Seam/WantHandoverTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Seam/WantHandoverTests.cs
@@ -733,6 +733,83 @@ public class WantHandoverTests
         };
 
     /// <summary>
+    /// A request made from a want records that it arrived over the seam, and that is the whole of
+    /// what it records about the handover.
+    /// <para>
+    /// The failure this stands against is an operator who finds a request filed against somebody and
+    /// has no way to see that no session stood behind the name on it. Which plugin handed it over is
+    /// deliberately absent, decided on #118, and the leg below asserts every field of the entry
+    /// rather than only the arrival, so a field quietly carrying a caller would show up here.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ARequestMadeFromAWantRecordsThatItArrivedOverTheSeam()
+    {
+        var store = new InMemoryRequestStore();
+
+        Assert.True(await Seam(store).AcceptAsync(Want(), CancellationToken.None));
+
+        var made = Assert.Single(await store.GetAllAsync(CancellationToken.None)).Request;
+        var entry = Assert.Single(made.History);
+
+        Assert.Equal(RequestArrival.Seam, entry.Arrival);
+        Assert.Equal(Asker, entry.ByUserId);
+        Assert.Equal(Noon, entry.At);
+        Assert.Equal(made.State, entry.From);
+        Assert.Equal(made.State, entry.To);
+        Assert.Null(entry.Reason);
+        Assert.Null(entry.Note);
+    }
+
+    /// <summary>
+    /// The same want handed over again records no second arrival. A replay is the ordinary case
+    /// here rather than the exception, and a history that grew a row every time the other side
+    /// restarted would say a request arrived as many times as the sibling was reinstalled.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task TheSameWantHandedOverAgainRecordsNoSecondArrival()
+    {
+        var store = new InMemoryRequestStore();
+        var handover = Seam(store);
+
+        Assert.True(await handover.AcceptAsync(Want(), CancellationToken.None));
+        Assert.True(await handover.AcceptAsync(Want(), CancellationToken.None));
+
+        var made = Assert.Single(await store.GetAllAsync(CancellationToken.None)).Request;
+
+        Assert.Equal(RequestArrival.Seam, Assert.Single(made.History).Arrival);
+    }
+
+    /// <summary>
+    /// Somebody joining a request that is already here adds no second arrival. The request arrived
+    /// once; what a later person did is join something already in the queue, and the entry is about
+    /// the record rather than about each person waiting on it.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task SomebodyJoiningOverTheSeamAddsNoSecondArrival()
+    {
+        var store = new InMemoryRequestStore();
+        var handover = Seam(store);
+
+        Assert.True(await handover.AcceptAsync(Want(), CancellationToken.None));
+        Assert.True(await handover.AcceptAsync(
+            Want() with
+            {
+                WantId = new Guid("44444444-4444-4444-4444-444444444444"),
+                RequestedByUserId = SecondAsker
+            },
+            CancellationToken.None));
+
+        var made = Assert.Single(await store.GetAllAsync(CancellationToken.None)).Request;
+
+        Assert.Equal([SecondAsker], made.JoinedByUserIds);
+        Assert.Equal(Asker, Assert.Single(made.History).ByUserId);
+    }
+
+    /// <summary>
     /// What the sibling had already recorded on a server that ran it before this plugin arrived.
     /// <para>
     /// Four wants, chosen for the shapes that go wrong together. Two people want one film, so the

--- a/Jellyfin.Plugin.Requests.Tests/Storage/FileRequestStoreDurabilityTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Storage/FileRequestStoreDurabilityTests.cs
@@ -55,6 +55,12 @@ public sealed class FileRequestStoreDurabilityTests : IDisposable
     /// record, so the request carries a history and the round trip has one to lose. A request whose
     /// history is empty would let a store that drops the field entirely pass this.
     /// </para>
+    /// <para>
+    /// The history is two rows rather than one, and they are of the two different kinds there are:
+    /// the arrival the surface wrote when the request came into existence, and the move an operator
+    /// made afterwards. A round trip over one kind would let a store that drops the arrival back
+    /// through, and the arrival is the row that carries the field this record gained last.
+    /// </para>
     /// </summary>
     /// <returns>A task that completes when the assertions have run.</returns>
     [Fact]
@@ -62,14 +68,19 @@ public sealed class FileRequestStoreDurabilityTests : IDisposable
     {
         var directory = ADirectory();
         var approvedBy = new Guid("2b7b4f1d-4f0e-4a63-9a3d-0f5a1c9e77aa");
+        var asked = ARequest(1) with
+        {
+            DisplayTitle = "A title with a comma, an accent é and a quote \"",
+            DisplayYear = 1999,
+            ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tmdb"] = "603", ["Imdb"] = "tt0133093" },
+            Availability = LibraryAvailability.Partial,
+            AvailabilityCheckedAt = new DateTimeOffset(2026, 3, 3, 0, 0, 0, TimeSpan.Zero)
+        };
+
         var full = RequestLifecycle.Move(
-            ARequest(1) with
+            asked with
             {
-                DisplayTitle = "A title with a comma, an accent é and a quote \"",
-                DisplayYear = 1999,
-                ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tmdb"] = "603", ["Imdb"] = "tt0133093" },
-                Availability = LibraryAvailability.Partial,
-                AvailabilityCheckedAt = new DateTimeOffset(2026, 3, 3, 0, 0, 0, TimeSpan.Zero)
+                History = [RequestHistoryEntry.Arriving(RequestArrival.Seam, asked)]
             },
             RequestState.Approved,
             new DateTimeOffset(2026, 8, 8, 9, 0, 0, TimeSpan.Zero),
@@ -108,10 +119,14 @@ public sealed class FileRequestStoreDurabilityTests : IDisposable
             full.ProviderIds.OrderBy(pair => pair.Key, StringComparer.Ordinal),
             readFull.Value.Request.ProviderIds.OrderBy(pair => pair.Key, StringComparer.Ordinal));
 
-        // Entry by entry, and the entries are records of values, so this compares what each move
-        // said and not which list it is in. The approval above is the one entry there is to lose.
+        // Entry by entry, and the entries are records of values, so this compares what each row
+        // said and not which list it is in. The arrival and the approval above are the two entries
+        // there are to lose, and the arrival is asserted by name because it is the only row
+        // carrying an arrival at all.
         Assert.Equal(full.History, readFull.Value.Request.History);
-        Assert.Single(readFull.Value.Request.History);
+        Assert.Equal(2, readFull.Value.Request.History.Count);
+        Assert.Equal(RequestArrival.Seam, readFull.Value.Request.History[0].Arrival);
+        Assert.Null(readFull.Value.Request.History[1].Arrival);
 
         Assert.Equal(full.JoinedByUserIds, readFull.Value.Request.JoinedByUserIds);
         Assert.Single(readFull.Value.Request.JoinedByUserIds);

--- a/Jellyfin.Plugin.Requests.Tests/Storage/FileRequestStoreDurabilityTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Storage/FileRequestStoreDurabilityTests.cs
@@ -78,10 +78,7 @@ public sealed class FileRequestStoreDurabilityTests : IDisposable
         };
 
         var full = RequestLifecycle.Move(
-            asked with
-            {
-                History = [RequestHistoryEntry.Arriving(RequestArrival.Seam, asked)]
-            },
+            RequestLifecycle.Arriving(asked, RequestArrival.Seam),
             RequestState.Approved,
             new DateTimeOffset(2026, 8, 8, 9, 0, 0, TimeSpan.Zero),
             RequestCaller.Administrator(approvedBy));

--- a/Jellyfin.Plugin.Requests/Api/RequestsController.cs
+++ b/Jellyfin.Plugin.Requests/Api/RequestsController.cs
@@ -246,10 +246,7 @@ public sealed class RequestsController : RequestsControllerBase
         // and cannot see which of them is asking, and because a request that joins an existing one
         // keeps that request's history: what is recorded is how the request arrived, not how each
         // later person reached it.
-        incoming = incoming with
-        {
-            History = [RequestHistoryEntry.Arriving(RequestArrival.Endpoint, incoming)]
-        };
+        incoming = RequestLifecycle.Arriving(incoming, RequestArrival.Endpoint);
 
         CreatedRequest answer;
 

--- a/Jellyfin.Plugin.Requests/Api/RequestsController.cs
+++ b/Jellyfin.Plugin.Requests/Api/RequestsController.cs
@@ -241,6 +241,16 @@ public sealed class RequestsController : RequestsControllerBase
             RequesterNote = body.Note
         };
 
+        // How the ask reached this server, written once at the head of the history and never again.
+        // It is set here rather than inside the intake because the intake is asked by both surfaces
+        // and cannot see which of them is asking, and because a request that joins an existing one
+        // keeps that request's history: what is recorded is how the request arrived, not how each
+        // later person reached it.
+        incoming = incoming with
+        {
+            History = [RequestHistoryEntry.Arriving(RequestArrival.Endpoint, incoming)]
+        };
+
         CreatedRequest answer;
 
         try

--- a/Jellyfin.Plugin.Requests/Model/RequestArrival.cs
+++ b/Jellyfin.Plugin.Requests/Model/RequestArrival.cs
@@ -1,0 +1,39 @@
+namespace Jellyfin.Plugin.Requests.Model;
+
+/// <summary>
+/// How an ask reached this plugin.
+/// <para>
+/// Two surfaces make requests and they carry different amounts of proof. The HTTP endpoint takes the
+/// requester from the authenticated session, so the person named on the request is the person the
+/// server says is calling. The seam has no session: the caller is another plugin in the same process
+/// and it passes a user identifier this side cannot verify, which is the trust position stated in
+/// <c>docs/seam.md</c> and repeated in <c>docs/personal-data.md</c>. An operator asked to answer for
+/// a request needs to know which of the two it was, and until this existed the record said nothing
+/// about it.
+/// </para>
+/// <para>
+/// <b>It says how, and never who.</b> Which plugin handed a want over is not recorded, decided on
+/// #118: the contract carries no field naming the caller, and reading one off an assembly name or a
+/// call stack would be this side inventing a value nobody agreed. A history that records an
+/// unverified self-declaration as fact is worse than one that records less.
+/// </para>
+/// </summary>
+public enum RequestArrival
+{
+    /// <summary>
+    /// Another plugin in this server process handed a want across the seam. The person named on the
+    /// request is whoever that caller said asked for it, and no session stands behind it.
+    /// <para>
+    /// It is the zero value on purpose, in the same direction as
+    /// <see cref="RequestActor.None"/>: a value nobody filled in reads as the arrival this side
+    /// could not check rather than as the one it could, so a defect that loses the value understates
+    /// what is known instead of claiming a session that was never there.
+    /// </para>
+    /// </summary>
+    Seam = 0,
+
+    /// <summary>
+    /// Somebody asked over this plugin's own HTTP endpoint, on a session the server authenticated.
+    /// </summary>
+    Endpoint = 1
+}

--- a/Jellyfin.Plugin.Requests/Model/RequestHistoryEntry.cs
+++ b/Jellyfin.Plugin.Requests/Model/RequestHistoryEntry.cs
@@ -3,7 +3,7 @@ using System;
 namespace Jellyfin.Plugin.Requests.Model;
 
 /// <summary>
-/// One move a request made, kept forever.
+/// One thing that happened to a request, kept forever. Every entry but the first is a move.
 /// <para>
 /// The state on a request answers what is true now. An operator dealing with a complaint needs what
 /// happened: who approved it, when, who declined the earlier one and for what reason, and whether a
@@ -15,6 +15,12 @@ namespace Jellyfin.Plugin.Requests.Model;
 /// An entry carries the reason and the note the move was made with, so a decline that is later taken
 /// back leaves its reason here rather than nowhere. That is the one thing the current-value fields
 /// cannot do: they are overwritten by the next move by definition.
+/// </para>
+/// <para>
+/// <b>The first entry is an arrival rather than a move.</b> It says how the ask reached this server,
+/// which is #118's condition and is a question about the record's provenance rather than about
+/// anything anybody decided. <see cref="Arriving"/> is the only way to build one, and
+/// <see cref="Arrival"/> is what separates it from the rows beneath it.
 /// </para>
 /// </summary>
 public sealed record RequestHistoryEntry
@@ -62,5 +68,53 @@ public sealed record RequestHistoryEntry
     {
         get => _note;
         init => _note = MediaRequest.Note(value, nameof(Note));
+    }
+
+    /// <summary>
+    /// Gets how the ask reached this server, on the entry recording that the request came into
+    /// existence, and <see langword="null"/> on every entry recording a move. A move is something
+    /// somebody did to a request that was already here, so it has no arrival to name.
+    /// </summary>
+    public RequestArrival? Arrival { get; init; }
+
+    /// <summary>
+    /// The entry a request comes into existence with, saying how the ask reached this server.
+    /// <para>
+    /// <b>It is derived from the request rather than passed beside it</b>, so a surface cannot write
+    /// an arrival that disagrees with the record it is on: the moment, the person and the state all
+    /// come off the request being made. What the caller supplies is the one thing the record does not
+    /// already hold, which is which surface it arrived on.
+    /// </para>
+    /// <para>
+    /// <b><see cref="From"/> and <see cref="To"/> both carry the state the request came into
+    /// existence in, because an arrival moves nothing.</b> Reading either of them alone therefore
+    /// answers "what state was this in" correctly at every row of a history including this one, and
+    /// the pair reading as a move that changed nothing is what <see cref="Arrival"/> is there to
+    /// separate. The alternative, a <see cref="From"/> that can be absent, changes what an existing
+    /// field means for every entry already written to somebody's disk, which
+    /// <c>docs/storage.md</c> is explicit costs a new on-disk version; adding a field an older
+    /// reader ignores does not.
+    /// </para>
+    /// </summary>
+    /// <param name="over">Which surface the ask arrived on.</param>
+    /// <param name="request">The request being made, as the surface built it.</param>
+    /// <returns>The entry to put at the head of that request's history.</returns>
+    /// <exception cref="ArgumentNullException">Where there is no request to derive it from.</exception>
+    public static RequestHistoryEntry Arriving(RequestArrival over, MediaRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        return new RequestHistoryEntry
+        {
+            From = request.State,
+            To = request.State,
+            At = request.RequestedAt,
+
+            // The person the request is filed against, which on the seam is whoever the calling
+            // plugin said asked for it. Nobody else has touched the request yet, so an entry naming
+            // anybody else here would be naming somebody who was not there.
+            ByUserId = request.RequestedByUserId,
+            Arrival = over
+        };
     }
 }

--- a/Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs
+++ b/Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs
@@ -250,6 +250,49 @@ public static class RequestLifecycle
     }
 
     /// <summary>
+    /// The request as it comes into existence, carrying the one entry that says how the ask reached
+    /// this server.
+    /// <para>
+    /// An arrival is the only row in a history that is not a move, and it lives here for the same
+    /// reason every move does: this is the one place a history grows. A surface assigning the list
+    /// itself is refused by <c>history-is-only-appended-to</c>, and the refusal is the rule rather
+    /// than a style preference, because a caller that can build a list can build one with a decision
+    /// left out of it.
+    /// </para>
+    /// <para>
+    /// It appends rather than replaces, and it refuses a request that already has a history, so the
+    /// row can only ever be the first. An arrival written underneath a decision would say a request
+    /// arrived after it was answered, and the history is append-only, so nothing could take it back
+    /// out afterwards.
+    /// </para>
+    /// <para>
+    /// What the entry says is derived from the request itself, in
+    /// <see cref="RequestHistoryEntry.Arriving"/>. The only thing this adds is which surface the ask
+    /// came in on, which is the one fact the record does not already hold.
+    /// </para>
+    /// </summary>
+    /// <param name="request">The request being made, as the surface built it.</param>
+    /// <param name="over">Which surface the ask arrived on.</param>
+    /// <returns>The request with its arrival recorded.</returns>
+    /// <exception cref="ArgumentNullException">Where no request was given.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Where the request already carries a history, which means it has already arrived.
+    /// </exception>
+    public static MediaRequest Arriving(MediaRequest request, RequestArrival over)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (request.History.Count > 0)
+        {
+            throw new InvalidOperationException(
+                FormattableString.Invariant(
+                    $"A request carrying {request.History.Count} history entries has already arrived, so recording an arrival on it would put one underneath a decision that was already made."));
+        }
+
+        return request with { History = [.. request.History, RequestHistoryEntry.Arriving(over, request)] };
+    }
+
+    /// <summary>
     /// The one place a request changes state, and therefore the one place the history grows and the
     /// one place a caller's authority is checked. Both public methods above go through here, so
     /// "every transition appends exactly one entry" and "every transition asks who is making it" are

--- a/Jellyfin.Plugin.Requests/Seam/WantHandover.cs
+++ b/Jellyfin.Plugin.Requests/Seam/WantHandover.cs
@@ -300,10 +300,7 @@ public sealed class WantHandover : IWantHandover
         // decided on #118, and a value read off anything else would be the sender saying who they
         // are. What this side knows is that no session stood behind the person named, and that is
         // what the entry says.
-        incoming = incoming with
-        {
-            History = [RequestHistoryEntry.Arriving(RequestArrival.Seam, incoming)]
-        };
+        incoming = RequestLifecycle.Arriving(incoming, RequestArrival.Seam);
 
         Answer<IntakeResult> intake;
 

--- a/Jellyfin.Plugin.Requests/Seam/WantHandover.cs
+++ b/Jellyfin.Plugin.Requests/Seam/WantHandover.cs
@@ -295,6 +295,16 @@ public sealed class WantHandover : IWantHandover
             WantIds = [want.WantId]
         };
 
+        // The one thing a request made here records about the seam. Which plugin handed the want
+        // over is not part of it and never will be: the contract carries no field naming the caller,
+        // decided on #118, and a value read off anything else would be the sender saying who they
+        // are. What this side knows is that no session stood behind the person named, and that is
+        // what the entry says.
+        incoming = incoming with
+        {
+            History = [RequestHistoryEntry.Arriving(RequestArrival.Seam, incoming)]
+        };
+
         Answer<IntakeResult> intake;
 
         try

--- a/docs/personal-data.md
+++ b/docs/personal-data.md
@@ -14,22 +14,22 @@ The record is one type, and everything below is a property of it or of an entry 
 identifiers are derived rather than listed from memory:
 
     git grep -nE 'public (required )?(Guid|Guid\?|IReadOnlyList<Guid>) ' -- Jellyfin.Plugin.Requests/Model/
-    Jellyfin.Plugin.Requests/Model/MediaRequest.cs:60:    public required Guid Id { get; init; }
-    Jellyfin.Plugin.Requests/Model/MediaRequest.cs:67:    public required Guid RequestedByUserId { get; init; }
-    Jellyfin.Plugin.Requests/Model/MediaRequest.cs:144:    public IReadOnlyList<Guid> JoinedByUserIds { get; init; } = [];
-    Jellyfin.Plugin.Requests/Model/MediaRequest.cs:165:    public IReadOnlyList<Guid> WantIds
-    Jellyfin.Plugin.Requests/Model/MediaRequest.cs:189:    public Guid? StateChangedByUserId { get; init; }
+    Jellyfin.Plugin.Requests/Model/MediaRequest.cs:61:    public required Guid Id { get; init; }
+    Jellyfin.Plugin.Requests/Model/MediaRequest.cs:68:    public required Guid RequestedByUserId { get; init; }
+    Jellyfin.Plugin.Requests/Model/MediaRequest.cs:145:    public IReadOnlyList<Guid> JoinedByUserIds { get; init; } = [];
+    Jellyfin.Plugin.Requests/Model/MediaRequest.cs:166:    public IReadOnlyList<Guid> WantIds
+    Jellyfin.Plugin.Requests/Model/MediaRequest.cs:190:    public Guid? StateChangedByUserId { get; init; }
     Jellyfin.Plugin.Requests/Model/RequestCaller.cs:52:    public Guid? UserId { get; }
-    Jellyfin.Plugin.Requests/Model/RequestHistoryEntry.cs:44:    public Guid? ByUserId { get; init; }
+    Jellyfin.Plugin.Requests/Model/RequestHistoryEntry.cs:50:    public Guid? ByUserId { get; init; }
 
 Four of those seven name a person. What each one is, and what it is for:
 
-| Field                               | Who it names                                         | Where it is written |
-| ----------------------------------- | ---------------------------------------------------- | ------------------- |
-| `MediaRequest.RequestedByUserId`    | the person who asked                                 | the queue file      |
-| `MediaRequest.JoinedByUserIds`      | everybody else who asked for the same title          | the queue file      |
-| `MediaRequest.StateChangedByUserId` | whoever last moved it, usually an operator           | the queue file      |
-| `RequestHistoryEntry.ByUserId`      | whoever made that one move, for every move ever made | the queue file      |
+| Field                               | Who it names                                                         | Where it is written |
+| ----------------------------------- | -------------------------------------------------------------------- | ------------------- |
+| `MediaRequest.RequestedByUserId`    | the person who asked                                                 | the queue file      |
+| `MediaRequest.JoinedByUserIds`      | everybody else who asked for the same title                          | the queue file      |
+| `MediaRequest.StateChangedByUserId` | whoever last moved it, usually an operator                           | the queue file      |
+| `RequestHistoryEntry.ByUserId`      | the person who asked, on the arrival row, and whoever moved it after | the queue file      |
 
 The other three name nothing about a person. `MediaRequest.Id` and `MediaRequest.WantIds` are this
 plugin's own identifier for a request and the browsing sibling's identifiers for the asks it handed
@@ -39,6 +39,20 @@ store writes that record whole.
 
     git grep -n 'public MediaRequest? Request' -- Jellyfin.Plugin.Requests/Storage/PersistedRequest.cs
     Jellyfin.Plugin.Requests/Storage/PersistedRequest.cs:29:    public MediaRequest? Request { get; init; }
+
+**Every request carries one of those history rows from the moment it is made.** The first entry on a
+request is not a move: it says how the ask reached this server, and it names the person it is filed
+against, so `RequestHistoryEntry.ByUserId` is written for every request rather than only for those
+somebody has decided on. It is the same identifier as `MediaRequest.RequestedByUserId` on the same
+record, so it names nobody the file did not already name, and what it adds is provenance rather than
+a person.
+
+    git grep -n 'public RequestArrival? Arrival' -- Jellyfin.Plugin.Requests/Model/RequestHistoryEntry.cs
+
+The value says which surface, and never which caller. A request handed over the seam is filed against
+whoever the calling plugin said asked for it, with no session behind the name, and one asked for over
+the endpoint is filed against the person the server authenticated. `docs/seam.md` argues why the
+plugin that handed it over is not recorded.
 
 **A person is held as the server's user identifier and never as a name.** No field carries a user
 name, a display name, an email address or an external account. Whoever the identifier belongs to is a

--- a/docs/seam.md
+++ b/docs/seam.md
@@ -403,7 +403,12 @@ A request made from a want carries one history entry saying so. It is written wh
 into existence, it is the head of that request's history, and every decision made on the request
 afterwards appends beneath it.
 
-    git grep -n 'RequestHistoryEntry.Arriving(RequestArrival.Seam' -- Jellyfin.Plugin.Requests/Seam/WantHandover.cs
+    git grep -n 'RequestLifecycle.Arriving(incoming, RequestArrival.Seam)' -- Jellyfin.Plugin.Requests/Seam/WantHandover.cs
+
+It is written through the lifecycle rather than onto the record, because that is the one place a
+request's history grows and a surface assigning the list itself is refused by name:
+
+    git grep -n 'id: history-is-only-appended-to' -- tools/opengrep/rules.yaml
 
 **What it says is how, and never who.** The entry names the surface and not the caller. The contract
 grows no field naming the plugin that handed the want over, decided on #118, because a field carrying

--- a/docs/seam.md
+++ b/docs/seam.md
@@ -358,15 +358,15 @@ somebody closed a browser, and a replay that can only be run once is one nobody 
     git grep -n 'TheWholeSetReplayedTwiceIsTheQueueItMadeTheFirstTime\|AReplayThatStoppedHalfwayIsSafeToRunAgainFromTheStart' -- Jellyfin.Plugin.Requests.Tests/Seam/WantHandoverTests.cs
 
 **What is not answered, and it is the rest of #93.** An adopted request is not distinguishable from
-one that arrived live. A request carries no history entry when it is made, and
-`RequestHistoryEntry` has no field that could say how the ask reached this side:
+one that arrived live. Both cross on the same call, so the entry a request now carries says the seam
+for either of them, and the moment on it is the moment the replay ran rather than the moment the
+person asked, because that is the only moment this side ever sees:
 
-    git grep -n 'public required RequestState From\|public Guid? ByUserId' -- Jellyfin.Plugin.Requests/Model/RequestHistoryEntry.cs
+    git grep -n 'At = request.RequestedAt' -- Jellyfin.Plugin.Requests/Model/RequestHistoryEntry.cs
 
-So an operator who finds a sudden queue cannot see where it came from. What a request records about
-having arrived over the seam is the entry below that belongs to #118, and it has to be settled there
-rather than added afterwards, because the history is append-only and entries written without it
-cannot be corrected.
+So an operator who finds a sudden queue can see that it came over the seam and cannot see that it is
+a replay. Telling the two apart needs something the contract does not carry, which is #93's question
+rather than this section's. What a request does record about having arrived is the section below.
 
 ## What this side trusts, and what it checks anyway
 
@@ -396,6 +396,40 @@ a user nobody has is a row no surface can ever show to anyone and a person nothi
 The check costs one reference, which is written down in `SiblingIndependenceTests` with the reason:
 the server's user manager answers this question with the user record, and this plugin reads nothing
 out of that record.
+
+## What a request records about having arrived over the seam
+
+A request made from a want carries one history entry saying so. It is written when the request comes
+into existence, it is the head of that request's history, and every decision made on the request
+afterwards appends beneath it.
+
+    git grep -n 'RequestHistoryEntry.Arriving(RequestArrival.Seam' -- Jellyfin.Plugin.Requests/Seam/WantHandover.cs
+
+**What it says is how, and never who.** The entry names the surface and not the caller. The contract
+grows no field naming the plugin that handed the want over, decided on #118, because a field carrying
+it would be the sender saying who they are, and a history that records an unverified self-declaration
+as fact is worse than one that records less. Reading a caller off an assembly name or a call stack
+instead is the same invented value with a different excuse.
+
+**That cost is permanent in one direction, and it is written here rather than only on the issue.** If
+a second handing sibling ever ships, the rows written before it do not carry the distinction and
+cannot be backfilled, because the history is append-only. The question "which plugin filed this"
+therefore becomes unanswerable for everything already landed, on the day somebody first asks it.
+
+**What the entry is for is the trust position above.** A request that arrived here is filed against
+whoever the caller said asked for it, with no session behind the name. A request asked for over this
+plugin's own endpoint carries the other value and means the opposite: the server authenticated the
+person it is filed against. An operator answering for a request can tell those two apart from the
+record now, which was not possible before this entry existed.
+
+    git grep -n '^    Seam = 0,\|^    Endpoint = 1' -- Jellyfin.Plugin.Requests/Model/RequestArrival.cs
+
+**One arrival per request, not one per person.** A want naming something already in the queue joins
+the request that is there, and a want handed over a second time writes nothing at all, so neither
+adds a row. What the entry records is how the request reached this server and not how each person
+waiting on it did.
+
+    git grep -n 'SomebodyJoiningOverTheSeamAddsNoSecondArrival\|TheSameWantHandedOverAgainRecordsNoSecondArrival' -- Jellyfin.Plugin.Requests.Tests/Seam/WantHandoverTests.cs
 
 ## A field set this side does not understand is refused whole
 
@@ -445,13 +479,10 @@ install is refusing and why is the diagnostics view in #63.
 
 ## What this document does not yet hold
 
-Named here so the absence is read as absence rather than as a decision nobody wrote down. Each is
-the closing condition of the issue beside it.
+Named here so an absence is read as absence rather than as a decision nobody wrote down. Each entry
+is the closing condition of the issue beside it.
 
-- What a request records about having arrived over the seam. Which caller handed it over is settled
-  and is not part of it: the contract grows no field naming the caller, decided on #118, because a
-  field carrying it would be the sender saying who they are, and a history that records an
-  unverified self-declaration as fact is worse than one that records less. That cost is permanent in
-  one direction. If a second handing sibling ever ships, the rows written before it do not carry the
-  distinction and cannot be backfilled, so the question becomes unanswerable for everything already
-  landed. What is still owed here is the history itself, which does not exist yet. #118.
+**Nothing today.** The one entry that stood here was what a request records about having arrived over
+the seam, and that is a section of this document now rather than a gap in it. The permanent cost it
+carried has moved with it and is not softened on the way: which plugin handed a want over is not
+recorded, and for everything already landed it never can be. #118.


### PR DESCRIPTION
Closes #118.

A request came into existence carrying nothing about where it came from. The endpoint takes the
requester from the session the server authenticated; the seam takes whatever the calling plugin says
and cannot check it. Those are opposite amounts of proof, and until now the record read the same
either way, so an operator holding a complaint about a request filed against somebody had no way to
see which of the two it was.

Every request now begins with one history entry saying which surface the ask arrived on.

## What the three conditions ask, and where each one stands

**A handover naming a user the server does not have is refused, proven by a test.** Met before this
change and unchanged by it.

    git grep -n 'public async Task AHandoverNamingAUserTheServerDoesNotHaveIsRefused' -- Jellyfin.Plugin.Requests.Tests/Seam/WantHandoverTests.cs

**The history of a request shows it arrived through the seam and names the caller.** This is what the
change builds, under the narrowing decided on the issue on 2026-08-21: the caller is not recorded,
and what is recorded is that a request arrived over the seam.

    git grep -n 'RequestLifecycle.Arriving(incoming, RequestArrival' -- Jellyfin.Plugin.Requests/

**`docs/seam.md` states the trust position in plain words, and the security documentation from #104
repeats the conclusion.** Met before this change, and both documents grow the entry beside the
position rather than restating it.

    git grep -n 'the only check on that path' -- docs/seam.md docs/personal-data.md

## Three decisions in the shape, each of which could have gone the other way

**The row is grown by `RequestLifecycle` rather than assigned at the surface.** That is the second
head of this branch rather than the first, and the reason is under "What the gate caught" below.

**The entry is derived from the request rather than passed beside it.** The moment, the person and
the state all come off the record being made, so a surface cannot write an arrival that disagrees
with the row it sits on. What a caller supplies is the one thing the record does not already hold,
which is which surface it was.

**`From` and `To` both carry the state the request came into existence in, because an arrival moves
nothing.** The other shape is a `From` that can be absent, which changes what an existing field means
for every entry already on somebody's disk. `docs/storage.md` is explicit that this costs a new
on-disk version and that adding a field an older reader ignores does not, so the version stays where
it is and no migration is owed.

`RequestArrival.Seam` is the zero value, in the same direction as `RequestActor.None`: a defect that
loses the value understates what is known rather than claiming a session that was never there.

The arrival is recorded where the request is built and not in the intake, because the intake is asked
by both surfaces and cannot see which one is asking, and because a request that joins an existing one
keeps that request's history. What the entry records is how the request reached this server, not how
each person waiting on it did.

## What the gate caught, and why the rule was right

The first head of this branch assigned `History` at each of the two surfaces. The invariant lint
refused both sites, in run 32791919712:

```
   ❯❯❱ tools.opengrep.history-is-only-appended-to
      Do not assign to History here. A request's history is append-only and RequestLifecycle is the
      only thing that grows it, so that a move cannot be rewritten out of the record after the fact
      (#43).
      251┆ History = [RequestHistoryEntry.Arriving(RequestArrival.Endpoint, incoming)]
      305┆ History = [RequestHistoryEntry.Arriving(RequestArrival.Seam, incoming)]
```

The rule is right and the assignment was wrong: a caller that can build the list can build one with a
decision left out of it, which is what that rule is there for. The row is added by
`RequestLifecycle.Arriving` now, which is already the one place a history grows. It appends rather
than replaces, and it refuses a request that already carries a history, so an arrival can only ever
be the first row. An arrival written underneath a decision would say a request arrived after it was
answered, and nothing could take it back out because the history is append-only.

This was found by the gate rather than by reading the rules file, and it is written down here because
the shape it produced is better than the one it refused.

## What is deliberately not recorded

Which plugin handed a want over. The contract grows no field naming the caller, decided on #118, and
reading one off an assembly name or a call stack is the same invented value with a different excuse.
That cost is permanent in one direction: the history is append-only, so if a second handing sibling
ever ships, the rows written before it cannot be backfilled and the question is unanswerable for
everything already landed. `docs/seam.md` carries that where a reader meets it rather than only on
the issue, and the section it used to sit in as an absence now says the document holds no absences.

## The suite, on both frameworks

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror

```
Bestanden!   : Fehler:     0, erfolgreich:   675, uebersprungen:     0, gesamt:   675 - net9.0
Bestanden!   : Fehler:     0, erfolgreich:   675, uebersprungen:     0, gesamt:   675 - net10.0
```

The two lines above are transcribed with one word spelled without its umlaut, because the run is on a
German-language machine, and nothing else about them is changed. 675 against 665 before the change.
The ten new legs are five on the model, three on the seam and two on the endpoint; the durability
round trip gained a second row rather than a leg of its own.

## Each guard watched failing, for the reason it names

Five one-change breaks, each run with `dotnet test ... -f net9.0` and put back afterwards. What is
worth reading is not that each went red but which legs went red in each case.

**The seam stops recording the arrival.** Three legs, all on the seam, and nothing on the endpoint:

```
  Fehler ...Seam.WantHandoverTests.SomebodyJoiningOverTheSeamAddsNoSecondArrival
  Fehler ...Seam.WantHandoverTests.ARequestMadeFromAWantRecordsThatItArrivedOverTheSeam
  Fehler ...Seam.WantHandoverTests.TheSameWantHandedOverAgainRecordsNoSecondArrival
Fehler!      : Fehler:     3, erfolgreich:   672, gesamt:   675
```

**The endpoint stops recording it.** Two legs, all on the endpoint, and nothing on the seam. The two
surfaces are held separately rather than by one leg that either of them could satisfy:

```
  Fehler ...Api.CreateRequestTests.JoiningARequestThatIsAlreadyHereAddsNoSecondArrival
  Fehler ...Api.CreateRequestTests.ARequestAskedForAtTheEndpointRecordsThatItArrivedThere
Fehler!      : Fehler:     2, erfolgreich:   673, gesamt:   675
```

**The entry stops being derived from the request**, with `ByUserId = request.RequestedByUserId`
replaced by `ByUserId = null`. It compiles, both surfaces still record a row, and five legs go red
including the one that exists for the derivation itself:

```
  Fehler ...Model.RequestHistoryTests.AnArrivalEntryIsDerivedFromTheRequestItIsOn
  Fehler ...Seam.WantHandoverTests.SomebodyJoiningOverTheSeamAddsNoSecondArrival
  Fehler ...Api.CreateRequestTests.JoiningARequestThatIsAlreadyHereAddsNoSecondArrival
  Fehler ...Api.CreateRequestTests.ARequestAskedForAtTheEndpointRecordsThatItArrivedThere
  Fehler ...Seam.WantHandoverTests.ARequestMadeFromAWantRecordsThatItArrivedOverTheSeam
Fehler!      : Fehler:     5, erfolgreich:   670, gesamt:   675
```

**The arrival stops reaching the disk**, with a serialisation attribute that leaves the field out.
This is the one no in-memory leg can see: both surfaces record the row, every assertion about it
passes, and the value is gone the moment the file is read back. One leg, and it is the round trip:

```
  Fehler ...Storage.FileRequestStoreDurabilityTests.EveryFieldComesBackFromAStoreOpenedFreshOverTheSameDirectory
Fehler!      : Fehler:     1, erfolgreich:   674, gesamt:   675
```

**The refusal of a second arrival is deleted.** One leg, and it is the one written for it:

```
  Fehler ...Model.RequestHistoryTests.ARequestThatHasAlreadyArrivedCannotArriveAgain
Fehler!      : Fehler:     1, erfolgreich:   674, gesamt:   675
```

## Formatting

    npx --yes prettier@3.6.2 --check "docs/seam.md" "docs/personal-data.md"
    Checking formatting...
    All matched files use Prettier code style!

## A correction found on the way

Five of the seven line numbers pasted into `docs/personal-data.md`, under the derivation of the
fields that can name a person, were one short of what the command beside them returns. It was found
by running that command rather than by reading it, which the paste had to be re-run for anyway
because this change moves one of the seven. The paste is replaced with the output at this commit and
nothing else in that block changes.

## The means

No new one. This is C# in the project the record already lives in, a document in the directory the
arguments already live in, and legs in the suite that already runs on both frameworks.

## What was not done

**Nothing here was run on a Jellyfin server.** The row is asserted where this plugin writes it and
where its own store reads it back, and no running server has been asked for a request's history. No
surface renders a history today, so there is nothing on a server to look at:

    git grep -n 'The history is not in the answer' -- docs/api.md
    docs/api.md:287:The history is not in the answer. Every entry names the administrator who made the move, and a list a

**This has had no second reader.** The five breaks above, the suite on both frameworks and the gate
stand in place of one, and that is a weaker thing than a reader rather than the same thing.
