### PR TITLE
Refuse the seam probe answer the chosen shape rests on, not only its silence

### DIFF
--- a/.github/workflows/seam-probe.yaml
+++ b/.github/workflows/seam-probe.yaml
@@ -8,22 +8,50 @@
 # `scripts/verify-seam-probe.sh` is what this runs and `tools/seam-probe` is the second plugin. Both
 # say more about the question than a workflow file usefully can.
 #
-# THIS RECORDS AN ANSWER RATHER THAN HOLDING A MERGE, which is why it is not on every pull request.
-# A shared load context and a separate one are both results, and each decides which of the three
-# options #117 lists is available. What reds is a run that produced no answer at all.
+# IT RECORDED AN ANSWER AND IT NOW REFUSES ONE. While #117 listed three options for where the shared
+# type comes from, a shared load context and a separate one were both results and each decided which
+# of the three was available, so the only thing that redded this was a run that produced no answer at
+# all. #117 chose one of them on 2026-08-21 and `docs/seam.md` says the choice rests on the answer
+# both lines gave, so the opposite answer is now a defect rather than a result.
+# `scripts/read-seam-probe-answer.sh` carries the reasons and `scripts/prove-seam-probe-refusals.sh`
+# is where each of them is watched biting. It is still not a required check: the required set is a
+# repository setting rather than a file in this tree, and #107 carries the criterion.
 name: What a second plugin can see
 
 on:
   workflow_dispatch:
-  push:
-    # The files the measurement is made of. A change to any of them makes the recorded answer a
-    # claim about a procedure that has moved, so the answer is taken again.
+  pull_request:
     paths:
       - 'tools/seam-probe/**'
+      - 'scripts/read-seam-probe-answer.sh'
+      - 'scripts/prove-seam-probe-refusals.sh'
       - 'scripts/verify-seam-probe.sh'
       - 'scripts/server-under-test.sh'
       - 'scripts/server-image-for.sh'
       - 'scripts/server-lines.tsv'
+      - 'Jellyfin.Plugin.Requests/Seam/**'
+      - 'Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs'
+      - '.github/workflows/seam-probe.yaml'
+  push:
+    # The files the measurement is made of. A change to any of them makes the recorded answer a
+    # claim about a procedure that has moved, so the answer is taken again.
+    #
+    # THE LAST TWO ARE WHAT THE PROBE IS ABOUT RATHER THAN WHAT IT IS MADE OF, and they are here
+    # because the failure this job now refuses arrives through them. The probe names the contract
+    # type by string, so moving that type into the contract package leaves the two constants in
+    # `tools/seam-probe/ContainerReport.cs` naming nothing, and a trigger listing only the probe's
+    # own files would not start the job on the change that broke it. What is still not covered is a
+    # rename of the assembly itself, which lives in the project file rather than under `Seam/`.
+    paths:
+      - 'tools/seam-probe/**'
+      - 'scripts/read-seam-probe-answer.sh'
+      - 'scripts/prove-seam-probe-refusals.sh'
+      - 'scripts/verify-seam-probe.sh'
+      - 'scripts/server-under-test.sh'
+      - 'scripts/server-image-for.sh'
+      - 'scripts/server-lines.tsv'
+      - 'Jellyfin.Plugin.Requests/Seam/**'
+      - 'Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs'
       - '.github/workflows/seam-probe.yaml'
 
 # Explicit deny-all at workflow level; the job grants what it needs.
@@ -38,6 +66,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  prove:
+    # The reader that decides a probe run, handed every answer it refuses, one log at a time. It
+    # starts no container and needs no server, so it answers in seconds and it answers on a machine
+    # that has neither. A reader nobody has watched saying no is a reader that might say yes to
+    # everything, and this job is the whole of what stands behind the refusals below.
+    name: the seam probe reader refuses what it says it refuses
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Every answer the reader refuses, refused for its own reason
+        run: |
+          set -euo pipefail
+          ./scripts/prove-seam-probe-refusals.sh
+
   probe:
     name: probe ${{ matrix.line }}
     runs-on: ubuntu-latest

--- a/docs/seam.md
+++ b/docs/seam.md
@@ -151,6 +151,38 @@ binds a compile-time reference to that same loaded assembly is a further step an
 here. And nothing above installs two copies of one contract assembly, so the premise the first
 rejected option rests on is still unmeasured, which is what that option's own paragraph says.
 
+### That answer is refused rather than reported, since 2026-08-26
+
+The run that took the measurement above refused one thing only: a probe that wrote nothing. Both
+answers were results while the three options were open, because each of them decided which options
+were available. They are not both results any more. The choice above rests on the answer the two
+lines gave, so a run that comes back with the other one is a defect and a run that prints it and
+passes tells nobody.
+
+`scripts/read-seam-probe-answer.sh` reads the one line the probe writes as a verdict and refuses four
+answers, each for its own reason: no assembly of that name loaded, more than one of them, a contract
+type a second plugin cannot reach, and a container that handed back nothing. The last of those is the
+silence #117's fourth condition is about, and it is refused here rather than printed.
+
+What made this worth doing before the package exists is that moving the type is what breaks it. The
+probe names the contract by string:
+
+    git grep -n 'OtherAssembly = \|Contract = ' -- tools/seam-probe/ContainerReport.cs
+    tools/seam-probe/ContainerReport.cs:38:    private const string OtherAssembly = "Jellyfin.Plugin.Requests";
+    tools/seam-probe/ContainerReport.cs:39:    private const string Contract = "Jellyfin.Plugin.Requests.Seam.IWantHandover";
+
+so the day the contract moves into the package neither string names anything that declares it, and
+under the old rule the job stayed green about an assembly that no longer held the type. It now reds
+and names the two constants. The trigger carries the same reasoning: `Jellyfin.Plugin.Requests/Seam/`
+and the service registrator are in the paths that start the job, because the change that breaks the
+measurement arrives through them rather than through the probe's own files. A rename of the assembly
+lives in the project file and is still not covered.
+
+Every refusal above is watched biting in `scripts/prove-seam-probe-refusals.sh`, over one log per
+answer, with the answer both lines gave beside them as the case that has to pass. It needs no
+container and no server, so the reader that decides a probe run is checked on machines that cannot
+run one.
+
 ### What the tree does today is not yet the choice above
 
 The type the sibling would name is declared in this plugin's own assembly, and this project

--- a/scripts/prove-seam-probe-refusals.sh
+++ b/scripts/prove-seam-probe-refusals.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Every refusal the seam-probe reader claims, watched refusing once, over a log written to carry the
+# answer it names.
+#
+# `scripts/read-seam-probe-answer.sh` is what decides whether a probe run passes. It runs on a server
+# in a container, on two claimed lines, and neither of those can be produced on every machine that
+# has to trust it; a reader nobody has watched saying no is a reader that might say yes to
+# everything. It reads a file, so every one of its answers can be handed to it directly.
+#
+# THE ONE THIS EXISTS FOR IS THE LOG WITH NO RESULT LINE IN IT. Until this reader landed, a run
+# passed if the probe wrote any line at all, so a probe reporting that the contract type was NOT
+# reachable was a green job. That is the shape #117 names on 2026-08-25 as the failure to build
+# against: the day the contract type moves into the package it stops being declared by the assembly
+# the probe names, and a run that only refuses silence goes on passing about nothing.
+#
+# The near-miss beside it is `head` where the reader has `tail`. A server that restarts its hosted
+# services writes the result line twice, and a reader taking the first one reports the answer of a
+# process that is no longer running.
+#
+# The fixtures are written here rather than committed. What is being proved is the reading of one
+# line, so a captured server log would add several hundred lines that mean nothing to it.
+#
+# It needs no container, no server and no network, so it runs in seconds.
+#
+# usage: scripts/prove-seam-probe-refusals.sh
+
+set -euo pipefail
+
+here=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+reader="$here/read-seam-probe-answer.sh"
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# A log of the shape the server writes: the probe's prose lines, and the verdict last.
+# usage: log <file> <result-line-or-empty>
+log() {
+    local file=$1 result=$2
+    {
+        printf '[2026-08-26 21:00:00.000 +00:00] [INF] [1] Main: Jellyfin version: 10.11.11\n'
+        printf '[2026-08-26 21:00:01.000 +00:00] [WRN] [9] Jellyfin.Plugin.SeamProbe.ContainerReport: SEAM-PROBE assemblies loaded under the name Jellyfin.Plugin.Requests: 1\n'
+        printf '[2026-08-26 21:00:01.000 +00:00] [WRN] [9] Jellyfin.Plugin.SeamProbe.ContainerReport: SEAM-PROBE one of them is at /config/plugins/Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.dll\n'
+        if [ -n "$result" ]; then
+            printf '[2026-08-26 21:00:01.000 +00:00] [WRN] [9] Jellyfin.Plugin.SeamProbe.ContainerReport: %s\n' "$result"
+        fi
+        printf '[2026-08-26 21:00:02.000 +00:00] [INF] [1] Main: Startup complete\n'
+    } > "$work/$file"
+}
+
+failures=0
+
+# usage: refuses <heading> <sentence the refusal must carry> -- <command...>
+refuses() {
+    local heading=$1 sentence=$2
+    shift 3
+    printf '\n== %s\n' "$heading"
+    local out status
+    set +e
+    out=$("$@" 2>&1)
+    status=$?
+    set -e
+    printf '%s\n' "$out" | sed 's/^/  /'
+    if [ "$status" -eq 0 ]; then
+        echo "  ACCEPTED it, so the rule does not bite."
+        failures=$((failures + 1))
+        return
+    fi
+    case "$out" in
+        *"$sentence"*) ;;
+        *)
+            echo "  refused, but for something other than: $sentence"
+            failures=$((failures + 1))
+            ;;
+    esac
+}
+
+printf '\n== the answer both claimed lines gave on 2026-08-22 passes\n'
+log clean.log 'SEAM-PROBE result assemblies=1 contract=reachable implementations=1'
+if out=$("$reader" "$work/clean.log" 2>&1); then
+    printf '%s\n' "$out" | sed 's/^/  /'
+else
+    printf '%s\n' "$out" | sed 's/^/  /'
+    echo "  REFUSED the answer the tree was built on, which is a reader that refuses everything."
+    failures=$((failures + 1))
+fi
+
+# The trap this reader exists for. The probe ran, said the type was not reachable, and every line it
+# wrote carries the marker the old run grepped for, so this log used to be a green job.
+log missing.log 'SEAM-PROBE result assemblies=1 contract=missing implementations=0'
+refuses "the contract type is not reachable, which used to pass" \
+    "the contract type is not reachable from a second plugin" \
+    -- "$reader" "$work/missing.log"
+
+log two.log 'SEAM-PROBE result assemblies=2 contract=reachable implementations=1'
+refuses "two assemblies of one name in one process" \
+    "Two copies of one contract assembly in one process is the failure this seam exists to avoid" \
+    -- "$reader" "$work/two.log"
+
+log none.log 'SEAM-PROBE result assemblies=0 contract=missing implementations=0'
+refuses "the plugin under test was not loaded at all" \
+    "no assembly named Jellyfin.Plugin.Requests was loaded" \
+    -- "$reader" "$work/none.log"
+
+log unanswered.log 'SEAM-PROBE result assemblies=1 contract=reachable implementations=0'
+refuses "the container handed back nothing, which is the silence an operator meets" \
+    "the container returned no implementation of the contract" \
+    -- "$reader" "$work/unanswered.log"
+
+# The probe threw before it reached an answer. It writes a line, and that line carries the marker, so
+# only a reader looking for the verdict rather than for the marker refuses this.
+log threw.log ''
+printf '[2026-08-26 21:00:01.000 +00:00] [WRN] [9] Jellyfin.Plugin.SeamProbe.ContainerReport: SEAM-PROBE the probe itself failed: System.TypeLoadException: no\n' >> "$work/threw.log"
+refuses "the probe failed before it had an answer" \
+    "the probe wrote no result line, so this run measured nothing" \
+    -- "$reader" "$work/threw.log"
+
+log shape.log 'SEAM-PROBE result contract=reachable assemblies=1 implementations=1'
+refuses "a result line whose fields this reader does not know" \
+    "does not have the shape this reader knows" \
+    -- "$reader" "$work/shape.log"
+
+# The near-miss: `head` where the reader has `tail`. The server restarted its hosted services, the
+# first answer was the good one and the process that is actually running gave the second.
+log restarted.log 'SEAM-PROBE result assemblies=1 contract=reachable implementations=1'
+printf '[2026-08-26 21:00:30.000 +00:00] [WRN] [9] Jellyfin.Plugin.SeamProbe.ContainerReport: SEAM-PROBE result assemblies=2 contract=reachable implementations=1\n' >> "$work/restarted.log"
+refuses "a restart whose second answer is the bad one" \
+    "Two copies of one contract assembly in one process is the failure this seam exists to avoid" \
+    -- "$reader" "$work/restarted.log"
+
+refuses "a log that was never written" \
+    "does not exist" \
+    -- "$reader" "$work/no-such.log"
+
+printf '\n'
+if [ "$failures" -ne 0 ]; then
+    echo "$failures of the rules above did not bite." >&2
+    exit 1
+fi
+echo "Every refusal the reader claims was watched refusing, and the answer both lines gave passes."

--- a/scripts/read-seam-probe-answer.sh
+++ b/scripts/read-seam-probe-answer.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Read the answer a seam probe run produced, and refuse the answers the tree cannot be built on.
+#
+# WHY THIS REFUSES NOW AND DID NOT BEFORE. When the probe was written, both answers were results:
+# #117 listed three options for where the shared contract type comes from, and a shared load context
+# and a separate one each decided which of the three was available. So the run refused silence and
+# nothing else. That is no longer the position. #117 chose one of the three on 2026-08-21 - a
+# contract-only package both sides compile against, with exactly one copy shipped - and `docs/seam.md`
+# carries the choice and says it rests on a plugin being able to name a type whose assembly ships in
+# another plugin's directory. Once a decision rests on an answer, the opposite answer is a defect
+# rather than a result, and a run that prints it and passes tells nobody.
+#
+# WHAT IT IS BUILT AGAINST is written on #117 on 2026-08-25: the contract type moves out of
+# `Jellyfin.Plugin.Requests` the day the package lands, the probe's two constants stop naming
+# anything that declares it, and a run that only refuses silence goes green on a measurement about an
+# assembly that no longer holds the type. Whoever moves the type meets a red job that names the
+# constants instead of discovering months later that the measurement had quietly stopped being about
+# anything.
+#
+# It reads a file and nothing else: no container, no server, no network. That is what lets
+# `scripts/prove-seam-probe-refusals.sh` watch every refusal here bite, one log at a time.
+#
+# usage: scripts/read-seam-probe-answer.sh <server-log>
+
+set -euo pipefail
+
+log=${1:?path to a file holding the server log written during a probe run}
+
+if [ ! -f "$log" ]; then
+    echo "read-seam-probe-answer: ${log} does not exist. The answer is read out of a run's log, never out of what a run was expected to say." >&2
+    exit 1
+fi
+
+# The last one, because a server that restarted its hosted services writes the line again and the
+# newest answer is the one about the process that ended up running.
+answer=$(grep -a "SEAM-PROBE result " "$log" | tail -1 || true)
+
+if [ -z "$answer" ]; then
+    echo "read-seam-probe-answer: the probe wrote no result line, so this run measured nothing. A probe that could not run is the one outcome nobody can read, and it is refused rather than reported." >&2
+    exit 1
+fi
+
+# Matched rather than word-split, so a line carrying the fields in some other order, or carrying a
+# field this reader does not know, is refused as unreadable instead of being read as a passing one.
+pattern='SEAM-PROBE result assemblies=([0-9]+) contract=(reachable|missing) implementations=([0-9]+)$'
+if [[ ! $answer =~ $pattern ]]; then
+    echo "read-seam-probe-answer: the result line does not have the shape this reader knows, so nothing about the run can be read from it: ${answer}" >&2
+    exit 1
+fi
+
+assemblies=${BASH_REMATCH[1]}
+contract=${BASH_REMATCH[2]}
+implementations=${BASH_REMATCH[3]}
+
+echo "the probe answered: assemblies=${assemblies} contract=${contract} implementations=${implementations}"
+
+if [ "$assemblies" -eq 0 ]; then
+    echo "read-seam-probe-answer: no assembly named Jellyfin.Plugin.Requests was loaded, so this is an answer about a server that does not have this plugin in it rather than about what a second plugin can see of it." >&2
+    exit 1
+fi
+
+if [ "$assemblies" -gt 1 ]; then
+    echo "read-seam-probe-answer: ${assemblies} assemblies named Jellyfin.Plugin.Requests were loaded. Two copies of one contract assembly in one process is the failure this seam exists to avoid: the type this plugin registers and the type a sibling names are then different types with the same name, the container returns nothing, and it looks exactly like the sibling not being installed." >&2
+    exit 1
+fi
+
+if [ "$contract" = "missing" ]; then
+    echo "read-seam-probe-answer: the contract type is not reachable from a second plugin. The shape chosen on #117 is one shipped copy of the contract that both sides name, so a type a second plugin cannot reach is that shape gone; if the type moved on purpose, the constants in tools/seam-probe/ContainerReport.cs are what name it and they move with it." >&2
+    exit 1
+fi
+
+if [ "$implementations" -eq 0 ]; then
+    echo "read-seam-probe-answer: the container returned no implementation of the contract to the second plugin. That is the silence #117's fourth condition is about - an operator cannot tell it from a sibling that was never installed - so it is refused here rather than printed." >&2
+    exit 1
+fi
+
+echo "One assembly, the contract reachable from a plugin that ships no copy of it, and ${implementations} implementation(s) handed back by the container. That is the shape docs/seam.md says the choice rests on."

--- a/scripts/verify-seam-probe.sh
+++ b/scripts/verify-seam-probe.sh
@@ -13,9 +13,14 @@
 # assembly reference would fail to resolve before anything could be reported on exactly the servers
 # where the answer is interesting, and a probe that cannot run is a probe that says nothing.
 #
-# THIS RECORDS AN ANSWER RATHER THAN REFUSING ONE. Both answers are results: a shared context and a
-# separate one each decide which of #117's three options is available. What it refuses is a run that
-# produced no answer at all, because that is the only outcome nobody can read.
+# THIS REFUSED ONLY SILENCE UNTIL 2026-08-26 AND NOW REFUSES THE ANSWER TOO. While #117 listed three
+# options for where the shared type comes from, a shared load context and a separate one were both
+# results, and each decided which of the three was available. #117 chose one of them on 2026-08-21 -
+# a contract-only package both sides compile against, with exactly one copy shipped - and
+# `docs/seam.md` says that choice rests on a plugin being able to name a type whose assembly ships in
+# another plugin's directory. Once a decision rests on an answer, the opposite answer is a defect and
+# not a result. `scripts/read-seam-probe-answer.sh` is what refuses it and carries the reasons one at
+# a time; `scripts/prove-seam-probe-refusals.sh` is where each of them is watched biting.
 #
 # usage: scripts/verify-seam-probe.sh <image> <target-framework> [host-port]
 #   scripts/verify-seam-probe.sh jellyfin/jellyfin:10.11.11 net9.0  18098
@@ -54,8 +59,11 @@ EXTRA_PLUGIN_DIRECTORY="$probe_out" EXTRA_PLUGIN_NAME="SeamProbe" \
 
 step "what the second plugin could see"
 dk logs "$CONTAINER" >"$probe_log" 2>&1 || true
-if ! grep -a "SEAM-PROBE" "$probe_log"; then
-    echo "The probe wrote nothing, so this run measured nothing." >&2
+grep -a "SEAM-PROBE" "$probe_log" || true
+
+# The prose above is for a person. The verdict is one line and is read by a script of its own, so the
+# same reading can be handed every answer it refuses without a server being started for each.
+if ! "$here/read-seam-probe-answer.sh" "$probe_log"; then
     echo "What the server said about loading plugins:" >&2
     grep -aiE "seamprobe|plugin" "$probe_log" | tail -40 >&2
     exit 1

--- a/tools/seam-probe/ContainerReport.cs
+++ b/tools/seam-probe/ContainerReport.cs
@@ -27,6 +27,14 @@ public sealed class ContainerReport : IHostedService
     /// </summary>
     public const string Marker = "SEAM-PROBE";
 
+    /// <summary>
+    /// The word that opens the one line a run reads as the answer. The lines around it are prose for
+    /// a person; this one is the verdict, in fields, so that reading it is not parsing sentences that
+    /// were written to be read rather than matched. `scripts/read-seam-probe-answer.sh` is what reads
+    /// it, and it refuses a log that carries no such line at all.
+    /// </summary>
+    public const string Result = "result";
+
     private const string OtherAssembly = "Jellyfin.Plugin.Requests";
     private const string Contract = "Jellyfin.Plugin.Requests.Seam.IWantHandover";
 
@@ -89,6 +97,7 @@ public sealed class ContainerReport : IHostedService
         if (contract is null)
         {
             Say("the type {0} is not reachable from this plugin", Contract);
+            Answer(loaded.Length, reachable: false, implementations: 0);
             return;
         }
 
@@ -96,6 +105,28 @@ public sealed class ContainerReport : IHostedService
 
         int returned = _services.GetServices(contract).Count();
         Say("the container returned {0} implementation(s) of it", returned);
+        Answer(loaded.Length, reachable: true, implementations: returned);
+    }
+
+    /// <summary>
+    /// The verdict, written once, in fields rather than in a sentence.
+    /// <para>
+    /// It is emitted on every path that reached an answer, including the one where the type was not
+    /// found, because "the type is missing" is an answer and only a probe that never ran is silence.
+    /// A run that produced no line of this shape is refused as having measured nothing.
+    /// </para>
+    /// </summary>
+    /// <param name="assemblies">How many assemblies of the named simple name were loaded.</param>
+    /// <param name="reachable">Whether the contract type resolved out of one of them.</param>
+    /// <param name="implementations">How many implementations the container returned for it.</param>
+    private void Answer(int assemblies, bool reachable, int implementations)
+    {
+        Say(
+            "{0} assemblies={1} contract={2} implementations={3}",
+            Result,
+            assemblies,
+            reachable ? "reachable" : "missing",
+            implementations);
     }
 
     private void Say(string format, params object[] values)


### PR DESCRIPTION
Closes nothing. Part of #117.

## What was wrong

The seam probe run refused one thing: a probe that wrote nothing. That was right while #117 listed three options for where the shared contract type comes from, because a shared load context and a separate one each decided which of the three was available. #117 chose one on 2026-08-21 — a contract-only package both sides compile against, with exactly one copy shipped — and `docs/seam.md` says the choice rests on the answer both claimed lines gave. Once a decision rests on an answer, the opposite answer is a defect rather than a result, and a run that prints it and passes tells nobody.

The concrete failure is the one written on #117 on 2026-08-25. The probe names the contract by string:

    git grep -n 'OtherAssembly = \|Contract = ' origin/master -- tools/seam-probe/ContainerReport.cs
    origin/master:tools/seam-probe/ContainerReport.cs:30:    private const string OtherAssembly = "Jellyfin.Plugin.Requests";
    origin/master:tools/seam-probe/ContainerReport.cs:31:    private const string Contract = "Jellyfin.Plugin.Requests.Seam.IWantHandover";

so the day that type moves into the contract package, neither string names anything that declares it, the probe reports the type as not reachable, and the old rule passed that log. It also would not have started the job at all: the trigger listed the probe's own files and not the types the probe is about.

## What changed

`ContainerReport` writes one verdict line in fields beside the prose it already wrote, on every path that reached an answer including the one where the type was missing, so silence is only a probe that never ran.

`scripts/read-seam-probe-answer.sh` reads that line and refuses four answers, each for its own reason: no assembly of that name loaded, more than one of them — the two-copies failure this seam exists against — a contract a second plugin cannot reach, and a container that handed back nothing, which is the silence #117's fourth condition is about. Two more refusals cover a log with no verdict in it and a verdict whose fields it does not know.

The trigger gains `Jellyfin.Plugin.Requests/Seam/**` and the service registrator, because the change that invalidates the measurement arrives through those. A rename of the assembly lives in the project file and is still not covered; the workflow says so at the trigger rather than leaving it to be discovered.

## The means

Bash, and it is not carried over from habit. The thing being read is a container's log, produced by a script that already exists in bash and is invoked from a workflow step; a second language here would add a runtime to a job whose whole purpose is to answer in seconds without one. It carries the three rules: every refusal is a named exit with its own sentence, each one is executed by a fixture below, and every claim in this body is a command.

## Every refusal watched biting

`scripts/prove-seam-probe-refusals.sh` hands the reader one log per answer and asserts each is refused for its own sentence, with the answer both lines gave on 2026-08-22 beside them as the case that has to pass. It starts no container and needs no server, so the reader that decides a probe run is checked on a machine that cannot run one.

    ./scripts/prove-seam-probe-refusals.sh

    == the answer both claimed lines gave on 2026-08-22 passes
      the probe answered: assemblies=1 contract=reachable implementations=1
      One assembly, the contract reachable from a plugin that ships no copy of it, and 1 implementation(s) handed back by the container. That is the shape docs/seam.md says the choice rests on.

    == the contract type is not reachable, which used to pass
      the probe answered: assemblies=1 contract=missing implementations=0
      read-seam-probe-answer: the contract type is not reachable from a second plugin. [...]

    == two assemblies of one name in one process
    == the plugin under test was not loaded at all
    == the container handed back nothing, which is the silence an operator meets
    == the probe failed before it had an answer
    == a result line whose fields this reader does not know
    == a restart whose second answer is the bad one
    == a log that was never written

    Every refusal the reader claims was watched refusing, and the answer both lines gave passes.

The near-miss is `head` where the reader has `tail`: a server that restarts its hosted services writes the verdict twice, and the process still running is the second one. The fixture puts the good answer first and the bad one last, so a reader taking the first line passes it.

**The proof itself was watched failing**, with the reader replaced by a script that exits zero, which is what a reader with no rules in it looks like:

    T=$(mktemp -d); cp scripts/read-seam-probe-answer.sh scripts/prove-seam-probe-refusals.sh "$T"/
    printf '#!/usr/bin/env bash\nexit 0\n' > "$T/read-seam-probe-answer.sh"
    bash "$T/prove-seam-probe-refusals.sh"; echo "EXIT=$?"
    ...
      ACCEPTED it, so the rule does not bite.
    8 of the rules above did not bite.
    EXIT=1

Eight, which is every refusal the reader claims.

## The rest of the tree

    dotnet build tools/seam-probe/SeamProbe.csproj -c Release --nologo -v quiet
    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror --nologo

The probe builds on both claimed target frameworks with no warnings, and the suite is unmoved. Quoted in the language the machine printed it in:

```
Der Buildvorgang wurde erfolgreich ausgeführt.
    0 Warnung(en)
    0 Fehler

Bestanden!   : Fehler:     0, erfolgreich:   715, übersprungen:     0, gesamt:   715, Dauer: 25 s - Jellyfin.Plugin.Requests.Tests.dll (net10.0)
Bestanden!   : Fehler:     0, erfolgreich:   715, übersprungen:     0, gesamt:   715, Dauer: 25 s - Jellyfin.Plugin.Requests.Tests.dll (net9.0)
```

## What this does not do

It does not close #117. What is left there is the contract package itself, and both remaining conditions are that package. This is the guard that stands between the decision and the day somebody builds it.

No probe run was made on this machine. The container engine is not answering here:

    docker version --format '{{.Server.Version}}'
    failed to connect to the docker API at npipe:////./pipe/dockerDesktopLinuxEngine; check if the path is correct and if the daemon is running: open //./pipe/dockerDesktopLinuxEngine: Das System kann die angegebene Datei nicht finden.

The last clause is the operating system saying the pipe is not there. What exercises the changed check against a real server of each line is this branch's own run of the workflow, which the push started because the trigger names these files.

This board had no second reader tonight and the commands above stand in place of one.
