### PR TITLE
Record who owns a person's notice switch, and point the operator at the user guide

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -194,10 +194,12 @@ with an address set is refused rather than treated as silence.
 than its absence, so the set above names the three movements the sink announces plus the one arrival
 path that has a switch, and it grows when a path does rather than ahead of one.
 
-**A switch for the message to the person who asked.** There is none. It reaches only the person the
-request belongs to and only while they are signed in, and whether an operator or that person should
-be the one to turn it off is a question nobody has taken. It is written down in
-[`notifications.md`](notifications.md) rather than answered by adding a field here.
+**A switch for the message to the person who asked.** There is none here and there is not going to
+be one. It reaches only the person the request belongs to and only while they are signed in, and who
+may turn it off was taken on #9 on 2026-08-24: that person, and nobody acting on their behalf. So its
+absence from this page is the answer rather than an omission, and an operator field for it would be
+the shape that answer refuses. #287 is where the person's own switch is built.
+[`notifications.md`](notifications.md) carries the answer and says what is not built yet.
 
 **A bridge address and a credential.** The only bridge in this tree is the one for a server that has
 none. A field for an address would be somewhere to type something nothing reads. #82 brings the

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -341,10 +341,18 @@ it stops there.
 hands nothing back for a caller to check, and every way a push can fail costs the same: a line in the
 server's log and nothing else. Nothing is retried and nothing is queued.
 
-**There is no setting for it.** The three switches below narrow the outbound sink and none of them
-reaches this, and the activity log has no switch either. Whether an operator or the person themself
-should be the one to turn this off is a question nobody has taken, and it is written here rather than
-answered by adding a field.
+**There is no setting for it, and who one would belong to is no longer an open question.** The three
+switches below narrow the outbound sink and none of them reaches this, and the activity log has no
+switch either. Whether an operator or the person themself should be the one to turn this off was
+taken on #9 on 2026-08-24: the switch belongs to the person who made the request, default on, because
+a person controls what they are told about their own request and nobody else does.
+
+**The answer is written down and the switch is not built**, which are two states rather than one. An
+operator setting is refused by the answer rather than missing from it, so no field is coming beside
+the three below; what a person's own switch needs is somewhere per person to keep a preference, and
+this plugin keeps nothing per person today. That is #287. Until it lands, the message goes to the
+person on every movement it has a sentence for, which is the default the answer names, and nobody -
+the person included - can turn it off.
 
 ## What a live administrator is told when something arrives
 

--- a/docs/operating.md
+++ b/docs/operating.md
@@ -77,6 +77,13 @@ A person who has asked for something reads their own requests on a page this plu
 [surface.md](surface.md). It is worth reading before you send it to a household, because a browser
 opening an address sends no session and the credential therefore travels in the address.
 
+**What to tell a person who asks you how to use this** is [user-guide.md](user-guide.md), which
+answers it per client family, because the answer differs by what the client in their hand can draw
+and there is no single one to give. It is not repeated here: an operator who paraphrases it into
+their own house rules ends up with a second copy that goes stale against the reach matrix in
+[surface.md](surface.md), and the families that get nothing from this plugin are exactly the ones a
+paraphrase gets wrong.
+
 ## Wiring an external request service
 
 **Nothing in this tree talks to one.** The only bridge that ships is the one for a server that has no


### PR DESCRIPTION
Two documents, two issues, one branch. Both land only markdown, so they share a pull request rather than moving the mainline under each other twice.

## What changed, and why

**Who owns the switch on what a person is told, on #9.** `docs/notifications.md` and `docs/configuration.md` both said that whether an operator or the person themself should be able to turn off the message about their own request was a question nobody had taken. It was taken on #9 on 2026-08-24: the person who made the request owns it, default on, and nobody acting on their behalf does. Both sentences were true when they were written and are false now, and a document that keeps calling a settled question open sends a reader looking for an argument that has finished.

What replaces them says who owns it and then says the other half plainly: the answer exists and the switch does not. There is nowhere per person in this plugin to keep a preference, so what ships today is the default the answer names with no way for anybody to leave it. I opened #287 for the switch itself rather than leaving that gap in a document only.

**A pointer from the operator guide to the user guide, on #103.** The operator guide walked an operator through giving people a way to ask and stopped at the endpoints and the page address. Nothing in the tree linked it to the per-family guide that answers what a person actually does:

    git grep -in user-guide origin/master -- docs/ README.md ; echo "exit=$?"
    exit=1

The new paragraph points at it and says why it is not repeated there, which is the third condition of #103.

## Evidence

Run at `9a0f2c4`, the head of this branch.

The suite, on both target frameworks:

    dotnet test Jellyfin.Plugin.Requests.sln -c Release --nologo
    Passed!  - Failed:     0, Passed:   675, Skipped:     0, Total:   675, Duration: 18 s - Jellyfin.Plugin.Requests.Tests.dll (net10.0)
    Passed!  - Failed:     0, Passed:   675, Skipped:     0, Total:   675, Duration: 18 s - Jellyfin.Plugin.Requests.Tests.dll (net9.0)

Formatting, against the pinned version this board's gate runs and with the tree's `.editorconfig` beside the files, because that file is what sets the indent and the line ending Prettier judges by:

    npx --yes prettier@3.6.2 --check "docs/*.md"
    Checking formatting...
    All matched files use Prettier code style!

Nothing but markdown is touched:

    git diff --name-only origin/master...HEAD
    docs/configuration.md
    docs/notifications.md
    docs/operating.md

## The means

Markdown, because every artefact here is prose that a reader reads and no behaviour changes. Nothing in either issue asks for a refusable property, and a change that added one would be claiming the switch is built.

## What this does not do

It does not build the switch. #287 holds that, and both documents now say the switch is absent rather than implying it exists.

It does not open a client and look. `docs/user-guide.md` still ends its browser and desktop sections in the two words that say nobody in this repository has opened that client, and the pointer added here changes nothing about that.

It does not touch the reach matrix or any row of it.

## Second reader

This board has no second reader tonight. The evidence above stands in place of one: every claim in it carries the command that produced it, run at the head commit.

Closes #9.
Closes #103.

## Why this is the second branch

The first push of this work carried no `Signed-off-by` trailer and the DCO job refused it. The repair is this branch under a new name rather than a rewritten history, because a branch that has been pushed is one somebody may have fetched. #288 is closed with that reason in its body and nothing of it is reused.
