### PR TITLE
Record that the signature rule arrived, and re-run every reading around it

### DIFF
--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -102,14 +102,28 @@ There are no bypass actors, and none is to be added. A rule with a bypass is a
 rule that holds for whoever did not think to ask, which is the opposite of what
 this list is for.
 
-Commits are to be signed. The ruleset carries no signature rule today and every
-commit on the default branch is already signed, so the rule costs nothing to add
-and closes the case where one is not:
+Commits are to be signed, and **the ruleset carries the rule now**. This
+paragraph said it did not, which is the half of this page a reader trusts most
+because it is the half that describes a setting rather than a file:
+
+    $ gh api repos/iderex/jellyfin-plugin-requests/rules/branches/master         --jq '[.[].type]'
+    ["deletion","non_fast_forward","pull_request","required_status_checks","required_signatures"]
+
+The argument for adding it was that every commit on the default branch was
+already signed, so the rule cost nothing to add and closed the case where one is
+not. That reading was pasted here as `{"total":39,"unverified":0,"verified":39}`
+and no longer reproduces, because the branch has moved past what one page of the
+API returns. Re-run now, and read the total as the page size rather than as the
+history:
 
     $ gh api 'repos/iderex/jellyfin-plugin-requests/commits?sha=master&per_page=100'         --jq '[.[] | .commit.verification.verified]
               | {total: length, verified: (map(select(.)) | length),
                  unverified: (map(select(. == false)) | length)}'
-    {"total":39,"unverified":0,"verified":39}
+    {"total":100,"unverified":0,"verified":100}
+
+Unverified is still zero, so the rule refuses nothing that this board is
+currently doing, which is what makes it cheap rather than what makes it
+pointless: what it holds is the commit nobody has pushed yet.
 
 Three checks that ran here when this list was written are deliberately not in
 it, and the three paragraphs under this one are those three. What has arrived
@@ -210,10 +224,22 @@ command is right:
     Reject Trojan Source Unicode
     Audit workflows (zizmor)
     Check formatting
+    Deterministic pull request hygiene checks
 
-Five of the fifteen. The rest of the set above is not applied: a ruleset is a
-repository setting rather than a file in this tree, and nothing in this change
+Six of the fifteen. This paste read five until the reading above, and the sixth
+arrived without anything on this page or on #30 moving, which is the way every
+previous one arrived too. The rest of the set above is not applied: a ruleset is
+a repository setting rather than a file in this tree, and nothing in this change
 touches one.
+
+Nine are missing and nothing is required that this page has not declared, which
+is the direction worth checking rather than assuming, because a name required
+here and absent above would be a gate nobody wrote a line for:
+
+    $ comm -13 declared.txt live.txt
+
+returns nothing, against the same `declared.txt` the section above builds and a
+`live.txt` from the command in this one.
 #30 carries the application and the demonstration that a red check refuses a
 merge.
 
@@ -251,8 +277,16 @@ merge.
   a job name of its own.
 - `DCO sign-off`, `dependency-review`, `Reject Trojan Source Unicode` and
   `Audit workflows (zizmor)` are the same name on both boards.
-- Signed commits are required by neither ruleset today. This set asks for them
-  here, which is a difference from there rather than parity with it.
+- Signed commits are required by **both** rulesets today, so this is parity and
+  not a difference. This line said neither required them and that this set asked
+  for them here as a difference from there; both halves have since stopped being
+  true, and the line carried no command, which is why it could go stale in
+  silence. The other board's rules are read on `main`, which is its default
+  branch, and asking for `master` there returns an empty list rather than an
+  error:
+
+      $ gh api repos/iderex/jellyfin-plugin-sso/rules/branches/main --jq '[.[].type]'
+      ["deletion","non_fast_forward","required_status_checks","pull_request","required_signatures"]
 
 ## One row per workflow on the other board
 

--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -277,16 +277,20 @@ merge.
   a job name of its own.
 - `DCO sign-off`, `dependency-review`, `Reject Trojan Source Unicode` and
   `Audit workflows (zizmor)` are the same name on both boards.
-- Signed commits are required by **both** rulesets today, so this is parity and
-  not a difference. This line said neither required them and that this set asked
-  for them here as a difference from there; both halves have since stopped being
-  true, and the line carried no command, which is why it could go stale in
-  silence. The other board's rules are read on `main`, which is its default
-  branch, and asking for `master` there returns an empty list rather than an
-  error:
+- Signed commits are required by **both** rulesets today, so this is parity
+  rather than a difference. This line said neither required them and that this
+  set asked for them here as a difference from there, and both halves have since
+  stopped being true. It carried no command, which is why it could go stale in
+  silence, and the command is below rather than in the line because the list is
+  one line per difference.
 
-      $ gh api repos/iderex/jellyfin-plugin-sso/rules/branches/main --jq '[.[].type]'
-      ["deletion","non_fast_forward","required_status_checks","pull_request","required_signatures"]
+The reading behind that last line, which is the only one here that needed one.
+The other board's rules are read on `main` because that is its default branch;
+asking for `master` there returns an empty list rather than an error, which is a
+way to read "no rules" off a board that has them:
+
+    $ gh api repos/iderex/jellyfin-plugin-sso/rules/branches/main --jq '[.[].type]'
+    ["deletion","non_fast_forward","required_status_checks","pull_request","required_signatures"]
 
 ## One row per workflow on the other board
 


### PR DESCRIPTION
Part of #30. This closes none of its three conditions and applies nothing. It corrects
`docs/quality-parity.md`, which is #30's declared scope and this board's authority for what the
merge gate asks for, in three places where it had stopped describing the live ruleset.

All three were found by running the commands the page itself prints. The page's own opening says
that where it and the setting disagree the commands are right, so a reader who follows that
instruction meets the disagreement and a reader who does not is misled by the prose.

## The signature rule is applied, and the page said it was not

```
$ gh api repos/iderex/jellyfin-plugin-requests/rules/branches/master --jq '[.[].type]'
["deletion","non_fast_forward","pull_request","required_status_checks","required_signatures"]
```

The page argued for adding the rule and said the ruleset carried none. I kept the argument as the
argument that was made and recorded that what it asked for is now in force. This is the half of the
page a reader trusts most, because it describes a setting rather than a file and there is nothing
in the tree to check it against.

Four comments on #30, the most recent on 25 August, say there is still no `required_signatures`
rule. That is the reading this replaces.

## The count under that argument had gone stale in the quieter way

The page pasted `{"total":39,"unverified":0,"verified":39}` for the commits on the default branch.
The same command returns:

```
$ gh api 'repos/iderex/jellyfin-plugin-requests/commits?sha=master&per_page=100' \
    --jq '[.[] | .commit.verification.verified]
          | {total: length, verified: (map(select(.)) | length),
             unverified: (map(select(. == false)) | length)}'
{"total":100,"unverified":0,"verified":100}
```

Unverified is still zero, so the paste's conclusion survives and only its figure moved. That is the
case worth correcting most and the easiest to leave: the sentence around a stale number still reads
correctly, and only the command underneath it disagrees. The page now says to read the total as the
page size rather than as the history, because it is capped at `per_page=100` and the branch has
moved past one page.

## The required set is six, and the page printed five

```
$ gh api repos/iderex/jellyfin-plugin-requests/rules/branches/master \
    --jq '.[] | select(.type=="required_status_checks")
          | .parameters.required_status_checks[].context'
call / build
call / test
Reject Trojan Source Unicode
Audit workflows (zizmor)
Check formatting
Deterministic pull request hygiene checks
```

`Deterministic pull request hygiene checks` is already one of the fifteen the page declares, so
#30's second condition moved by one without anybody deciding anything new — which is how every
previous one arrived too. The page had been corrected once before for exactly this, in #245, when
it printed three under a promise to print what is live.

I checked the other direction with it, which is the one nobody has been checking:

```
$ comm -13 declared.txt live.txt
```

returns nothing. Nothing is required that this page has not declared. A name required and
undeclared would be a gate on this board that nobody wrote a line for, which is the defect the
page's opening paragraph defines itself against.

Nine of the fifteen are still not required, and that is unchanged in substance.

## Signed commits are parity with the other board, not a difference from it

The difference list said signed commits are required by neither ruleset and that this set asks for
them here as a difference. Both halves have stopped being true:

```
$ gh api repos/iderex/jellyfin-plugin-sso/rules/branches/main --jq '[.[].type]'
["deletion","non_fast_forward","required_status_checks","pull_request","required_signatures"]
```

That line carried no command, which is how it could go stale in silence, so it carries one now. It
is read on `main` because that is the other board's default branch; asking for `master` there
returns an empty list rather than an error, which is a way to read "no rules" off a board that has
them, so the page says which branch and why.

## What this does not do

It applies no ruleset and chooses nothing. #30's remaining two conditions are unchanged: nine
contexts and the set-membership question are a repository setting and a scope choice, and both are
already written on the issue by somebody who is not me.

## Evidence that this is only what it says

One file, and it is the file #30 declares:

```
$ git diff --name-only origin/master...HEAD
docs/quality-parity.md
```

`Check formatting` is the gate over this file, and **this body carried a run of it that was not
the gate.** The first version of this pull request quoted prettier passing. It was run against a
copy of the file in a scratch directory, so it never saw this repository's `.editorconfig` and
answered about a different configuration. The real gate reds `85e8235`, and the log says so:

```
2026-08-28T12:34:00.0176281Z [warn] docs/quality-parity.md
2026-08-28T12:34:00.7821341Z [warn] Code style issues found in the above file.
##[error]Process completed with exit code 1.
```

`208cdd8` repairs it. The command that commit added sat as an indented code block inside a list
item, and prettier does not converge on that construct: it asks for two more spaces on every pass,
six then eight then ten, so no indentation of it satisfies the gate. The reading moved to a
paragraph below the list, which is what every other pasted command on this page already is.

Run at the path the workflow globs, and checked for a second pass rather than only a first:

```
$ npx --yes prettier@3.6.2 --check "docs/quality-parity.md"
Checking formatting...
All matched files use Prettier code style!

$ npx --yes prettier@3.6.2 "docs/quality-parity.md" | diff -q docs/quality-parity.md -
(no output)
```

Running the workflow's own glob here lists 31 other files, and all of them are this Windows
checkout's CRLF endings rather than anything in the tree; `docs/quality-parity.md` is not among
them. The verdict that counts is the one on this head, not either run above.

## The means

Markdown in `docs/`, unchanged: the artefact is a page that already exists, the change is prose and
pasted command output, and the formatter that judges it is already required on this board. Nothing
is added.

## Second reader

There is no second reader for this on this board tonight, so this body carries the evidence in
place of one: every claim above is a command and its output, run before the sentence was written
rather than afterwards to justify one. What it does not carry is somebody else's judgement about
whether the argument the page makes for the signature rule should have been kept once the rule
landed, and that stays unread.
