### PR TITLE
Point at the open call rather than at a closed issue for the adapter

### DIFF
--- a/Jellyfin.Plugin.Requests/Bridge/BackendAccounts.cs
+++ b/Jellyfin.Plugin.Requests/Bridge/BackendAccounts.cs
@@ -23,10 +23,11 @@ namespace Jellyfin.Plugin.Requests.Bridge;
 /// sees something that is not theirs.
 /// </para>
 /// <para>
-/// Where the table is kept, and how an operator edits it, arrives with the adapter that reads it in
-/// #82. Nothing on this side reads it yet, so a settings field for it now would be somewhere to type
-/// something nothing uses. <c>docs/bridge.md</c> carries the decision, the two shapes it was chosen
-/// over, and what each of them costs.
+/// Where the table is kept, and how an operator edits it, arrives with the adapter that reads it.
+/// There is no adapter in this tree and no issue on this board asks for one, so nothing on this side
+/// reads the table yet and a settings field for it now would be somewhere to type something nothing
+/// uses. <c>docs/bridge.md</c> carries the decision, the two shapes it was chosen over, what each of
+/// them costs, and where the question of an adapter stands.
 /// </para>
 /// </summary>
 public sealed class BackendAccounts

--- a/Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs
@@ -30,8 +30,8 @@ namespace Jellyfin.Plugin.Requests.Configuration;
 /// <para>
 /// There is no bridge address and no credential. The only implementation of the bridge in this tree
 /// is the one for a server that has none, so a field for an address would be a place to type
-/// something nothing reads. #82 brings the adapter and #85 decides where a credential is kept and
-/// what may be claimed about it.
+/// something nothing reads. No issue on this board asks for the adapter that would need one, and
+/// #85 decides where a credential is kept and what may be claimed about it once there is one.
 /// </para>
 /// </summary>
 public class PluginConfiguration : BasePluginConfiguration

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -12,6 +12,13 @@ server without a service runs is
 over is below, and what happens when the service misbehaves is a separate question this page does not
 answer. Where a credential lives is answered at the end of it.
 
+**There is no adapter in this tree, and no issue on this board asks for one.** #82 closed as
+completed on 2026-08-23 having built the submission path behind the interface, and it did not produce
+a client that speaks to a service: the only implementation of the interface is still the one for a
+server without one. Whether such an adapter is written on this board at all is an open call, recorded
+on #113. So every sentence below that says something arrives with the adapter is waiting on that
+call, and not on an issue somebody can pick up.
+
 ## The mapping
 
 The table is data, in
@@ -140,9 +147,9 @@ under the service's own account, so the service is told that a request was made 
 Attribution is turned on one person at a time, by writing a row, and writing the row is what says
 that person's account name may leave.
 
-Where the table is kept and how it is edited arrives with the adapter that reads it, in #82. Nothing
-on this side reads it today, so a settings field for it now would be somewhere to type something
-nothing uses.
+Where the table is kept and how it is edited arrives with the adapter that reads it, and no issue on
+this board asks for that adapter. Nothing on this side reads the table today, so a settings field for
+it now would be somewhere to type something nothing uses.
 
 ### What leaves the server when a bridge is configured
 
@@ -248,8 +255,8 @@ a second implementation arriving in the plugin assembly unnamed for the same rea
 **There is no credential today and nothing here holds one.** The only implementation of the bridge in
 this tree is the one for a server that has no service, it makes no call, and the configuration
 carries no field for an address or for a secret. Everything below is what will be true the day the
-adapter in #82 adds one, written now so that it is a position rather than a description written
-afterwards to fit whatever was built.
+adapter adds one, written now so that it is a position rather than a description written afterwards
+to fit whatever was built.
 
 ### Where it goes
 
@@ -314,7 +321,7 @@ service the operator configured.
 **None of the four is enforced, because there is nothing yet to enforce them over.** The lint rule
 that would refuse a log or a diagnostics call reaching it, and the test that would assert it does not
 appear in a log written during a bridge failure, are the other two conditions of #85, and both
-quantify over a value that does not exist. They land with the adapter in #82 and not before.
+quantify over a value that does not exist. They land with the adapter and not before.
 
 ## Where the list of words came from
 
@@ -324,6 +331,6 @@ in this tree can read one.** No fixture here was captured from a service, no sch
 the suite makes no outbound call.
 
 So the list is this board's own statement of the vocabulary rather than a measurement of it, and the
-rule for an unseen word is what stands between that and a wrong answer. Whoever writes the adapter in
-#82 is the first person in a position to compare the two, and a word that arrives from a real service
-and is not here is a row this table is missing rather than a fault in the service.
+rule for an unseen word is what stands between that and a wrong answer. Whoever writes the adapter is
+the first person in a position to compare the two, and a word that arrives from a real service and is
+not here is a row this table is missing rather than a fault in the service.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,7 +165,7 @@ fulfilled.
 
 Nothing leaves the server. The outbound notification sink exists and has nowhere to send to, because
 `OutboundNoticeAddress` is empty until an operator types one; there is no credential to hold and no
-other path that could carry anything, since the bridge adapter is #82 and is not built. Two things do
+other path that could carry anything, since no adapter to a request service is built here. Two things do
 happen on a fresh install and neither is a path off the machine. Every transition is written to the
 server's own activity log, which is a record rather than a message. And the person who asked is told
 on whatever they are signed in on when their own request is answered, down the connection the server
@@ -207,9 +207,9 @@ this page overrides it**, and none ever will. [`notifications.md`](notifications
 lives, what the two endpoints are, and why neither of them takes an identifier.
 
 **A bridge address and a credential.** The only bridge in this tree is the one for a server that has
-none. A field for an address would be somewhere to type something nothing reads. #82 brings the
-adapter; where a credential is kept when there is one, who on the machine can read it, and what is
-refused by name are in [`bridge.md`](bridge.md).
+none. A field for an address would be somewhere to type something nothing reads. No issue
+on this board asks for the adapter that would read one; where a credential is kept when there is one,
+who on the machine can read it, and what is refused by name are in [`bridge.md`](bridge.md).
 
 ## What an uninstall leaves behind
 


### PR DESCRIPTION
Closes #296.

Eight sentences in four files said that the adapter which talks to a real request service arrives in #82. #82 closed as completed on 2026-08-23 having built the submission path behind the interface, and it produced no such adapter, so each of those sentences told a reader that the missing thing already had a home.

    gh issue view 82 --repo Flowfin/jellyfin-plugin-requests --json state,stateReason,closedAt --jq '"\(.state)/\(.stateReason) \(.closedAt)"'
    CLOSED/COMPLETED 2026-08-23T18:22:36Z

    git grep -n ': IRequestBackend' origin/master -- Jellyfin.Plugin.Requests/
    origin/master:Jellyfin.Plugin.Requests/Bridge/NoRequestBackend.cs:23:public sealed class NoRequestBackend : IRequestBackend

    gh issue list --repo Flowfin/jellyfin-plugin-requests --state all --limit 200 --search 'adapter in:title' --json number,title --jq '.[] | "\(.number)\t\(.title)"'

The last one prints nothing: no issue on this board asks for an adapter, in any state. Whether one is written here at all is an open call, recorded on #113 on 2026-08-25.

## What changed

Each of the eight now says what is true today, and `docs/bridge.md` carries the statement once in its opening rather than eight times: there is no adapter here, no issue asks for one, and the question is open on #113. The base is `b7c97b1`.

    git diff --name-only origin/master...HEAD
    Jellyfin.Plugin.Requests/Bridge/BackendAccounts.cs
    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs
    docs/bridge.md
    docs/configuration.md

## What the population is, and why a line-wise grep undercounts it

Three of the thirteen sentences naming #82 wrap across lines, so the population is derived with the comment markers stripped and each file joined. Run at `origin/master`, `b7c97b1e173e8747ec9d5e24f54f06026ad23f24`:

    unwrap(){ for f in $(git grep -l '#82' origin/master -- docs/ Jellyfin.Plugin.Requests/ | sed 's/^[^:]*://'); do
      git show "origin/master:$f" | sed -E 's@^[[:space:]]*(///|//)[[:space:]]?@@' | tr '\n' ' ' | tr -s ' ' \
        | grep -o -E '[^.|]*#82[^.|]*'
    done; }
    unwrap | wc -l
    13
    unwrap | grep -c adapter
    8

The same derivation over the head of this branch, with the paths written out because the branch is not on the remote's default:

    for f in docs/bridge.md docs/configuration.md docs/personal-data.md docs/queue.md docs/seam.md \
             Jellyfin.Plugin.Requests/Bridge/BackendAccounts.cs Jellyfin.Plugin.Requests/Bridge/IRequestBackend.cs \
             Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs; do
      sed -E 's@^[[:space:]]*(///|//)[[:space:]]?@@' "$f" | tr -d '\r' | tr '\n' ' ' | tr -s ' ' | grep -o -E '[^.|]*#82[^.|]*'
    done | grep -c adapter
    0

**The five sites that name #82 as the issue a question belongs to are unchanged**, in `Jellyfin.Plugin.Requests/Bridge/IRequestBackend.cs`, `docs/bridge.md`, `docs/personal-data.md`, `docs/queue.md` and `docs/seam.md`. A reader who opens #82 from those finds an answer rather than a promise, which is what those sentences claim.

**A count written on #10 yesterday says seven and the population is eight.** That reading used a line-wise pattern and added the wrapped sentences it had found by hand; it missed the one in `docs/configuration.md` where `#82 brings the` ends a line and `adapter;` starts the next. I found it by re-deriving the population with the files joined instead of extending the earlier grep.

## The means

Markdown prose and C# XML documentation comments, which is what these four artefacts already are. This change repairs sentences in place: it adds no language, no runtime and no dependency, and the suites that already read `docs/bridge.md` and `docs/configuration.md` by their section markers keep holding those sections. A means that could carry a refusable property would be a different change, and the paragraph below says why none is proposed.

## What is not enforced

**Nothing refuses the next one.** No check here has a sentence naming a closed issue as a future arrival as its subject. Deciding that a pointer is forward-looking is a judgement about meaning, and deciding that its issue is closed needs the tracker, which nothing in this tree reads. This is a repair of eight sites and a disclosure that the class is unguarded, not a mechanism against it.

## What was run

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    0 Warnung(en)
    0 Fehler

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Fehler: 0, erfolgreich: 715, ubersprungen: 0, gesamt: 715 - net10.0
    Fehler: 0, erfolgreich: 715, ubersprungen: 0, gesamt: 715 - net9.0

Those two runs printed in German, which is the machine's locale rather than anything this repository sets, and the second line of each is transcribed with the counts unchanged.

No test was added and no guard was deleted to watch it go red, because this change alters no behaviour: the eight sites are prose and documentation comments, and the build treats the comments as comments.

**Prettier was checked and it needs reading carefully.** In this checkout `--check` reds both edited documents, and it reds two files this change never touched:

    npx --yes prettier@3.6.2 --check docs/queue.md docs/seam.md
    [warn] docs/queue.md
    [warn] docs/seam.md

The cause is the line endings of this working copy rather than the content. The same two edited files with the carriage returns stripped, which is what the runner checks out, pass:

    tr -d '\r' < docs/bridge.md > lfcheck/docs/bridge.md
    tr -d '\r' < docs/configuration.md > lfcheck/docs/configuration.md
    cd lfcheck && npx --yes prettier@3.6.2 --check docs/bridge.md docs/configuration.md
    All matched files use Prettier code style!

The `Check formatting` job on this pull request is the reading that counts, and it is required on `master`.

**Nothing was run against an external service, and none exists in this tree to run against.** Every command above reads this repository or the tracker.

**There is no second reader on this board tonight**, so nothing here has been read by anybody but the account that wrote it. What stands in place of one is the transcript above: the population is derived by a command rather than counted by eye, the derivation is repeated over the head of this branch, and the five sites that are deliberately unchanged are named so that a later reader can check the split rather than take it.
