### PR TITLE
Say what already refuses a version bump with no changelog entry

### DIFF
--- a/Jellyfin.Plugin.Requests/Api/RequestsController.cs
+++ b/Jellyfin.Plugin.Requests/Api/RequestsController.cs
@@ -290,8 +290,9 @@ public sealed class RequestsController : RequestsControllerBase
 
         // 201 with no Location header, on purpose. Nothing reads one request back yet, so a
         // Location would point at something that answers 404, and a header that lies is worse than
-        // one that is absent. Adding it when #53 lands is not a breaking change under the rule in
-        // docs/api.md.
+        // one that is absent. No route here reads one request back: #53 landed a list rather than a
+        // read of one, and adding the header when something does read one back is not a breaking
+        // change under the rule in docs/api.md.
         return answer.Outcome == RequestOutcome.Created
             ? StatusCode(StatusCodes.Status201Created, answer)
             : Ok(answer);

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -112,7 +112,15 @@ release. A version bump and a changelog entry are one change: raising
 `PluginVersion` without writing what moved leaves an operator with a number and
 no reason for it.
 
-Nothing refuses that today. No check reads `CHANGELOG.md`, and a commit raising
-`PluginVersion` with the file untouched is green everywhere. #26 is the hygiene
-check that would refuse it, and #107 stays open on that condition until it
-lands.
+Something refuses that, one step away from the number this page is about.
+`PluginVersion` cannot move on its own: `PluginVersionMatchesThePackagingMetadata`
+reds the suite until `build.yaml` and `build-jf12.yaml` carry the same number, and
+a pull request in which either of those `version:` fields moves without touching
+`CHANGELOG.md` fails the `Deterministic pull request hygiene checks` job, which
+#26 landed.
+
+Two absences the old wording named are still absences and are not softened here.
+The job asks whether `CHANGELOG.md` was touched and never what was written in it,
+so an entry that says nothing passes. And it is not in the required set on
+`master`, so a red one reports rather than holds a merge; whether it becomes
+required is #30's.


### PR DESCRIPTION
Closes #298.

Two sentences described something that has landed as something still to come. The base is `025b71d`, and everything below was read there.

## `docs/versioning.md` said nothing refuses, and something does

    git grep -n 'Nothing refuses that today' 025b71d -- docs/versioning.md
    025b71d:docs/versioning.md:115:Nothing refuses that today. No check reads `CHANGELOG.md`, and a commit raising

The paragraph also said that a commit raising `PluginVersion` with the file untouched is green everywhere, and that #26 was the check which would refuse it once it landed.

    gh issue view 26 --repo Flowfin/jellyfin-plugin-requests --json state,stateReason,title --jq '"\(.state)/\(.stateReason) \(.title)"'
    CLOSED/COMPLETED Adopt the deterministic pull request hygiene checks

    git grep -n "PACKAGING_FILES = \|!changed.includes('CHANGELOG.md')" 025b71d -- .github/workflows/pr-hygiene.yaml
    025b71d:.github/workflows/pr-hygiene.yaml:213:            const PACKAGING_FILES = ['build.yaml', 'build-jf12.yaml'];
    025b71d:.github/workflows/pr-hygiene.yaml:221:              !changed.includes('CHANGELOG.md')

    git grep -n 'public void PluginVersionMatchesThePackagingMetadata' 025b71d -- Jellyfin.Plugin.Requests.Tests/
    025b71d:Jellyfin.Plugin.Requests.Tests/PackagingMetadataTests.cs:28:    public void PluginVersionMatchesThePackagingMetadata(string packagingFile)

The two meet: `PluginVersion` cannot move without both packaging files moving to match, and either of those moving without `CHANGELOG.md` fails the hygiene job.

**Both absences the old wording named survive this edit and neither is softened.** The job asks whether `CHANGELOG.md` was touched, never what was written in it, so an entry that says nothing passes. And it holds no merge, because it is not in the required set:

    gh api repos/Flowfin/jellyfin-plugin-requests/rules/branches/master --jq '.[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context'
    call / build
    call / test
    Reject Trojan Source Unicode
    Audit workflows (zizmor)
    Check formatting

Whether that job becomes required is #30's, and this change answers nothing there. It also asserts nothing about #107: it describes what the tree does, and reads no condition of that issue.

## `RequestsController.cs` named a closed issue as the moment a header becomes addable

    gh issue view 53 --repo Flowfin/jellyfin-plugin-requests --json state,stateReason,title --jq '"\(.state)/\(.stateReason) \(.title)"'
    CLOSED/COMPLETED List and filter requests

**The reason the comment gives is unchanged, because it is still true.** #53 landed a list rather than a read of one request, so nothing reads one request back and a `Location` header would still point at a 404:

    git grep -nE '\[Http(Get|Post|Put|Delete)\("Requests' 025b71d -- Jellyfin.Plugin.Requests/Api/RequestsController.cs
    025b71d:Jellyfin.Plugin.Requests/Api/RequestsController.cs:196:    [HttpPost("Requests")]
    025b71d:Jellyfin.Plugin.Requests/Api/RequestsController.cs:322:    [HttpGet("Requests")]
    025b71d:Jellyfin.Plugin.Requests/Api/RequestsController.cs:445:    [HttpGet("Requests/Queue")]
    025b71d:Jellyfin.Plugin.Requests/Api/RequestsController.cs:510:    [HttpPost("Requests/{id}/Approve")]
    025b71d:Jellyfin.Plugin.Requests/Api/RequestsController.cs:558:    [HttpPost("Requests/{id}/Decline")]
    025b71d:Jellyfin.Plugin.Requests/Api/RequestsController.cs:611:    [HttpPost("Requests/Approve")]
    025b71d:Jellyfin.Plugin.Requests/Api/RequestsController.cs:644:    [HttpPost("Requests/Decline")]

## The means

Markdown prose and a C# line comment, which is what the two artefacts already are. Nothing here adds a language, a runtime or a dependency, and no behaviour moves: the comment is a comment and the page is read by nobody's test.

## What was run

    git diff --name-only 025b71d...HEAD
    Jellyfin.Plugin.Requests/Api/RequestsController.cs
    docs/versioning.md

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    0 Warnung(en)
    0 Fehler

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Fehler: 0, erfolgreich: 715, ubersprungen: 0, gesamt: 715 - net10.0
    Fehler: 0, erfolgreich: 715, ubersprungen: 0, gesamt: 715 - net9.0

Those runs print in German, which is this machine's locale rather than anything this repository sets, and the counts are transcribed unchanged.

No test was added and no guard was deleted to watch it go red. This change alters no behaviour: one line comment and one paragraph, and the build treats the comment as a comment.

**Prettier reds this working copy for its line endings rather than for the content.** Untouched documents red here too. The edited page with the carriage returns stripped, which is what the runner checks out, passes:

    tr -d '\r' < docs/versioning.md > lfcheck/docs/versioning.md
    cd lfcheck && npx --yes prettier@3.6.2 --check docs/versioning.md
    All matched files use Prettier code style!

The `Check formatting` job on this pull request is the reading that counts, and it is required on `master`.

**Nothing was run against a server**, and no claim here rests on one.

**There is no second reader on this board tonight**, so nothing here has been read by anybody but the account that wrote it. What stands in place of one is the transcript above, and in particular the two absences that are quoted back rather than dropped: a reader checking this change should check those two sentences first, because they are the half a repair of this kind gets wrong.
