### PR TITLE
Stop saying three things are absent that are in the tree

### DIFF
--- a/Jellyfin.Plugin.Requests/Model/MediaRequest.cs
+++ b/Jellyfin.Plugin.Requests/Model/MediaRequest.cs
@@ -220,8 +220,8 @@ public sealed record MediaRequest
     /// <para>
     /// It is cleared when a request leaves <see cref="RequestState.Declined"/>, because a reason
     /// standing on an approved request is a sentence that is no longer true. What the request used
-    /// to say is the append-only history in #43, and until that exists the earlier reason is gone
-    /// rather than kept somewhere else.
+    /// to say is in <see cref="History"/>, where the entry carries the reason the move was made
+    /// with, so clearing this field loses the current value and not the record of it.
     /// </para>
     /// </summary>
     public DeclineReason? DeclineReason { get; init; }

--- a/Jellyfin.Plugin.Requests/Model/RequestedItemKind.cs
+++ b/Jellyfin.Plugin.Requests/Model/RequestedItemKind.cs
@@ -18,8 +18,8 @@ public enum RequestedItemKind
     Movie = 0,
 
     /// <summary>
-    /// A series. Which seasons were asked for is not on this record yet; the queue needs it to be
-    /// decidable and #59 is where that is settled.
+    /// A series. Which seasons were asked for is on the request rather than here, in
+    /// <see cref="MediaRequest.Seasons"/>, where empty means the whole series.
     /// </summary>
     Series = 1
 }

--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -571,10 +571,11 @@ check on this board refuses either of them:
     score is 8: nugetCommand not pinned by hash
 
 `Branch-Protection` at 3 is a repository setting rather than a file here, and
-what the ruleset should require is #30. `Security-Policy` at 0 is a file this
-tree does not have yet, which is #106. Neither is closed by this decision and
-neither is a reason for a floor: a floor would report the same absences the
-report already reports.
+what the ruleset should require is #30. `Security-Policy` at 0 was a file this
+tree did not have when that report ran; `SECURITY.md` has landed since, under
+#106, and **the score above has not been re-read here**. Neither is closed by
+this decision and neither is a reason for a floor: a floor would report the same
+absences the report already reports.
 
 So the workflow keeps its shape, its header says in the file that it refuses
 nothing, and #25's second condition is answered for the fifth workflow by there


### PR DESCRIPTION
Closes #300.

Three sentences said something does not exist while the thing sits in the tree beside them. The base is `a7b609e`, and everything below was read there.

## A decline reason is kept, and the field's comment said it is lost

    git grep -n 'until that exists the earlier reason is gone' a7b609e -- Jellyfin.Plugin.Requests/
    a7b609e:Jellyfin.Plugin.Requests/Model/MediaRequest.cs:223:    /// to say is the append-only history in #43, and until that exists the earlier reason is gone

    git grep -n 'public IReadOnlyList<RequestHistoryEntry> History' a7b609e -- Jellyfin.Plugin.Requests/Model/MediaRequest.cs
    a7b609e:Jellyfin.Plugin.Requests/Model/MediaRequest.cs:265:    public IReadOnlyList<RequestHistoryEntry> History { get; init; } = [];

    git grep -n 'public void AReasonSurvivesTheDeclineBeingTakenBack' a7b609e -- Jellyfin.Plugin.Requests.Tests/
    a7b609e:Jellyfin.Plugin.Requests.Tests/Model/RequestHistoryTests.cs:186:    public void AReasonSurvivesTheDeclineBeingTakenBack()

**This is the one to read twice.** The comment did not merely point at a closed issue: it told a reader of the field that clearing it loses the earlier reason, and a test one directory away asserts that it does not.

## The seasons asked for are on the record, and the enum said they are not

    git grep -n 'Which seasons were asked for is not on this record yet' a7b609e -- Jellyfin.Plugin.Requests/
    a7b609e:Jellyfin.Plugin.Requests/Model/RequestedItemKind.cs:21:    /// A series. Which seasons were asked for is not on this record yet; the queue needs it to be

    git grep -n 'public IReadOnlyList<int> Seasons' a7b609e -- Jellyfin.Plugin.Requests/Model/MediaRequest.cs
    a7b609e:Jellyfin.Plugin.Requests/Model/MediaRequest.cs:125:    public IReadOnlyList<int> Seasons

## The security policy is a file this tree has

    git grep -n 'is a file this' a7b609e -- docs/quality-parity.md
    a7b609e:docs/quality-parity.md:574:what the ruleset should require is #30. `Security-Policy` at 0 is a file this

    git log --oneline -1 a7b609e -- SECURITY.md
    b4dc783 Link the reporting form the security policy describes (#246) (#247)

**The Scorecard number is left as it was measured and is now marked as not re-read.** The report scored `Security-Policy` at 0 when it ran, and this change says the file has since landed rather than claiming a number nobody measured again. Nothing here re-runs Scorecard, and nothing here takes a decision belonging to #30, which owns what the ruleset should require.

## The means

C# XML documentation comments and Markdown prose, which is what these three artefacts already are. No behaviour moves and nothing is added to the tree that was not already in it.

## What was run

    git diff --name-only a7b609e...HEAD
    Jellyfin.Plugin.Requests/Model/MediaRequest.cs
    Jellyfin.Plugin.Requests/Model/RequestedItemKind.cs
    docs/quality-parity.md

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    0 Warnung(en)
    0 Fehler

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Fehler: 0, erfolgreich: 715, ubersprungen: 0, gesamt: 715 - net10.0
    Fehler: 0, erfolgreich: 715, ubersprungen: 0, gesamt: 715 - net9.0

Those runs print in German, which is this machine's locale rather than anything this repository sets, and the counts are transcribed unchanged.

No test was added and no guard was deleted to watch it go red. Nothing here changes behaviour: three comments and one paragraph, and the build treats the comments as comments. The test that contradicts the first of them already exists and is quoted above rather than written for this change.

**Prettier reds this working copy for its line endings rather than for the content**, and it reds untouched documents here too. The edited page with the carriage returns stripped, which is what the runner checks out, passes:

    tr -d '\r' < docs/quality-parity.md > lfcheck/docs/quality-parity.md
    cd lfcheck && npx --yes prettier@3.6.2 --check docs/quality-parity.md
    All matched files use Prettier code style!

The `Check formatting` job on this pull request is the reading that counts, and it is required on `master`.

**One site was read and deliberately left alone**, and #300 carries it: `docs/storage.md` says the round trip belongs in the suite when the store exists. The store exists, so that condition is met, but whether the round trip is in the suite is a reading of the test project rather than of the sentence, and neither this change nor its issue takes it.

**There is no second reader on this board tonight**, so nothing here has been read by anybody but the account that wrote it. What stands in place of one is the transcript above, and the first repair is the one to check: the claim that the reason survives is held by a named test rather than by this body.
