### PR TITLE
Stand in for the notice preferences so the registration tests do not read a static no test sets

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/PluginServiceRegistrationTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/PluginServiceRegistrationTests.cs
@@ -7,6 +7,7 @@ using Jellyfin.Plugin.Requests.Bridge;
 using Jellyfin.Plugin.Requests.Configuration;
 using Jellyfin.Plugin.Requests.Identity;
 using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Notify;
 using Jellyfin.Plugin.Requests.People;
 using Jellyfin.Plugin.Requests.Seam;
 using Jellyfin.Plugin.Requests.Storage;
@@ -24,6 +25,19 @@ namespace Jellyfin.Plugin.Requests.Tests;
 /// server is told which implementation to use, so a registration that was dropped or pointed at the
 /// wrong type would leave the plugin resolving nothing on a real server while every test that hands
 /// its own doubles in went on passing.
+/// <para>
+/// RUN THIS CLASS ON ITS OWN AFTER CHANGING IT, because a whole-suite run cannot tell you what it
+/// covers here. Several registrations resolve <c>Plugin.Instance</c>, a static the host sets while
+/// loading and no test sets, and another collection running first leaves an instance in it often
+/// enough that the graph resolves anyway. So a test here that reaches the static passes in the
+/// suite and fails alone, which is how one of them stood from the day it landed until it reddened
+/// one target framework out of two on the mainline. The gate runs the whole suite and nothing in
+/// it runs this class by itself, so what catches the next one is the run below rather than the gate.
+/// </para>
+/// <para>
+/// <c>dotnet test Jellyfin.Plugin.Requests.sln --configuration Release --filter
+/// "FullyQualifiedName~PluginServiceRegistrationTests"</c>.
+/// </para>
 /// </summary>
 [SuppressMessage(
     "Design",
@@ -190,16 +204,24 @@ public class PluginServiceRegistrationTests
     }
 
     /// <summary>
-    /// The registration as it ships, with the five things behind it that only a running server has.
+    /// The registration as it ships, with the six things behind it that only a running server has.
     /// <para>
-    /// Each of the five is stood in for because reaching the real one from a test would read
-    /// something other than the registration. The logger factory, the user manager and the session
-    /// manager come from the server's own container and are not in this collection at all. The store
-    /// and the settings both reach the plugin instance, which is a static the host sets while loading
-    /// and which any test running beside this one replaces, so a test resolving them would fail for a
-    /// reason nobody caused; <c>ServerInstallSettings</c> says so about itself where it takes its
-    /// second constructor. What is left over the five is the seam's own registration, which is what
-    /// these tests are about.
+    /// Each of the six is stood in for because reaching the real one from a test would read something
+    /// other than the registration. The logger factory, the user manager and the session manager come
+    /// from the server's own container and are not in this collection at all. The store, the settings
+    /// and the notice preferences all reach the plugin instance, which is a static the host sets while
+    /// loading and which any test running beside this one replaces, so a test resolving them would
+    /// fail for a reason nobody caused; <c>ServerInstallSettings</c> says so about itself where it
+    /// takes its second constructor, and the registration of <c>FileNoticePreferences</c> throws by
+    /// name when the static is empty. What is left over the six is the seam's own registration, which
+    /// is what these tests are about.
+    /// </para>
+    /// <para>
+    /// THOSE THREE ARE THE WHOLE POPULATION AS THIS IS WRITTEN, and what says so is the static rather
+    /// than this list, which drifts: <c>git grep -n "Plugin.Instance" --
+    /// Jellyfin.Plugin.Requests/</c> returns the settings, the store's directory and the notice
+    /// preferences' directory and nothing else. A registration added to that set and not to this
+    /// helper resolves here only while another collection has run first.
     /// </para>
     /// <para>
     /// The session manager arrived with the arrival notice the seam announces through. It is the
@@ -221,6 +243,7 @@ public class PluginServiceRegistrationTests
         services.AddSingleton<IInstallSettings>(new FakeInstallSettings());
         services.AddSingleton<IKnownUsers>(new FakeKnownUsers(Asker));
         services.AddSingleton<ISessionManager>(new ASessionManagerThatOnlyDelivers());
+        services.AddSingleton<INoticePreferences>(new InMemoryNoticePreferences());
 
         return services.BuildServiceProvider();
     }


### PR DESCRIPTION
Closes #310.

`ServerGetsTheThingThatHearsAnAccountBeingDeleted` resolved a service graph that reaches
`Plugin.Instance`, which no test sets. It passed only when another collection in the same process
had already put an instance in that static, so whether it passed was decided by which collections
xUnit happened to run first.

## What I changed

`RegisteredWithTheServerStoodInFor` already overrode the five services only a running server has.
The notice preferences are a sixth of the same kind and were not stood in for, so I registered the
double that already exists for them:

```
services.AddSingleton<INoticePreferences>(new InMemoryNoticePreferences());
```

Standing it in removes the reach into the static rather than arranging for the static to be set.
Setting it would make this class depend on a value every parallel test replaces, which is the
hazard the helper's own comment already names for the store and the settings.

No file under `Jellyfin.Plugin.Requests/` is touched. The registration is correct as it ships - a
running server sets that static while loading - so the production path is unchanged.

## The population, read rather than recalled

Three registrations reach the static, and after this change the helper stands in for all three:

```
$ git grep -n "Plugin\.Instance" -- Jellyfin.Plugin.Requests/
Jellyfin.Plugin.Requests/Configuration/ServerInstallSettings.cs:35:        : this(static () => Plugin.Instance?.Configuration)
Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs:69:            (Plugin.Instance ?? throw new InvalidOperationException(
Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs:153:            (Plugin.Instance ?? throw new InvalidOperationException(
```

Line 35 is `IInstallSettings`, line 69 is the store's data folder, line 153 is the notice
preferences'. The first two were already stood in for. The helper's comment now names the command
above rather than restating the list, because a list in a comment drifts against the thing it
describes.

## The class alone, before and after

Before, at `97e7c39`, on `net10.0`:

```
$ dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -f net10.0 --filter "FullyQualifiedName~PluginServiceRegistrationTests"
Fehler!      : Fehler:     1, erfolgreich:     7, übersprungen:     0, gesamt:     8, Dauer: 230 ms - Jellyfin.Plugin.Requests.Tests.dll (net10.0)
```

That run is in German because this machine's shell is; every run below sets
`DOTNET_CLI_UI_LANGUAGE=en` so the output is quotable here without translation.

After, at `c3bf9a1`:

```
$ DOTNET_CLI_UI_LANGUAGE=en dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -f net10.0 --filter "FullyQualifiedName~PluginServiceRegistrationTests"
Passed!  - Failed:     0, Passed:     8, Skipped:     0, Total:     8, Duration: 102 ms - Jellyfin.Plugin.Requests.Tests.dll (net10.0)

$ DOTNET_CLI_UI_LANGUAGE=en dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -f net9.0 --filter "FullyQualifiedName~PluginServiceRegistrationTests"
Passed!  - Failed:     0, Passed:     8, Skipped:     0, Total:     8, Duration: 217 ms - Jellyfin.Plugin.Requests.Tests.dll (net9.0)
```

## Proof that the stand-in is what fixed it

I deleted the one added line, left everything else in place, and ran the class alone on both
frameworks. Both go red, and for the reason the change names rather than for some other one:

```
=== MUTATION net10.0 ===
   System.InvalidOperationException : What people have set about being told was asked for before this plugin was loaded, so there is no data directory to keep it in.
Failed!  - Failed:     1, Passed:     7, Skipped:     0, Total:     8, Duration: 117 ms - Jellyfin.Plugin.Requests.Tests.dll (net10.0)
=== MUTATION net9.0 ===
   System.InvalidOperationException : What people have set about being told was asked for before this plugin was loaded, so there is no data directory to keep it in.
Failed!  - Failed:     1, Passed:     7, Skipped:     0, Total:     8, Duration: 120 ms - Jellyfin.Plugin.Requests.Tests.dll (net9.0)
```

**`net9.0` was red alone too, and the issue did not measure that.** #310 records the class-alone
failure on `net10.0` only, and its mainline run was green on `net9.0`. That green was the ordering,
not the framework: run by itself the class failed identically on both. So the defect was never one
framework's, and the gate's disagreement between the two was the symptom rather than the shape.

## Whole suite, both frameworks, at `c3bf9a1`

```
$ DOTNET_CLI_UI_LANGUAGE=en dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -f net10.0
Passed!  - Failed:     0, Passed:   744, Skipped:     0, Total:   744, Duration: 18 s - Jellyfin.Plugin.Requests.Tests.dll (net10.0)

$ DOTNET_CLI_UI_LANGUAGE=en dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -f net9.0
Passed!  - Failed:     0, Passed:   744, Skipped:     0, Total:   744, Duration: 14 s - Jellyfin.Plugin.Requests.Tests.dll (net9.0)
```

## The bound, which is the third done-condition

A whole-suite run is silent about this class of defect: another collection puts an instance in the
static early enough often enough that the graph resolves, which is why this stood from the day the
registration landed and surfaced as one red framework out of two. Nothing in the gate runs this
class by itself, so the suite going green here is not evidence that the next one would be caught.

I wrote that into the class summary rather than into a document, because the class summary is what
somebody editing these tests reads, and it carries the command that would catch it. Nothing refuses
a test that reaches the static; the comment is prose and this sentence is the disclosure, not a
softening of it.

## The means

C# and the existing xUnit suite, unchanged: the subject is a registration graph in this assembly,
the double being registered already exists in `Doubles/`, and the change is four lines of the same
kind as the three above it. Nothing outside this repository forces anything else, and no language,
runtime or dependency is added.

## Second reader

There is no second reader for this on this board tonight, so this body carries the evidence in
place of one: the before and after runs, the mutation that reddens both frameworks for the named
reason, the whole-suite runs, and the command behind the claim that the three reaching sites are
all of them. What it does not carry is somebody else's judgement about whether the comment says
the right thing, and that stays unread.

## Why this is the second pull request for one change

#312 carries the same tree and the same patch, and its commit had no `Signed-off-by:` trailer, so
`DCO sign-off` reds it. Correcting that means rewriting the commit, and a rewritten branch is not
force-pushed here under any circumstance, so the correction arrives under a new name and #312 is
closed rather than repaired. The content is identical and that is measured rather than asserted:

```
$ git rev-parse c3bf9a1^{tree} 8c8cf12^{tree}
65bce82123894c7131ac16d520a0aebb77c15d8c
65bce82123894c7131ac16d520a0aebb77c15d8c

$ git show c3bf9a1 | git patch-id --stable; git show 8c8cf12 | git patch-id --stable
f73d008559a34f413c056663653c00142052f1d9 c3bf9a13a7281f516b7542fb1efce7891ba3c14b
f73d008559a34f413c056663653c00142052f1d9 8c8cf12c7779e409eab387ba2148e686c47e5986
```

So every run quoted above was taken on the tree this branch carries, and the only difference
between the two commits is the trailer.
