### PR TITLE
Write the manifest from the packages instead of leaving one unwritten

### DIFF
--- a/.github/workflows/manifest.yaml
+++ b/.github/workflows/manifest.yaml
@@ -1,0 +1,63 @@
+# The manifest generator, watched refusing what it says it refuses.
+#
+# A Jellyfin server installs a plugin from a manifest it fetches, so that document is the product as
+# far as an installing operator is concerned. It is also the one release artefact nothing else
+# checks: an entry whose checksum does not match its archive, or whose targetAbi lets a server take
+# a build it cannot load, is a broken install for everybody who added the repository, and the run
+# that wrote it is green.
+#
+# `scripts/build-manifest.sh` writes that document from the packages themselves. This runs
+# `scripts/prove-manifest-refusals.sh`, which drives it over one manifest per defect and asserts
+# that each is refused for its own reason, with a clean pair of packages beside them that has to
+# pass. A generator that has never said no writes a manifest for a clean pair, which is also what a
+# generator with no rules in it does.
+#
+# THE TWO RULES THIS EXISTS FOR ARE THE ORDERING RULES, because they are the ones a reader has to
+# take on trust. A server keeps every entry whose targetAbi is at or below its own version and then
+# picks the highest version number of what is left, so two entries at one version number are one
+# entry to it, and an entry with a higher version and a lower targetAbi is what a newer server takes
+# in preference to the build meant for it. Neither shape is visible in the JSON.
+#
+# It needs no container, no server and no network, so it answers in seconds.
+#
+# THIS IS NOT A REQUIRED CHECK. The required set is a repository setting rather than a file in this
+# tree, #107 carries the criterion and the list it produced, so a red job here does not by itself
+# hold a merge today.
+name: Manifest
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: ["**"]
+  workflow_dispatch:
+
+# Explicit deny-all at workflow level; the job grants only what it needs.
+permissions: {}
+
+# Cancel a superseded run on the same ref so a new push or pull-request update does not queue behind
+# an obsolete check.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prove:
+    # The check name a branch ruleset would require. It is matched literally and it is built from no
+    # matrix value, so it does not move when a claimed server line is added or dropped.
+    name: the manifest refuses what it says it refuses
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Nothing here pushes, so do not leave the token in .git/config.
+          persist-credentials: false
+
+      - name: Every rule the generator claims, refused for its own reason
+        run: |
+          set -euo pipefail
+          ./scripts/prove-manifest-refusals.sh

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -67,7 +67,49 @@ that downloads the archive and runs no build tooling.
 
 Nothing here writes a plugin catalog. A GitHub release is the whole output. If this
 repository previously published through the Jellyfin meta plugins workflow, that path
-is gone and no catalog is fed until a manifest generator is added.
+is gone, and no catalog is fed by this route. The generator that would write one now
+exists and this route does not call it; the section below says what it does and what
+is still missing between it and an operator adding a repository.
+
+## The manifest
+
+A Jellyfin server does not install from a GitHub release. It fetches a manifest,
+finds the newest entry whose `targetAbi` its own version accepts, downloads the
+`sourceUrl` and checks the download against the entry's `checksum`.
+
+`scripts/build-manifest.sh` writes that document from built packages. Every field
+except the checksum is copied out of the `<archive>.zip.meta.json` the packaging tool
+writes beside each archive, so the entry describes the package that shipped rather
+than a file read back out of the tree, and the checksum is the MD5 of the archive's
+own bytes. `MANIFEST_BASE` names the manifest already published, so a release adds
+its versions to it instead of replacing them.
+
+Run over the release that exists today:
+
+```
+gh release download 0.1.0.0-stable --repo Flowfin/jellyfin-plugin-requests
+SOURCE_URL_PREFIX=https://github.com/Flowfin/jellyfin-plugin-requests/releases/download/0.1.0.0-stable/ \
+  scripts/build-manifest.sh manifest.json requests_0.1.0.0.zip
+```
+
+The output is reproducible: the entries are sorted by version, and there is no build
+timestamp and no serial number in it, so two runs over the same packages produce the
+same bytes and can be compared with `diff`.
+
+**What it refuses is the pair of packages a server cannot tell apart.** A server
+keeps every entry whose `targetAbi` is at or below its own version and then takes the
+highest version number of what is left, so the version number is the only thing
+separating two entries it has already accepted. Two entries at one version are one
+entry to it, and an entry with a higher version and a lower `targetAbi` is what a
+newer server takes in preference to the build meant for it. Both are refused rather
+than written, and `scripts/prove-manifest-refusals.sh` drives one manifest per defect
+and asserts each is refused for its own reason, with a clean pair beside them that has
+to pass.
+
+**Two things stand between this and an operator adding a repository, and neither is
+in this document.** The release route publishes one package for the one line
+`build.yaml` names and does not call the generator, and both packaging files declare
+one version number, which is the pair the generator refuses. #110 carries both.
 
 ## The bill of materials
 

--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -291,12 +291,12 @@ produce several.
 Twelve files here map onto a file there and are placed by the table above:
 `dco.yml`, `dependency-review.yml`, `invariant-lint.yaml`, `mutation.yaml`,
 `package.yaml`, `prettier.yml`, `pr-hygiene.yaml`, `publish.yaml`,
-`scan-codeql.yaml`, `scorecard.yml`, `unicode-guard.yml` and `zizmor.yml`. Eight
-of the rows below name a file that is present, and twelve plus eight is what the
+`scan-codeql.yaml`, `scorecard.yml`, `unicode-guard.yml` and `zizmor.yml`. Nine
+of the rows below name a file that is present, and twelve plus nine is what the
 directory holds:
 
     $ ls .github/workflows/ | wc -l
-    20
+    21
 
 This paragraph said eleven and three and pasted 14, and the three numbers were
 wrong in one way: `package.yaml`, `seam-probe.yaml` and `user-isolation.yaml` had
@@ -327,6 +327,7 @@ longer tracks it.
 | `seam-probe.yaml`       | adopted, landed   | What a second plugin in the same server process can see of this one, measured on a real server of each line with `tools/seam-probe` as the second plugin. It records an answer rather than holding a merge, so what reds it is a run that produced no answer at all. #117.   |
 | `user-isolation.yaml`   | adopted, landed   | Two ordinary accounts on a real server of each line, each asking for something and reading back what they are given, with the queue asked as somebody who is not an administrator. The server's own evaluation of a policy is the half no double here reaches. #67.          |
 | `full-disk.yaml`        | adopted, landed   | What a caller sees when the volume the store writes to runs out of room, on a mount with a hard size, on the runtime of each line. The suite cannot ask it: filling a filesystem needs one to fill, and the headless rule refuses a test that needs a container engine. #46. |
+| `manifest.yaml`         | adopted, landed   | The manifest generator watched refusing what it says it refuses, over one manifest per defect, with a clean pair of packages beside them. A generator that has never said no writes a manifest for a clean pair, which is also what a generator with no rules does. #110.    |
 | `changelog.yaml`        | declined, deleted | It drafts a release changelog against a version scheme this repository has not fixed, and nothing covers that risk here because there is nothing to release yet; #107.                                                                                                       |
 | `command-dispatch.yaml` | declined, deleted | It turns issue comments into workflow runs, which is a surface this repository does not use, and nothing here needs covering because nothing depends on it.                                                                                                                  |
 | `command-rebase.yaml`   | declined, deleted | Same comment-driven surface, the half that rewrites pull request branches on command, and the same absence.                                                                                                                                                                  |

--- a/scripts/build-manifest.sh
+++ b/scripts/build-manifest.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# Write the plugin repository manifest a Jellyfin server fetches, from the packages themselves.
+#
+# A server installs a plugin from a manifest, so the manifest is the product as far as an installing
+# operator is concerned. What makes it dangerous is that it is the one release artefact nothing else
+# checks: an entry whose checksum does not match its archive, or whose targetAbi lets a server take
+# a build it cannot load, is a broken install for everybody who added the repository, and the run
+# that produced it is green.
+#
+# Every field here is therefore derived from a built package rather than typed. The archive is
+# hashed for the checksum, and everything else comes out of the `<archive>.meta.json` the packaging
+# tool writes beside it, which is the metadata of the package that actually shipped rather than a
+# file read back out of the tree.
+#
+# THE ONE RULE THAT IS NOT A SHAPE CHECK IS THE ORDERING, and it is the reason this is a script
+# rather than a jq one-liner. A Jellyfin server picks a version in two steps: it keeps every entry
+# whose targetAbi is at or below its own version, then takes the highest version number of what is
+# left. Both steps are in Emby.Server.Implementations/Updates/InstallationManager.cs:
+#
+#     .Where(x => string.IsNullOrEmpty(x.TargetAbi) || Version.Parse(x.TargetAbi) <= appVer);
+#     foreach (var v in availableVersions.OrderByDescending(x => x.VersionNumber))
+#
+# So the version number is the only thing that separates two entries a server has already accepted.
+# Two entries at one version number are indistinguishable to it, and an entry with a higher version
+# and a lower targetAbi is offered to a newer server in preference to the build meant for it. This
+# script refuses both, because a manifest carrying either one installs the wrong package on a real
+# server and says nothing while it does.
+#
+# usage: scripts/build-manifest.sh <output.json> <archive> [<archive> ...]
+#
+#   SOURCE_URL_PREFIX=https://github.com/Flowfin/jellyfin-plugin-requests/releases/download/0.1.0.0-stable/ \
+#     scripts/build-manifest.sh manifest.json requests_0.1.0.0.zip
+#
+#   MANIFEST_BASE names a manifest the new entries are added to, so a release adds its versions to
+#   what is already published instead of replacing it. Absent, the output starts empty.
+#
+# The output is reproducible. The entries are sorted by version, there is no build timestamp and no
+# serial number, so the same packages always produce the same bytes and two manifests can be
+# compared with `diff`.
+
+set -euo pipefail
+
+output=${1:?path to write the manifest to, for example manifest.json}
+shift || true
+
+if [ "$#" -eq 0 ]; then
+    echo "build-manifest: no package was named. A manifest is written from the packages it lists, so there is nothing to write." >&2
+    exit 1
+fi
+
+: "${SOURCE_URL_PREFIX:?the URL each archive is downloaded from, up to and including the last slash}"
+
+case "${SOURCE_URL_PREFIX}" in
+    */) ;;
+    *)
+        echo "build-manifest: SOURCE_URL_PREFIX '${SOURCE_URL_PREFIX}' does not end in a slash. The archive file name is appended to it, and without the slash the download URL names a sibling of the directory rather than a file in it." >&2
+        exit 1
+        ;;
+esac
+
+for archive in "$@"; do
+    if [ ! -f "${archive}" ]; then
+        echo "build-manifest: ${archive} does not exist. The manifest lists packages that were built, never packages that were meant to be." >&2
+        exit 1
+    fi
+    if [ ! -f "${archive}.meta.json" ]; then
+        echo "build-manifest: ${archive}.meta.json does not exist. Every field of an entry except the checksum comes out of the metadata the packaging tool writes beside the archive, so an archive without it cannot be described." >&2
+        exit 1
+    fi
+done
+
+if [ -n "${MANIFEST_BASE:-}" ] && [ ! -f "${MANIFEST_BASE}" ]; then
+    echo "build-manifest: MANIFEST_BASE names ${MANIFEST_BASE}, which does not exist. Leave it unset to start a manifest rather than pointing it at a file that is missing: a published manifest read back as absent drops every version already released." >&2
+    exit 1
+fi
+
+# python3 is what scripts/bill-of-materials.sh and scripts/verify-plugin-loads.sh already reach for,
+# so this adds no runtime the release job did not carry. It reads the packages, orders the entries
+# and writes the JSON through a real encoder, because the fields being copied are prose an operator
+# wrote and escaping them is the part a shell gets wrong quietly.
+python3 - "${output}" "$@" <<'PY'
+import hashlib
+import json
+import os
+import sys
+
+output, archives = sys.argv[1], sys.argv[2:]
+
+# The fields a catalogue holds once per plugin rather than once per version. A manifest carrying two
+# of them is an entry whose text flips depending on which package was published last, so they are
+# compared across every package and against whatever was already published.
+IDENTITY = ("guid", "name", "description", "overview", "owner", "category", "imageUrl")
+
+# The fields an entry cannot be written without. `changelog` and `timestamp` come from the same
+# place and are allowed to be absent, because a server shows them and installs without them.
+PER_VERSION = ("version", "targetAbi")
+
+
+def refuse(message):
+    sys.exit("build-manifest: " + message)
+
+
+def version_key(text):
+    """Order a version string the way the server does, which is System.Version."""
+    parts = text.split(".")
+    if not 2 <= len(parts) <= 4:
+        refuse(
+            "version '%s' is not two to four numeric parts. A server parses this with "
+            "System.Version and drops the whole entry when it cannot." % text
+        )
+    numbers = []
+    for part in parts:
+        if not part.isdigit():
+            refuse(
+                "version '%s' has a part that is not a number. A server parses this with "
+                "System.Version and drops the whole entry when it cannot." % text
+            )
+        numbers.append(int(part))
+    # System.Version treats an absent field as zero, so 0.1.0 and 0.1.0.0 are one version written
+    # two ways. Comparing the strings would let that pair into one manifest as two entries.
+    while len(numbers) < 4:
+        numbers.append(0)
+    return tuple(numbers)
+
+
+base = {}
+existing = []
+base_path = os.environ.get("MANIFEST_BASE") or ""
+if base_path:
+    with open(base_path, "r", encoding="utf-8") as handle:
+        try:
+            document = json.load(handle)
+        except json.JSONDecodeError as problem:
+            refuse(
+                "%s is not readable JSON (%s). A manifest that cannot be read is one every "
+                "already published version disappears from." % (base_path, problem)
+            )
+    if not isinstance(document, list) or len(document) != 1:
+        refuse(
+            "%s is not a list of exactly one plugin, and this repository publishes exactly one. A "
+            "manifest of another shape is not one this script may rewrite." % base_path
+        )
+    base = document[0]
+    existing = list(base.get("versions") or [])
+
+entries = []
+for archive in archives:
+    with open(archive + ".meta.json", "r", encoding="utf-8") as handle:
+        try:
+            metadata = json.load(handle)
+        except json.JSONDecodeError as problem:
+            refuse("%s.meta.json is not readable JSON (%s)." % (archive, problem))
+
+    for field in IDENTITY + PER_VERSION:
+        if not metadata.get(field):
+            refuse(
+                "%s.meta.json declares no '%s'. The manifest entry is copied from that file, and a "
+                "server reads that field." % (archive, field)
+            )
+
+    identity = {field: metadata[field] for field in IDENTITY}
+    if not base:
+        base = dict(identity)
+    for field in IDENTITY:
+        if base.get(field) != identity[field]:
+            refuse(
+                "%s.meta.json declares %s '%s' and the manifest already carries '%s'. A catalogue "
+                "holds one entry per plugin, so a divergence here is an entry whose text changes "
+                "with whichever package was published last."
+                % (archive, field, identity[field], base.get(field))
+            )
+
+    with open(archive, "rb") as handle:
+        checksum = hashlib.md5(handle.read()).hexdigest()
+
+    entry = {
+        "version": metadata["version"],
+        "targetAbi": metadata["targetAbi"],
+        "sourceUrl": os.environ["SOURCE_URL_PREFIX"] + os.path.basename(archive),
+        # The server hashes the download with MD5 and compares it case-insensitively against this,
+        # in InstallationManager.InstallPackageInternal. It is the one field here that describes the
+        # bytes rather than the package, which is why it is computed and never copied.
+        "checksum": checksum,
+    }
+    for field in ("changelog", "timestamp"):
+        if metadata.get(field):
+            entry[field] = metadata[field]
+    entries.append(entry)
+
+versions = existing + entries
+if not versions:
+    refuse("no version entry was produced, so the manifest would list a plugin nobody can install.")
+
+# Newest first, which is the order a catalogue is read in and is what makes the output reproducible.
+versions.sort(key=lambda item: version_key(item["version"]), reverse=True)
+
+seen = {}
+for entry in versions:
+    key = version_key(entry["version"])
+    if key in seen:
+        refuse(
+            "version %s is carried by two entries, targetAbi %s and targetAbi %s. A server keeps "
+            "every entry whose targetAbi is at or below its own version and then takes the highest "
+            "version number of what is left, so two entries at one version are one entry to it and "
+            "which package it installs is decided by nothing."
+            % (entry["version"], seen[key], entry["targetAbi"])
+        )
+    seen[key] = entry["targetAbi"]
+
+# Sorted by version descending above, so comparing neighbours is enough: an entry newer than the one
+# after it must also claim a server line at least as new.
+for newer, older in zip(versions, versions[1:]):
+    if version_key(newer["targetAbi"]) < version_key(older["targetAbi"]):
+        refuse(
+            "version %s claims targetAbi %s and version %s claims targetAbi %s, so the newer "
+            "version is the one for the older server line. A server on the newer line accepts both "
+            "entries and takes the highest version number, which is the package built for the "
+            "server it is not."
+            % (newer["version"], newer["targetAbi"], older["version"], older["targetAbi"])
+        )
+
+base["versions"] = versions
+
+with open(output, "w", encoding="utf-8", newline="\n") as handle:
+    json.dump([base], handle, indent=2, sort_keys=True)
+    handle.write("\n")
+
+print(
+    "build-manifest: wrote %s listing %d version(s) of %s."
+    % (output, len(versions), base["name"])
+)
+PY

--- a/scripts/prove-manifest-refusals.sh
+++ b/scripts/prove-manifest-refusals.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# Every refusal the manifest generator claims, watched refusing once, over a manifest written to
+# carry the defect it names.
+#
+# `scripts/build-manifest.sh` writes the document a Jellyfin server fetches to find out that a
+# version of this plugin exists. Nothing downstream of it checks that document, so a generator that
+# has never said no is a claim: it writes a manifest for a clean pair of packages, which is also
+# what a generator with no rules in it does.
+#
+# The two rules worth the harness are the ordering rules, because they are the ones a reader has to
+# take on trust. A server keeps every entry whose targetAbi is at or below its own version and then
+# picks the highest version number of what is left, so a pair of packages the manifest cannot
+# separate installs the wrong build on a real server and reports success. Neither shape is visible
+# in the JSON, and both are one edit away from the correct manifest beside them.
+#
+# The fixtures are written here rather than committed. An entry is described by its `.meta.json`
+# and the archive is read only to be hashed, so a fixture archive is a few bytes of text and its
+# contents mean nothing: what is being proved is the rule over the metadata, and a real zip would
+# add a binary to the tree that proves nothing extra.
+#
+# It needs no container, no server and no network, so it runs in seconds.
+#
+# usage: scripts/prove-manifest-refusals.sh
+
+set -euo pipefail
+
+here=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+generator="$here/build-manifest.sh"
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+prefix="https://github.com/Flowfin/jellyfin-plugin-requests/releases/download/0.1.0.0-stable/"
+
+# One package: a file to hash and the metadata the packaging tool writes beside it.
+# usage: package <name> <version> <targetAbi> [<guid>]
+package() {
+    local name=$1 version=$2 abi=$3 guid=${4:-0f9c9107-b31b-459e-81fa-6d35dac25e79}
+    printf 'not a real archive, and nothing here reads it as one\n' > "$work/$name"
+    cat > "$work/$name.meta.json" <<META
+{
+    "category": "General",
+    "changelog": "changelog\n",
+    "description": "A user who cannot find something asks for it from inside Jellyfin.",
+    "guid": "$guid",
+    "imageUrl": "https://raw.githubusercontent.com/Flowfin/jellyfin-plugin-requests/master/img/logo.png",
+    "name": "Requests",
+    "overview": "A user asks the server for a film or a series.",
+    "owner": "Flowfin",
+    "targetAbi": "$abi",
+    "timestamp": "2026-08-08T09:39:09Z",
+    "version": "$version"
+}
+META
+}
+
+failures=0
+
+# usage: refuses <heading> <sentence the refusal must carry> -- <command...>
+refuses() {
+    local heading=$1 sentence=$2
+    shift 3
+    printf '\n== %s\n' "$heading"
+    local out status
+    set +e
+    out=$("$@" 2>&1)
+    status=$?
+    set -e
+    printf '%s\n' "$out" | sed 's/^/  /'
+    if [ "$status" -eq 0 ]; then
+        echo "  ACCEPTED it, so the rule does not bite."
+        failures=$((failures + 1))
+        return
+    fi
+    case "$out" in
+        *"$sentence"*) ;;
+        *)
+            echo "  refused, but for something other than: $sentence"
+            failures=$((failures + 1))
+            ;;
+    esac
+}
+
+printf '\n== a pair of packages the server can tell apart passes\n'
+package requests_0.1.0.0.zip 0.1.0.0 10.11.0.0
+package requests_0.2.0.0.zip 0.2.0.0 12.0.0.0
+if out=$(cd "$work" && SOURCE_URL_PREFIX="$prefix" "$generator" clean.json \
+    requests_0.1.0.0.zip requests_0.2.0.0.zip 2>&1); then
+    printf '%s\n' "$out" | sed 's/^/  /'
+    # The newer version has to be the one for the newer line, otherwise the pair only passed
+    # because the rule was not reached.
+    if [ "$(jq -r '.[0].versions[0].targetAbi' "$work/clean.json")" != "12.0.0.0" ]; then
+        echo "  the newest entry is not the 12.0 one, so this fixture is not the clean case."
+        failures=$((failures + 1))
+    fi
+else
+    printf '%s\n' "$out" | sed 's/^/  /'
+    echo "  REFUSED the clean pair, which is a generator that refuses everything."
+    failures=$((failures + 1))
+fi
+
+printf '\n== a release adds its versions to what is already published\n'
+package requests_0.3.0.0.zip 0.3.0.0 12.0.0.0
+if out=$(cd "$work" && MANIFEST_BASE=clean.json SOURCE_URL_PREFIX="$prefix" "$generator" \
+    merged.json requests_0.3.0.0.zip 2>&1); then
+    printf '%s\n' "$out" | sed 's/^/  /'
+    if [ "$(jq '.[0].versions | length' "$work/merged.json")" != "3" ]; then
+        echo "  the already published versions did not survive the merge."
+        failures=$((failures + 1))
+    fi
+else
+    printf '%s\n' "$out" | sed 's/^/  /'
+    echo "  REFUSED a release added to a published manifest."
+    failures=$((failures + 1))
+fi
+
+# The state this repository is in today: both packaging files carry one version number, so the two
+# packages are one entry to every server that accepts both.
+package requests_a.zip 0.1.0.0 10.11.0.0
+package requests_b.zip 0.1.0.0 12.0.0.0
+refuses "two packages at one version number" \
+    "is carried by two entries" -- \
+    env -C "$work" SOURCE_URL_PREFIX="$prefix" "$generator" out.json requests_a.zip requests_b.zip
+
+# The near miss: System.Version reads an absent fourth field as zero, so these two strings are one
+# version. Comparing the strings would let the pair through.
+package requests_c.zip 0.2.0 10.11.0.0
+package requests_d.zip 0.2.0.0 12.0.0.0
+refuses "one version number written with a different number of parts" \
+    "is carried by two entries" -- \
+    env -C "$work" SOURCE_URL_PREFIX="$prefix" "$generator" out.json requests_c.zip requests_d.zip
+
+# The other direction, and the expensive one: each entry is fine on its own and the pair sends the
+# newer server the older line's build.
+package requests_e.zip 0.3.0.0 10.11.0.0
+package requests_f.zip 0.2.0.0 12.0.0.0
+refuses "the newer version claims the older server line" \
+    "is the one for the older server line" -- \
+    env -C "$work" SOURCE_URL_PREFIX="$prefix" "$generator" out.json requests_e.zip requests_f.zip
+
+package requests_g.zip 0.4.0.0 12.0.0.0 11111111-2222-3333-4444-555555555555
+refuses "the two packages claim different plugins" \
+    "holds one entry per plugin" -- \
+    env -C "$work" SOURCE_URL_PREFIX="$prefix" "$generator" out.json requests_a.zip requests_g.zip
+
+package requests_h.zip 0.5.0.0 12.0.0.0
+python3 - "$work/requests_h.zip.meta.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as handle:
+    document = json.load(handle)
+del document["targetAbi"]
+with open(path, "w", encoding="utf-8", newline="\n") as handle:
+    json.dump(document, handle, indent=4, sort_keys=True)
+PY
+refuses "a package whose metadata names no server line" \
+    "declares no 'targetAbi'" -- \
+    env -C "$work" SOURCE_URL_PREFIX="$prefix" "$generator" out.json requests_h.zip
+
+package requests_i.zip 0.6.0.rc1 12.0.0.0
+refuses "a version a server cannot parse" \
+    "has a part that is not a number" -- \
+    env -C "$work" SOURCE_URL_PREFIX="$prefix" "$generator" out.json requests_i.zip
+
+package requests_j.zip 0.7.0.0 12.0.0.0
+rm -f "$work/requests_j.zip.meta.json"
+refuses "an archive with no metadata beside it" \
+    "meta.json does not exist" -- \
+    env -C "$work" SOURCE_URL_PREFIX="$prefix" "$generator" out.json requests_j.zip
+
+refuses "an archive that was never built" \
+    "does not exist" -- \
+    env -C "$work" SOURCE_URL_PREFIX="$prefix" "$generator" out.json requests_never_built.zip
+
+refuses "a download URL that would name a sibling of the directory" \
+    "does not end in a slash" -- \
+    env -C "$work" SOURCE_URL_PREFIX="https://example.invalid/download" "$generator" \
+        out.json requests_a.zip
+
+refuses "a published manifest read back as missing" \
+    "which does not exist" -- \
+    env -C "$work" MANIFEST_BASE=nothing-here.json SOURCE_URL_PREFIX="$prefix" "$generator" \
+        out.json requests_a.zip
+
+refuses "a manifest written from no packages at all" \
+    "no package was named" -- \
+    env -C "$work" SOURCE_URL_PREFIX="$prefix" "$generator" out.json
+
+printf '\n'
+if [ "$failures" -ne 0 ]; then
+    echo "$failures rule(s) did not bite."
+    exit 1
+fi
+echo "Every rule bit, for the reason it names."


### PR DESCRIPTION
## What this is

A Jellyfin server does not install from a GitHub release. It fetches a manifest, keeps every entry whose `targetAbi` is at or below its own version, takes the highest version number of what is left, downloads that entry's `sourceUrl` and checks the download against that entry's `checksum`. This repository publishes releases and no manifest, so the release route ends one document short of anything an operator can install from.

`scripts/build-manifest.sh` writes that document from built packages. Every field except the checksum is copied out of the `<archive>.zip.meta.json` the packaging tool writes beside each archive, so an entry describes the package that shipped rather than a file read back out of the tree. The checksum is the MD5 of the archive's own bytes, which is the value the server compares.

Scope: `.github/workflows/`, the manifest.

## The rule it exists for

The version number is the only thing separating two entries a server has already accepted. Both steps are the server's own, read at `release-10.11.z`:

```
gh api "repos/jellyfin/jellyfin/contents/Emby.Server.Implementations/Updates/InstallationManager.cs?ref=release-10.11.z" \
  -H "Accept: application/vnd.github.raw" \
  | grep -nE 'Version.Parse\(x.TargetAbi\) <= appVer|OrderByDescending\(x => x.VersionNumber\)'
266:                .Where(x => string.IsNullOrEmpty(x.TargetAbi) || Version.Parse(x.TargetAbi) <= appVer);
277:            foreach (var v in availableVersions.OrderByDescending(x => x.VersionNumber))
```

So two entries at one version are one entry to a server, and an entry with a higher version and a lower `targetAbi` is what a newer server takes in preference to the build meant for it. Neither shape is visible in the JSON, and both are refused rather than written.

## The proof that each rule bites

`scripts/prove-manifest-refusals.sh` drives one manifest per defect, asserts each is refused **for its own reason** rather than merely refused, and keeps two passing cases beside them: a clean pair of packages, and a release added to a manifest that already carries versions. It needs no container, no server and no network.

```
$ ./scripts/prove-manifest-refusals.sh

== a pair of packages the server can tell apart passes
  build-manifest: wrote clean.json listing 2 version(s) of Requests.

== a release adds its versions to what is already published
  build-manifest: wrote merged.json listing 3 version(s) of Requests.

== two packages at one version number
  build-manifest: version 0.1.0.0 is carried by two entries, targetAbi 10.11.0.0 and targetAbi 12.0.0.0. ...

== one version number written with a different number of parts
  build-manifest: version 0.2.0.0 is carried by two entries, targetAbi 10.11.0.0 and targetAbi 12.0.0.0. ...

== the newer version claims the older server line
  build-manifest: version 0.3.0.0 claims targetAbi 10.11.0.0 and version 0.2.0.0 claims targetAbi 12.0.0.0, so the newer version is the one for the older server line. ...

== the two packages claim different plugins
== a package whose metadata names no server line
== a version a server cannot parse
== an archive with no metadata beside it
== an archive that was never built
== a download URL that would name a sibling of the directory
== a published manifest read back as missing
== a manifest written from no packages at all

Every rule bit, for the reason it names.
```

**Both ordering arms were deleted one at a time and the harness watched go red.** With the inversion arm removed:

```
== the newer version claims the older server line
  build-manifest: wrote out.json listing 2 version(s) of Requests.
  ACCEPTED it, so the rule does not bite.

1 rule(s) did not bite.
exit=1
```

With the duplicate-version arm removed, the two duplicate cases are still refused, by the inversion arm, and the harness reds anyway because the reason is wrong:

```
== two packages at one version number
  build-manifest: version 0.1.0.0 claims targetAbi 10.11.0.0 and version 0.1.0.0 claims targetAbi 12.0.0.0, so the newer version is the one for the older server line. ...
  refused, but for something other than: is carried by two entries

2 rule(s) did not bite.
exit=1
```

The near miss is a case of its own. `System.Version` reads an absent fourth field as zero, so `0.2.0` and `0.2.0.0` are one version written twice, and comparing the strings would let that pair into one manifest as two entries.

## Run against the release that exists

```
$ gh release download 0.1.0.0-stable --repo Flowfin/jellyfin-plugin-requests
$ SOURCE_URL_PREFIX=https://github.com/Flowfin/jellyfin-plugin-requests/releases/download/0.1.0.0-stable/ \
    scripts/build-manifest.sh manifest.json requests_0.1.0.0.zip
build-manifest: wrote manifest.json listing 1 version(s) of Requests.

$ jq -r '.[0].versions[0].checksum' manifest.json
1167d5e454c800bc024d98a6899cdb4c
$ cut -d' ' -f1 requests_0.1.0.0.md5
1167d5e454c800bc024d98a6899cdb4c
```

The checksum it computes equals the `.md5` that release publishes. Running it a second time and comparing with `diff` produces no difference, which is what the absence of a timestamp and a serial number buys.

## The means

Shell around a `python3` heredoc, which is the shape `scripts/bill-of-materials.sh` already has beside it, for the reason that file gives: the fields being copied are prose an operator wrote, and escaping them is the part a shell gets wrong quietly. It adds no language and no runtime this repository did not already carry, and the artefact it produces is checkable by anybody who downloads a release, which is what the release-route neighbours are held to.

## The suite and the gate

```
$ dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
Bestanden!   : Fehler: 0, erfolgreich: 715, übersprungen: 0, gesamt: 715 (net10.0)
Bestanden!   : Fehler: 0, erfolgreich: 715, übersprungen: 0, gesamt: 715 (net9.0)
```

`EveryWorkflowInTheTreeHasARowInTheParityDocument` is why `docs/quality-parity.md` moves here: a workflow with no row reds it. The count in the paragraph above that table is a hand count and it moved with the file, re-run rather than adjusted:

```
$ ls .github/workflows/ | wc -l
21
```

## What this does not do, and it is the larger half

- **The release route still publishes one package.** `publish.yaml` builds the one line `build.yaml` names and does not call this generator. The manifest is not written by any run yet.
- **Both packaging files declare one version number**, so the two packages of this repository are exactly the pair this generator refuses. That is the version scheme half of #110, and it is not taken here.
- **Where the manifest is served from is not decided in this change** and nothing here publishes it anywhere.
- **Nothing was fetched by a server.** No manifest this wrote has been added to a Jellyfin server, and no install has been attempted from one, so #110's first and third conditions are untouched by this.

## Size

538 lines, above the inherited 400-line cap, and it is one thing rather than two: the generator and the harness that watches every one of its rules refuse are a guard and its proof, and a guard shipped without the proof is the shape this repository refuses. The property a reader checks across every changed byte is that no rule is asserted without a fixture that carries its defect.

## Reading

**This had no second reader.** Everything above was run on this machine at the head of this branch, and the transcripts are the evidence in place of one.
