### PR TITLE
Record who owns a person's notice switch, and point the operator at the user guide

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -194,10 +194,12 @@ with an address set is refused rather than treated as silence.
 than its absence, so the set above names the three movements the sink announces plus the one arrival
 path that has a switch, and it grows when a path does rather than ahead of one.
 
-**A switch for the message to the person who asked.** There is none. It reaches only the person the
-request belongs to and only while they are signed in, and whether an operator or that person should
-be the one to turn it off is a question nobody has taken. It is written down in
-[`notifications.md`](notifications.md) rather than answered by adding a field here.
+**A switch for the message to the person who asked.** There is none here and there is not going to
+be one. It reaches only the person the request belongs to and only while they are signed in, and who
+may turn it off was taken on #9 on 2026-08-24: that person, and nobody acting on their behalf. So its
+absence from this page is the answer rather than an omission, and an operator field for it would be
+the shape that answer refuses. #287 is where the person's own switch is built.
+[`notifications.md`](notifications.md) carries the answer and says what is not built yet.
 
 **A bridge address and a credential.** The only bridge in this tree is the one for a server that has
 none. A field for an address would be somewhere to type something nothing reads. #82 brings the

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -341,10 +341,18 @@ it stops there.
 hands nothing back for a caller to check, and every way a push can fail costs the same: a line in the
 server's log and nothing else. Nothing is retried and nothing is queued.
 
-**There is no setting for it.** The three switches below narrow the outbound sink and none of them
-reaches this, and the activity log has no switch either. Whether an operator or the person themself
-should be the one to turn this off is a question nobody has taken, and it is written here rather than
-answered by adding a field.
+**There is no setting for it, and who one would belong to is no longer an open question.** The three
+switches below narrow the outbound sink and none of them reaches this, and the activity log has no
+switch either. Whether an operator or the person themself should be the one to turn this off was
+taken on #9 on 2026-08-24: the switch belongs to the person who made the request, default on, because
+a person controls what they are told about their own request and nobody else does.
+
+**The answer is written down and the switch is not built**, which are two states rather than one. An
+operator setting is refused by the answer rather than missing from it, so no field is coming beside
+the three below; what a person's own switch needs is somewhere per person to keep a preference, and
+this plugin keeps nothing per person today. That is #287. Until it lands, the message goes to the
+person on every movement it has a sentence for, which is the default the answer names, and nobody -
+the person included - can turn it off.
 
 ## What a live administrator is told when something arrives
 

--- a/docs/operating.md
+++ b/docs/operating.md
@@ -77,6 +77,13 @@ A person who has asked for something reads their own requests on a page this plu
 [surface.md](surface.md). It is worth reading before you send it to a household, because a browser
 opening an address sends no session and the credential therefore travels in the address.
 
+**What to tell a person who asks you how to use this** is [user-guide.md](user-guide.md), which
+answers it per client family, because the answer differs by what the client in their hand can draw
+and there is no single one to give. It is not repeated here: an operator who paraphrases it into
+their own house rules ends up with a second copy that goes stale against the reach matrix in
+[surface.md](surface.md), and the families that get nothing from this plugin are exactly the ones a
+paraphrase gets wrong.
+
 ## Wiring an external request service
 
 **Nothing in this tree talks to one.** The only bridge that ships is the one for a server that has no


### PR DESCRIPTION
Superseded by #289 and closed without merging.

This branch carried no `Signed-off-by` trailer on either commit, so the DCO job refused it:

    gh pr checks 288 --repo Flowfin/jellyfin-plugin-requests
    DCO sign-off	fail	4s

Every other check on it passed. The repair is a new branch with the same two changes signed off, rather than a rewritten history on this one: a branch that has been pushed is one somebody may already have fetched, and repairing it under a new name costs one branch name and destroys nothing.

Nothing from this branch is reused. #289 carries the whole change and the evidence for it.
