### PR TITLE
Mint 0.2.0.0 and write everything the release owes before its tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
 One section per released version, newest first, and an `Unreleased` section
-holding what has landed since the last one. The scheme the numbers follow, and
-what each part of a number means for somebody who has this plugin installed, is
-in [docs/versioning.md](docs/versioning.md).
+holding what has landed since the last one. A section carrying a number that no
+tag has been pushed for is the version being prepared; it becomes a released
+section when the tag goes out, and nothing in the file changes at that moment.
+The scheme the numbers follow, and what each part of a number means for somebody
+who has this plugin installed, is in [docs/versioning.md](docs/versioning.md).
 
 Entries say what changed for somebody using the plugin. A change that alters
 nothing an operator or a user can observe, such as a workflow or a test, does
@@ -11,11 +13,15 @@ not need an entry; the git history is where that is read.
 
 ## Unreleased
 
-Nothing has been released. There are no tags and no packages, so everything in
-the tree is unreleased and this section starts here rather than reconstructing
-what came before it. What landed before this file existed is in the git history,
-where it carries the pull request and the issue it came from, and rewriting it
-from memory into entries would be a description nobody measured.
+Nothing has landed since the entries below were collected under `0.2.0.0`.
+
+## 0.2.0.0
+
+Two of the entries below change what a server already doing its work does, which
+is the kind of change the scheme reserves for a `MAJOR` bump. Below `1.0.0.0` a
+`MINOR` bump is allowed to carry one and the entry says so, which is what the
+marked entries do. What each part of a number means is in
+[docs/versioning.md](docs/versioning.md).
 
 - The queue no longer drifts away from an external request service. A scheduled
   task asks that service, hourly and at startup, where the requests handed to it
@@ -32,7 +38,9 @@ from memory into entries would be a description nobody measured.
   file sits in is told the same thing about that title as somebody whose server
   does not have it. Until now the row carried what the server holds, which said
   that a library they cannot open has something in it. The lookup is made only
-  for the rows on the page being returned.
+  for the rows on the page being returned. **This gives an existing response
+  field a different meaning**, which above `1.0.0.0` would be a `MAJOR` bump;
+  below it, this entry is the notice the scheme asks for.
 
 - The person who asked is told when their own request is answered. Approving,
   declining or fulfilling a request pushes one message to that person's
@@ -56,6 +64,10 @@ from memory into entries would be a description nobody measured.
   days, counted from the move that finished it, and it runs daily and at
   startup. A request nobody has answered is never removed by age. Until now the
   number was a setting nothing acted on and a server kept every request.
+  **A server that upgrades into this starts deleting records it was keeping**,
+  under a number nobody had to choose before, which above `1.0.0.0` would be a
+  `MAJOR` bump; below it, this entry is the notice the scheme asks for. Read
+  `FinishedRequestRetentionDays` before updating.
 
 - A person signed in to the server can open a page in a browser and see what
   they asked for and what happened to it, at `MediaRequests/v1/Page`. It shows
@@ -63,6 +75,11 @@ from memory into entries would be a description nobody measured.
   no session. What it costs to open one in a browser, which is a credential in
   the address, is in [docs/surface.md](docs/surface.md).
 
+## 0.1.0.0
+
+Published on 2026-08-08. What that release carries is the entry below and
+nothing else; everything under `0.2.0.0` landed after its tag.
+
 - The version starts at `0.1.0.0`. It was `1.0.0.0`, inherited from the
-  template, which claimed a released first version of a plugin that has never
+  template, which claimed a released first version of a plugin that had never
   been released.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,7 +39,7 @@
              scheme this number follows, what each part of it means to somebody who has the plugin
              installed, and why it starts below one, are in docs/versioning.md. Raising it and
              writing the changelog entry are one change. -->
-        <PluginVersion>0.1.0.0</PluginVersion>
+        <PluginVersion>0.2.0.0</PluginVersion>
         <Version>$(PluginVersion)</Version>
         <AssemblyVersion>$(PluginVersion)</AssemblyVersion>
         <FileVersion>$(PluginVersion)</FileVersion>

--- a/build-jf12.yaml
+++ b/build-jf12.yaml
@@ -18,7 +18,7 @@ overview: "A user asks the server for a film or a series, an administrator answe
 description: >
   A user who cannot find something asks for it from inside Jellyfin rather than through a message to whoever runs the server. The ask lands in a queue an administrator works through, and the person who asked can see what happened to it.
 
-  This is not finished and there is no release yet. The tree holds the plugin shell and one data model. Installing it today adds nothing a user can see.
+  This is not finished. A user can ask for a title and follow what happened to their own asks, and an administrator answers them in a queue. There is no gesture that finds a title the server does not have unless a browsing sibling plugin supplies one, and nothing here downloads anything: approving a request moves a record, and whatever the operator already runs is what fetches. The packaged install has not been tried on a server on either claimed line.
 category: "General"
 owner: "Flowfin"
 artifacts:

--- a/build-jf12.yaml
+++ b/build-jf12.yaml
@@ -10,7 +10,7 @@ name: "Requests"
 # PackagingMetadataTests.BothPackagesClaimTheSameIdentity refuses them diverging on it.
 guid: "0f9c9107-b31b-459e-81fa-6d35dac25e79"
 imageUrl: "https://raw.githubusercontent.com/Flowfin/jellyfin-plugin-requests/master/img/logo.png"
-version: "0.1.0.0"
+version: "0.2.0.0"
 # The 12.0 line's floor and the runtime it provides.
 targetAbi: "12.0.0.0"
 framework: "net10.0"

--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@
 name: "Requests"
 guid: "0f9c9107-b31b-459e-81fa-6d35dac25e79"
 imageUrl: "https://raw.githubusercontent.com/Flowfin/jellyfin-plugin-requests/master/img/logo.png"
-version: "0.1.0.0"
+version: "0.2.0.0"
 # Packaging metadata for the Jellyfin 10.11 line. The oldest server of that line this package claims
 # to load on, and the runtime that line provides. The project compiles against a newer 10.11.x SDK,
 # so a floor build against this number is what would show that every API the plugin calls also exists

--- a/build.yaml
+++ b/build.yaml
@@ -13,7 +13,7 @@ overview: "A user asks the server for a film or a series, an administrator answe
 description: >
   A user who cannot find something asks for it from inside Jellyfin rather than through a message to whoever runs the server. The ask lands in a queue an administrator works through, and the person who asked can see what happened to it.
 
-  This is not finished and there is no release yet. The tree holds the plugin shell and one data model. Installing it today adds nothing a user can see.
+  This is not finished. A user can ask for a title and follow what happened to their own asks, and an administrator answers them in a queue. There is no gesture that finds a title the server does not have unless a browsing sibling plugin supplies one, and nothing here downloads anything: approving a request moves a record, and whatever the operator already runs is what fetches. The packaged install has not been tried on a server on either claimed line.
 category: "General"
 owner: "Flowfin"
 artifacts:

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -78,15 +78,19 @@ promised from then on is #105.
 
 ## Where the number starts
 
-`0.1.0.0`. The template's `1.0.0.0` claimed a released first version, and
-nothing has been released:
+`0.1.0.0`, and the reading that chose it does not reproduce any more. On the day
+the number was picked the template's `1.0.0.0` claimed a released first version
+and nothing had been released. One release exists now, so the command returns a
+different number and is written here as the current reading rather than as the
+one that decided anything:
 
-    $ gh release list --repo iderex/jellyfin-plugin-requests --json tagName --jq 'length'
-    0
+    $ gh release list --repo Flowfin/jellyfin-plugin-requests --json tagName --jq 'length'
+    1
 
-A version that says 1.0 to a catalogue, to a dashboard and to an operator, for a
-plugin with no request API and no store behind it, is a claim this tree cannot
-back.
+A version that said 1.0 to a catalogue, to a dashboard and to an operator, for a
+tree that then held no request API and no store behind it, was a claim it could
+not back. Where the number goes from here is the scheme above, and the weaker
+promise below `1.0.0.0` holds until the first `1.0.0.0`.
 
 ## What a bump does to an installed server, and what is not measured here
 


### PR DESCRIPTION
**Closed and replaced by #303, which carries the same content with the sign-off
this branch was missing.**

`DCO sign-off` refused all three commits here by name:

```
FAIL  263353adf009e405b642aa30cc980a590f908b0d is missing: Signed-off-by: Nils Lehnen <30603423+iderex@users.noreply.github.com>
FAIL  7a0d08a898c1158721a1148df062b516ab0ed61c is missing: Signed-off-by: Nils Lehnen <30603423+iderex@users.noreply.github.com>
FAIL  9cc3e19b7348c4fb51f0d86905ad685e488bbb29 is missing: Signed-off-by: Nils Lehnen <30603423+iderex@users.noreply.github.com>
```

The repair is a new branch rather than a rewrite of this one. Nothing was
force-pushed and this branch is left exactly where it is. #303 carries the
proof that its content is identical: equal trees and matching patch-ids.

Everything below is what this pull request said, kept as it stood.

---

Prepares the second release of this plugin up to the act that publishes it. It
mints `0.2.0.0`, writes the notes that number owes, and repairs two texts the
release would otherwise carry out with false statements in them. It pushes no
tag, so nothing is published by merging it.

Part of #152.

## The number, and why it is this one

`docs/versioning.md` decides it rather than anybody's preference. Behaviour is
added and nothing is removed across everything that landed after
`0.1.0.0-stable`, so `MINOR` moves and the number is `0.2.0.0`.

Two entries are the ones to read before agreeing with that. The availability a
person sees on their own row now answers for them rather than for the server,
which gives an existing response field a different meaning, and
`FinishedRequestRetentionDays` is now enforced, so a server that upgrades starts
deleting finished records it was keeping. Above `1.0.0.0` each is a `MAJOR`
bump. Below it the scheme allows a `MINOR` bump to carry one **provided the
changelog entry says so**, and both entries now say so in the entry itself
rather than in a preamble somebody skips.

## What the released version carried is read from the tag, not reconstructed

`CHANGELOG.md` had no section for `0.1.0.0` and said in its preamble that
nothing had been released and that there were no tags and no packages. Both
stopped being true on 2026-08-08:

```
$ gh release list --repo Flowfin/jellyfin-plugin-requests --limit 10
0.1.0.0-stable	Latest	0.1.0.0-stable	2026-08-08T09:39:39Z

$ git ls-remote --tags origin
9e80758946dacdd069509569a1bac8d10b850927	refs/tags/0.1.0.0-stable
c44552645f0dba120c49599deedbc0244b59dcec	refs/tags/0.1.0.0-stable^{}
```

Which entries belong to that release is read at the tagged commit rather than
guessed. At `c4455264` the file held exactly one entry, the one about where the
number starts, so every other entry now under `0.2.0.0` landed after the tag:

```
$ git show c4455264:CHANGELOG.md | sed -n '11,22p'
## Unreleased

Nothing has been released. There are no tags and no packages, so everything in
the tree is unreleased and this section starts here rather than reconstructing
what came before it. What landed before this file existed is in the git history,
where it carries the pull request and the issue it came from, and rewriting it
from memory into entries would be a description nobody measured.

- The version starts at `0.1.0.0`. It was `1.0.0.0`, inherited from the
  template, which claimed a released first version of a plugin that has never
  been released.
```

## The two texts the release would have carried out

**The package description.** It is what a catalogue and the dashboard show
somebody before they install, and it said there is no release yet, that the tree
holds the plugin shell and one data model, and that installing it adds nothing a
user can see. The next release publishes that text beside an archive holding a
queue, a per-user page, per-user notifications and a retention task. The
replacement keeps every negative rather than trading it away: still not
finished, still no gesture that finds an unheld title without a browsing
sibling, still nothing here downloads anything, and still not installed on a
server on either claimed line.

**The starting-number reading in `docs/versioning.md`.** It justified `0.1.0.0`
with a present-tense claim that nothing has been released and pasted a command
returning `0`. Re-run today:

```
$ gh release list --repo Flowfin/jellyfin-plugin-requests --json tagName --jq 'length'
1
```

The paste did not reproduce, in the document that governs the number the release
path reads. It is now past tense, dated to the choice it explains, with the
current reading beside it.

## The guard was watched biting on this change

`PluginVersionMatchesThePackagingMetadata` and `BothPackagesClaimTheSameIdentity`
are what refuse the number moving in one file and not the others. Setting
`version` in `build.yaml` back to `0.1.0.0` on this branch and running only that
class:

```
$ dotnet test --nologo --filter "FullyQualifiedName~PackagingMetadataTests"
  Failed Jellyfin.Plugin.Requests.Tests.PackagingMetadataTests.BothPackagesClaimTheSameIdentity(field: "version") [10 ms]
   Assert.Equal() Failure: Values differ
Expected: 0.1.0.0
Actual:   0.2.0.0
  Failed Jellyfin.Plugin.Requests.Tests.PackagingMetadataTests.PluginVersionMatchesThePackagingMetadata(packagingFile: "build.yaml") [< 1 ms]
   Assert.Equal() Failure: Values differ
Expected: 0.2.0.0
Actual:   0.1.0.0
Failed!  - Failed:     2, Passed:     3, Skipped:     0, Total:     5 - Jellyfin.Plugin.Requests.Tests.dll (net9.0)
Failed!  - Failed:     2, Passed:     3, Skipped:     0, Total:     5 - Jellyfin.Plugin.Requests.Tests.dll (net10.0)
```

Restored, the whole suite is green on both claimed lines:

```
$ dotnet test --nologo
Passed!  - Failed:     0, Passed:   715, Skipped:     0, Total:   715, Duration: 28 s - Jellyfin.Plugin.Requests.Tests.dll (net10.0)
Passed!  - Failed:     0, Passed:   715, Skipped:     0, Total:   715, Duration: 28 s - Jellyfin.Plugin.Requests.Tests.dll (net9.0)
```

## The means

No new means. The version is an MSBuild property the tree already holds in one
place, the packaging metadata is the YAML the release path already reads, and
the notes are the Markdown the changelog already is. Nothing here adds a
language, a runtime or a dependency, and every claim above is a command in a
shell that the checks on this pull request also run.

## What this does NOT do

- **It publishes nothing.** No tag is pushed, no release is created, and merging
  this changes nothing an installed server sees. What `0.2.0.0` means to a
  server begins at the tag.
- **It does not answer either call #110 is waiting on.** Both packaging files
  carry `0.2.0.0`, which is what the tree's own guard requires and what the
  manifest generator refuses as a pair a server cannot tell apart. Separating
  the server lines by version number, and the address the manifest is served
  from, are unchanged and still open there.
- **Nothing was installed into a Jellyfin server.** The packaged install path
  has not been tried on either claimed line, which is what the package
  description now says rather than what it hides.

## Reading

This board has no second reader tonight. The evidence above stands in place of
one: every claim carries the command that produced it, run on this branch, and
the checks on this pull request are the other half.
