### PR TITLE
Record a run of the bill-of-materials check against a real release

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -149,25 +149,90 @@ PACKAGE_VERSION=<version> \
 diff regenerated.cdx.json <archive>.cdx.json
 ```
 
-A recorded run of the first command against `0.1.0.0-stable`, which is the release
-that exists at the time of writing:
+A recorded run of both commands against `0.2.0.0-stable`, which is the first release
+the publish route produced a bill of materials for:
 
 ```
-gh release download 0.1.0.0-stable --repo Flowfin/jellyfin-plugin-requests \
-  --pattern 'requests_0.1.0.0.zip'
-gh attestation verify requests_0.1.0.0.zip --repo Flowfin/jellyfin-plugin-requests
+gh release download 0.2.0.0-stable --repo Flowfin/jellyfin-plugin-requests \
+  --pattern 'requests_0.2.0.0.zip' --pattern 'requests_0.2.0.0.cdx.json'
+gh attestation verify requests_0.2.0.0.zip --repo Flowfin/jellyfin-plugin-requests
 echo "exit=$?"
 exit=0
 ```
 
-The command prints its result only to a terminal, so a run whose output is captured
-to a file or a pipe shows the exit status and nothing else. Reading the statement
-itself rather than the verdict takes `--format json`. Pointed at a repository that did
-not build the archive it exits 1 with an HTTP 404, which is the failing direction of
-the same command.
+```
+SOURCE_REPOSITORY=Flowfin/jellyfin-plugin-requests \
+SOURCE_COMMIT=60faf415328e88461656d4c245e093e357883983 \
+PACKAGE_VERSION=0.2.0.0 \
+  scripts/bill-of-materials.sh requests_0.2.0.0.zip regenerated.cdx.json
+bill-of-materials: wrote regenerated.cdx.json describing 2 file(s) from requests_0.2.0.0.zip.
+diff regenerated.cdx.json requests_0.2.0.0.cdx.json
+echo "exit=$?"
+exit=0
+```
+
+The commit to put in `SOURCE_COMMIT` is the one the shipped document names, which is
+read out of it rather than guessed:
+
+```
+python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["metadata"]["component"]["externalReferences"][0]["comment"])' \
+  requests_0.2.0.0.cdx.json
+built from commit 60faf415328e88461656d4c245e093e357883983
+```
+
+The first command prints its result only to a terminal, so a run whose output is
+captured to a file or a pipe shows the exit status and nothing else. Reading the
+statement itself rather than the verdict takes `--format json`. Pointed at a
+repository that did not build the archive it exits 1 with an HTTP 404, which is the
+failing direction of the same command.
+
+The second check was watched failing in both of the directions it exists for, on the
+same archive. A file inside the archive changed by one byte:
+
+```
+unzip -q requests_0.2.0.0.zip -d tampered && printf '\n' >> tampered/meta.json
+( cd tampered && zip -q -r ../tampered_0.2.0.0.zip . )
+SOURCE_REPOSITORY=Flowfin/jellyfin-plugin-requests \
+SOURCE_COMMIT=60faf415328e88461656d4c245e093e357883983 \
+PACKAGE_VERSION=0.2.0.0 \
+  scripts/bill-of-materials.sh tampered_0.2.0.0.zip tampered.cdx.json
+diff tampered.cdx.json requests_0.2.0.0.cdx.json
+26c26
+<           "content": "2e32254bbf780ae1de376734a16370be43b0de0bd2cc11cf9ceda6edad3a94f6"
+---
+>           "content": "62293889c33fe2ab3551336f50a6b0280f43bb3e97fda0eb4688990b923f21fc"
+33c33
+<           "value": "1205"
+---
+>           "value": "1204"
+echo "exit=$?"
+exit=1
+```
+
+and a regeneration claiming a different source commit:
+
+```
+SOURCE_COMMIT=bcee7a79feb7f31ae6e1d7441e9e20d4853dacc1 ... \
+  scripts/bill-of-materials.sh requests_0.2.0.0.zip wrong-commit.cdx.json
+diff wrong-commit.cdx.json requests_0.2.0.0.cdx.json
+44c44
+<           "comment": "built from commit bcee7a79feb7f31ae6e1d7441e9e20d4853dacc1"
+---
+>           "comment": "built from commit 60faf415328e88461656d4c245e093e357883983"
+echo "exit=$?"
+exit=1
+```
+
+The tampered run also differs on the archive's own name, because the name is a field
+of the document. That is worth knowing before somebody renames a download and reads
+the two name lines as a finding: compare a download under the name it was published
+under.
 
 `0.1.0.0-stable` was built before the bill of materials existed and carries no
-`.cdx.json`, so the second check has nothing to run against until the next release.
+`.cdx.json`, so the second check still has nothing to run against for that release
+and never will. A release's assets are not touched again on this route, and a
+document written by hand afterwards is the thing the first check exists instead of.
+The first check runs against it unchanged.
 
 ## What fails the run
 


### PR DESCRIPTION
Closes #109.

## What was missing, and what arrived on its own

`docs/RELEASING.md` documented two checks for somebody who downloaded a package and carried a
recorded run of only one of them. The second, regenerating the bill of materials from the download
and diffing it against the shipped document, had nothing to run against: `0.1.0.0-stable` was built
before the generator existed and carries no `.cdx.json`. The document said exactly that.

`0.2.0.0-stable` was published this morning and is the first release the publish route produced a
bill of materials for:

    gh release view 0.2.0.0-stable --repo Flowfin/jellyfin-plugin-requests --json publishedAt,assets --jq '.publishedAt, (.assets[].name)'
    2026-08-27T06:51:59Z
    requests_0.2.0.0.cdx.json
    requests_0.2.0.0.md5
    requests_0.2.0.0.sha256
    requests_0.2.0.0.zip
    requests_0.2.0.0.zip.meta.json

    gh api repos/Flowfin/jellyfin-plugin-requests/actions/runs/33047356728/jobs --jq '.jobs[] | [.name,.conclusion]|@tsv'
    Release metadata gate    success
    Build package            success
    Attest build provenance  success
    Publish the release      success

So the wiring the earlier note on #109 said was "proven by the next release and not before" has now
been proven by one.

## What this change adds

The run of both checks against that release, taken here rather than pasted from anywhere:

    gh attestation verify requests_0.2.0.0.zip --repo Flowfin/jellyfin-plugin-requests ; echo "exit=$?"
    exit=0

    SOURCE_REPOSITORY=Flowfin/jellyfin-plugin-requests \
    SOURCE_COMMIT=60faf415328e88461656d4c245e093e357883983 \
    PACKAGE_VERSION=0.2.0.0 \
      scripts/bill-of-materials.sh requests_0.2.0.0.zip regenerated.cdx.json
    bill-of-materials: wrote regenerated.cdx.json describing 2 file(s) from requests_0.2.0.0.zip.
    diff regenerated.cdx.json requests_0.2.0.0.cdx.json ; echo "exit=$?"
    exit=0

It also adds the one step a reader needs and had to guess at, which is where `SOURCE_COMMIT` comes
from: the shipped document names it, and the document is the place to read it rather than the tree.

## The failing direction, watched rather than described

A documented check whose failure has never been seen is a check nobody knows is wired up. Both
directions this one exists for were driven on the same archive.

One byte added to a file inside the package:

    diff tampered.cdx.json requests_0.2.0.0.cdx.json ; echo "exit=$?"
    26c26
    <           "content": "2e32254bbf780ae1de376734a16370be43b0de0bd2cc11cf9ceda6edad3a94f6"
    ---
    >           "content": "62293889c33fe2ab3551336f50a6b0280f43bb3e97fda0eb4688990b923f21fc"
    33c33
    <           "value": "1205"
    ---
    >           "value": "1204"
    exit=1

A regeneration claiming a different source commit:

    diff wrong-commit.cdx.json requests_0.2.0.0.cdx.json ; echo "exit=$?"
    44c44
    <           "comment": "built from commit bcee7a79feb7f31ae6e1d7441e9e20d4853dacc1"
    ---
    >           "comment": "built from commit 60faf415328e88461656d4c245e093e357883983"
    exit=1

The tampered run also differs on the archive's own name, and the document now says so, because
somebody who renamed a download would otherwise read those two lines as a finding.

## The negative disclosure is kept and is sharper than it was

The sentence saying `0.1.0.0-stable` carries no bill of materials stays. What it now adds is that
this never changes: a release's assets are not touched again on the publish route, so that package
never gains one, and a document written by hand afterwards is the thing the attestation check exists
instead of. Nothing here claims a bill of materials for the first release.

## The means

Markdown in `docs/`, which is where this tree argues everything, and no new tool: the two commands
recorded are the two the document already names, run with `gh`, `python3` and `scripts/bill-of-materials.sh`,
all of which this repository already depends on. Adding a format or a runtime to record a run of a
shell command would be a cost paid for nothing.

## Scope, and what this does not touch

One file, `docs/RELEASING.md`, and nothing under `.github/workflows/`: the two steps #109 asks for
are already in the publish workflow and have now executed, so what was left was the recorded run
rather than a change to the path.

    git diff --name-only origin/master...HEAD
    docs/RELEASING.md

This board had no second reader tonight and the commands above stand in place of one.
