### PR TITLE
Stop the queue drifting away from the request service behind it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ what came before it. What landed before this file existed is in the git history,
 where it carries the pull request and the issue it came from, and rewriting it
 from memory into entries would be a description nobody measured.
 
+- The queue no longer drifts away from an external request service. A scheduled
+  task asks that service, hourly and at startup, where the requests handed to it
+  stand, and applies what it says through the mapping table: today that means a
+  request the service gave up on stops sitting in approved looking like an
+  operator forgot about it. A decision made on this server is never reversed by
+  anything the service says, a word the table does not hold is reported and moves
+  nothing, and a service that did not answer leaves every request exactly as it
+  is. On a server with no such service the task does nothing at all.
+
 - Whether the title somebody asked for has arrived is now answered for them
   rather than for the server. Their own list asks the library on their behalf, so
   a person restricted by a parental rating or without access to the library a

--- a/Jellyfin.Plugin.Requests.Tests/Bridge/NoBackendCompletenessTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Bridge/NoBackendCompletenessTests.cs
@@ -30,7 +30,13 @@ public class NoBackendCompletenessTests
     /// Everything in the plugin that touches the bridge. Each is a place that has to keep working
     /// on a server with no external service.
     /// </summary>
-    private static readonly string[] Expected = ["BridgeSubmission", "CapabilitiesController", "HealthController"];
+    private static readonly string[] Expected =
+    [
+        "BridgeReconciliation",
+        "BridgeSubmission",
+        "CapabilitiesController",
+        "HealthController"
+    ];
 
     /// <summary>
     /// Everything that takes the bridge is named in the register, and nothing is named there that

--- a/Jellyfin.Plugin.Requests.Tests/Bridge/ReconcilingWithTheServiceTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Bridge/ReconcilingWithTheServiceTests.cs
@@ -1,0 +1,535 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Bridge;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Bridge;
+
+/// <summary>
+/// What asking the external service where things stand does to the queue, and what it refuses to do
+/// to it.
+/// <para>
+/// The condition worth protecting here is the third one on #83, and it is the failure an operator
+/// never forgives: a decision made on this server is never reversed by anything the service says. It
+/// is held by which requests the run looks at rather than by a check inside the loop, so the legs
+/// below assert that a declined request is not asked about at all - a stronger claim than that it did
+/// not move, because the second could be true by accident.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class ReconcilingWithTheServiceTests
+{
+    private static readonly Guid Asker = new Guid("c9000000-0000-0000-0000-000000000001");
+    private static readonly Guid Operator = new Guid("c9000000-0000-0000-0000-000000000002");
+    private static readonly DateTimeOffset Started = new DateTimeOffset(2026, 8, 25, 9, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset Later = Started.AddHours(3);
+
+    private readonly SequentialIdentifierSource _identifiers = new SequentialIdentifierSource();
+
+    /// <summary>
+    /// A service that says it gave up moves the request to failed, through the table, with the
+    /// plugin as the actor and an entry in the history for it.
+    /// <para>
+    /// This is the second condition of #83 in one leg. The actor is the part that is easy to lose: a
+    /// move made on somebody else's word is not a move a person made, and a history entry naming an
+    /// operator for it would put a decision in front of somebody who did not take one.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AServiceThatGaveUpMovesTheRequestToFailedWithThePluginAsTheActor()
+    {
+        var store = new InMemoryRequestStore();
+        var journal = new RecordingJournal();
+        var approved = await AnApprovedRequestAsync(store, "svc-1").ConfigureAwait(true);
+
+        var report = await ReconcilingAsync(store, Saying("svc-1", "FAILED"), journal: journal).ConfigureAwait(true);
+        var held = await Held(store, approved.Request.Id).ConfigureAwait(true);
+        var entry = held.Request.History[^1];
+
+        Assert.Equal(1, report.Moved);
+        Assert.Equal(1, report.Examined);
+        Assert.Equal(RequestState.Failed, held.Request.State);
+        Assert.Equal(RequestState.Approved, entry.From);
+        Assert.Equal(RequestState.Failed, entry.To);
+        Assert.Null(entry.ByUserId);
+        Assert.Equal(Later, entry.At);
+        Assert.Single(journal.Written);
+    }
+
+    /// <summary>
+    /// A local decline is not reversed by anything the service says, and it is not asked about at
+    /// all.
+    /// <para>
+    /// The service is told to say the one word that moves a request, about the reference the declined
+    /// request still carries. Both halves are asserted: the request is still declined, and the run
+    /// never asked, which is what makes the rule a property of the run's shape rather than of a
+    /// mapping that happens not to reach it.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ALocalDeclineIsNeverReversedAndIsNeverAskedAbout()
+    {
+        var store = new InMemoryRequestStore();
+        var approved = await AnApprovedRequestAsync(store, "svc-1").ConfigureAwait(true);
+
+        var declined = await store.ReplaceAsync(
+            RequestLifecycle.Decline(
+                approved.Request,
+                DeclineReason.NotWanted,
+                note: null,
+                Started,
+                RequestCaller.Administrator(Operator)),
+            approved.Revision,
+            CancellationToken.None).ConfigureAwait(true);
+
+        var service = Saying("svc-1", "FAILED");
+        var report = await ReconcilingAsync(store, service).ConfigureAwait(true);
+        var held = await Held(store, declined.Request.Id).ConfigureAwait(true);
+
+        Assert.Empty(service.AskedAbout);
+        Assert.Equal(0, report.Examined);
+        Assert.Equal(0, report.Moved);
+        Assert.Equal(RequestState.Declined, held.Request.State);
+        Assert.Equal(declined.Revision, held.Revision);
+    }
+
+    /// <summary>
+    /// A fulfilled request is not asked about either, for the same reason and a different one: the
+    /// library said the person can watch it, and no service on another machine knows better.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AFulfilledRequestIsNeverAskedAbout()
+    {
+        var store = new InMemoryRequestStore();
+        var approved = await AnApprovedRequestAsync(store, "svc-1").ConfigureAwait(true);
+
+        await store.ReplaceAsync(
+            RequestLifecycle.Move(approved.Request, RequestState.Fulfilled, Started, RequestCaller.Plugin),
+            approved.Revision,
+            CancellationToken.None).ConfigureAwait(true);
+
+        var service = Saying("svc-1", "FAILED");
+        var report = await ReconcilingAsync(store, service).ConfigureAwait(true);
+        var held = await Held(store, approved.Request.Id).ConfigureAwait(true);
+
+        Assert.Empty(service.AskedAbout);
+        Assert.Equal(RequestState.Fulfilled, held.Request.State);
+        Assert.Equal(0, report.Examined);
+    }
+
+    /// <summary>
+    /// A request nothing was ever handed over for is not asked about, because there is nothing to ask
+    /// about it with.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ARequestThatWasNeverHandedOverIsNeverAskedAbout()
+    {
+        var store = new InMemoryRequestStore();
+        var open = await AnOpenRequestAsync(store).ConfigureAwait(true);
+
+        await store.ReplaceAsync(
+            RequestLifecycle.Move(open.Request, RequestState.Approved, Started, RequestCaller.Administrator(Operator)),
+            open.Revision,
+            CancellationToken.None).ConfigureAwait(true);
+
+        var service = Saying("svc-1", "FAILED");
+        var report = await ReconcilingAsync(store, service).ConfigureAwait(true);
+
+        Assert.Empty(service.AskedAbout);
+        Assert.Equal(0, report.Examined);
+    }
+
+    /// <summary>
+    /// A word the mapping table has never seen produces a logged refusal and leaves the request
+    /// exactly as it is.
+    /// <para>
+    /// This is the other half of not corrupting a request on a surprising answer. Nothing here
+    /// guesses at a word it does not hold, because a guess is a request in a state nobody chose and
+    /// the cost of being wrong lands on somebody who cannot see why.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AWordNothingKnowsIsRefusedInTheLogAndMovesNothing()
+    {
+        var store = new InMemoryRequestStore();
+        var log = new RecordingLogger();
+        var approved = await AnApprovedRequestAsync(store, "svc-1").ConfigureAwait(true);
+
+        var report = await ReconcilingAsync(store, Saying("svc-1", "ABANDONED"), log).ConfigureAwait(true);
+        var held = await Held(store, approved.Request.Id).ConfigureAwait(true);
+
+        Assert.Equal(1, report.Examined);
+        Assert.Equal(0, report.Moved);
+        Assert.Equal(1, report.Refused);
+        Assert.Equal(RequestState.Approved, held.Request.State);
+        Assert.Equal(approved.Revision, held.Revision);
+        Assert.Contains(
+            log.At(LogLevel.Warning),
+            line => line.Message.Contains("ABANDONED", StringComparison.Ordinal)
+                && line.Message.Contains(approved.Request.Id.ToString(), StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// A word the table knows and deliberately does nothing about moves nothing and is not a refusal.
+    /// <para>
+    /// The two are different answers and the report tells them apart. A run that counted an inert row
+    /// as a refusal would have an operator looking for a defect every time their service reported
+    /// that its own approval step had run.
+    /// </para>
+    /// </summary>
+    /// <param name="reported">A word the table holds and acts on in neither direction.</param>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Theory]
+    [InlineData("PENDING")]
+    [InlineData("APPROVED")]
+    [InlineData("COMPLETED")]
+    [InlineData("AVAILABLE")]
+    public async Task AWordTheTableKnowsAndDoesNothingAboutIsNotARefusal(string reported)
+    {
+        var store = new InMemoryRequestStore();
+        var approved = await AnApprovedRequestAsync(store, "svc-1").ConfigureAwait(true);
+
+        var report = await ReconcilingAsync(store, Saying("svc-1", reported)).ConfigureAwait(true);
+        var held = await Held(store, approved.Request.Id).ConfigureAwait(true);
+
+        Assert.Equal(1, report.Examined);
+        Assert.Equal(0, report.Moved);
+        Assert.Equal(0, report.Refused);
+        Assert.Equal(RequestState.Approved, held.Request.State);
+    }
+
+    /// <summary>
+    /// The service's word is matched however it is spelled, because the table already ignores case
+    /// and this run reads the table rather than the word.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task TheWordIsMatchedHoweverTheServiceSpellsIt()
+    {
+        var store = new InMemoryRequestStore();
+        var approved = await AnApprovedRequestAsync(store, "svc-1").ConfigureAwait(true);
+
+        var report = await ReconcilingAsync(store, Saying("svc-1", "failed")).ConfigureAwait(true);
+        var held = await Held(store, approved.Request.Id).ConfigureAwait(true);
+
+        Assert.Equal(1, report.Moved);
+        Assert.Equal(RequestState.Failed, held.Request.State);
+    }
+
+    /// <summary>
+    /// A service that did not answer says so in the log, walks nothing and moves nothing.
+    /// <para>
+    /// One line for the run rather than one per request. The fact is about the service, and a run
+    /// that asked about every request in turn against a service that is down would produce a page of
+    /// failures for a single thing an operator has to fix.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AnUnreachableServiceIsSaidRatherThanSwallowedAndNothingIsWalked()
+    {
+        var store = new InMemoryRequestStore();
+        var log = new RecordingLogger();
+        var approved = await AnApprovedRequestAsync(store, "svc-1").ConfigureAwait(true);
+
+        var service = new AServiceThatSaysWhereThingsStand(
+            Says("svc-1", "FAILED"),
+            BackendReachability.Unreachable);
+
+        var report = await ReconcilingAsync(store, service, log).ConfigureAwait(true);
+        var held = await Held(store, approved.Request.Id).ConfigureAwait(true);
+
+        Assert.False(report.Asked);
+        Assert.Equal(BackendReachability.Unreachable, report.Reachability);
+        Assert.Equal(0, report.Examined);
+        Assert.Empty(service.AskedAbout);
+        Assert.Equal(RequestState.Approved, held.Request.State);
+        Assert.Single(log.At(LogLevel.Warning));
+    }
+
+    /// <summary>
+    /// A service that could not be asked whether it is there is the same answer as one that did not
+    /// answer, and it is reported rather than raised out of the task.
+    /// <para>
+    /// An unhandled exception in a scheduled task is a task that stops running, and a reconciliation
+    /// that stopped running is a queue that drifts with nothing saying so.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AServiceThatCouldNotBeAskedIsReportedRatherThanRaised()
+    {
+        var store = new InMemoryRequestStore();
+        var log = new RecordingLogger();
+        await AnApprovedRequestAsync(store, "svc-1").ConfigureAwait(true);
+
+        var report = await ReconcilingAsync(
+            store,
+            new AServiceThatSaysWhereThingsStand(refusesTheCheck: true),
+            log).ConfigureAwait(true);
+
+        Assert.False(report.Asked);
+        Assert.Equal(BackendReachability.Unreachable, report.Reachability);
+        Assert.Single(log.At(LogLevel.Warning));
+    }
+
+    /// <summary>
+    /// An install with no service configured does nothing, walks nothing, and says nothing above
+    /// debug.
+    /// <para>
+    /// This is what most servers are, and the run costs one call on them. A line per run at warning
+    /// would fill an operator's log with the fact that they run one plugin rather than two systems.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AnInstallWithNoServiceDoesNothingAndIsQuietAboutIt()
+    {
+        var store = new InMemoryRequestStore();
+        var log = new RecordingLogger();
+        await AnApprovedRequestAsync(store, "svc-1").ConfigureAwait(true);
+
+        var service = new AServiceThatSaysWhereThingsStand(
+            Says("svc-1", "FAILED"),
+            BackendReachability.NotConfigured);
+
+        var report = await ReconcilingAsync(store, service, log).ConfigureAwait(true);
+
+        Assert.False(report.Asked);
+        Assert.Equal(BackendReachability.NotConfigured, report.Reachability);
+        Assert.Empty(service.AskedAbout);
+        Assert.Empty(log.At(LogLevel.Warning));
+        Assert.Empty(log.At(LogLevel.Error));
+        Assert.Empty(log.At(LogLevel.Information));
+    }
+
+    /// <summary>
+    /// One request the service cannot answer about does not stop the others.
+    /// <para>
+    /// The failure is a fact about one reference - it may have been issued by a service an operator
+    /// has since replaced - and a run that stopped at the first one would let a single unknown title
+    /// hold up every other request on the server.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task OneRequestTheServiceCannotAnswerAboutDoesNotStopTheOthers()
+    {
+        var store = new InMemoryRequestStore();
+        var log = new RecordingLogger();
+        var first = await AnApprovedRequestAsync(store, "svc-1").ConfigureAwait(true);
+        var second = await AnApprovedRequestAsync(store, "svc-2").ConfigureAwait(true);
+
+        var service = new AServiceThatSaysWhereThingsStand(
+            Says("svc-2", "FAILED"),
+            cannotAnswerAbout: ["svc-1"]);
+
+        var report = await ReconcilingAsync(store, service, log).ConfigureAwait(true);
+
+        Assert.Equal(2, report.Examined);
+        Assert.Equal(1, report.Moved);
+        Assert.Equal(RequestState.Approved, (await Held(store, first.Request.Id).ConfigureAwait(true)).Request.State);
+        Assert.Equal(RequestState.Failed, (await Held(store, second.Request.Id).ConfigureAwait(true)).Request.State);
+        Assert.Single(log.At(LogLevel.Warning));
+    }
+
+    /// <summary>
+    /// A reference the service knows nothing about moves nothing and is not a refusal.
+    /// <para>
+    /// Nothing known is an ordinary answer rather than a fault: a reference issued by a service an
+    /// operator has since replaced is a fact about the install, which is what the interface says of
+    /// its own null answer.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AReferenceTheServiceKnowsNothingAboutMovesNothing()
+    {
+        var store = new InMemoryRequestStore();
+        var log = new RecordingLogger();
+        var approved = await AnApprovedRequestAsync(store, "svc-1").ConfigureAwait(true);
+
+        var report = await ReconcilingAsync(store, new AServiceThatSaysWhereThingsStand(), log).ConfigureAwait(true);
+        var held = await Held(store, approved.Request.Id).ConfigureAwait(true);
+
+        Assert.Equal(1, report.Examined);
+        Assert.Equal(0, report.Moved);
+        Assert.Equal(0, report.Refused);
+        Assert.Equal(RequestState.Approved, held.Request.State);
+        Assert.Empty(log.At(LogLevel.Warning));
+    }
+
+    /// <summary>
+    /// The mapping table holds no word in both of the service's lists.
+    /// <para>
+    /// This is the assumption the run rests on rather than one it makes. The interface hands back one
+    /// word and does not say which vocabulary it came from, so the run asks each list in turn; a word
+    /// in both would make the answer depend on the order of two lines. Refused here rather than
+    /// worked around, because the repair is a row in the table and not a branch in the loop.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void NoWordTheServiceUsesIsInBothOfItsLists()
+    {
+        var inBoth = BackendStates.Table
+            .GroupBy(row => row.Reported, StringComparer.OrdinalIgnoreCase)
+            .Where(words => words.Select(row => row.Vocabulary).Distinct().Count() > 1)
+            .Select(words => words.Key)
+            .OrderBy(word => word, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.NotEmpty(BackendStates.Table);
+        Assert.Equal([], inBoth);
+    }
+
+    /// <summary>
+    /// A request that moved while the service was being asked about it is left as the newer decision
+    /// left it.
+    /// <para>
+    /// Dropped rather than retried, and that is the precedence rule again in its narrowest form: a
+    /// retry here would put the service's word over an operator's answer given a moment ago.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ARequestThatMovedUnderTheRunIsLeftAsTheNewerDecisionLeftIt()
+    {
+        var inner = new InMemoryRequestStore();
+        var approved = await AnApprovedRequestAsync(inner, "svc-1").ConfigureAwait(true);
+
+        // Wrapped after the request is in place, so the one write this double interferes with is the
+        // run's own rather than the one that set the leg up.
+        var store = new StoreThatMovesARequestUnderTheWrite(
+            inner,
+            request => RequestLifecycle.Decline(
+                request,
+                DeclineReason.NotWanted,
+                note: null,
+                Started,
+                RequestCaller.Administrator(Operator)));
+
+        var report = await ReconcilingAsync(store, Saying("svc-1", "FAILED")).ConfigureAwait(true);
+        var held = await Held(inner, approved.Request.Id).ConfigureAwait(true);
+
+        Assert.Equal(1, report.Examined);
+        Assert.Equal(0, report.Moved);
+        Assert.Equal(1, report.Refused);
+        Assert.Equal(RequestState.Declined, held.Request.State);
+    }
+
+    /// <summary>
+    /// What the service reports for one reference.
+    /// </summary>
+    /// <param name="id">The reference.</param>
+    /// <param name="reported">The word.</param>
+    /// <returns>The dictionary the double takes.</returns>
+    private static Dictionary<string, string?> Says(string id, string reported)
+        => new Dictionary<string, string?>(StringComparer.Ordinal) { [id] = reported };
+
+    /// <summary>
+    /// A service that reports one word about one reference and is reachable.
+    /// </summary>
+    /// <param name="id">The reference.</param>
+    /// <param name="reported">The word.</param>
+    /// <returns>The service.</returns>
+    private static AServiceThatSaysWhereThingsStand Saying(string id, string reported)
+        => new AServiceThatSaysWhereThingsStand(Says(id, reported));
+
+    /// <summary>
+    /// What the store holds for one request, which is what a leg asserts against rather than the
+    /// report the run returned.
+    /// </summary>
+    /// <param name="store">The store.</param>
+    /// <param name="id">The request.</param>
+    /// <returns>The request and its revision.</returns>
+    private static async Task<StoredRequest> Held(InMemoryRequestStore store, Guid id)
+    {
+        var stored = await store.GetAsync(id, CancellationToken.None).ConfigureAwait(false);
+
+        return Assert.NotNull(stored);
+    }
+
+    /// <summary>
+    /// One run of the reconciliation over the store and service handed in.
+    /// </summary>
+    /// <param name="store">Where the requests are.</param>
+    /// <param name="service">The service.</param>
+    /// <param name="log">Where the run reports.</param>
+    /// <param name="journal">The activity log.</param>
+    /// <returns>What the run looked at and what it did.</returns>
+    private static Task<ReconciliationReport> ReconcilingAsync(
+        IRequestStore store,
+        IRequestBackend service,
+        RecordingLogger? log = null,
+        RecordingJournal? journal = null)
+        => new BridgeReconciliation(
+            store,
+            service,
+            new TestClock(Later),
+            journal ?? new RecordingJournal(),
+            new RecordingRequesterNotice(),
+            new BridgeWatch(),
+            log ?? new RecordingLogger()).ReconcileAsync(CancellationToken.None);
+
+    /// <summary>
+    /// One open request in the store.
+    /// </summary>
+    /// <param name="store">Where it goes.</param>
+    /// <returns>The request and the revision the store holds it at.</returns>
+    private async Task<StoredRequest> AnOpenRequestAsync(InMemoryRequestStore store)
+        => await store.AddAsync(
+            new MediaRequest
+            {
+                Id = _identifiers.NewId(),
+                RequestedByUserId = Asker,
+                RequestedAt = Started,
+                StateChangedAt = Started,
+                Kind = RequestedItemKind.Movie,
+                DisplayTitle = "Solaris",
+                DisplayYear = 1972,
+
+                // An approval needs one. A request nothing can match in a library and nothing can be
+                // submitted for is refused the moves that need an identifier, which is the model
+                // holding a rule this file is not about.
+                ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tmdb"] = "593" }
+            },
+            CancellationToken.None).ConfigureAwait(true);
+
+    /// <summary>
+    /// One approved request carrying the reference a service issued for it, which is the state a
+    /// handover leaves behind.
+    /// </summary>
+    /// <param name="store">Where it goes.</param>
+    /// <param name="reference">What the service called it.</param>
+    /// <returns>The request and the revision the store holds it at.</returns>
+    private async Task<StoredRequest> AnApprovedRequestAsync(InMemoryRequestStore store, string reference)
+    {
+        var open = await AnOpenRequestAsync(store).ConfigureAwait(true);
+        var approved = RequestLifecycle.Move(
+            open.Request,
+            RequestState.Approved,
+            Started,
+            RequestCaller.Administrator(Operator));
+
+        return await store.ReplaceAsync(
+            approved with { Backend = AServiceThatSaysWhereThingsStand.Reference(reference) },
+            open.Revision,
+            CancellationToken.None).ConfigureAwait(true);
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/Doubles/AServiceThatSaysWhereThingsStand.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/AServiceThatSaysWhereThingsStand.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Bridge;
+using Jellyfin.Plugin.Requests.Model;
+
+namespace Jellyfin.Plugin.Requests.Tests.Doubles;
+
+/// <summary>
+/// An external request service that answers where the things it was handed stand.
+/// <para>
+/// The bridges the suite already has answer nothing when asked about a reference, which is the
+/// honest behaviour of a server with no service and useless for watching a reconciliation. This is
+/// the other half: a test says what the service reports for each reference it issued, and this
+/// answers exactly that.
+/// </para>
+/// <para>
+/// It records what it was asked about, in order, so a test can assert the shape of a run rather than
+/// only its outcome: that a declined request was never asked about at all is a stronger claim than
+/// that it did not move, because the second could be true by accident.
+/// </para>
+/// </summary>
+internal sealed class AServiceThatSaysWhereThingsStand : IRequestBackend
+{
+    /// <summary>
+    /// What this service calls itself when it issues a reference.
+    /// </summary>
+    public const string Name = "a-service";
+
+    private readonly Dictionary<string, string?> _says;
+    private readonly HashSet<string> _cannotAnswerAbout;
+    private readonly List<string> _askedAbout = [];
+    private readonly BackendReachability _reachability;
+    private readonly bool _refusesTheCheck;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AServiceThatSaysWhereThingsStand"/> class.
+    /// </summary>
+    /// <param name="says">
+    /// What it reports per reference identifier. A null value is a reference it knows nothing about,
+    /// and a reference not in the dictionary at all is the same answer.
+    /// </param>
+    /// <param name="reachability">What it says when it is asked whether it is there.</param>
+    /// <param name="cannotAnswerAbout">References asking about raises on rather than answers.</param>
+    /// <param name="refusesTheCheck">Whether asking whether it is there raises rather than answers.</param>
+    public AServiceThatSaysWhereThingsStand(
+        IReadOnlyDictionary<string, string?>? says = null,
+        BackendReachability reachability = BackendReachability.Reachable,
+        IReadOnlyCollection<string>? cannotAnswerAbout = null,
+        bool refusesTheCheck = false)
+    {
+        _says = says is null
+            ? new Dictionary<string, string?>(StringComparer.Ordinal)
+            : new Dictionary<string, string?>(says, StringComparer.Ordinal);
+        _reachability = reachability;
+        _cannotAnswerAbout = cannotAnswerAbout is null ? [] : [.. cannotAnswerAbout];
+        _refusesTheCheck = refusesTheCheck;
+    }
+
+    /// <summary>
+    /// Gets every reference this service was asked about, in the order it was asked.
+    /// </summary>
+    public IReadOnlyList<string> AskedAbout => _askedAbout;
+
+    /// <summary>
+    /// A reference this service would have issued.
+    /// </summary>
+    /// <param name="id">What it calls the request.</param>
+    /// <returns>The reference.</returns>
+    public static BackendReference Reference(string id) => new BackendReference { Service = Name, Id = id };
+
+    /// <inheritdoc />
+    public Task<BackendReachability> CheckReachableAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return _refusesTheCheck
+            ? throw new InvalidOperationException("This service could not be asked whether it is there.")
+            : Task.FromResult(_reachability);
+    }
+
+    /// <inheritdoc />
+    public Task<BackendReference?> SubmitAsync(MediaRequest request, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return Task.FromResult<BackendReference?>(null);
+    }
+
+    /// <inheritdoc />
+    public Task<BackendReport?> ReportAsync(BackendReference reference, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(reference);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        _askedAbout.Add(reference.Id);
+
+        if (_cannotAnswerAbout.Contains(reference.Id))
+        {
+            throw new InvalidOperationException("This service could not be asked about that reference.");
+        }
+
+        return Task.FromResult(
+            _says.TryGetValue(reference.Id, out var said) && said is not null
+                ? new BackendReport { Reported = said }
+                : null);
+    }
+
+    /// <inheritdoc />
+    public Task WithdrawAsync(BackendReference reference, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return Task.CompletedTask;
+    }
+}

--- a/Jellyfin.Plugin.Requests/Bridge/BridgeReconciliation.cs
+++ b/Jellyfin.Plugin.Requests/Bridge/BridgeReconciliation.cs
@@ -1,0 +1,409 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Localisation;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Notify;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Time;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.Requests.Bridge;
+
+/// <summary>
+/// Asks the external service where the requests handed to it stand, and applies what it says through
+/// the table rather than to the record.
+/// <para>
+/// The service is where a handed-over request is actually worked on, so its state moves without this
+/// plugin being told. Without this the queue drifts from what is really happening and an operator
+/// learns not to trust it, which costs more than the queue being wrong: a page nobody believes is a
+/// page nobody reads.
+/// </para>
+/// <para>
+/// <b>The precedence rule is the shape and not a condition.</b> A decision made on this server is
+/// never reversed by anything the service says, and what enforces that is which requests this run
+/// looks at: only requests that are still <see cref="RequestState.Approved"/>, which is the one
+/// state a handover leaves behind. A declined request carrying a reference is never asked about, so
+/// there is no answer that could resurrect it, and a fulfilled one is never asked about either,
+/// because the library said it arrived and the service cannot know better. A local decline that a
+/// remote system keeps resurrecting is the failure an operator never forgives, and it is cheaper to
+/// build into the loop than to add to one that already reads well.
+/// </para>
+/// <para>
+/// <b>Nothing is invented for a word the table has never seen.</b>
+/// <see cref="BackendStates.Lookup"/> answers nothing for it, and this refuses and says so rather
+/// than guessing, which is what keeps a surprising external state from becoming a request in a state
+/// nobody chose. A word the table knows and deliberately does nothing about is a different answer
+/// and passes silently, because that is the table doing its job.
+/// </para>
+/// <para>
+/// <b>An unreachable service is said rather than swallowed, and nothing is walked.</b> A run that
+/// asked about every request in turn against a service that is down would produce one failure per
+/// request for one fact, and the fact is about the service. An install with no service configured is
+/// not a failure at all and says nothing above debug: that is what most servers are.
+/// </para>
+/// <para>
+/// <b>One request's failure never stops the others.</b> A service that cannot answer about one
+/// reference is a fact about that reference - it may have been issued by a service an operator has
+/// since replaced - so the run reports it and carries on. Which failures an adapter tells apart, and
+/// what each of them then does, is #86 and is not decided here.
+/// </para>
+/// </summary>
+public sealed class BridgeReconciliation
+{
+    private readonly IRequestStore _store;
+    private readonly IRequestBackend _backend;
+    private readonly IClock _clock;
+    private readonly IActivityJournal _journal;
+    private readonly IRequesterNotice _told;
+    private readonly BridgeWatch _watch;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BridgeReconciliation"/> class.
+    /// </summary>
+    /// <param name="store">Where the requests are.</param>
+    /// <param name="backend">The service, or the one that has none behind it.</param>
+    /// <param name="clock">The injected clock, so a move carries a moment a test can choose.</param>
+    /// <param name="journal">The activity log an operator reads afterwards.</param>
+    /// <param name="told">The path that tells the person who asked.</param>
+    /// <param name="watch">Where a service answering is recorded for the operator page.</param>
+    /// <param name="logger">The server's log, where every refusal names the request it was about.</param>
+    /// <exception cref="ArgumentNullException">Where anything it needs is missing.</exception>
+    public BridgeReconciliation(
+        IRequestStore store,
+        IRequestBackend backend,
+        IClock clock,
+        IActivityJournal journal,
+        IRequesterNotice told,
+        BridgeWatch watch,
+        ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(backend);
+        ArgumentNullException.ThrowIfNull(clock);
+        ArgumentNullException.ThrowIfNull(journal);
+        ArgumentNullException.ThrowIfNull(told);
+        ArgumentNullException.ThrowIfNull(watch);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _store = store;
+        _backend = backend;
+        _clock = clock;
+        _journal = journal;
+        _told = told;
+        _watch = watch;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Whether this run may ask the service about this request.
+    /// <para>
+    /// Two conditions and both are necessary. It has to have been handed over, or there is nothing
+    /// to ask about; and it has to still be approved, which is the state a handover leaves behind
+    /// and the only one a decision here has not since moved it out of.
+    /// </para>
+    /// </summary>
+    /// <param name="request">The request being judged.</param>
+    /// <returns><see langword="true"/> where the service may be asked about it.</returns>
+    public static bool IsOutstanding(MediaRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        return request.Backend is not null && request.State == RequestState.Approved;
+    }
+
+    /// <summary>
+    /// Asks the service about every outstanding request and applies what it says.
+    /// </summary>
+    /// <param name="cancellationToken">Cancels the run between requests.</param>
+    /// <returns>What the run looked at and what it did.</returns>
+    public async Task<ReconciliationReport> ReconcileAsync(CancellationToken cancellationToken)
+    {
+        var reachability = await ReachabilityAsync(cancellationToken).ConfigureAwait(false);
+
+        if (reachability != BackendReachability.Reachable)
+        {
+            return new ReconciliationReport { Asked = false, Reachability = reachability };
+        }
+
+        var held = await _store.GetAllAsync(cancellationToken).ConfigureAwait(false);
+        var examined = 0;
+        var moved = 0;
+        var refused = 0;
+
+        foreach (var stored in held)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!IsOutstanding(stored.Request) || stored.Request.Backend is not BackendReference reference)
+            {
+                continue;
+            }
+
+            examined++;
+
+            var report = await ReportedAsync(stored.Request.Id, reference, cancellationToken).ConfigureAwait(false);
+
+            if (report is null)
+            {
+                // Either the service knows nothing about this reference, which is an ordinary answer
+                // about a reference issued by a service an operator has since replaced, or the call
+                // failed and has already been reported. Neither is a refusal to count: nothing was
+                // said for this run to decline to act on.
+                continue;
+            }
+
+            var destination = Destination(stored.Request.Id, report);
+
+            if (destination is not RequestState to)
+            {
+                // A word the table knows and does nothing about, or one it has never seen. The
+                // second was counted and reported inside Destination; the first is the table doing
+                // its job and passes in silence.
+                refused += Known(report) ? 0 : 1;
+                continue;
+            }
+
+            if (await MovedAsync(stored, to, cancellationToken).ConfigureAwait(false))
+            {
+                moved++;
+            }
+            else
+            {
+                refused++;
+            }
+        }
+
+        // At information rather than debug when anything moved: these are requests this plugin moved
+        // on somebody else's word, and an operator asked why a request failed should find the run
+        // that did it in the log they already read.
+        if (moved > 0 && _logger.IsEnabled(LogLevel.Information))
+        {
+            _logger.LogInformation(
+                "Reconciled {Examined} request(s) with the external request service and moved {Moved} of them.",
+                examined,
+                moved);
+        }
+
+        return new ReconciliationReport
+        {
+            Asked = true,
+            Reachability = reachability,
+            Examined = examined,
+            Moved = moved,
+            Refused = refused
+        };
+    }
+
+    /// <summary>
+    /// Whether the table holds this word at all, in either of the service's two lists.
+    /// </summary>
+    /// <param name="report">What the service said.</param>
+    /// <returns><see langword="true"/> where some row names it.</returns>
+    private static bool Known(BackendReport report)
+        => BackendStates.Lookup(BackendVocabulary.RequestStatus, report) is not null
+            || BackendStates.Lookup(BackendVocabulary.MediaStatus, report) is not null;
+
+    /// <summary>
+    /// Asks the bridge whether it is there, records the answer for the operator page, and turns every
+    /// way of not answering into one.
+    /// </summary>
+    /// <param name="cancellationToken">Cancels the check.</param>
+    /// <returns>What the bridge said, and <see cref="BackendReachability.Unreachable"/> where asking failed.</returns>
+    private async Task<BackendReachability> ReachabilityAsync(CancellationToken cancellationToken)
+    {
+        BackendReachability reachability;
+
+        try
+        {
+            reachability = await _backend.CheckReachableAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // The caller asked to stop before anything was walked, which is not a service that is
+            // down and must not be recorded as one.
+            throw;
+        }
+        catch (Exception reason)
+        {
+            _logger.LogWarning(
+                reason,
+                "The external request service could not be asked whether it is there, so nothing was reconciled this run. Every request handed to it is left exactly as it is and the next run will ask again.");
+
+            return BackendReachability.Unreachable;
+        }
+
+        _watch.Saw(reachability, _clock.UtcNow);
+
+        switch (reachability)
+        {
+            case BackendReachability.NotConfigured:
+                // Most servers. Not a failure and not worth a line above debug, because saying it
+                // once a run would fill an operator's log with the fact that they run one plugin
+                // rather than two systems.
+                _logger.LogDebug(
+                    "There is no external request service on this install, so there is nothing to reconciliate against and this run did nothing.");
+                break;
+
+            case BackendReachability.Unreachable:
+                // Said rather than swallowed, which is this issue's fourth condition. One line for
+                // the run and not one per request: the fact is about the service.
+                _logger.LogWarning(
+                    "The external request service did not answer, so nothing was reconciled this run. Every request handed to it is left exactly as it is and the next run will ask again.");
+                break;
+
+            default:
+                break;
+        }
+
+        return reachability;
+    }
+
+    /// <summary>
+    /// Asks the service about one reference, turning a failure into no answer.
+    /// </summary>
+    /// <param name="requestId">Which request, for the log to name.</param>
+    /// <param name="reference">What the service called it.</param>
+    /// <param name="cancellationToken">Cancels the question.</param>
+    /// <returns>What the service said, or <see langword="null"/> where it said nothing or could not be asked.</returns>
+    private async Task<BackendReport?> ReportedAsync(
+        Guid requestId,
+        BackendReference reference,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await _backend.ReportAsync(reference, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception reason)
+        {
+            // One request rather than the run. A service that cannot answer about one reference is a
+            // fact about that reference, and stopping here would let one unknown title hold up every
+            // other request on the server.
+            _logger.LogWarning(
+                reason,
+                "The external request service could not be asked about request {RequestId}, so it was left exactly as it is and the rest of this run carried on.",
+                requestId);
+
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// What the service's word means here, or nothing.
+    /// </summary>
+    /// <param name="requestId">Which request, for the log to name.</param>
+    /// <param name="report">What the service said.</param>
+    /// <returns>The state to move into, or <see langword="null"/> where nothing moves.</returns>
+    private RequestState? Destination(Guid requestId, BackendReport report)
+    {
+        // Both lists, because the interface hands back one word and does not say which of the
+        // service's two vocabularies it came from. No word appears in both, which the suite refuses
+        // rather than this method assuming, so asking each in turn cannot produce two answers.
+        var row = BackendStates.Lookup(BackendVocabulary.RequestStatus, report)
+            ?? BackendStates.Lookup(BackendVocabulary.MediaStatus, report);
+
+        if (row is null)
+        {
+            // A logged refusal rather than a corrupt request. Nothing here guesses at a word the
+            // table has never seen, because a guess is a request put into a state nobody chose and
+            // the whole cost of being wrong lands on somebody who cannot see why.
+            _logger.LogWarning(
+                "The external request service said {Reported} about request {RequestId} and nothing here knows that word, so the request was left exactly as it is. A word this plugin should act on is a row in the mapping table rather than a branch here.",
+                report.Reported,
+                requestId);
+
+            return null;
+        }
+
+        return row.MoveTo;
+    }
+
+    /// <summary>
+    /// Moves one request, through the table and into the history, and tells the two paths that are
+    /// told about every other move.
+    /// </summary>
+    /// <param name="stored">The request as the store holds it.</param>
+    /// <param name="to">Where the table says it goes.</param>
+    /// <param name="cancellationToken">Cancels the write.</param>
+    /// <returns><see langword="true"/> where it moved.</returns>
+    private async Task<bool> MovedAsync(StoredRequest stored, RequestState to, CancellationToken cancellationToken)
+    {
+        MediaRequest moved;
+
+        try
+        {
+            // Through the table and never around it, with the plugin as the actor: nothing this run
+            // moves was decided by a person, and the entry the history keeps says so by carrying no
+            // identifier. A move the table refuses is reported here rather than forced, which is the
+            // second half of not corrupting a request on a surprising answer.
+            moved = RequestLifecycle.Move(stored.Request, to, _clock.UtcNow, RequestCaller.Plugin);
+        }
+        catch (IllegalRequestTransitionException reason)
+        {
+            _logger.LogWarning(
+                "The external request service put request {RequestId} at {To} and the transition table does not allow that move from {From}, so the request was left exactly as it is. {Why}",
+                stored.Request.Id,
+                to,
+                stored.Request.State,
+                reason.Message);
+
+            return false;
+        }
+        catch (RequestMoveNotPermittedException reason)
+        {
+            _logger.LogWarning(
+                "The transition table allows request {RequestId} to move to {To} and does not admit this plugin for it, so the request was left exactly as it is. {Why}",
+                stored.Request.Id,
+                to,
+                reason.Message);
+
+            return false;
+        }
+
+        StoredRequest written;
+
+        try
+        {
+            written = await _store.ReplaceAsync(moved, stored.Revision, cancellationToken).ConfigureAwait(false);
+        }
+        catch (RequestConcurrencyException)
+        {
+            // Somebody decided on this request between the read and the write, and their decision is
+            // the newer one. It is dropped rather than retried, for the reason the retention sweep
+            // drops one: a retry here would apply the service's word over an operator's answer given
+            // a moment ago, which is exactly what this run may never do.
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug(
+                    "Request {RequestId} moved while the external request service was being asked about it, so what the service said was dropped and the next run will ask again.",
+                    stored.Request.Id);
+            }
+
+            return false;
+        }
+
+        // After the write and never before it, for the reason the endpoint writes its entry after
+        // one: an entry describing a move the store then refused is a line in the operator's list
+        // for something that did not happen.
+        if (ActivityNote.For(stored.Request, written.Request) is ActivityNote note)
+        {
+            await _journal.WriteAsync(note, cancellationToken).ConfigureAwait(false);
+
+            // Under the same condition as the entry. Nothing is told for a move to failed today,
+            // because no sentence is written for that state; RequesterMessage.ForMove is where that
+            // is decided and this run does not decide it a second time.
+            if (RequesterMessage.ForMove(written.Request, StringCatalogue.Shipped) is RequesterMessage message)
+            {
+                _told.Tell(message);
+            }
+        }
+
+        return true;
+    }
+}

--- a/Jellyfin.Plugin.Requests/Bridge/ReconciliationReport.cs
+++ b/Jellyfin.Plugin.Requests/Bridge/ReconciliationReport.cs
@@ -1,0 +1,41 @@
+namespace Jellyfin.Plugin.Requests.Bridge;
+
+/// <summary>
+/// What one reconciliation run looked at and what it did, as the answer the run hands back.
+/// <para>
+/// It exists so a test can assert a run's shape rather than reading a log for it, and so the task
+/// above can say nothing at all: a scheduled task that swallows its own outcome is where a bridge
+/// silently stops reconciling.
+/// </para>
+/// </summary>
+public sealed record ReconciliationReport
+{
+    /// <summary>
+    /// Gets a value indicating whether the run asked the service anything at all. False on an
+    /// install with no service configured and on one whose service did not answer, which are two
+    /// different reasons and are told apart by <see cref="Reachability"/>.
+    /// </summary>
+    public required bool Asked { get; init; }
+
+    /// <summary>
+    /// Gets what the bridge said when it was asked whether it was there.
+    /// </summary>
+    public required BackendReachability Reachability { get; init; }
+
+    /// <summary>
+    /// Gets how many handed-over requests this run asked the service about.
+    /// </summary>
+    public int Examined { get; init; }
+
+    /// <summary>
+    /// Gets how many requests this run moved.
+    /// </summary>
+    public int Moved { get; init; }
+
+    /// <summary>
+    /// Gets how many answers this run refused to act on: a word the mapping table has never seen, a
+    /// move the transition table does not allow, and a request that moved underneath the run. Each
+    /// one is a line in the log naming which request it was about.
+    /// </summary>
+    public int Refused { get; init; }
+}

--- a/Jellyfin.Plugin.Requests/Bridge/ReconciliationTask.cs
+++ b/Jellyfin.Plugin.Requests/Bridge/ReconciliationTask.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Model.Tasks;
+
+namespace Jellyfin.Plugin.Requests.Bridge;
+
+/// <summary>
+/// What makes the reconciliation happen without an operator remembering, which is the half of #83's
+/// first condition a loop in a class cannot be.
+/// <para>
+/// It runs on a schedule and at startup. The schedule is what keeps the queue from drifting on a
+/// server nobody is watching; startup is what a server that was switched off for a week needs,
+/// because everything the service decided while the machine was off is waiting to be asked about.
+/// </para>
+/// <para>
+/// Hourly, and the interval is stated rather than tuned. What it costs is one call per handed-over
+/// request against a service on the same machine or the same network, and what it buys is a queue
+/// no more than an hour behind. A shorter interval would ask a service that has not changed the same
+/// question more often; a longer one is a page an operator finds wrong often enough to stop reading.
+/// </para>
+/// <para>
+/// <b>On the ordinary install it does nothing and costs one call.</b> Most servers run no external
+/// service, and the run ends at the reachability check rather than walking the store. The task is
+/// registered on every install anyway, for the reason the bridge itself is: whether a service exists
+/// is a value in a file an operator edits while the server is running, and a task list built at
+/// startup would answer with whatever was true then.
+/// </para>
+/// </summary>
+public sealed class ReconciliationTask : IScheduledTask
+{
+    private static readonly TimeSpan Interval = TimeSpan.FromHours(1);
+
+    private readonly BridgeReconciliation _reconciliation;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReconciliationTask"/> class.
+    /// </summary>
+    /// <param name="reconciliation">The one thing that asks the service and applies what it says.</param>
+    /// <exception cref="ArgumentNullException">Where no reconciliation was given.</exception>
+    public ReconciliationTask(BridgeReconciliation reconciliation)
+    {
+        ArgumentNullException.ThrowIfNull(reconciliation);
+
+        _reconciliation = reconciliation;
+    }
+
+    /// <inheritdoc />
+    public string Name => "Ask the external request service where handed-over requests stand";
+
+    /// <inheritdoc />
+    public string Description =>
+        "Asks whatever else on this server fetches media about the requests handed to it, and applies what it says through the mapping table. It does nothing on a server that has no such service.";
+
+    /// <inheritdoc />
+    public string Category => "Requests";
+
+    /// <summary>
+    /// Gets the identifier the server keeps this task's schedule under. Written out rather than
+    /// derived from the type name, so renaming the class does not silently discard an interval an
+    /// operator changed.
+    /// </summary>
+    public string Key => "RequestsBridgeReconciliation";
+
+    /// <inheritdoc />
+    public IEnumerable<TaskTriggerInfo> GetDefaultTriggers() =>
+    [
+        new TaskTriggerInfo { Type = TaskTriggerInfoType.StartupTrigger },
+        new TaskTriggerInfo { Type = TaskTriggerInfoType.IntervalTrigger, IntervalTicks = Interval.Ticks }
+    ];
+
+    /// <inheritdoc />
+    public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(progress);
+
+        progress.Report(0);
+
+        await _reconciliation.ReconcileAsync(cancellationToken).ConfigureAwait(false);
+
+        progress.Report(100);
+    }
+}

--- a/Jellyfin.Plugin.Requests/Notify/RequesterMessage.cs
+++ b/Jellyfin.Plugin.Requests/Notify/RequesterMessage.cs
@@ -70,9 +70,15 @@ public sealed record RequesterMessage
     /// <para>
     /// <b>A state with no arm sends nothing, and so does a decline carrying no reason.</b>
     /// <see cref="RequestState.Open"/> is where a request starts and there is nothing to tell
-    /// anybody about arriving at it, <see cref="RequestState.Failed"/> has no path that reaches it
-    /// in this tree, and a state added later arrives here with nobody having written the sentence
-    /// for it. A decline is required to carry a reason and the model is what holds it to that, so a
+    /// anybody about arriving at it, <see cref="RequestState.Failed"/> has no sentence written for
+    /// it, and a state added later arrives here with nobody having written the sentence for it.
+    /// </para>
+    /// <para>
+    /// <b>Failed said no path reached it until the reconciliation landed, and now one does.</b> The
+    /// run in #83 moves a request there on the service's word and no sentence is written for that
+    /// state, so the person waiting is not told and finds out on their own page. That is a gap
+    /// rather than a decision, and closing it is a sentence in the catalogue and an arm here rather
+    /// than anything about this method's shape. A decline is required to carry a reason and the model is what holds it to that, so a
     /// declined request without one is a request written by something older than that rule; the
     /// sentence for it would have a hole where the reason goes, and sending nothing is what a person
     /// can recover from by opening their own page.

--- a/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
@@ -223,6 +223,22 @@ public sealed class PluginServiceRegistrator : IPluginServiceRegistrator
 
         serviceCollection.AddSingleton<IScheduledTask, RetentionTask>();
 
+        // What asks the external request service where the requests handed to it stand. Registered
+        // on every install rather than only where a service is configured, for the reason the bridge
+        // itself is: whether one exists is a value in a file an operator edits while the server is
+        // running, and a task list built at startup would answer with whatever was true then. On an
+        // install with no service the run ends at the reachability check and walks nothing.
+        serviceCollection.AddSingleton(provider => new BridgeReconciliation(
+            provider.GetRequiredService<IRequestStore>(),
+            provider.GetRequiredService<IRequestBackend>(),
+            provider.GetRequiredService<IClock>(),
+            provider.GetRequiredService<IActivityJournal>(),
+            provider.GetRequiredService<IRequesterNotice>(),
+            provider.GetRequiredService<BridgeWatch>(),
+            provider.GetRequiredService<ILogger<BridgeReconciliation>>()));
+
+        serviceCollection.AddSingleton<IScheduledTask, ReconciliationTask>();
+
         // The surface every client can reach. The server resolves its channels out of this
         // container, so this registration is what puts a place beside a person's libraries on
         // clients this project will never change.

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -162,6 +162,57 @@ as an improvement in the diff.
 What a request itself carries to the service, as opposed to whose name it carries, is #82's, and it
 is not decided here.
 
+## Asking the service where things stand
+
+The service is where a handed-over request is actually worked on, so its state moves without this
+plugin being told. `ReconciliationTask` asks, hourly and at startup, in the `Requests` category of
+the server's own task list; `BridgeReconciliation` is what it runs.
+
+**What it looks at is the rule rather than a check inside it.** Only requests that are still
+approved and carry a reference are asked about. That is the one state a handover leaves behind, and
+it is what makes the precedence rule a property of the run's shape:
+
+- **A local decline is never reversed**, because a declined request is never asked about, so there
+  is no answer that could resurrect it. A decline an operator has to make twice because a remote
+  system keeps undoing it is the failure they never forgive.
+- **A fulfilled request is never asked about either.** Fulfilled is the library's word here,
+  observed when the person who asked can actually watch it, and no service on another machine knows
+  better.
+- **A request nothing was handed over for is never asked about**, because there is nothing to ask
+  with.
+
+**Every change goes through the transition table, with the plugin as the actor.** The entry the
+history keeps carries no person, which is true: nobody here decided it. A move the table refuses is
+reported in the log naming the request, and the request is left exactly as it is. Today the only
+word that moves anything moves an approved request to failed, so a request that has been sent onward
+and will not arrive stops looking like an operator forgot about it.
+
+**A word this table has not seen is a logged refusal and nothing else**, which is the section above
+applied at the one place that could have guessed.
+
+**A service that did not answer is said rather than swallowed**, once for the run and not once per
+request: the fact is about the service. Nothing is walked, every request is left as it is, and the
+next run asks again. A service that could not be asked at all is the same answer, because an
+unhandled exception in a scheduled task is a task that stops running.
+
+**One request the service cannot answer about does not stop the others.** That failure is a fact
+about one reference - it may have been issued by a service an operator has since replaced - and a
+run that stopped at the first would let one unknown title hold up every other request on the server.
+
+**A request that moved underneath the run is left as the newer decision left it.** What the service
+said is dropped rather than retried, because a retry would put its word over an answer an operator
+gave a moment ago.
+
+**On the ordinary install this does nothing and costs one call.** Most servers have no service, the
+run ends at the reachability check, and it says nothing above debug.
+
+**What is not claimed.** No run of this task on a server has been watched, and no service was
+reached: what the suite measures is the reconciliation against a double, on both claimed target
+frameworks. Which failures an adapter tells apart, and what each of them then does, is #86 and is
+not decided here. And **the person who asked is not told when their request fails this way** - no
+sentence is written for that state, so they find out on their own page. That is a gap rather than a
+decision, and `RequesterMessage.ForMove` is where it is written down.
+
 ## What needs a bridge
 
 Nothing does, and that is a claim the suite refuses to let drift rather than a sentence somebody
@@ -174,11 +225,12 @@ cannot arrive quietly: it either gets a line in this table saying so, or the cha
 
 <!-- needs-a-bridge begins -->
 
-| What                     | Without a bridge                                                          |
-| ------------------------ | ------------------------------------------------------------------------- |
-| `BridgeSubmission`       | Hands nothing over, keeps nothing, and writes no line about it.           |
-| `CapabilitiesController` | Answers, and says that no bridge is configured.                           |
-| `HealthController`       | Answers, and says the bridge is not configured rather than not answering. |
+| What                     | Without a bridge                                                                |
+| ------------------------ | ------------------------------------------------------------------------------- |
+| `BridgeReconciliation`   | Ends at the reachability check, walks no request, and says nothing above debug. |
+| `BridgeSubmission`       | Hands nothing over, keeps nothing, and writes no line about it.                 |
+| `CapabilitiesController` | Answers, and says that no bridge is configured.                                 |
+| `HealthController`       | Answers, and says the bridge is not configured rather than not answering.       |
 
 <!-- needs-a-bridge ends -->
 


### PR DESCRIPTION
Closes #83.

## Why this can be built now, when the notes on the issue said to wait

Every note on #83 says the same thing: this follows #82, because a reconciliation loop written against a bridge with nothing behind it "would each be asserted against a double with no counterpart in any install".

#82 closed in #284 on 2026-08-23 and it landed on exactly that basis. The submission path hands a request to `IRequestBackend`, the only implementation in the tree is the one for a server with no service, and the legs that prove it are asserted against a double:

    git grep -n ": IRequestBackend" origin/master -- Jellyfin.Plugin.Requests/
    origin/master:Jellyfin.Plugin.Requests/Bridge/NoRequestBackend.cs:23:public sealed class NoRequestBackend : IRequestBackend

So the standard that let the submission land is the standard this is built to. What still waits on an adapter is #35's last two fixtures and #85's first two conditions, because both quantify over real client code; the four conditions here do not.

The mapping table already says as much about itself. Its own documentation names this issue as the caller it was written for:

    git grep -n "What a caller does with an unseen word is #83" origin/master -- Jellyfin.Plugin.Requests/Bridge/BackendStates.cs
    origin/master:Jellyfin.Plugin.Requests/Bridge/BackendStates.cs:32:/// cost of being wrong lands on somebody who cannot see why. What a caller does with an unseen word

## The means

C#, in this repository's own project and suite, following the two scheduled sweeps this tree already has. `RetentionTask`/`RetentionSweep` and `FulfilmentTask`/`FulfilmentSweep` are the shape: a class that does the work and takes its dependencies, and a thin `IScheduledTask` beside it that the server finds by scanning the assembly. Nothing new arrives - no language, no runtime, no dependency - and every rule below is refusable by the suite this tree already is.

## The four done-conditions

**A scheduled task reconciles outstanding requests and appears in the server's task list.**

`ReconciliationTask`, hourly and at startup, in the `Requests` category, keyed `RequestsBridgeReconciliation`. It is the same shape as the two tasks already there and is registered beside them.

**Every change it makes goes through the transition table and appears in the history with the plugin as the actor.**

`RequestLifecycle.Move(..., RequestCaller.Plugin)` and nothing else. `AServiceThatGaveUpMovesTheRequestToFailedWithThePluginAsTheActor` asserts the state, the history entry's `From` and `To`, that its `ByUserId` is null - nobody here decided it - the moment off the injected clock, and the activity entry beside it. A move the table refuses is logged naming the request and the request is left as it is.

**A local decline is not reversed by anything the external service says, proven by a test.**

`ALocalDeclineIsNeverReversedAndIsNeverAskedAbout`. The service is told to report the one word that moves a request, about the reference the declined request still carries, and two things are asserted: it is still declined at the same revision, and **it was never asked about at all**.

That second half is what makes this a property of the run's shape rather than of a mapping that happens not to reach it. Only requests still in `Approved` and carrying a reference are looked at, which is the one state a handover leaves behind. `AFulfilledRequestIsNeverAskedAbout` and `ARequestThatWasNeverHandedOverIsNeverAskedAbout` hold the two neighbouring cases.

**The task is safe to run when the service is unreachable and says so rather than failing silently.**

`AnUnreachableServiceIsSaidRatherThanSwallowedAndNothingIsWalked`: nothing is walked, the request is untouched, and there is exactly one warning - for the run rather than one per request, because the fact is about the service. `AServiceThatCouldNotBeAskedIsReportedRatherThanRaised` covers the check itself throwing, which is the same answer: an unhandled exception in a scheduled task is a task that stops running.

## Three guards, each watched failing

Dropping the state condition from what the run looks at, so every request carrying a reference is asked about:

    Fehler ... ReconcilingWithTheServiceTests.ALocalDeclineIsNeverReversedAndIsNeverAskedAbout
    Fehler ... ReconcilingWithTheServiceTests.AFulfilledRequestIsNeverAskedAbout
    Fehler!  : Fehler: 2, erfolgreich: 713, gesamt: 715 (net9.0 and net10.0)

Returning a state for a word the table has never seen instead of refusing:

    Fehler ... ReconcilingWithTheServiceTests.AWordNothingKnowsIsRefusedInTheLogAndMovesNothing
    Fehler!  : Fehler: 1, erfolgreich: 714, gesamt: 715 (net9.0 and net10.0)

Walking the store when the service did not answer:

    Fehler ... ReconcilingWithTheServiceTests.AnUnreachableServiceIsSaidRatherThanSwallowedAndNothingIsWalked
    Fehler ... ReconcilingWithTheServiceTests.AServiceThatCouldNotBeAskedIsReportedRatherThanRaised
    Fehler!  : Fehler: 2, erfolgreich: 713, gesamt: 715 (net9.0 and net10.0)

Each was put back after being watched.

## One assumption made refusable rather than assumed

`IRequestBackend.ReportAsync` hands back one word and does not say which of the service's two vocabularies it came from, so the run asks each list in turn. That is only safe while no word is in both lists, and a word in both would make the answer depend on the order of two lines.

`NoWordTheServiceUsesIsInBothOfItsLists` refuses that over the table rather than the run guarding against it, because the repair is a row in the table and not a branch in the loop.

## What moves, and what the ordinary install gets

Today exactly one word moves anything: the service saying it gave up moves an approved request to failed, so it stops sitting in approved looking like an operator forgot about it. Everything else the table holds is a row that deliberately moves nothing, and `AWordTheTableKnowsAndDoesNothingAboutIsNotARefusal` walks all four of them and asserts they are not counted as refusals - a run that counted an inert row as one would have an operator looking for a defect every time their service reported that its own approval step had run.

On a server with no external service the run ends at the reachability check, walks nothing and says nothing above debug. `AnInstallWithNoServiceDoesNothingAndIsQuietAboutIt` asserts all three, including that the log carries nothing at warning, error or information. That is what most servers are, and the task still registers on every install for the reason the bridge does: whether a service exists is a value an operator changes while the server is running.

## What is measured, and what is not

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    0 Warnung(en) / 0 Fehler

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden! : Fehler: 0, erfolgreich: 715, uebersprungen: 0, gesamt: 715 (net9.0)
    Bestanden! : Fehler: 0, erfolgreich: 715, uebersprungen: 0, gesamt: 715 (net10.0)

    npx --yes prettier@3.6.2 --check --end-of-line auto "**/*.{html,css,js,md}"
    All matched files use Prettier code style!

`--end-of-line auto` is on the local run only: this working copy has CRLF from `core.autocrlf` and every tracked file fails the pinned default without it. The gate checks out with LF and needs no such flag.

**No server ran and no service was reached.** Nothing here watched a Jellyfin list or start this task, and nothing here spoke to an external request service - there is none to speak to. What is measured is the reconciliation against a double, on both claimed target frameworks. That is the same unrun procedure every other scheduled behaviour on this board carries, and `docs/testing.md` is where the headless rule that produces it is written.

**Which failures an adapter tells apart is not decided here.** Unreachable, a rejected credential, a version this side does not know and a title the service has never heard of are #86, and they are failures of a call this tree cannot yet make. What this run decides is only that none of them stops the task or corrupts a request.

## One thing this makes true that was written as false

`RequesterMessage.ForMove` said `RequestState.Failed` "has no path that reaches it in this tree". This is that path. No sentence is written for that state, so **the person who asked is not told when their request fails this way** and finds out on their own page. It is corrected there, and named in `docs/bridge.md` under what is not claimed, as a gap rather than a decision: closing it is a sentence in the catalogue and an arm in that method, which is a change to what this plugin says rather than to what it reconciles, and it is not this issue's.

## What else moved

`docs/bridge.md` gains the section on asking the service where things stand, and its register of what touches the bridge gains `BridgeReconciliation` with what it does on a server that has none. `NoBackendCompletenessTests` reds until both move together, which it did while this was being written.

## No second reader

Nothing on this board read this change but the run that produced it. The evidence above stands in place of one.
