### PR TITLE
Record two readings this tree was asserting from something adjacent

### DIFF
--- a/docs/seam.md
+++ b/docs/seam.md
@@ -175,6 +175,49 @@ registration and what the probe resolves it finds by name, and neither of those 
 package. And nothing separates a container that found no implementation from one that found none
 because the type did not match, so an operator meeting either one meets the same silence.
 
+### What the package actually contains, read out of the package
+
+The paragraphs above read the project file. #11's third condition refuses that reading as sufficient
+on purpose: it asks that this plugin builds, installs, runs and passes its suite with no sibling
+present, proven by the package's dependency list rather than by the project file. The Package check
+builds the package on every push to `master` and keeps the archive, so that list can be read out of
+the thing that ships.
+
+Taken from the run of `037a664567acbd9eb0defa88118ddf6331ff3bed`:
+
+    gh run download 32888209248 --repo Flowfin/jellyfin-plugin-requests --dir pkg
+    unzip -l pkg/package-10.11.0.0/requests_0.1.0.0.zip
+          900  2026-08-25 19:13   meta.json
+       380928  2026-08-25 19:13   Jellyfin.Plugin.Requests.dll
+    unzip -l pkg/package-12.0.0.0/requests_0.1.0.0.zip
+          899  2026-08-25 19:12   meta.json
+       380928  2026-08-25 19:12   Jellyfin.Plugin.Requests.dll
+
+Two files on each claimed line: this plugin's own assembly and the metadata a server reads. Nothing
+of the other board ships, and nothing that could be a second copy of a shared type ships either,
+which is the baseline the choice above changes: when the contract package exists, exactly one side
+carries it and this listing is where that becomes visible.
+
+That list is derived rather than asserted. The same job publishes the plugin and compares what the
+publish leaves behind against the `artifacts:` list in `build.yaml`, ending non-zero on a name in
+either set and not the other, so an assembly the host does not provide cannot be absent from both:
+
+    gh api repos/Flowfin/jellyfin-plugin-requests/actions/jobs/97933626171/logs | grep -a -A3 "published assemblies:"
+    published assemblies:
+    Jellyfin.Plugin.Requests.dll
+    named in artifacts:
+    Jellyfin.Plugin.Requests.dll
+
+It then installs the package's own bytes into a server of the line it was built for and requires that
+server to report the plugin active, which is the reading no file in this repository can make on its
+own.
+
+**What this does not say.** Neither of those servers held the sibling, so nothing here measures the
+two plugins in one process; that is the section above, which was measured separately and by a probe
+built for it. The archive read here is the one the check keeps for fourteen days rather than a
+released asset, so the download command stops resolving after that and the reading has to be retaken
+against a newer run; `0.1.0.0-stable` is no substitute, because it predates every line of this seam.
+
 ## Both sides watch the library, and neither tells the other
 
 This plugin decides that a request is fulfilled by watching the server's library for the thing

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -258,6 +258,64 @@ visible today, and the conditions above are what decide the next one. A test ref
 condition not yet met by any proposal gets its own entry here when the proposal arrives, together
 with what replaces it.
 
+### The rule, run from a clean clone
+
+The condition #3 holds this rule to is that `dotnet test` passes from a clean clone, on a machine
+with no display, with no administrator rights, and with no certificate installed by this project.
+That is a property of a run rather than of the tree, so what is recorded here is a run, what it
+reached, and the one part of the condition it did not reach.
+
+Taken at `037a664567acbd9eb0defa88118ddf6331ff3bed`, into a directory that is no working tree of this
+repository:
+
+    git clone https://github.com/Flowfin/jellyfin-plugin-requests.git cleanclone
+    git -C cleanclone rev-parse HEAD
+    037a664567acbd9eb0defa88118ddf6331ff3bed
+    git -C cleanclone status --short
+    (prints nothing)
+
+    dotnet --list-sdks
+    10.0.301 [C:\Program Files\dotnet\sdk]
+
+    cd cleanclone
+    DOTNET_CLI_UI_LANGUAGE=en dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror ; echo "EXIT=$?"
+    Passed!  - Failed:     0, Passed:   715, Skipped:     0, Total:   715, Duration: 22 s - Jellyfin.Plugin.Requests.Tests.dll (net9.0)
+    Passed!  - Failed:     0, Passed:   715, Skipped:     0, Total:   715, Duration: 22 s - Jellyfin.Plugin.Requests.Tests.dll (net10.0)
+    EXIT=0
+
+715 tests on each claimed target framework, none failed and none skipped, from a restore and a build
+the clone made for itself. One SDK was installed on that machine and it built both frameworks. The
+language variable is in the command because that machine prints its summary in its own language
+otherwise, and this document is written in English.
+
+Two of the three machine conditions were established by that run.
+
+**No administrator rights.** The process that ran it held no administrator role, and nothing in the
+run asked for elevation or raised a consent prompt:
+
+    powershell -NoProfile -Command "([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)"
+    False
+
+**No certificate installed by this project.** Nothing was written to a trust store: the clone was
+made, the solution restored, the tests executed, and nothing else ran against that machine. What
+makes that a property rather than the habit of one run is `no-certificate-store-access` above, which
+refuses the constructs a test would need in order to do it.
+
+**No display was NOT established by this run, and the reason is the machine rather than the suite.**
+That machine has a display attached, so the run says nothing about one that has none. What it says
+is narrower and is worth keeping narrow: nothing in the run opened a window and nothing needed one.
+
+The half it cannot reach is covered by a different machine rather than by this paragraph. The gate
+runs the same suite on a hosted Linux runner, which has no display and is not a clone of anybody's
+working tree:
+
+    git grep -n "runs-on" .github/workflows/gate.yaml
+
+That job reported `success` at the same commit. So one machine is a clean clone with a display and
+the other is a machine with no display that is not a clean clone, and the condition stands on the
+two together. Neither is the whole of it, and a later reader should not take this section for a
+single run that met all three at once.
+
 ## Coverage, and the rule it does not replace
 
 Full unit-test coverage is a claim somebody has to be able to check, so the gate collects the number


### PR DESCRIPTION
Part of #3 and part of #11. Two recorded readings, both documents, one branch: each is a measurement
this tree asserted from something adjacent instead of from the thing itself, and neither closes its
issue.

They travel together because they are documents rather than behaviour, and landing them separately
moves the mainline under whichever of the two is still open for no gain.

## 1. `docs/testing.md`: the headless rule, run from a clean clone (#3)

The document states the rule and carried no run of it. #3's second done-condition is a property of a
run rather than of the tree, so a reader met the rule with nothing to check it against, and a
sentence claiming the suite passes from a clean clone with no elevation could be written from memory
and read as measured.

Taken at `037a664567acbd9eb0defa88118ddf6331ff3bed`, into a directory that is no working tree of this
repository:

    git clone https://github.com/Flowfin/jellyfin-plugin-requests.git cleanclone
    git -C cleanclone rev-parse HEAD
    037a664567acbd9eb0defa88118ddf6331ff3bed
    git -C cleanclone status --short
    (prints nothing)

    dotnet --list-sdks
    10.0.301 [C:\Program Files\dotnet\sdk]

    cd cleanclone
    DOTNET_CLI_UI_LANGUAGE=en dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror ; echo "EXIT=$?"
    Passed!  - Failed:     0, Passed:   715, Skipped:     0, Total:   715, Duration: 22 s - Jellyfin.Plugin.Requests.Tests.dll (net9.0)
    Passed!  - Failed:     0, Passed:   715, Skipped:     0, Total:   715, Duration: 22 s - Jellyfin.Plugin.Requests.Tests.dll (net10.0)
    EXIT=0

    powershell -NoProfile -Command "([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)"
    False

**The no-display half was NOT established by that run, and the section says so where a reader meets
it.** That machine has a display attached. What the run says is that nothing in it opened a window
and nothing needed one; the gate's Linux runner is named as the machine that covers the other half,
and the condition stands on two machines rather than on either.

## 2. `docs/seam.md`: the sibling-independence claim, read out of the package (#11)

The document establishes that nothing of the other board ships by reading this project's reference
list. #11's third condition refuses that reading as sufficient and asks for the package's own
dependency list, because a reference list is a statement about a build input and what an operator
installs is an archive. No reading of an archive was written anywhere; the last one attempted found
only a release predating the whole seam.

    gh run download 32888209248 --repo Flowfin/jellyfin-plugin-requests --dir pkg
    unzip -l pkg/package-10.11.0.0/requests_0.1.0.0.zip
          900  2026-08-25 19:13   meta.json
       380928  2026-08-25 19:13   Jellyfin.Plugin.Requests.dll
    unzip -l pkg/package-12.0.0.0/requests_0.1.0.0.zip
          899  2026-08-25 19:12   meta.json
       380928  2026-08-25 19:12   Jellyfin.Plugin.Requests.dll

That run is the Package check on `037a664`, whose job also derives the list rather than asserting it
and installs the package's own bytes into a server of the line it was built for.

**What it declines to claim.** Neither server held the sibling, so this is no measurement of two
plugins in one process. The archive is kept for fourteen days, so the download command stops
resolving and the reading has to be retaken rather than cited.

## The means

Markdown in `docs/`, for both. Each artefact is a record a person reads beside the rule it is about,
this tree already keeps its recorded runs there, and it adds no language, no runtime and no
dependency. Both files are inside the scope their issue declares.

## Checks

Two markdown files and nothing else:

    git diff --name-only origin/master...HEAD
    docs/seam.md
    docs/testing.md

Formatting was checked before pushing, against the version and the glob the gate uses, on copies
with the line endings the runner checks out:

    npx --yes prettier@3.6.2 --check "docs/seam.md" "docs/testing.md"
    All matched files use Prettier code style!

## Second reader

This board had no second reader tonight. The commands in both sections stand in place of one, and
both readings are reproducible: the first from the clone command upward, the second for as long as
that run's archive is kept.
