### PR TITLE
Name the manifest address, and answer #66's conditions instead of calling them re-planned

### DIFF
--- a/docs/catalogue.md
+++ b/docs/catalogue.md
@@ -151,3 +151,70 @@ What it keeps is the repository, the release route already in [RELEASING.md](REL
 version numbers minted here rather than replaced by the timestamp the catalogue's build script
 writes over them. The two-line packaging problem in the table above stays this board's own, which it
 would have been under either answer.
+
+## The address an operator adds, and what it carries today
+
+    https://flowfin.dev/manifest.json
+
+That is the manifest the decision above distributes from. Until this section no file on this board
+named it: the decision said self-hosted under Flowfin's control and stopped there, so the one thing
+an operator has to type had nowhere to be read from, and the price accepted above -- that somebody
+reaches this plugin only by being told the URL -- was being paid without the URL being written down.
+
+Read back rather than asserted, on 2026-08-28:
+
+    curl -sS -o manifest.json -w '%{http_code}\n' https://flowfin.dev/manifest.json
+    200
+
+    jq -r '.[] | select(.name == "Requests") | .versions[] | [.version, .targetAbi] | @tsv' manifest.json
+    0.2.0.0 10.11.0.0
+    0.1.0.0 10.11.0.0
+
+### The checksums are the ones the packages hash to
+
+The one field of an entry that describes bytes rather than metadata, checked against the archives
+the entries name rather than against the `.md5` published beside them:
+
+    curl -sSL -O https://github.com/Flowfin/jellyfin-plugin-requests/releases/download/0.1.0.0-stable/requests_0.1.0.0.zip
+    curl -sSL -O https://github.com/Flowfin/jellyfin-plugin-requests/releases/download/0.2.0.0-stable/requests_0.2.0.0.zip
+    md5sum requests_0.1.0.0.zip requests_0.2.0.0.zip
+    1167d5e454c800bc024d98a6899cdb4c *requests_0.1.0.0.zip
+    76c0a82e31d04228e7daf1f67383182d *requests_0.2.0.0.zip
+
+Both equal the `checksum` of their entry, so a server that downloads either one and hashes it gets
+the value the manifest promised.
+
+### Both entries claim the 10.11 line, and the 12.0 line has none
+
+The scheme is one entry per server line, each carrying its line's `targetAbi`. What is published is
+two entries for one line. This board claims two:
+
+    grep -nE '^(version|targetAbi|framework):' build.yaml build-jf12.yaml
+    build.yaml:5:version: "0.2.0.0"
+    build.yaml:10:targetAbi: "10.11.0.0"
+    build.yaml:11:framework: "net9.0"
+    build-jf12.yaml:13:version: "0.2.0.0"
+    build-jf12.yaml:15:targetAbi: "12.0.0.0"
+    build-jf12.yaml:16:framework: "net10.0"
+
+and the release route builds the one `build.yaml` names, which is why there is no second package for
+an entry to point at. `publish.yaml` says so about itself in its own header and refuses a `framework`
+that is not the one it builds.
+
+**So a server on the 12.0 line is offered the `net9.0` build.** A server keeps every entry whose
+`targetAbi` is at or below its own version and then takes the highest version number of what is
+left, read at the 10.11 line's own source on 2026-08-28:
+
+    gh api "repos/jellyfin/jellyfin/contents/Emby.Server.Implementations/Updates/InstallationManager.cs?ref=release-10.11.z" \
+      -H "Accept: application/vnd.github.raw" \
+      | grep -nE 'Version.Parse\(x.TargetAbi\) <= appVer|OrderByDescending\(x => x.VersionNumber\)'
+    266:                .Where(x => string.IsNullOrEmpty(x.TargetAbi) || Version.Parse(x.TargetAbi) <= appVer);
+    277:            foreach (var v in availableVersions.OrderByDescending(x => x.VersionNumber))
+
+`10.11.0.0` is at or below `12.0.0.0`, so the filter keeps it and there is nothing else for the
+ordering to prefer.
+
+**Nothing here was installed into a server.** The address was fetched and the archives were hashed;
+no Jellyfin was started, no repository was added to one, and no install was attempted on either
+line. What the paragraph above describes is the comparison the server's source makes, not an install
+anybody watched take the wrong package.

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -479,13 +479,73 @@ server once when the plugin is registered rather than per person, so there is no
 them against and no catalogue entry could reach them. What a language file changes is everything
 inside the pages, not the entry in the dashboard's own menu.
 
+## What #66 asked for, and where each of its three conditions stands
+
+#66 is closed and replaced by #316, which states the same goal against the two surfaces that exist
+rather than against the one it was written for. A replacement makes the older issue's conditions
+somebody's to answer rather than nobody's, so they are answered here one at a time. Re-planned is
+not a disposition; met and deliberately dropped are.
+
+**Grouped by state, on a client this project has never touched. The client half is dropped, and the
+state half is met as a column rather than as groups.** The channel is what that condition was
+written for, and since #67 it answers one folder to every caller and never reads who is asking:
+
+    grep -n 'answers the same single folder to every caller\|public bool IsEnabledFor' Jellyfin.Plugin.Requests/Surface/RequestsChannel.cs
+    37:/// answers the same single folder to every caller, it never asks who is browsing, and it never
+    91:    public bool IsEnabledFor(string userId) => true;
+
+So no surface here puts a person's own list in front of an unmodified television client, and the
+reach matrix above is where that stands rather than being softened by this section. What is dropped
+is the client, and what is left is why: a per-person channel was the thing #67 measured being handed
+to the wrong person on a running server of each line.
+
+The state half is met on both surfaces. The endpoint carries where each request stands, and the page
+draws it beside the sentence for what happens next:
+
+    grep -n 'public required RequestState State' Jellyfin.Plugin.Requests/Api/MyRequest.cs
+    58:    public required RequestState State { get; init; }
+
+    grep -n 'mine.column.state"\|named("mine.state"' Jellyfin.Plugin.Requests/Web/mine.html
+    87:                        <th scope="col" data-i18n="mine.column.state"></th>
+    297:                        cell(row, named("mine.state", request.State));
+
+A column and not groups, and that is the shape rather than an approximation of one: a person reading
+their own handful of asks reads the whole table, and grouping it would repeat the same heading over
+one row each.
+
+**A declined request shows its reason where one was given. Met.** The row carries the closed-list
+reason, and the sentence an operator wrote beside it where they wrote one:
+
+    grep -n 'public DeclineReason? DeclineReason\|public string? DeclineNote' Jellyfin.Plugin.Requests/Api/MyRequest.cs
+    88:    public DeclineReason? DeclineReason { get; init; }
+    94:    public string? DeclineNote { get; init; }
+
+**The view is empty and harmless for a user who has never asked for anything. Met.** No matches
+draws the sentence saying so, rather than an empty table a person has to interpret:
+
+    grep -n 'MatchCount === 0' -A 3 Jellyfin.Plugin.Requests/Web/mine.html
+    310:                    if (answer.MatchCount === 0) {
+    311-                        summary.textContent = word("mine.empty");
+    312-                        return;
+    313-                    }
+
+Harmless is the other half of that word and is the endpoint's rather than the page's: a caller with
+no requests reads their own list and nothing wider, because the narrowing is the store lookup rather
+than a filter over a wider read, which `WhatAPersonIsToldTests` and `ListRequestsTests` hold.
+
+**None of this was read on a running server or in a browser.** The commands above read this
+repository. What a client draws is outside what the suite can see, which is the headless rule in
+[testing.md](testing.md), and the reach matrix above still has no cell checked against a real
+client.
+
 ## What the rest of this milestone follows from
 
 Every issue after #65 in milestone 8 is read against the decision above.
 
 - #66, the user's view of their own requests on a client this project has never touched, was the
-  channel rendering. It was built and then taken out by #67, so what that issue asks for is not
-  reachable through this surface and the issue wants re-planning rather than finishing.
+  channel rendering. It was built and then taken out by #67, and the issue is closed and replaced
+  by #316. Where each of its three conditions stands is the section above rather than a word here,
+  because two of them are met and only one is dropped.
 - #67, proving one user cannot see another's requests through the surface, was measured on a
   running server of each claimed line and could not be shown. Its third condition is what this
   channel now is.


### PR DESCRIPTION
Two documents, no code. `Part of #110` and `Part of #316`, on one branch because both land
documents only and every separate landing moves the mainline under the other.

## What was wrong

**Nothing on this board named the manifest address.** `docs/catalogue.md` declines the official
catalogue, records that the plugin is distributed from a manifest under Flowfin's control, and
states in its own words that the price is an operator reaching this plugin only by being told the
URL and adding it by hand. The URL was in no file here, so the price was being charged without the
thing that makes it payable.

**`docs/surface.md` called #66 re-planned.** That issue is closed and replaced by #316. Re-planned
is not a disposition: it leaves three conditions belonging to nobody, and each reader of either
issue derives them again.

## The address, and what it carries today

    curl -sS -o manifest.json -w '%{http_code}\n' https://flowfin.dev/manifest.json
    200

    jq -r '.[] | select(.name == "Requests") | .versions[] | [.version, .targetAbi] | @tsv' manifest.json
    0.2.0.0 10.11.0.0
    0.1.0.0 10.11.0.0

The checksums are the ones the packages hash to, checked against the archives the entries name
rather than against the `.md5` published beside them:

    md5sum requests_0.1.0.0.zip requests_0.2.0.0.zip
    1167d5e454c800bc024d98a6899cdb4c *requests_0.1.0.0.zip
    76c0a82e31d04228e7daf1f67383182d *requests_0.2.0.0.zip

Both equal the `checksum` of their entry.

**Both published entries claim the 10.11 line and the 12.0 line has none**, while this board claims
two lines. A server keeps every entry whose `targetAbi` is at or below its own version and then
takes the highest version number of what is left, re-read at the 10.11 line's own source rather
than cited from the earlier note on #110:

    gh api "repos/jellyfin/jellyfin/contents/Emby.Server.Implementations/Updates/InstallationManager.cs?ref=release-10.11.z" \
      -H "Accept: application/vnd.github.raw" \
      | grep -nE 'Version.Parse\(x.TargetAbi\) <= appVer|OrderByDescending\(x => x.VersionNumber\)'
    266:                .Where(x => string.IsNullOrEmpty(x.TargetAbi) || Version.Parse(x.TargetAbi) <= appVer);
    277:            foreach (var v in availableVersions.OrderByDescending(x => x.VersionNumber))

`10.11.0.0` is at or below `12.0.0.0`, so a server on the 12.0 line is offered the `net9.0` build,
and there is nothing else for the ordering to prefer. The section says that this was read off the
server's source and not watched happening.

## #66's three conditions, answered one at a time

Two met, one dropped in half, each with the command it was read from. The channel answers one
folder to every caller since #67 and never reads who is asking, so the client half is out of reach
and the reach matrix stays the place that says so; the state half is met as a column on both
surfaces. A declined request carries its reason and the sentence written beside it. An answer of no
matches draws the sentence saying so rather than an empty table.

## What this does not claim

**Nothing was installed into a Jellyfin server and no page was opened in a browser.** The address
was fetched and the two archives were hashed; no server was started, no repository was added to
one, and no install was attempted on either line. Both new sections say so in their own words, and
the reach matrix in `docs/surface.md` still has no cell checked against a real client.

**Neither issue closes on this.** #110's third condition is an install nobody has made, and #316's
second names the settings page, which in this tree's vocabulary is the dashboard page and is the
administrator's. That reading is written into #316 rather than settled here.

## What was run

    npx --yes prettier@3.6.2 --check docs/surface.md docs/catalogue.md
    Checking formatting...
    All matched files use Prettier code style!

    dotnet test Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj \
      --configuration Release -f net9.0 --filter "FullyQualifiedName~RepositoryDocumentsTests"
    Passed!  - Failed: 0, Passed: 15, Skipped: 0, Total: 15

The suite legs that read the tree are unchanged by a documentation edit; the full suite runs on
this pull request rather than here.

**This board had no second reader tonight, and the commands above stand in place of one.**
