### PR TITLE
Give the person who asked the switch on what they are told

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,17 @@ from memory into entries would be a description nobody measured.
   signed-in clients and to nobody else's, carrying the title and, on a decline,
   the reason. It reaches whoever is connected at that moment and nothing
   remembers who was missed, so the answer to rely on is still their own page,
-  which shows the state whenever they next look. There is no setting for it and
-  nothing leaves the machine.
+  which shows the state whenever they next look. Nothing leaves the machine, and
+  the person it is about can turn it off, which is the entry below.
+
+- A person can turn off the message this plugin pushes them about their own
+  request. The switch is a checkbox on their own requests page and it is theirs
+  alone: no setting an operator can reach overrides it, and nothing an
+  administrator can call changes anybody's but their own. It is on by default, so
+  a server that upgrades into this behaves exactly as it did before, and what is
+  kept is a small file of the people who said no rather than a row per person. A
+  setting that cannot be read leaves the message unsent rather than sending it,
+  and says so in the server log.
 
 - `FinishedRequestRetentionDays` is enforced. A scheduled task removes a request
   that has been fulfilled, declined or failed for longer than that number of

--- a/Jellyfin.Plugin.Requests.Tests/Api/EndpointPolicyTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/EndpointPolicyTests.cs
@@ -70,6 +70,17 @@ public sealed class EndpointPolicyTests
         // sits where the queue sits, which is the only other place the whole store is readable.
         "HealthController.HealthAsync GET Health -> RequiresElevation",
 
+        // Reading the one setting a person owns here. A signed-in person, and it may never be more
+        // than that: an elevated policy would say an administrator is who reads this, and there is
+        // nothing on it to read but the caller's own answer.
+        "MyNoticeSettingController.MineAsync GET Notices/Mine -> (the server's default)",
+
+        // Setting it. The same policy as reading it, and it is the one place on this API where a
+        // signed-in person writes something that is not a request. What stops an administrator
+        // reaching somebody else's is not a policy and could not be one: the endpoint takes no
+        // identifier, so there is no call that names another person to refuse.
+        "MyNoticeSettingController.SetMineAsync POST Notices/Mine -> (the server's default)",
+
         // The page a person opens in a browser to see their own requests. A signed-in person, and
         // it is the policy that makes the page a page rather than a shell: a caller the server has
         // not authenticated is turned away instead of being handed the document and left to meet

--- a/Jellyfin.Plugin.Requests.Tests/Api/PublishedApiDocumentTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/PublishedApiDocumentTests.cs
@@ -12,6 +12,7 @@ using Jellyfin.Plugin.Requests.Configuration;
 using Jellyfin.Plugin.Requests.Fulfilment;
 using Jellyfin.Plugin.Requests.Localisation;
 using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Notify;
 using Jellyfin.Plugin.Requests.Storage;
 using Jellyfin.Plugin.Requests.Tests.Doubles;
 using Microsoft.AspNetCore.Mvc;
@@ -85,6 +86,10 @@ public sealed class PublishedApiDocumentTests
         // is reading it to find out why.
         "GET MediaRequests/v1/Health () -> 200:PluginHealth",
 
+        // The one setting a person owns. No parameter at all: whose setting it is comes off the
+        // credential, and the absence of a parameter is the mechanism rather than an omission.
+        "GET MediaRequests/v1/Notices/Mine () -> 200:MyNoticeSetting, 403:RequestFailure, 503:RequestFailure",
+
         // The page a browser opens. One status and one shape, and the shape is a string because
         // what comes back is a document rather than a record: a generated client that expected a
         // record here would parse the markup. It refuses nothing of its own, so it publishes no
@@ -109,6 +114,12 @@ public sealed class PublishedApiDocumentTests
         // recognises is answered in English rather than refused, because a caller asking for words
         // wants words and the catalogue already falls back per key.
         "GET MediaRequests/v1/Strings (culture@Query:String) -> 200:PageStrings",
+
+        // Setting it. The body carries one field and no identifier, so the 400 is a body that said
+        // nothing rather than one that named the wrong person: there is no field on it that could.
+        "POST MediaRequests/v1/Notices/Mine"
+            + " (body@Body:SetMyNoticeBody)"
+            + " -> 200:MyNoticeSetting, 400:RequestFailure, 403:RequestFailure, 503:RequestFailure",
 
         // Asking for something. Two success codes with one shape: 201 is a new request and 200 is
         // one that was joined or was already the caller's, and a client tells them apart by the
@@ -289,6 +300,8 @@ public sealed class PublishedApiDocumentTests
         const string DeclineMany = "POST MediaRequests/v1/Requests/Decline";
         const string Strings = "GET MediaRequests/v1/Strings";
         const string Health = "GET MediaRequests/v1/Health";
+        const string ReadNotice = "GET MediaRequests/v1/Notices/Mine";
+        const string SetNotice = "POST MediaRequests/v1/Notices/Mine";
 
         // What this install allows. One call and one status: it reads no store, refuses nothing and
         // has no failure to walk, which is why it publishes one code where every other endpoint
@@ -324,6 +337,22 @@ public sealed class PublishedApiDocumentTests
         Saw(Mine, await ControllerFor(store, Asker).MineAsync(take: RequestsController.MaximumPageSize + 1, cancellationToken: CancellationToken.None).ConfigureAwait(true));
         Saw(Mine, await ControllerFor(store, caller: null).MineAsync(cancellationToken: CancellationToken.None).ConfigureAwait(true));
         Saw(Mine, await ControllerFor(unreadable, Asker).MineAsync(cancellationToken: CancellationToken.None).ConfigureAwait(true));
+
+        // The one setting a person owns. Three calls each: the answer, the caller that names no
+        // person, and the setting that could not be read. There is no fourth on the read and no
+        // fifth on the write, because neither endpoint takes anything that could be wrong except
+        // the one field the body carries.
+        var preferences = new InMemoryNoticePreferences();
+        var refusingPreferences = new NoticePreferencesThatCannotBeRead();
+
+        Saw(ReadNotice, await NoticesFor(preferences, Asker).MineAsync(CancellationToken.None).ConfigureAwait(true));
+        Saw(ReadNotice, await NoticesFor(preferences, caller: null).MineAsync(CancellationToken.None).ConfigureAwait(true));
+        Saw(ReadNotice, await NoticesFor(refusingPreferences, Asker).MineAsync(CancellationToken.None).ConfigureAwait(true));
+
+        Saw(SetNotice, await NoticesFor(preferences, Asker).SetMineAsync(new SetMyNoticeBody { TellsMe = false }, CancellationToken.None).ConfigureAwait(true));
+        Saw(SetNotice, await NoticesFor(preferences, Asker).SetMineAsync(new SetMyNoticeBody(), CancellationToken.None).ConfigureAwait(true));
+        Saw(SetNotice, await NoticesFor(preferences, caller: null).SetMineAsync(new SetMyNoticeBody { TellsMe = false }, CancellationToken.None).ConfigureAwait(true));
+        Saw(SetNotice, await NoticesFor(refusingPreferences, Asker).SetMineAsync(new SetMyNoticeBody { TellsMe = false }, CancellationToken.None).ConfigureAwait(true));
 
         Saw(Queue, await ControllerFor(store, Operator).QueueAsync(cancellationToken: CancellationToken.None).ConfigureAwait(true));
         Saw(Queue, await ControllerFor(store, Operator).QueueAsync(take: RequestsController.MaximumPageSize + 1, cancellationToken: CancellationToken.None).ConfigureAwait(true));
@@ -542,6 +571,15 @@ public sealed class PublishedApiDocumentTests
     /// <returns>The controller under test.</returns>
     private RequestsController ControllerFor(IRequestStore store, Guid? caller)
         => ControllerFor(store, caller, new FakeInstallSettings());
+
+    /// <summary>
+    /// The endpoint that holds one person's own switch, wired to what is kept and to one identity.
+    /// </summary>
+    /// <param name="preferences">What is kept about who wants to be told.</param>
+    /// <param name="caller">Who the server says is calling.</param>
+    /// <returns>The controller.</returns>
+    private static MyNoticeSettingController NoticesFor(INoticePreferences preferences, Guid? caller)
+        => new MyNoticeSettingController(new FakeCallerIdentity(caller), preferences);
 
     /// <summary>
     /// A controller wired to one store, one identity and one install, for the answer that depends on

--- a/Jellyfin.Plugin.Requests.Tests/Doubles/InMemoryNoticePreferences.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/InMemoryNoticePreferences.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Notify;
+
+namespace Jellyfin.Plugin.Requests.Tests.Doubles;
+
+/// <summary>
+/// Who wants to be told, kept in memory instead of in a file.
+/// <para>
+/// It is the double for every test whose subject is a path rather than the keeping: what a test of
+/// the endpoint or of the switch in front of the notice can assert is which person was asked about
+/// and what happened next. Whether a setting survives a restart is
+/// <c>FileNoticePreferences</c>'s own, and is tested against a directory of its own.
+/// </para>
+/// <para>
+/// It keeps the refusals rather than a row per person, exactly as the file does, so a test that
+/// never touches this gets the shipped default without saying so.
+/// </para>
+/// </summary>
+internal sealed class InMemoryNoticePreferences : INoticePreferences
+{
+    private readonly HashSet<Guid> _quiet = [];
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InMemoryNoticePreferences"/> class.
+    /// </summary>
+    /// <param name="quiet">Who has already turned it off.</param>
+    public InMemoryNoticePreferences(params Guid[] quiet) => _quiet = [.. quiet];
+
+    /// <summary>
+    /// Gets how many times a setting has been written, so a test can assert that a call which
+    /// changes nothing writes nothing.
+    /// </summary>
+    public int Writes { get; private set; }
+
+    /// <inheritdoc />
+    public Task<bool> TellsThemAsync(Guid userId, CancellationToken cancellationToken)
+        => Task.FromResult(!_quiet.Contains(userId));
+
+    /// <inheritdoc />
+    public Task<bool> SetAsync(Guid userId, bool tellsThem, CancellationToken cancellationToken)
+    {
+        if (tellsThem ? _quiet.Remove(userId) : _quiet.Add(userId))
+        {
+            Writes++;
+        }
+
+        return Task.FromResult(tellsThem);
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/Doubles/NoticePreferencesThatCannotBeRead.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/NoticePreferencesThatCannotBeRead.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Notify;
+
+namespace Jellyfin.Plugin.Requests.Tests.Doubles;
+
+/// <summary>
+/// What is kept about who wants to be told, on a disk that will not answer.
+/// <para>
+/// It refuses both calls rather than only the read, because a write reads before it decides and a
+/// double that let the write through would let a test pass that the shipped code fails.
+/// </para>
+/// </summary>
+internal sealed class NoticePreferencesThatCannotBeRead : INoticePreferences
+{
+    /// <inheritdoc />
+    public Task<bool> TellsThemAsync(Guid userId, CancellationToken cancellationToken)
+        => throw new NoticePreferencesException();
+
+    /// <inheritdoc />
+    public Task<bool> SetAsync(Guid userId, bool tellsThem, CancellationToken cancellationToken)
+        => throw new NoticePreferencesException();
+}

--- a/Jellyfin.Plugin.Requests.Tests/Notify/APersonsOwnSwitchTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Notify/APersonsOwnSwitchTests.cs
@@ -1,0 +1,312 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Api;
+using Jellyfin.Plugin.Requests.Notify;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Notify;
+
+/// <summary>
+/// The switch a person owns over what this plugin pushes at them about their own request: who it
+/// obeys, who may move it, and what it does on an install nobody has touched.
+/// <para>
+/// The rule it is built to keep is #9's decision of 2026-08-24. The person who made the request owns
+/// this, default on, and no operator setting overrides it - which is why the leg that has an
+/// administrator try is here rather than in a document.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class APersonsOwnSwitchTests
+{
+    private static readonly Guid Asker = new Guid("f2000000-0000-0000-0000-000000000001");
+    private static readonly Guid Somebody = new Guid("f2000000-0000-0000-0000-000000000002");
+    private static readonly Guid Administrator = new Guid("f2000000-0000-0000-0000-000000000003");
+
+    /// <summary>
+    /// A person who has turned it off is not told, and everybody else still is.
+    /// <para>
+    /// Both halves in one leg on purpose. A switch that silenced everybody would pass the first half
+    /// alone, and it is the failure a person would notice last.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task SomebodyWhoTurnedItOffIsNotToldAndNobodyElseIsAffected()
+    {
+        var inner = new RecordingRequesterNotice();
+        var switched = new QuietedRequesterNotice(inner, new InMemoryNoticePreferences(Asker), new RecordingLogger());
+
+        switched.Tell(Message(Asker));
+        switched.Tell(Message(Somebody));
+
+        await switched.QuietAsync(CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Equal([Somebody], inner.Told.Select(message => message.ToUserId).ToArray());
+    }
+
+    /// <summary>
+    /// An install nobody has touched tells everybody, which is what it did before this existed.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AnInstallNobodyHasTouchedTellsEverybody()
+    {
+        var inner = new RecordingRequesterNotice();
+        var switched = new QuietedRequesterNotice(inner, new InMemoryNoticePreferences(), new RecordingLogger());
+
+        switched.Tell(Message(Asker));
+        switched.Tell(Message(Somebody));
+
+        await switched.QuietAsync(CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Equal([Asker, Somebody], inner.Told.Select(message => message.ToUserId).ToArray());
+    }
+
+    /// <summary>
+    /// A setting that cannot be read silences the message and says so in the log.
+    /// <para>
+    /// The two ways of being wrong are not equal. Not sending a courtesy costs somebody a line they
+    /// would have read on their own page anyway; sending it costs a person who asked not to be told
+    /// being told, which is the whole of what the switch is for. So the failure goes the quiet way,
+    /// and it is written to the log so an operator meets a file to repair rather than silence
+    /// nobody can explain.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ASettingThatCannotBeReadDropsTheMessageAndIsReported()
+    {
+        var inner = new RecordingRequesterNotice();
+        var logger = new RecordingLogger();
+        var switched = new QuietedRequesterNotice(inner, new NoticePreferencesThatCannotBeRead(), logger);
+
+        switched.Tell(Message(Asker));
+
+        await switched.QuietAsync(CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Empty(inner.Told);
+        Assert.Single(logger.At(LogLevel.Error));
+        Assert.DoesNotContain(Asker.ToString(), logger.At(LogLevel.Error)[0].Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The endpoint answers the caller's own setting, and it is on where they have never touched it.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task TheEndpointAnswersTheCallersOwnSetting()
+    {
+        var preferences = new InMemoryNoticePreferences(Somebody);
+
+        Assert.True(await ReadAsync(preferences, Asker).ConfigureAwait(true));
+        Assert.False(await ReadAsync(preferences, Somebody).ConfigureAwait(true));
+    }
+
+    /// <summary>
+    /// Turning it off through the endpoint is what the notice path then obeys.
+    /// <para>
+    /// Through both halves rather than by reading the store, because what this issue asks for is
+    /// that a person can turn the message off from a surface they can reach: a setting written by
+    /// one and ignored by the other is two mechanisms that agree today.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task WhatSomebodySetsThroughTheEndpointIsWhatTheNoticePathObeys()
+    {
+        var preferences = new InMemoryNoticePreferences();
+        var inner = new RecordingRequesterNotice();
+        var switched = new QuietedRequesterNotice(inner, preferences, new RecordingLogger());
+
+        Assert.False(await SetAsync(preferences, Asker, tellsMe: false).ConfigureAwait(true));
+
+        switched.Tell(Message(Asker));
+        await switched.QuietAsync(CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Empty(inner.Told);
+
+        Assert.True(await SetAsync(preferences, Asker, tellsMe: true).ConfigureAwait(true));
+
+        switched.Tell(Message(Asker));
+        await switched.QuietAsync(CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Equal([Asker], inner.Told.Select(message => message.ToUserId).ToArray());
+    }
+
+    /// <summary>
+    /// An administrator calling this endpoint changes their own setting and nobody else's.
+    /// <para>
+    /// This is the leg #287's second condition asks for, and what it can assert is stronger than a
+    /// refusal: there is no call that reaches somebody else's setting, because there is no field,
+    /// route segment or parameter on either endpoint that names a person. So the administrator here
+    /// sends the body an administrator would send if they wanted to silence the asker, and what
+    /// moves is the administrator's own row.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AnAdministratorTurningItOffTurnsOffTheirOwn()
+    {
+        var preferences = new InMemoryNoticePreferences();
+
+        Assert.False(await SetAsync(preferences, Administrator, tellsMe: false).ConfigureAwait(true));
+
+        Assert.True(await ReadAsync(preferences, Asker).ConfigureAwait(true));
+        Assert.False(await ReadAsync(preferences, Administrator).ConfigureAwait(true));
+
+        // And the notice path agrees with the store, so nothing about the asker went quiet.
+        var inner = new RecordingRequesterNotice();
+        var switched = new QuietedRequesterNotice(inner, preferences, new RecordingLogger());
+
+        switched.Tell(Message(Asker));
+        switched.Tell(Message(Administrator));
+        await switched.QuietAsync(CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Equal([Asker], inner.Told.Select(message => message.ToUserId).ToArray());
+    }
+
+    /// <summary>
+    /// A body that says nothing is refused rather than read as a refusal to be told.
+    /// <para>
+    /// The direction where a mistake is not noticed. A client sending an empty object would
+    /// otherwise silence the person, and the person would find out by not being told something.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ABodyThatSaysNothingIsRefusedRatherThanTakenAsOff()
+    {
+        var preferences = new InMemoryNoticePreferences();
+        var answered = await ControllerFor(preferences, Asker)
+            .SetMineAsync(new SetMyNoticeBody(), CancellationToken.None)
+            .ConfigureAwait(true);
+
+        Assert.Equal(RequestFailureCode.InvalidBody, Refused(answered).Code);
+        Assert.Equal(0, preferences.Writes);
+        Assert.True(await ReadAsync(preferences, Asker).ConfigureAwait(true));
+    }
+
+    /// <summary>
+    /// A call that authenticated and names no person is refused rather than kept against nobody.
+    /// <para>
+    /// An API key reaches this endpoint under the server's default policy and there is nobody whose
+    /// setting it would be. Writing it against the empty identifier would silence whoever that
+    /// identifier is next taken for, which is the entry the store refuses on its way back in.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ACallNamingNobodyIsRefusedOnBothEndpoints()
+    {
+        var preferences = new InMemoryNoticePreferences();
+
+        var read = await ControllerFor(preferences, caller: null).MineAsync(CancellationToken.None).ConfigureAwait(true);
+        var written = await ControllerFor(preferences, caller: null)
+            .SetMineAsync(new SetMyNoticeBody { TellsMe = false }, CancellationToken.None)
+            .ConfigureAwait(true);
+
+        Assert.Equal(RequestFailureCode.NoUserOnTheCall, Refused(read).Code);
+        Assert.Equal(RequestFailureCode.NoUserOnTheCall, Refused(written).Code);
+        Assert.Equal(0, preferences.Writes);
+    }
+
+    /// <summary>
+    /// A setting that cannot be read is an unavailable answer rather than an exception out of the
+    /// endpoint, and nothing of the refusal reaches the caller.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ASettingThatCannotBeReadIsAnswerAsUnavailable()
+    {
+        var refusing = new NoticePreferencesThatCannotBeRead();
+
+        var read = await ControllerFor(refusing, Asker).MineAsync(CancellationToken.None).ConfigureAwait(true);
+        var written = await ControllerFor(refusing, Asker)
+            .SetMineAsync(new SetMyNoticeBody { TellsMe = false }, CancellationToken.None)
+            .ConfigureAwait(true);
+
+        Assert.Equal(RequestFailureCode.TheStoreCouldNotBeRead, Refused(read).Code);
+        Assert.Equal(RequestFailureCode.TheStoreCouldNotBeRead, Refused(written).Code);
+    }
+
+    /// <summary>
+    /// One message for one person.
+    /// </summary>
+    /// <param name="toUserId">Who it is for.</param>
+    /// <returns>The message.</returns>
+    private static RequesterMessage Message(Guid toUserId)
+        => new RequesterMessage { ToUserId = toUserId, Header = "Requests", Text = "It arrived." };
+
+    /// <summary>
+    /// The endpoint, as one caller sees it.
+    /// </summary>
+    /// <param name="preferences">What is kept.</param>
+    /// <param name="caller">Who the server says is calling.</param>
+    /// <returns>The controller.</returns>
+    private static MyNoticeSettingController ControllerFor(INoticePreferences preferences, Guid? caller)
+        => new MyNoticeSettingController(new FakeCallerIdentity(caller), preferences);
+
+    /// <summary>
+    /// What the endpoint answers one caller about their own setting.
+    /// </summary>
+    /// <param name="preferences">What is kept.</param>
+    /// <param name="caller">Who is asking.</param>
+    /// <returns>Whether they are told.</returns>
+    private static async Task<bool> ReadAsync(INoticePreferences preferences, Guid caller)
+    {
+        var answered = await ControllerFor(preferences, caller).MineAsync(CancellationToken.None).ConfigureAwait(false);
+
+        return Answered(answered).TellsMe;
+    }
+
+    /// <summary>
+    /// What the endpoint answers after one caller sets their own setting.
+    /// </summary>
+    /// <param name="preferences">What is kept.</param>
+    /// <param name="caller">Who is setting it.</param>
+    /// <param name="tellsMe">Which way.</param>
+    /// <returns>Whether they are told afterwards.</returns>
+    private static async Task<bool> SetAsync(INoticePreferences preferences, Guid caller, bool tellsMe)
+    {
+        var answered = await ControllerFor(preferences, caller)
+            .SetMineAsync(new SetMyNoticeBody { TellsMe = tellsMe }, CancellationToken.None)
+            .ConfigureAwait(false);
+
+        return Answered(answered).TellsMe;
+    }
+
+    /// <summary>
+    /// The setting out of an answer that carried one.
+    /// </summary>
+    /// <param name="answered">What the endpoint returned.</param>
+    /// <returns>The setting.</returns>
+    private static MyNoticeSetting Answered(ActionResult<MyNoticeSetting> answered)
+    {
+        var ok = Assert.IsType<OkObjectResult>(answered.Result);
+
+        return Assert.IsType<MyNoticeSetting>(ok.Value);
+    }
+
+    /// <summary>
+    /// The failure out of an answer that carried one.
+    /// </summary>
+    /// <param name="answered">What the endpoint returned.</param>
+    /// <returns>The failure.</returns>
+    private static RequestFailure Refused(ActionResult<MyNoticeSetting> answered)
+    {
+        var refusal = Assert.IsType<ObjectResult>(answered.Result);
+
+        Assert.Equal(RequestFailure.StatusFor(Assert.IsType<RequestFailure>(refusal.Value).Code), refusal.StatusCode);
+
+        return Assert.IsType<RequestFailure>(refusal.Value);
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/Notify/NoticePreferencesTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Notify/NoticePreferencesTests.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Notify;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Notify;
+
+/// <summary>
+/// What this plugin keeps about who does not want to be told, held to the three properties the
+/// switch rests on: the default is on, a refusal survives a restart, and a file that cannot be read
+/// is refused rather than read as an empty set.
+/// <para>
+/// The last of those is the one worth being careful about, and it is why this file exists at all
+/// rather than only a test of the endpoint. An empty set here means everybody wants to be told, so a
+/// store that answered empty on a file it could not parse would turn a disk fault into every person
+/// on the server having their setting silently reversed.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class NoticePreferencesTests : IDisposable
+{
+    private static readonly Guid Asker = new Guid("f1000000-0000-0000-0000-000000000001");
+    private static readonly Guid Somebody = new Guid("f1000000-0000-0000-0000-000000000002");
+
+    private readonly string _directory = TestRunDirectory.CreateSubdirectory();
+
+    /// <summary>
+    /// A person who has never touched this is told, and an install nobody has touched holds no file
+    /// at all.
+    /// <para>
+    /// The second half is what makes the third condition of #287 a property of the shape: the
+    /// default is the absence of a value rather than a value somebody has to remember to write, so
+    /// an install that upgrades into this behaves exactly as it did before it existed.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ANobodyHasTouchedIsToldAndNothingIsOnTheDisk()
+    {
+        using var preferences = new FileNoticePreferences(_directory);
+
+        Assert.True(await preferences.TellsThemAsync(Asker, CancellationToken.None).ConfigureAwait(true));
+        Assert.False(File.Exists(Path.Combine(_directory, FileNoticePreferences.FileName)));
+    }
+
+    /// <summary>
+    /// Turning it off survives a restart, and turning it back on survives one too.
+    /// <para>
+    /// Read through a second instance over the same directory rather than through the one that
+    /// wrote it, because the one that wrote it holds the set in memory and would answer from there:
+    /// a write that never reached the disk would pass a test made against the writer.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task WhatSomebodySetIsWhatANewInstanceReads()
+    {
+        using (var setting = new FileNoticePreferences(_directory))
+        {
+            Assert.False(await setting.SetAsync(Asker, tellsThem: false, CancellationToken.None).ConfigureAwait(true));
+        }
+
+        using (var afterARestart = new FileNoticePreferences(_directory))
+        {
+            Assert.False(await afterARestart.TellsThemAsync(Asker, CancellationToken.None).ConfigureAwait(true));
+            Assert.True(await afterARestart.TellsThemAsync(Somebody, CancellationToken.None).ConfigureAwait(true));
+            Assert.True(await afterARestart.SetAsync(Asker, tellsThem: true, CancellationToken.None).ConfigureAwait(true));
+        }
+
+        using var afterAnother = new FileNoticePreferences(_directory);
+
+        Assert.True(await afterAnother.TellsThemAsync(Asker, CancellationToken.None).ConfigureAwait(true));
+    }
+
+    /// <summary>
+    /// One person's setting is not anybody else's, on the disk as well as in memory.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task OnePersonsRefusalLeavesEverybodyElseBeingTold()
+    {
+        using (var setting = new FileNoticePreferences(_directory))
+        {
+            await setting.SetAsync(Asker, tellsThem: false, CancellationToken.None).ConfigureAwait(true);
+        }
+
+        using var afterARestart = new FileNoticePreferences(_directory);
+
+        Assert.False(await afterARestart.TellsThemAsync(Asker, CancellationToken.None).ConfigureAwait(true));
+        Assert.True(await afterARestart.TellsThemAsync(Somebody, CancellationToken.None).ConfigureAwait(true));
+    }
+
+    /// <summary>
+    /// A file that is not the document this keeps is refused, in both directions.
+    /// <para>
+    /// Refused rather than answered as an empty set, because an empty set here reads as everybody
+    /// wanting to be told: a person who asked not to be told would start being told again, and
+    /// nothing afterwards could tell that from a person who never asked.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AFileThisCannotReadIsRefusedRatherThanReadAsNobody()
+    {
+        await File.WriteAllTextAsync(
+            Path.Combine(_directory, FileNoticePreferences.FileName),
+            "{ this is not the document",
+            Encoding.UTF8,
+            CancellationToken.None).ConfigureAwait(true);
+
+        using var preferences = new FileNoticePreferences(_directory);
+
+        await Assert.ThrowsAsync<NoticePreferencesException>(
+            () => preferences.TellsThemAsync(Asker, CancellationToken.None)).ConfigureAwait(true);
+
+        await Assert.ThrowsAsync<NoticePreferencesException>(
+            () => preferences.SetAsync(Asker, tellsThem: false, CancellationToken.None)).ConfigureAwait(true);
+    }
+
+    /// <summary>
+    /// A file written by a later version of this plugin is refused and is left exactly as it was.
+    /// <para>
+    /// The same rule the request store keeps, for the same reason: a downgraded server cannot know
+    /// what a field it has never heard of means, and writing its guess back replaces the only copy.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AFileFromALaterVersionIsRefusedAndLeftAlone()
+    {
+        var path = Path.Combine(_directory, FileNoticePreferences.FileName);
+        var written = "{\"Version\":" + (FileNoticePreferences.OnDiskVersion + 1) + ",\"Quiet\":[\"" + Asker + "\"]}";
+
+        await File.WriteAllTextAsync(path, written, Encoding.UTF8, CancellationToken.None).ConfigureAwait(true);
+
+        using var preferences = new FileNoticePreferences(_directory);
+
+        await Assert.ThrowsAsync<NoticePreferencesException>(
+            () => preferences.TellsThemAsync(Asker, CancellationToken.None)).ConfigureAwait(true);
+
+        Assert.Equal(
+            written,
+            await File.ReadAllTextAsync(path, Encoding.UTF8, CancellationToken.None).ConfigureAwait(true),
+            StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// An entry naming nobody is refused.
+    /// <para>
+    /// The empty identifier is what a caller with no session would be recorded as, and a setting
+    /// kept against it silences whoever that identifier is next taken for. It cannot be written
+    /// through this plugin, which is what the endpoint's refusal of a call naming no person is for,
+    /// so what this covers is a file that arrived some other way.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AnEntryNamingNobodyIsRefused()
+    {
+        await File.WriteAllTextAsync(
+            Path.Combine(_directory, FileNoticePreferences.FileName),
+            "{\"Version\":" + FileNoticePreferences.OnDiskVersion + ",\"Quiet\":[\"" + Guid.Empty + "\"]}",
+            Encoding.UTF8,
+            CancellationToken.None).ConfigureAwait(true);
+
+        using var preferences = new FileNoticePreferences(_directory);
+
+        await Assert.ThrowsAsync<NoticePreferencesException>(
+            () => preferences.TellsThemAsync(Somebody, CancellationToken.None)).ConfigureAwait(true);
+    }
+
+    /// <summary>
+    /// A setting that is already what it is being set to writes nothing.
+    /// <para>
+    /// A person opening their page and leaving the control alone should not touch a file, and a
+    /// write that replaces a file with the same bytes is a write that can fail for a reason nobody
+    /// asked for. Measured by the file not appearing at all, which is the strongest form available
+    /// here and is the shipped default's own case.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task SettingItToWhatItAlreadyIsWritesNothing()
+    {
+        using var preferences = new FileNoticePreferences(_directory);
+
+        Assert.True(await preferences.SetAsync(Asker, tellsThem: true, CancellationToken.None).ConfigureAwait(true));
+        Assert.False(File.Exists(Path.Combine(_directory, FileNoticePreferences.FileName)));
+    }
+
+    /// <summary>
+    /// Nothing is left on the disk when the test is done with it.
+    /// </summary>
+    public void Dispose() => TestRunDirectory.Remove(_directory);
+}

--- a/Jellyfin.Plugin.Requests.Tests/Web/BrowserPageTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Web/BrowserPageTests.cs
@@ -42,9 +42,17 @@ namespace Jellyfin.Plugin.Requests.Tests.Web;
 public sealed class BrowserPageTests
 {
     /// <summary>
+    /// The one endpoint the page is allowed to send to, and the one element a person can operate on
+    /// it. Both are the switch on what this plugin pushes at whoever is reading the page, which is
+    /// the only kind of control that belongs here: a setting about this person rather than a
+    /// decision about a request.
+    /// </summary>
+    private const string TheOneItSendsTo = "Notices/Mine";
+
+    /// <summary>
     /// The endpoints the page is allowed to name, in the order the assertion compares them.
     /// </summary>
-    private static readonly string[] TheTwoItAsksFor = ["Requests", "Strings"];
+    private static readonly string[] TheThreeItAsksFor = ["Notices/Mine", "Requests", "Strings"];
 
     /// <summary>
     /// The elements a browser gives a person something to operate. Anything a page offers a
@@ -110,30 +118,36 @@ public sealed class BrowserPageTests
     }
 
     /// <summary>
-    /// The page asks this plugin for two things and they are its own words and the caller's own
-    /// requests.
+    /// The page asks this plugin for three things and they are its own words, the caller's own
+    /// requests, and the caller's own setting about being told.
     /// <para>
     /// The address is built against the page's own, so what is asserted is the relative part and
-    /// that there is one place that builds it. A third call added to this page is a third thing a
+    /// that there is one place that builds it. A fourth call added to this page is a fourth thing a
     /// user's browser asks for on their behalf, and that is the shape by which an administrator's
     /// answer arrives on a page that was never meant to hold one. The set is written out rather
     /// than counted, so a call swapped for another of the same number fails here too.
     /// </para>
     /// <para>
-    /// The words are the second because the page ships with none, which is #73. What that costs is
+    /// The words are among them because the page ships with none, which is #73. What that costs is
     /// in the page's own comment: a catalogue that cannot be fetched leaves the page wordless.
+    /// </para>
+    /// <para>
+    /// Two <c>fetch</c> calls rather than one, because reading and sending are two shapes and the
+    /// sending one carries a method and a body. One <c>new URL</c> still, which is the thing that
+    /// actually matters: every address this page uses is built in the one place that carries the
+    /// credential no further than the call.
     /// </para>
     /// </summary>
     [Fact]
-    public void ThePageAsksForNothingButItsWordsAndTheCallersOwnRequests()
+    public void ThePageAsksForNothingButItsWordsAndTheCallersOwn()
     {
         var body = Page();
 
-        Assert.Equal(1, Occurrences(body, "fetch("));
+        Assert.Equal(2, Occurrences(body, "fetch("));
         Assert.Equal(1, Occurrences(body, "new URL("));
         Assert.Equal(
-            TheTwoItAsksFor,
-            Regex.Matches(body, @"fetched\(""(?<endpoint>[A-Za-z]+)""")
+            TheThreeItAsksFor,
+            Regex.Matches(body, @"(?:fetched|sent)\(""(?<endpoint>[A-Za-z/]+)""")
                 .Select(match => match.Groups["endpoint"].Value)
                 .Distinct(StringComparer.Ordinal)
                 .OrderBy(endpoint => endpoint, StringComparer.Ordinal)
@@ -195,16 +209,24 @@ public sealed class BrowserPageTests
     }
 
     /// <summary>
-    /// The page offers no way to decide anything.
+    /// The page offers no way to decide anything about a request, and exactly one way to set
+    /// something about the person reading it.
     /// <para>
-    /// A control is how a decision arrives on a page, and this one has none: everything it could
-    /// offer is either an administrator's or waits on a state a request can be withdrawn into,
-    /// which is an open decision on #113. So the assertion is over the elements a person can
-    /// operate rather than over the words on the page, and it reds the moment one is added.
+    /// A control is how a decision arrives on a page. This one carries a single checkbox, and what
+    /// it sets is what this plugin pushes at whoever is signed in; everything else a page like this
+    /// could offer is either an administrator's or waits on a state a request can be withdrawn
+    /// into, which is an open decision on #113. So the assertion is over the elements a person can
+    /// operate rather than over the words, and it reds the moment a second one is added.
+    /// </para>
+    /// <para>
+    /// The second half is the one that matters more, because a control is only as narrow as what it
+    /// sends: the page's one sending call goes to the endpoint that takes no identifier, so there
+    /// is no address on this page through which anybody's setting but the caller's own could be
+    /// changed.
     /// </para>
     /// </summary>
     [Fact]
-    public void ThePageCarriesNoControlAPersonCanOperate()
+    public void TheOnlyControlThePageCarriesIsThePersonsOwnSwitch()
     {
         var body = Page();
 
@@ -212,8 +234,10 @@ public sealed class BrowserPageTests
             .Where(element => body.Contains(element, StringComparison.OrdinalIgnoreCase))
             .ToArray();
 
-        Assert.Empty(carried);
-        Assert.DoesNotContain(@"method: ""POST""", body, StringComparison.Ordinal);
+        Assert.Equal(["<input"], carried);
+        Assert.Equal(1, Occurrences(body, "<input"));
+        Assert.Equal(1, Occurrences(body, @"method: ""POST"""));
+        Assert.Equal(1, Occurrences(body, @"sent(""" + TheOneItSendsTo + @""""));
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Requests/Api/MyNoticeSetting.cs
+++ b/Jellyfin.Plugin.Requests/Api/MyNoticeSetting.cs
@@ -1,0 +1,17 @@
+namespace Jellyfin.Plugin.Requests.Api;
+
+/// <summary>
+/// What the caller has set about being told when their own request moves.
+/// <para>
+/// It names nobody. There is one person this can be about and it is whoever made the call, so an
+/// identifier on it would be a field a caller could read as one they may also send.
+/// </para>
+/// </summary>
+public sealed record MyNoticeSetting
+{
+    /// <summary>
+    /// Gets a value indicating whether this plugin pushes a message to the caller when one of their
+    /// own requests moves. True on an install nobody has touched.
+    /// </summary>
+    public required bool TellsMe { get; init; }
+}

--- a/Jellyfin.Plugin.Requests/Api/MyNoticeSettingController.cs
+++ b/Jellyfin.Plugin.Requests/Api/MyNoticeSettingController.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Notify;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Jellyfin.Plugin.Requests.Api;
+
+/// <summary>
+/// The one switch a person owns on this plugin: whether it pushes them a message when a request of
+/// their own moves.
+/// <para>
+/// <b>Nobody can reach anybody else's setting from here, and it is the shape rather than a check.</b>
+/// The person is read off the call and there is no parameter, no route segment and no body field
+/// that names one, so there is no call an administrator can make that changes what somebody else is
+/// told. That is the decision recorded on #9: an operator decides what leaves their server, and a
+/// person decides what is pushed at them about their own request.
+/// </para>
+/// <para>
+/// A controller of its own rather than two more actions beside the queue, for the reason
+/// <see cref="MyRequestsPageController"/> is one: it reads no request, needs no store, no clock and
+/// no identifier source, and putting it there would hand every store test a preference file to
+/// carry.
+/// </para>
+/// </summary>
+[Authorize]
+public sealed class MyNoticeSettingController : RequestsControllerBase
+{
+    private readonly ICallerIdentity _callers;
+    private readonly INoticePreferences _preferences;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MyNoticeSettingController"/> class.
+    /// </summary>
+    /// <param name="callers">Who the server says is calling.</param>
+    /// <param name="preferences">What is kept about who wants to be told.</param>
+    public MyNoticeSettingController(ICallerIdentity callers, INoticePreferences preferences)
+    {
+        _callers = callers;
+        _preferences = preferences;
+    }
+
+    /// <summary>
+    /// What the caller has set about being told when their own request moves.
+    /// </summary>
+    /// <param name="cancellationToken">Cancels the call.</param>
+    /// <returns>The caller's own setting, which is on where they have never touched it.</returns>
+    [HttpGet("Notices/Mine")]
+    [Authorize]
+    [ProducesResponseType<MyNoticeSetting>(StatusCodes.Status200OK)]
+    [ProducesResponseType<RequestFailure>(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType<RequestFailure>(StatusCodes.Status503ServiceUnavailable)]
+    public async Task<ActionResult<MyNoticeSetting>> MineAsync(CancellationToken cancellationToken)
+    {
+        var caller = await _callers.UserIdAsync(HttpContext).ConfigureAwait(false);
+
+        if (caller is not Guid person)
+        {
+            return NoUser("This call is authenticated but names no user, so there is nobody whose setting this would be.");
+        }
+
+        try
+        {
+            return Ok(new MyNoticeSetting
+            {
+                TellsMe = await _preferences.TellsThemAsync(person, cancellationToken).ConfigureAwait(false)
+            });
+        }
+        catch (NoticePreferencesException)
+        {
+            return CouldNotBeRead();
+        }
+    }
+
+    /// <summary>
+    /// Turns the message about the caller's own requests on or off, for the caller and nobody else.
+    /// </summary>
+    /// <param name="body">Which way to set it.</param>
+    /// <param name="cancellationToken">Cancels the call.</param>
+    /// <returns>The setting as it stands after the call.</returns>
+    [HttpPost("Notices/Mine")]
+    [Authorize]
+    [ProducesResponseType<MyNoticeSetting>(StatusCodes.Status200OK)]
+    [ProducesResponseType<RequestFailure>(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType<RequestFailure>(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType<RequestFailure>(StatusCodes.Status503ServiceUnavailable)]
+    public async Task<ActionResult<MyNoticeSetting>> SetMineAsync(
+        [FromBody] SetMyNoticeBody body,
+        CancellationToken cancellationToken)
+    {
+        if (body?.TellsMe is not bool tellsMe)
+        {
+            return Invalid(
+                "tellsMe",
+                "This call says nothing about which way to set it, and a call that says nothing is not a call to turn it off.");
+        }
+
+        var caller = await _callers.UserIdAsync(HttpContext).ConfigureAwait(false);
+
+        if (caller is not Guid person)
+        {
+            return NoUser("This call is authenticated but names no user, so there is nobody whose setting this would be.");
+        }
+
+        try
+        {
+            return Ok(new MyNoticeSetting
+            {
+                TellsMe = await _preferences.SetAsync(person, tellsMe, cancellationToken).ConfigureAwait(false)
+            });
+        }
+        catch (NoticePreferencesException)
+        {
+            return CouldNotBeRead();
+        }
+    }
+
+    /// <summary>
+    /// One failure, under the status code its class is reported with, which is
+    /// <see cref="RequestFailure.StatusFor"/>'s pairing rather than one chosen here.
+    /// </summary>
+    /// <param name="code">What went wrong.</param>
+    /// <param name="message">The sentence for the person reading it.</param>
+    /// <param name="field">The field that is wrong, where there is one.</param>
+    /// <returns>The failure, under its status code.</returns>
+    private ObjectResult Failed(RequestFailureCode code, string message, string? field = null)
+        => StatusCode(
+            RequestFailure.StatusFor(code),
+            new RequestFailure { Code = code, Message = message, Field = field });
+
+    /// <summary>
+    /// A body that cannot be acted on, naming the field that is wrong.
+    /// </summary>
+    /// <param name="field">The field, spelled as the body spells it.</param>
+    /// <param name="reason">What is wrong with it.</param>
+    /// <returns>The failure.</returns>
+    private ObjectResult Invalid(string field, string reason)
+        => Failed(RequestFailureCode.InvalidBody, reason, field: field);
+
+    /// <summary>
+    /// A call that authenticated and names no person.
+    /// </summary>
+    /// <param name="reason">What that means for this endpoint.</param>
+    /// <returns>The failure.</returns>
+    private ObjectResult NoUser(string reason)
+        => Failed(RequestFailureCode.NoUserOnTheCall, reason);
+
+    /// <summary>
+    /// What is kept about who wants to be told could not be read.
+    /// <para>
+    /// Nothing from the exception reaches the caller: its message is written for an operator reading
+    /// the log and this one is written for the person reading the screen, and neither of them is
+    /// served by a path on the server's disk.
+    /// </para>
+    /// </summary>
+    /// <returns>The failure.</returns>
+    private ObjectResult CouldNotBeRead()
+        => Failed(
+            RequestFailureCode.TheStoreCouldNotBeRead,
+            "This setting could not be read, so nothing was changed. Nothing is wrong with the call, and the server log says what an operator has to repair.");
+}

--- a/Jellyfin.Plugin.Requests/Api/SetMyNoticeBody.cs
+++ b/Jellyfin.Plugin.Requests/Api/SetMyNoticeBody.cs
@@ -1,0 +1,24 @@
+namespace Jellyfin.Plugin.Requests.Api;
+
+/// <summary>
+/// What a person sends to turn the message about their own requests on or off.
+/// <para>
+/// <b>There is no field naming whose setting this is, and that is the whole mechanism.</b> The
+/// person is read off the call by <see cref="ICallerIdentity"/>, so there is nowhere for a caller to
+/// put somebody else's identifier and no branch that would have to refuse one. An administrator
+/// sending this changes their own setting, exactly as anybody else does.
+/// </para>
+/// </summary>
+public sealed record SetMyNoticeBody
+{
+    /// <summary>
+    /// Gets a value indicating whether this plugin is to push a message to the caller when one of
+    /// their own requests moves.
+    /// <para>
+    /// It is nullable so that a body that left it out is a body that said nothing, rather than one
+    /// that said off: a client sending an empty object would otherwise silence the person, which is
+    /// the direction where a mistake is not noticed.
+    /// </para>
+    /// </summary>
+    public bool? TellsMe { get; init; }
+}

--- a/Jellyfin.Plugin.Requests/Localisation/Strings/en.json
+++ b/Jellyfin.Plugin.Requests/Localisation/Strings/en.json
@@ -49,6 +49,8 @@
   "mine.countAll": "{0} in all",
   "mine.countSome": "The first {0} of {1}",
   "mine.empty": "You have not asked for anything yet.",
+  "mine.notices.label": "Tell me here when one of my requests moves",
+  "mine.notices.notSaved": "That setting could not be saved, so it is left as it was.",
   "mine.notRead": "Your requests could not be read. If this page was opened from a link that has expired, sign in again and open it afresh.",
   "mine.state.Approved": "Approved",
   "mine.state.Declined": "Declined",

--- a/Jellyfin.Plugin.Requests/Notify/FileNoticePreferences.cs
+++ b/Jellyfin.Plugin.Requests/Notify/FileNoticePreferences.cs
@@ -1,0 +1,294 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jellyfin.Plugin.Requests.Notify;
+
+/// <summary>
+/// What this plugin keeps about who does not want to be told, in one small file in the plugin's own
+/// data directory beside the requests.
+/// <para>
+/// <b>It keeps the refusals and never a row per person.</b> The default is on, so a person who has
+/// never touched this has nothing here, and an install nobody has touched has no file at all. That
+/// is what makes the third condition of #287 a property of the shape rather than a default value
+/// somebody has to remember to set.
+/// </para>
+/// <para>
+/// <b>It is not the plugin configuration and it may not be.</b> The configuration file is rewritten
+/// whole by the dashboard whenever an administrator saves the page, and this is a list that grows
+/// with the number of people on the server; <c>docs/storage.md</c> gives both reasons for requests
+/// and they are the same ones here. It also belongs to a different owner: what is in the
+/// configuration is the operator's to change, and this is not.
+/// </para>
+/// <para>
+/// <b>Whole or not at all, the same way the request store writes.</b> A write serialises the whole
+/// set into <see cref="PendingFileName"/>, flushes it, and only then replaces <see cref="FileName"/>
+/// in one step, so a process that dies mid-write leaves either the set before it or the set after
+/// it. A file that cannot be read is refused with <see cref="NoticePreferencesException"/> rather
+/// than treated as empty, because an empty set here reads as everybody wanting to be told.
+/// </para>
+/// </summary>
+public sealed class FileNoticePreferences : INoticePreferences, IDisposable
+{
+    /// <summary>
+    /// The file the loader reads. It is only ever created by replacing it whole.
+    /// </summary>
+    public const string FileName = "notices.json";
+
+    /// <summary>
+    /// The file a write is built in before it replaces <see cref="FileName"/>. This is the only file
+    /// that can be found half written, and nothing ever reads it.
+    /// </summary>
+    public const string PendingFileName = "notices.json.writing";
+
+    /// <summary>
+    /// The shape this writes, and the highest it can read. A file carrying a higher number is
+    /// refused rather than read as if the fields it has never heard of were absent, which is the
+    /// rule the request store keeps and the reason a downgraded server leaves a newer file alone.
+    /// </summary>
+    public const int OnDiskVersion = 1;
+
+    private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions
+    {
+        WriteIndented = false
+    };
+
+    private readonly string _directoryPath;
+    private readonly string _filePath;
+    private readonly string _pendingFilePath;
+
+    /// <summary>
+    /// Held for the whole of a write, so no two writes build the pending file at once and no write
+    /// decides against a set another write has already replaced.
+    /// </summary>
+    private readonly SemaphoreSlim _writes = new SemaphoreSlim(1, 1);
+
+    /// <summary>
+    /// Who has turned it off, or null before the first call has read the file. Replaced whole and
+    /// never edited, so a reader takes the current one without waiting and never sees half a change.
+    /// </summary>
+    private HashSet<Guid>? _quiet;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileNoticePreferences"/> class.
+    /// </summary>
+    /// <param name="directoryPath">The plugin's own data directory.</param>
+    /// <exception cref="ArgumentNullException">Where there is no directory to keep the file in.</exception>
+    public FileNoticePreferences(string directoryPath)
+    {
+        ArgumentNullException.ThrowIfNull(directoryPath);
+
+        _directoryPath = directoryPath;
+        _filePath = Path.Combine(directoryPath, FileName);
+        _pendingFilePath = Path.Combine(directoryPath, PendingFileName);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> TellsThemAsync(Guid userId, CancellationToken cancellationToken)
+    {
+        var quiet = await HeldAsync(cancellationToken).ConfigureAwait(false);
+
+        return !quiet.Contains(userId);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> SetAsync(Guid userId, bool tellsThem, CancellationToken cancellationToken)
+    {
+        await _writes.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            var quiet = new HashSet<Guid>(LoadedWhileHoldingTheWriteLock());
+
+            // Nothing is written where nothing changes. A person opening their page and leaving the
+            // control alone should not touch a file, and a write replacing a file with the same
+            // bytes is a write that can fail for a reason nobody asked for.
+            if (tellsThem ? !quiet.Remove(userId) : !quiet.Add(userId))
+            {
+                return tellsThem;
+            }
+
+            await PersistAsync(quiet, cancellationToken).ConfigureAwait(false);
+
+            // After the disk has taken it and never before, so what this plugin acts on and what
+            // survives a restart cannot disagree.
+            Volatile.Write(ref _quiet, quiet);
+
+            return tellsThem;
+        }
+        finally
+        {
+            _writes.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _writes.Dispose();
+    }
+
+    /// <summary>
+    /// The refusal, with the reason in it and never the path: the sentence reaches an operator
+    /// through the log and a caller through a status code, and neither of them is served by a path
+    /// on somebody else's disk.
+    /// </summary>
+    /// <param name="because">Why the file was refused.</param>
+    /// <param name="reason">What the runtime raised underneath, where anything did.</param>
+    /// <returns>The refusal to throw.</returns>
+    private static NoticePreferencesException Refusing(string because, Exception? reason = null)
+    {
+        var said = "What this plugin keeps about who wants to be told about their own requests could not be read, because " + because;
+
+        return reason is null ? new NoticePreferencesException(said) : new NoticePreferencesException(said, reason);
+    }
+
+    /// <summary>
+    /// The set, reading the file on the first call that needs it.
+    /// </summary>
+    /// <param name="cancellationToken">Cancels the wait for the first read.</param>
+    /// <returns>Who has turned it off.</returns>
+    private async Task<HashSet<Guid>> HeldAsync(CancellationToken cancellationToken)
+    {
+        var quiet = Volatile.Read(ref _quiet);
+
+        if (quiet is not null)
+        {
+            return quiet;
+        }
+
+        await _writes.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            return LoadedWhileHoldingTheWriteLock();
+        }
+        finally
+        {
+            _writes.Release();
+        }
+    }
+
+    /// <summary>
+    /// The set, read from the file if this is the first call. The caller has to be holding
+    /// <see cref="_writes"/>.
+    /// </summary>
+    /// <returns>Who has turned it off.</returns>
+    private HashSet<Guid> LoadedWhileHoldingTheWriteLock()
+    {
+        var quiet = _quiet;
+
+        if (quiet is not null)
+        {
+            return quiet;
+        }
+
+        quiet = Read();
+        Volatile.Write(ref _quiet, quiet);
+        return quiet;
+    }
+
+    /// <summary>
+    /// Reads the file, refusing anything it cannot read whole.
+    /// </summary>
+    /// <returns>Who has turned it off, and nobody where there is no file yet.</returns>
+    private HashSet<Guid> Read()
+    {
+        if (!File.Exists(_filePath))
+        {
+            return [];
+        }
+
+        PersistedNotices? persisted;
+
+        try
+        {
+            using var stream = new FileStream(_filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            persisted = JsonSerializer.Deserialize<PersistedNotices>(stream, SerializerOptions);
+        }
+        catch (JsonException reason)
+        {
+            throw Refusing(
+                "it is not the document this keeps, which is what an interruption in the middle of the file would leave if a write were made in place.",
+                reason);
+        }
+
+        if (persisted is null)
+        {
+            throw Refusing("it holds nothing at all, and an empty file here would read as everybody wanting to be told.");
+        }
+
+        if (persisted.Version > OnDiskVersion)
+        {
+            throw Refusing("it was written by a later version of this plugin, so what its fields mean is not something this version can know.");
+        }
+
+        var quiet = new HashSet<Guid>();
+
+        foreach (var userId in persisted.Quiet ?? [])
+        {
+            if (userId == Guid.Empty)
+            {
+                throw Refusing("one of the entries names nobody, and a setting kept against nobody silences whoever the empty identifier is next taken for.");
+            }
+
+            quiet.Add(userId);
+        }
+
+        return quiet;
+    }
+
+    /// <summary>
+    /// Puts the set on the disk, whole or not at all. Every failure here reaches the caller, so a
+    /// full disk is reported rather than absorbed and the in-memory set is left as it was.
+    /// </summary>
+    /// <param name="quiet">Who has turned it off.</param>
+    /// <param name="cancellationToken">Cancels the write.</param>
+    /// <returns>A task that completes when the set is on the disk.</returns>
+    private async Task PersistAsync(HashSet<Guid> quiet, CancellationToken cancellationToken)
+    {
+        var persisted = new PersistedNotices
+        {
+            Version = OnDiskVersion,
+            Quiet = [.. quiet.OrderBy(userId => userId)]
+        };
+
+        Directory.CreateDirectory(_directoryPath);
+
+        var pending = new FileStream(
+            _pendingFilePath,
+            FileMode.Create,
+            FileAccess.Write,
+            FileShare.None,
+            bufferSize: 4096,
+            FileOptions.WriteThrough);
+
+        await using (pending.ConfigureAwait(false))
+        {
+            await JsonSerializer.SerializeAsync(pending, persisted, SerializerOptions, cancellationToken).ConfigureAwait(false);
+            await pending.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        File.Move(_pendingFilePath, _filePath, overwrite: true);
+    }
+
+    /// <summary>
+    /// The document on the disk: a version and the identifiers of the people who said no.
+    /// </summary>
+    private sealed record PersistedNotices
+    {
+        /// <summary>
+        /// Gets the shape the file is in.
+        /// </summary>
+        public int Version { get; init; }
+
+        /// <summary>
+        /// Gets who has turned it off.
+        /// </summary>
+        public IReadOnlyList<Guid>? Quiet { get; init; }
+    }
+}

--- a/Jellyfin.Plugin.Requests/Notify/INoticePreferences.cs
+++ b/Jellyfin.Plugin.Requests/Notify/INoticePreferences.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jellyfin.Plugin.Requests.Notify;
+
+/// <summary>
+/// Whether one person wants to be told when their own request moves, kept per person.
+/// <para>
+/// <b>It is the person's and not the operator's.</b> The three settings on the plugin configuration
+/// narrow what leaves the server on the outbound sink; none of them reaches the message pushed to
+/// whoever asked, and none of them may, because an administrator able to silence what somebody else
+/// is told is a different thing from an administrator deciding what their server sends outward.
+/// <c>docs/notifications.md</c> carries who owns which switch.
+/// </para>
+/// <para>
+/// <b>The default is on and it is the absence of a value rather than a value.</b> An install nobody
+/// has touched holds nothing here at all, so it behaves exactly as it did before this existed, and
+/// what is kept is the list of people who said no rather than a row per person on the server.
+/// </para>
+/// <para>
+/// It is a seam for the same reason the clock and the store are: what keeps the answer is a file in
+/// the plugin's data directory, and a test of the path that reads it should not need one.
+/// </para>
+/// </summary>
+public interface INoticePreferences
+{
+    /// <summary>
+    /// Whether this person is to be told about their own requests.
+    /// </summary>
+    /// <param name="userId">Whose setting to read.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns><see langword="true"/> where they are, which is what a person who has never touched it gets.</returns>
+    /// <exception cref="NoticePreferencesException">Where what is kept cannot be read.</exception>
+    Task<bool> TellsThemAsync(Guid userId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Sets whether this person is to be told, and keeps it across a restart.
+    /// </summary>
+    /// <param name="userId">Whose setting to write. There is one identifier here and it is always the caller's own.</param>
+    /// <param name="tellsThem">Whether to tell them.</param>
+    /// <param name="cancellationToken">Cancels the write.</param>
+    /// <returns>What the setting is after the write, which is what a caller shows back to the person.</returns>
+    /// <exception cref="NoticePreferencesException">Where what is kept cannot be read or cannot be written.</exception>
+    Task<bool> SetAsync(Guid userId, bool tellsThem, CancellationToken cancellationToken);
+}

--- a/Jellyfin.Plugin.Requests/Notify/NoticePreferencesException.cs
+++ b/Jellyfin.Plugin.Requests/Notify/NoticePreferencesException.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace Jellyfin.Plugin.Requests.Notify;
+
+/// <summary>
+/// What is kept about who wants to be told could not be read, or could not be written.
+/// <para>
+/// It is raised rather than answered as a default, for the reason the request store refuses to open
+/// on a file it cannot parse: a read that quietly answers "yes, tell them" is a person who asked not
+/// to be told being told anyway, and nothing afterwards can tell that from a person who never asked.
+/// </para>
+/// </summary>
+public sealed class NoticePreferencesException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NoticePreferencesException"/> class.
+    /// </summary>
+    public NoticePreferencesException()
+        : base("What is kept about who wants to be told about their own requests could not be read.")
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NoticePreferencesException"/> class.
+    /// </summary>
+    /// <param name="message">What went wrong.</param>
+    public NoticePreferencesException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NoticePreferencesException"/> class.
+    /// </summary>
+    /// <param name="message">What went wrong.</param>
+    /// <param name="innerException">What the runtime raised underneath.</param>
+    public NoticePreferencesException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/Jellyfin.Plugin.Requests/Notify/QuietedRequesterNotice.cs
+++ b/Jellyfin.Plugin.Requests/Notify/QuietedRequesterNotice.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.Requests.Notify;
+
+/// <summary>
+/// The person's own switch, in front of the path that pushes to them.
+/// <para>
+/// <b>It is one place rather than a condition at each call site.</b> Two paths tell somebody their
+/// request moved, the endpoint an administrator decides on and the fulfilment sweep, and a third
+/// will arrive. A check written at each of them is a check the third one forgets, so the switch sits
+/// where the message goes out and nothing above it knows the switch exists.
+/// </para>
+/// <para>
+/// <b>A setting that cannot be read silences the message rather than sending it.</b> The two ways of
+/// being wrong are not equal: not sending a courtesy costs somebody a line they would have read on
+/// their own page anyway, and sending it costs a person who asked not to be told being told, which
+/// is the whole of what this issue was about. The refusal is written to the log, so an operator
+/// meets a file they have to repair rather than silence nobody can explain.
+/// </para>
+/// <para>
+/// <b>Telling still costs the caller nothing.</b> Reading the setting is a file read on the first
+/// call and a set lookup afterwards, and both happen off the calling thread for the reason
+/// <see cref="ServerRequesterNotice"/> pushes off it: what this interface promises is that a caller
+/// which has just moved a request tells the person and carries on.
+/// </para>
+/// </summary>
+public sealed class QuietedRequesterNotice : IRequesterNotice
+{
+    private readonly IRequesterNotice _inner;
+    private readonly INoticePreferences _preferences;
+    private readonly ILogger _logger;
+    private readonly object _gate = new object();
+
+    private Task _inFlight = Task.CompletedTask;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QuietedRequesterNotice"/> class.
+    /// </summary>
+    /// <param name="inner">The path that actually tells somebody.</param>
+    /// <param name="preferences">Who has turned it off.</param>
+    /// <param name="logger">Where a setting that could not be read is reported.</param>
+    /// <exception cref="ArgumentNullException">Where any of the three is absent.</exception>
+    public QuietedRequesterNotice(IRequesterNotice inner, INoticePreferences preferences, ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        ArgumentNullException.ThrowIfNull(preferences);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _inner = inner;
+        _preferences = preferences;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public void Tell(RequesterMessage message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        var asking = Task.Run(() => TellIfTheyWantItAsync(message));
+
+        lock (_gate)
+        {
+            _inFlight = Both(_inFlight, asking);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task QuietAsync(CancellationToken cancellationToken)
+    {
+        Task waiting;
+
+        lock (_gate)
+        {
+            waiting = _inFlight;
+        }
+
+        return Settled(waiting, _inner, cancellationToken);
+    }
+
+    /// <summary>
+    /// Both, as one thing to wait for. Written out rather than done with <c>Task.WhenAll</c> so that
+    /// a chain of messages does not grow an array per message, which is the reason
+    /// <see cref="ServerRequesterNotice"/> writes its own out.
+    /// </summary>
+    /// <param name="earlier">What was already being asked about.</param>
+    /// <param name="later">What has just been asked about.</param>
+    /// <returns>A task that completes when both have.</returns>
+    private static async Task Both(Task earlier, Task later)
+    {
+        await earlier.ConfigureAwait(false);
+        await later.ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Nothing here is still being decided and nothing underneath is still in flight. Both halves,
+    /// and in that order: a message this has not finished deciding about has not reached the path
+    /// below yet, so waiting on that path first would answer before it was handed anything.
+    /// </summary>
+    /// <param name="deciding">What is still being decided here.</param>
+    /// <param name="inner">The path underneath.</param>
+    /// <param name="cancellationToken">Gives up waiting.</param>
+    /// <returns>A task that completes when nothing is in flight.</returns>
+    private static async Task Settled(Task deciding, IRequesterNotice inner, CancellationToken cancellationToken)
+    {
+        await deciding.WaitAsync(cancellationToken).ConfigureAwait(false);
+        await inner.QuietAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// One message, passed on or dropped.
+    /// </summary>
+    /// <param name="message">What to say, and who to say it to.</param>
+    /// <returns>A task that completes once the message has been passed on or dropped.</returns>
+    private async Task TellIfTheyWantItAsync(RequesterMessage message)
+    {
+        bool wanted;
+
+        try
+        {
+            wanted = await _preferences.TellsThemAsync(message.ToUserId, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (NoticePreferencesException refused)
+        {
+            // The identifier is not in the line. Which person could not be told is a fact about a
+            // person and the file is the same file for everybody, so the sentence an operator needs
+            // is that the file is unreadable rather than whose message went with it.
+            _logger.LogError(
+                refused,
+                "Nobody is being told about their own requests, because what this plugin keeps about who wants to be told cannot be read. The message that was about to go out was dropped rather than sent to somebody who may have asked not to receive it.");
+
+            return;
+        }
+
+        if (wanted)
+        {
+            _inner.Tell(message);
+        }
+    }
+}

--- a/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
@@ -141,14 +141,32 @@ public sealed class PluginServiceRegistrator : IPluginServiceRegistrator
             provider.GetRequiredService<ILogger<OutboundSink>>(),
             OutboundSink.DefaultAnswerWithin));
 
+        // Who has said they do not want to be told about their own requests. One per server for the
+        // reason the request store is: it holds the set in memory and serialises its writes against
+        // it, and a second instance over one directory would be two sets deciding independently what
+        // the file should say. Built from a factory for the same reason too, because the directory
+        // is the plugin's own data folder and only the plugin knows it.
+        serviceCollection.AddSingleton<INoticePreferences>(_ => new FileNoticePreferences(
+            (Plugin.Instance ?? throw new InvalidOperationException(
+                "What people have set about being told was asked for before this plugin was loaded, so there is no data directory to keep it in."))
+            .DataFolderPath));
+
         // The path that tells the person who asked that their own request moved, on whatever they
         // are signed in on right now. Registered beside the two above rather than instead of either:
         // the journal is the record an operator reads afterwards, the sink is what leaves the
         // machine on an install that has somewhere to send to, and this is the only one of the three
         // aimed at the person waiting.
-        serviceCollection.AddSingleton<IRequesterNotice>(provider => new ServerRequesterNotice(
-            provider.GetRequiredService<ISessionManager>(),
-            provider.GetRequiredService<ILogger<ServerRequesterNotice>>()));
+        //
+        // The person's own switch is in front of it rather than inside it, so the one class that
+        // names the host stays the one call it is, and so that neither of the two paths that tell
+        // somebody has to remember to ask. What is registered is the wrapper, because everything
+        // above resolves the interface and nothing above may reach past the switch.
+        serviceCollection.AddSingleton<IRequesterNotice>(provider => new QuietedRequesterNotice(
+            new ServerRequesterNotice(
+                provider.GetRequiredService<ISessionManager>(),
+                provider.GetRequiredService<ILogger<ServerRequesterNotice>>()),
+            provider.GetRequiredService<INoticePreferences>(),
+            provider.GetRequiredService<ILogger<QuietedRequesterNotice>>()));
 
         // The path that tells whoever administers the server that somebody has asked for something,
         // on whatever they are signed in on right now. It is a fourth registration rather than a

--- a/Jellyfin.Plugin.Requests/Web/mine.html
+++ b/Jellyfin.Plugin.Requests/Web/mine.html
@@ -61,12 +61,22 @@
             <!--
                 What this page is and is not. It shows one person their own requests and offers no
                 decision, because a decision is an administrator's and the endpoints that make one
-                require elevation. The reason it holds no control at all is that everything it
-                could offer is either an administrator's or waits on a state this plugin does not
-                have: cancelling something still open needs a state a request can be withdrawn
-                into, which is an open decision on #113.
+                require elevation. The one control it holds is below, and it is the only kind that
+                belongs here: a setting about this person rather than about a request. Cancelling
+                something still open is still absent, because it needs a state a request can be
+                withdrawn into, which is an open decision on #113.
             -->
             <p class="requestsMineMessage" role="status"></p>
+
+            <!--
+                The switch on what this plugin pushes at the person reading the page. It ships
+                hidden and is revealed once the endpoint has answered, so a page that could not
+                reach it shows no control rather than an unchecked box that reads as "off".
+            -->
+            <p class="requestsMineNotices" hidden>
+                <input type="checkbox" id="RequestsMineNotices" />
+                <label for="RequestsMineNotices" data-i18n="mine.notices.label"></label>
+            </p>
 
             <table>
                 <caption class="requestsMineSummary" aria-live="polite"></caption>
@@ -93,6 +103,8 @@
                 var rows = page.querySelector(".requestsMineRows");
                 var summary = page.querySelector(".requestsMineSummary");
                 var message = page.querySelector(".requestsMineMessage");
+                var notices = page.querySelector(".requestsMineNotices");
+                var noticesBox = page.querySelector("#RequestsMineNotices");
 
                 /*
                  * The largest page the endpoint serves. This page asks for it in one call and has
@@ -164,6 +176,25 @@
 
                 function fetched(endpoint, asked) {
                     return fetch(address(endpoint, asked), { headers: { Accept: "application/json" } }).then(function (answered) {
+                        if (!answered.ok) {
+                            throw new Error(String(answered.status));
+                        }
+
+                        return answered.json();
+                    });
+                }
+
+                /*
+                 * The one call this page makes that changes anything. It sends no identifier: whose
+                 * setting is being changed is read off the credential by the endpoint, which is what
+                 * makes it impossible for this page, or for anything else, to change somebody else's.
+                 */
+                function sent(endpoint, body) {
+                    return fetch(address(endpoint), {
+                        method: "POST",
+                        headers: { Accept: "application/json", "Content-Type": "application/json" },
+                        body: JSON.stringify(body),
+                    }).then(function (answered) {
                         if (!answered.ok) {
                             throw new Error(String(answered.status));
                         }
@@ -290,9 +321,9 @@
 
                 /*
                  * Every element that names a key gets the word under it. Attributes are not walked
-                 * here because nothing on this page carries a translatable one; the two that would
-                 * be, a label and a title on a control, arrive with the controls this page does not
-                 * have.
+                 * here because nothing on this page carries a translatable one: the label on the
+                 * one control is an element of its own rather than an attribute, exactly so that it
+                 * arrives through this walk like every other word.
                  */
                 function fill() {
                     document.querySelectorAll("[data-i18n]").forEach(function (element) {
@@ -311,6 +342,40 @@
                     return window.navigator && window.navigator.language ? { culture: window.navigator.language } : {};
                 }
 
+                /*
+                 * The switch, once the endpoint has said which way it is set. It is shown only
+                 * after that answer, because a checkbox drawn before it is a control claiming a
+                 * state nobody has read, and the state it would claim is the one somebody would
+                 * least want claimed for them.
+                 *
+                 * A change that the endpoint refuses puts the box back where it was. Leaving it
+                 * where the person clicked would show them a setting the server does not hold, and
+                 * the next thing they would notice is a message they thought they had turned off.
+                 */
+                function showNotices(setting) {
+                    noticesBox.checked = Boolean(setting.TellsMe);
+                    notices.hidden = false;
+                }
+
+                function changeNotices() {
+                    var wanted = noticesBox.checked;
+
+                    noticesBox.disabled = true;
+
+                    return sent("Notices/Mine", { TellsMe: wanted })
+                        .then(function (setting) {
+                            noticesBox.checked = Boolean(setting.TellsMe);
+                            tell("");
+                        })
+                        .catch(function () {
+                            noticesBox.checked = !wanted;
+                            tell("mine.notices.notSaved");
+                        })
+                        .then(function () {
+                            noticesBox.disabled = false;
+                        });
+                }
+
                 function read() {
                     return fetched("Strings", culture())
                         .then(function (answer) {
@@ -322,11 +387,25 @@
                         .then(function (answer) {
                             tell("");
                             draw(answer);
+
+                            /*
+                             * After the rows and never instead of them. The setting is a courtesy
+                             * about a courtesy, and a page that could not read it is still the page
+                             * that answers what somebody came here for, so this failure leaves the
+                             * requests drawn and takes the control away rather than the list.
+                             */
+                            return fetched("Notices/Mine")
+                                .then(showNotices)
+                                .catch(function () {
+                                    notices.hidden = true;
+                                });
                         })
                         .catch(function () {
                             tell("mine.notRead");
                         });
                 }
+
+                noticesBox.addEventListener("change", changeNotices);
 
                 read();
             })();

--- a/docs/api.md
+++ b/docs/api.md
@@ -338,6 +338,40 @@ a real cost and it is stated here and in [surface.md](surface.md) rather than le
 This endpoint neither creates such a credential nor extends one, and the page carries what it was
 opened with no further than the one call it makes.
 
+## The one setting a person owns
+
+    GET  MediaRequests/v1/Notices/Mine
+    POST MediaRequests/v1/Notices/Mine
+
+Whether this plugin pushes the caller a message when one of their own requests moves. Both carry the
+server's default policy, so any signed-in caller reaches them, and what each answers is about the
+caller and nobody else.
+
+**Neither takes an identifier, and that is the mechanism rather than a check.** There is no path
+segment, no query parameter and no body field naming a person: whose setting is read or written comes
+off the credential the call carries. So there is no call an administrator can make that changes what
+somebody else is told, and no refusal for one is documented because there is no such call to refuse.
+Who the switch belongs to was decided on #9 and the reasoning is in
+[notifications.md](notifications.md).
+
+The body of the write carries one field:
+
+```json
+{ "TellsMe": false }
+```
+
+**A body that leaves it out is refused rather than read as `false`.** A client sending an empty
+object would otherwise silence the person, which is the direction in which a mistake is not noticed:
+the person finds out by not being told something. The refusal is `InvalidBody` naming `tellsMe`.
+
+**The answer is the setting as it stands after the call**, so a client draws what the server holds
+rather than what it sent. A call that sets it to what it already is answers the same shape and writes
+nothing.
+
+**A setting that cannot be read is `503` and not `500`.** Nothing is wrong with the call; the file
+this plugin keeps it in could not be read, and an operator repairing that makes the same call work.
+Nothing of the underlying refusal reaches the caller, because its message is written for a log.
+
 ## Reading the queue
 
     GET MediaRequests/v1/Requests/Queue

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -198,8 +198,13 @@ path that has a switch, and it grows when a path does rather than ahead of one.
 be one. It reaches only the person the request belongs to and only while they are signed in, and who
 may turn it off was taken on #9 on 2026-08-24: that person, and nobody acting on their behalf. So its
 absence from this page is the answer rather than an omission, and an operator field for it would be
-the shape that answer refuses. #287 is where the person's own switch is built.
-[`notifications.md`](notifications.md) carries the answer and says what is not built yet.
+the shape that answer refuses.
+
+The switch itself is built and it is the person's own. It is on their own requests page, it is kept
+in `notices.json` in the plugin's data directory rather than in the settings file this page is about,
+and it is on by default so an install nobody has touched behaves as it always did. **No setting on
+this page overrides it**, and none ever will. [`notifications.md`](notifications.md) carries where it
+lives, what the two endpoints are, and why neither of them takes an identifier.
 
 **A bridge address and a credential.** The only bridge in this tree is the one for a server that has
 none. A field for an address would be somewhere to type something nothing reads. #82 brings the

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -341,18 +341,40 @@ it stops there.
 hands nothing back for a caller to check, and every way a push can fail costs the same: a line in the
 server's log and nothing else. Nothing is retried and nothing is queued.
 
-**There is no setting for it, and who one would belong to is no longer an open question.** The three
-switches below narrow the outbound sink and none of them reaches this, and the activity log has no
-switch either. Whether an operator or the person themself should be the one to turn this off was
-taken on #9 on 2026-08-24: the switch belongs to the person who made the request, default on, because
-a person controls what they are told about their own request and nobody else does.
+### The switch, and whose it is
 
-**The answer is written down and the switch is not built**, which are two states rather than one. An
-operator setting is refused by the answer rather than missing from it, so no field is coming beside
-the three below; what a person's own switch needs is somewhere per person to keep a preference, and
-this plugin keeps nothing per person today. That is #287. Until it lands, the message goes to the
-person on every movement it has a sentence for, which is the default the answer names, and nobody -
-the person included - can turn it off.
+**It belongs to the person who made the request, and to nobody else.** That was taken on #9 on
+2026-08-24: a person controls what they are told about their own request. The three operator switches
+below narrow the outbound sink and none of them reaches this path; the activity log has no switch
+either. **No operator setting overrides a person's own**, and that is a refusal rather than an
+omission - an administrator able to silence what somebody else is told is the shape the decision
+refuses, so no field is coming beside the three below.
+
+**Where it lives.** On the person's own page, which is the surface every signed-in person can reach
+without a dashboard, and behind two endpoints under the versioned prefix:
+
+    GET  MediaRequests/v1/Notices/Mine
+    POST MediaRequests/v1/Notices/Mine   {"TellsMe": false}
+
+**Neither of them takes an identifier, and that is the whole mechanism rather than a check.** Whose
+setting is being read or written comes off the credential the call carries, so there is no field,
+route segment or parameter through which any caller - an administrator included - could name somebody
+else. A refusal of such a call is not written anywhere because there is no such call to refuse.
+
+**The default is on**, and it is the absence of a value rather than a value. A server that upgrades
+into this holds nothing at all about anybody, so it behaves exactly as it did before the switch
+existed, and what is kept is the list of people who said no rather than a row per person.
+
+**Where it is kept.** `notices.json` in the plugin's own data directory, beside `requests.json`,
+written whole or not at all the same way. It is deliberately not the plugin configuration: that file
+is rewritten whole by the dashboard whenever an administrator saves the page, it is the operator's to
+change, and this is not.
+
+**A setting that cannot be read silences the message rather than sending it.** The two ways of being
+wrong are not equal. Not sending a courtesy costs somebody a line they would have read on their own
+page anyway; sending it costs a person who asked not to be told being told, and nothing afterwards
+can tell that from a person who never asked. The refusal is written to the server log, so an operator
+meets a file to repair rather than silence nobody can explain.
 
 ## What a live administrator is told when something arrives
 

--- a/docs/personal-data.md
+++ b/docs/personal-data.md
@@ -31,6 +31,18 @@ Four of those seven name a person. What each one is, and what it is for:
 | `MediaRequest.StateChangedByUserId` | whoever last moved it, usually an operator                           | the queue file      |
 | `RequestHistoryEntry.ByUserId`      | the person who asked, on the arrival row, and whoever moved it after | the queue file      |
 
+One more identifier is held outside the record, so the derivation above does not reach it and it is
+named here rather than left to be found:
+
+| Field                       | Who it names                                   | Where it is written |
+| --------------------------- | ---------------------------------------------- | ------------------- |
+| `notices.json` -> `Quiet[]` | everybody who has turned their own notices off | the notices file    |
+
+It is the switch [notifications.md](notifications.md) describes. What it holds is a list of
+identifiers and nothing else: no title, no date, no request. The list is the people who said no,
+because the default is on, so a person who has never touched it is not in the file and an install
+nobody has touched has no file.
+
 The other three name nothing about a person. `MediaRequest.Id` and `MediaRequest.WantIds` are this
 plugin's own identifier for a request and the browsing sibling's identifiers for the asks it handed
 over. `RequestCaller.UserId` is who is making the call being handled right now, and it is an argument
@@ -80,11 +92,12 @@ when.
 
 ## Where it is
 
-Two files, both under the server's own data directory, and the table of them is in
+Three files, all under the server's own data directory, and the table of them is in
 [storage.md](storage.md) under "What is on the disk, and where". This page does not repeat the paths,
 because two copies of a path are two answers the day one of them moves.
 
-Everything above is in the queue file. The settings file holds no person at all, which is the whole
+Everything in the first table above is in the queue file, and the identifier in the second is in the
+notices file. The settings file holds no person at all, which is the whole
 of that class rather than a sample:
 
     git grep -nE '^    public (const )?(int|bool|string) ' -- Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs
@@ -165,6 +178,12 @@ sweep, against the store the plugin ships, on both claimed target frameworks; th
 and starts the task on either line is the same unrun procedure every other scheduled behaviour here
 carries, in [testing.md](testing.md).
 
+**Nothing removes an entry from the notices file by age, and nothing should.** It is a setting rather
+than an event: it has no date on it, it stops meaning anything the moment it is dropped, and a sweep
+that removed it after a year would turn a person's own choice back on without telling them. What it
+holds about somebody is that they said no, and the way it goes is that they say yes or that their
+account goes, which is the section below.
+
 ## What happens when a Jellyfin user is deleted
 
 **Nothing.** No part of this plugin is told that a user was removed, and nothing looks:
@@ -180,6 +199,14 @@ going away.
 So a request record outlives the account it names. The identifier stays in the file, in up to four
 places for one deleted person: their own requests, requests they joined that somebody else asked for,
 and every decision they made as an operator, which is written into the record and into its history.
+
+**And there is now a fifth place, in the other file.** Somebody who turned their own notices off is
+an identifier in the notices file, and a deleted account leaves it there exactly as it leaves the
+four above. It is the least revealing of the five - it says that a person on this server once said
+no and nothing more - and it is still an identifier for somebody who is gone. #49 is where the rule
+for all of them is decided, and this one is deliberately not answered ahead of the other four: a
+plugin that swept one file on a deletion it is not told about would be describing a behaviour it does
+not have.
 
 **What the rule should be is open, and it is open for a reason rather than by neglect.** The history
 a decision is written into is append-only and a lint rule refuses any other writer, so stripping an

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -208,14 +208,23 @@ by hand, which is the thing this rule is against.
 
 ### What is on the disk, and where
 
-Two files, both under the directory the server keeps its own data in, so a backup of that directory
-is a backup of this plugin and an operator has nothing extra to configure:
+Everything is under the directory the server keeps its own data in, so a backup of that directory is
+a backup of this plugin and an operator has nothing extra to configure:
 
-| What              | Where                                                    | In a backup |
-| ----------------- | -------------------------------------------------------- | ----------- |
-| The queue         | `plugins/Jellyfin.Plugin.Requests/requests.json`         | Required    |
-| The settings      | `plugin-configurations/Jellyfin.Plugin.Requests.xml`     | Required    |
-| A write in flight | `plugins/Jellyfin.Plugin.Requests/requests.json.writing` | Not needed  |
+| What                 | Where                                                    | In a backup |
+| -------------------- | -------------------------------------------------------- | ----------- |
+| The queue            | `plugins/Jellyfin.Plugin.Requests/requests.json`         | Required    |
+| The settings         | `plugin-configurations/Jellyfin.Plugin.Requests.xml`     | Required    |
+| Who wants no notices | `plugins/Jellyfin.Plugin.Requests/notices.json`          | Required    |
+| A write in flight    | `plugins/Jellyfin.Plugin.Requests/requests.json.writing` | Not needed  |
+| A write in flight    | `plugins/Jellyfin.Plugin.Requests/notices.json.writing`  | Not needed  |
+
+The third row is absent on a server where nobody has turned their own notices off, which is what a
+fresh install is: the default is the absence of a value rather than a value, so the file appears the
+first time somebody says no. A backup taken before that carries nothing about anybody, and that is
+correct rather than a gap. It is `Required` because a restore without it turns everybody's own
+setting back on, and the person who set it would find out by being told something they had asked not
+to be told. [`notifications.md`](notifications.md) is where the switch itself is written down.
 
 The paths are relative to the server's data directory. Where that directory is differs by
 installation and by operating system, and this document does not name it: the server is the
@@ -236,9 +245,10 @@ that line reads is a static that any other test class can replace while a leg is
 built on it would fail for reasons nobody caused. It is a line to read rather than a property the
 suite holds.
 
-The third row is the file a write is built in before it replaces the queue. It is listed so a backup
-that swept it up is not read as a problem: a restore that carries one ignores it and reads the queue,
-which is `APendingFileCarriedIntoTheBackupIsNotWhatIsRestored`.
+The last two rows are the files a write is built in before it replaces the one beside it. They are
+listed so a backup that swept one up is not read as a problem: a restore that carries one ignores it
+and reads the file it was going to replace, which for the queue is
+`APendingFileCarriedIntoTheBackupIsNotWhatIsRestored`.
 
 ### Restoring
 

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -167,10 +167,22 @@ operator handing this address to their household should treat it as handing over
 
 ### What the page does not do
 
-**It offers no decision and no control at all.** Approving and declining need an administrator, and
+**It offers no decision about a request.** Approving and declining need an administrator, and
 cancelling something still open needs a state a request can be withdrawn into, which this plugin does
 not have: whether there is a cancelled state is an open decision on #113. So the page is a thing to
 read, and a control that could not do anything would be worse than none.
+
+**It carries one control, and it is not a decision.** A checkbox that turns off the message this
+plugin pushes at the person reading the page when one of their own requests moves. It belongs there
+because it is a setting about that person rather than about a request, and because the surface it
+would otherwise live on is the dashboard, which is the administrator's - an operator able to silence
+what somebody else is told is the shape #9's decision refuses.
+[notifications.md](notifications.md) carries the switch and both endpoints.
+
+The checkbox is hidden until the endpoint has answered which way it is set, so a page that could not
+read it shows no control rather than an unchecked box that reads as "off". A change the server
+refuses puts it back where it was, because showing somebody a setting the server does not hold is how
+a person finds out by being told something they thought they had turned off.
 
 **It has no pager.** It asks for the largest page the endpoint serves and says how many matched
 beside how many it drew, so somebody with more requests than that is told so rather than shown a


### PR DESCRIPTION
Closes #287.

## What this does

A person can turn off the message this plugin pushes them when one of their own requests moves, from a surface they can reach, and nobody else can turn it off for them.

Who owns that switch was decided on #9 on 2026-08-24: the person who made the request, default on. This builds it. The issue says the work is not the boolean but somewhere per person to keep a preference, which this plugin had for nothing at all, and that is most of what is here.

## The means

C#, in this repository's own project and suite, and HTML and JavaScript in the page the assembly already embeds. Nothing new: the switch is refusable by the analyzers and the invariant lint this tree already runs, it is proven by the ledger this suite already is, and every claim below carries the command that produced it. A per-person preference needs somewhere to keep it, and the medium is the one `docs/storage.md` already argues for the queue, so no second medium and no dependency arrives.

## The four done-conditions

**A person can turn it off from a surface they can reach, and the setting survives a restart.**

A checkbox on their own requests page, and two endpoints under the versioned prefix:

    GET  MediaRequests/v1/Notices/Mine
    POST MediaRequests/v1/Notices/Mine   {"TellsMe": false}

It survives a restart because it is on the disk. `WhatSomebodySetIsWhatANewInstanceReads` writes through one instance and reads through a second one over the same directory, rather than through the instance that wrote it: an instance holds the set in memory and would answer from there, so a write that never reached the disk would pass a test made against the writer.

**Nobody but that person can change it, proven by a test that has an administrator try.**

`AnAdministratorTurningItOffTurnsOffTheirOwn` sends the body an administrator would send if they wanted to silence somebody else, and what moves is the administrator's own row: the asker is still told and the administrator is not.

What that leg can assert is stronger than a refusal, and the shape is why. Neither endpoint takes an identifier - no path segment, no query parameter, no body field - so whose setting is read or written comes off the credential the call carries. There is no call naming another person for anything to refuse, which is also why nothing here documents a refusal for one.

**The default is on, so an install nobody touches behaves exactly as today.**

The default is the absence of a value rather than a value. `ANobodyHasTouchedIsToldAndNothingIsOnTheDisk` asserts both halves: a person nobody has recorded is told, and the file does not exist. What is kept is the list of people who said no, so a server upgrading into this holds nothing about anybody.

`SettingItToWhatItAlreadyIsWritesNothing` is the neighbouring case - a person opening the page and leaving the control alone touches no file.

**`docs/notifications.md` and `docs/configuration.md` state where it lives and that no operator setting overrides it.**

`notifications.md` gains "The switch, and whose it is": where it lives, both endpoints, why neither takes an identifier, the default, where it is kept, and what happens when the setting cannot be read. `configuration.md`'s paragraph on this said the switch was not built and named the issue; it now says the switch is the person's, that it is kept outside the settings file, and that nothing on that page overrides it.

## Where the switch sits, and why not at the call sites

In front of the notice path, as `QuietedRequesterNotice` wrapping `ServerRequesterNotice`. Two paths tell somebody their request moved - the endpoint an administrator decides on and the fulfilment sweep - and a condition written at each of them is the one a third path forgets. Nothing above the registration knows the switch exists.

## Three guards, each watched failing

Deleting the branch that honours the switch, so every message goes out:

    Fehler ... APersonsOwnSwitchTests.WhatSomebodySetsThroughTheEndpointIsWhatTheNoticePathObeys
    Fehler ... APersonsOwnSwitchTests.SomebodyWhoTurnedItOffIsNotToldAndNobodyElseIsAffected
    Fehler ... APersonsOwnSwitchTests.AnAdministratorTurningItOffTurnsOffTheirOwn
    Fehler!  : Fehler: 3, erfolgreich: 695, gesamt: 698 (net9.0)
    Fehler!  : Fehler: 3, erfolgreich: 695, gesamt: 698 (net10.0)

Making an unreadable setting send the message rather than drop it:

    Fehler ... APersonsOwnSwitchTests.ASettingThatCannotBeReadDropsTheMessageAndIsReported
    Fehler!  : Fehler: 1, erfolgreich: 697, gesamt: 698 (net9.0 and net10.0)

Making the store answer a file it cannot parse as an empty set instead of refusing:

    Fehler ... NoticePreferencesTests.AFileThisCannotReadIsRefusedRatherThanReadAsNobody
    Fehler!  : Fehler: 1, erfolgreich: 697, gesamt: 698 (net9.0 and net10.0)

Each was put back after being watched.

## The trade in the failure direction, stated rather than implied

A setting that cannot be read leaves the message unsent and writes the refusal to the log. The two ways of being wrong are not equal: not sending a courtesy costs somebody a line they would have read on their own page anyway, and sending it costs a person who asked not to be told being told, which nothing afterwards can tell from a person who never asked. The cost is that one unreadable file silences everybody until an operator repairs it, and the log line is what makes that a repair rather than silence nobody can explain.

## Where it is kept, and why not the configuration

`notices.json` in the plugin's data directory, beside `requests.json`, written whole or not at all the same way: a pending file, flushed, then one replace.

Not the plugin configuration, for two reasons both already written in this tree. That file is rewritten whole by the dashboard whenever an administrator saves the page, and a list that grows with the number of people on the server does not belong in it. And it is the operator's to change, which this is not.

## What this adds to what is held about a person, said plainly

A fifth place a user identifier lives, and the first outside the queue file. `docs/personal-data.md` carries it in its own table and says what follows: a deleted account leaves that identifier behind exactly as it leaves the four in the queue file. **That is not repaired here and is not claimed to be.** #49 holds the rule for all five, and answering it for one file while the other four wait would be describing a behaviour this plugin does not have - nothing in it is told that a user was deleted.

Nothing removes an entry by age either, and `personal-data.md` says why: it is a setting rather than an event, it carries no date, and a sweep that dropped it after a year would turn somebody's own choice back on without telling them.

## What is measured, and what is not

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    0 Warnung(en) / 0 Fehler

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden! : Fehler: 0, erfolgreich: 698, uebersprungen: 0, gesamt: 698 (net9.0)
    Bestanden! : Fehler: 0, erfolgreich: 698, uebersprungen: 0, gesamt: 698 (net10.0)

    npx --yes prettier@3.6.2 --check --end-of-line auto "**/*.{html,css,js,md}"
    All matched files use Prettier code style!

`--end-of-line auto` is on the local run only, because this working copy has CRLF from `core.autocrlf` and every tracked file fails the pinned default without it. The gate's own run checks out with LF and needs no such flag.

**No server ran and no browser ran.** Nothing here watched a person tick the checkbox, and nothing watched a client show or not show the message. What is held is what this plugin asked the server to send and to whom, which is the bound the headless rule in `docs/testing.md` sets and which every notification leg on this board already carries. The invariant lint was not run locally either: it is a Linux binary this machine does not carry, so what covers the page rules on this change is the gate rather than a local run.

## What else moved, and why

`docs/storage.md`'s backup table gains the new file and its pending file. It is `Required` in a backup: a restore without it turns everybody's own setting back on, and the person who set it finds out by being told something they had asked not to be told. `docs/api.md` gains the two endpoints. `docs/surface.md`'s "what the page does not do" said the page carries no control at all, which stopped being true, and now says it carries one and that it is a setting rather than a decision.

`BrowserPageTests.ThePageCarriesNoControlAPersonCanOperate` asserted the same absence and could not survive this. It is now `TheOnlyControlThePageCarriesIsThePersonsOwnSwitch` and asserts what replaces it: exactly one operable element, exactly one POST, and that the one address it sends to is the endpoint that takes no identifier. The guard is narrower in what it forbids and no weaker on the failure it exists for.

## Size, and one path outside this issue's own area

This is larger than a change of this kind usually is, and the reason is the issue's own: a per-person preference needed a store, an interface, an endpoint pair, a switch on the notice path, and a control on a page that had none. Splitting it would produce halves that only make sense together.

`docs/personal-data.md` belongs to #104's area rather than to this issue. It is edited here because this change adds an identifier to what this plugin holds, and a page that accounts for that and does not mention it would be wrong the moment this merges.

## No second reader

Nothing on this board read this change but the run that produced it. The evidence above stands in place of one.
