### PR TITLE
Take the handover by name, and make the seam a written ABI two guards hold still

### DIFF
--- a/.github/workflows/seam-probe.yaml
+++ b/.github/workflows/seam-probe.yaml
@@ -11,11 +11,18 @@
 # IT RECORDED AN ANSWER AND IT NOW REFUSES ONE. While #117 listed three options for where the shared
 # type comes from, a shared load context and a separate one were both results and each decided which
 # of the three was available, so the only thing that redded this was a run that produced no answer at
-# all. #117 chose one of them on 2026-08-21 and `docs/seam.md` says the choice rests on the answer
-# both lines gave, so the opposite answer is now a defect rather than a result.
-# `scripts/read-seam-probe-answer.sh` carries the reasons and `scripts/prove-seam-probe-refusals.sh`
-# is where each of them is watched biting. It is still not a required check: the required set is a
-# repository setting rather than a file in this tree, and #107 carries the criterion.
+# all. #117 took the third option on 2026-08-28 - no shared type, the handover taken by name through
+# reflection - after two runs of this job measured the other two unavailable on both claimed lines,
+# and `docs/seam.md` carries the choice with both measurements. So the opposite answer is a defect
+# rather than a result. `scripts/read-seam-probe-answer.sh` carries the reasons and
+# `scripts/prove-seam-probe-refusals.sh` is where each of them is watched biting.
+#
+# WHAT THE JOB MEASURES GREW WITH THE CHOICE. The probe used to stop at the lookup. Under a seam
+# resolved by name at runtime, the call is where the risk sits and a lookup that answers is not a
+# handover, so the probe makes the call a sibling makes and the verdict carries what became of it.
+#
+# It is still not a required check: the required set is a repository setting rather than a file in
+# this tree, and #107 carries the criterion.
 name: What a second plugin can see
 
 on:

--- a/Jellyfin.Plugin.Requests.Tests/Seam/SeamAnnouncementTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Seam/SeamAnnouncementTests.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Seam;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Seam;
+
+/// <summary>
+/// #117's fourth condition: that a server with no sibling installed and a server whose sibling is
+/// asking for something this side does not answer to do not look the same to the operator.
+/// <para>
+/// Under a compile-time contract the second of those is a build failure on the other board. Under
+/// the shape #117 took on 2026-08-28 it is a lookup that returns nothing, which is exactly what the
+/// first one returns, and the container says nothing about the difference because from where it
+/// stands there is none. What separates them is this line.
+/// </para>
+/// <para>
+/// What is asserted is that the two states produce different sentences and that the sentence carries
+/// the names somebody would compare. Nothing here asserts that a mismatch is DETECTED, because it is
+/// not: this side cannot see what another plugin asked the container for, and a test claiming
+/// otherwise would be proving a sentence rather than a capability.
+/// </para>
+/// </summary>
+public class SeamAnnouncementTests
+{
+    private static readonly string[] AServerWithNoSibling =
+    [
+        "System.Private.CoreLib",
+        "Jellyfin.Server",
+        "MediaBrowser.Controller",
+        "Jellyfin.Plugin.Requests"
+    ];
+
+    private static readonly string[] AServerWithTheSibling =
+    [
+        "System.Private.CoreLib",
+        "Jellyfin.Server",
+        "MediaBrowser.Controller",
+        "Jellyfin.Plugin.Requests",
+        "Jellyfin.Plugin.Discover"
+    ];
+
+    /// <summary>
+    /// The two states are two sentences. This is the condition itself, and it is asserted before
+    /// anything about what either sentence says, because a pair of lines that happened to differ in
+    /// a detail nobody reads would satisfy a weaker test and not the condition.
+    /// </summary>
+    [Fact]
+    public void NoSiblingAndASiblingDoNotReadTheSame()
+        => Assert.NotEqual(
+            SeamAnnouncement.Compose(AServerWithNoSibling),
+            SeamAnnouncement.Compose(AServerWithTheSibling),
+            StringComparer.Ordinal);
+
+    /// <summary>
+    /// The ordinary server, which is most of them. It says there is nothing to expect, so an
+    /// operator reading it is not left wondering whether something failed.
+    /// </summary>
+    [Fact]
+    public void AServerWithNoSiblingIsToldThereIsNothingToExpect()
+    {
+        string said = SeamAnnouncement.Compose(AServerWithNoSibling);
+
+        Assert.Contains("No other Jellyfin plugin is loaded on this server", said, StringComparison.Ordinal);
+        Assert.DoesNotContain("Jellyfin.Plugin.Discover", said, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The server this exists for. The other plugin is named, and the operator is told that a name
+    /// that does not match is answered with nothing rather than with an error, which is the fact
+    /// that makes the silence readable.
+    /// </summary>
+    [Fact]
+    public void AServerWithASiblingIsToldWhichOneAndWhatToCompare()
+    {
+        string said = SeamAnnouncement.Compose(AServerWithTheSibling);
+
+        Assert.Contains("Jellyfin.Plugin.Discover", said, StringComparison.Ordinal);
+        Assert.Contains("a name that does not match is answered with nothing", said, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Both sentences carry the four names and the version, because the line is only worth reading
+    /// if what it prints is the thing to compare. They are taken from <see cref="SeamSurface"/>,
+    /// which reads them off the types, so a rename moves the line with it.
+    /// </summary>
+    /// <param name="siblingLoaded">Whether the process has another plugin in it.</param>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void EitherWayTheNamesASiblingHasToGetRightAreInIt(bool siblingLoaded)
+    {
+        string said = SeamAnnouncement.Compose(siblingLoaded ? AServerWithTheSibling : AServerWithNoSibling);
+
+        Assert.Contains(SeamSurface.TypeName, said, StringComparison.Ordinal);
+        Assert.Contains(SeamSurface.AssemblyName, said, StringComparison.Ordinal);
+        Assert.Contains(SeamSurface.MemberName, said, StringComparison.Ordinal);
+        Assert.Contains(SeamSurface.WantTypeName, said, StringComparison.Ordinal);
+        Assert.Contains(
+            SeamSurface.Version.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            said,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// This plugin's own assemblies are not siblings of it. The test project loads
+    /// <c>Jellyfin.Plugin.Requests.Tests</c> beside the plugin, so a rule matching the plugin prefix
+    /// alone would report the suite as a sibling on every run and would report a second assembly of
+    /// this plugin's own as one on a server.
+    /// </summary>
+    [Fact]
+    public void ThisPluginsOwnAssembliesAreNotSiblings()
+    {
+        string said = SeamAnnouncement.Compose(
+            ["Jellyfin.Plugin.Requests", "Jellyfin.Plugin.Requests.Tests"]);
+
+        Assert.Contains("No other Jellyfin plugin is loaded on this server", said, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The line reaches the log the operator is reading, rather than being a sentence a test can
+    /// compose and a server never writes.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task TheServerWritesItAtStartup()
+    {
+        var logger = new RecordingLogger();
+        var announcement = new SeamAnnouncement(logger, () => AServerWithTheSibling);
+
+        await announcement.StartAsync(CancellationToken.None);
+        await announcement.StopAsync(CancellationToken.None);
+
+        Assert.Contains(
+            logger.Lines,
+            line => line.Message.Contains(SeamSurface.TypeName, StringComparison.Ordinal)
+                && line.Message.Contains("Jellyfin.Plugin.Discover", StringComparison.Ordinal));
+    }
+}

--- a/Jellyfin.Plugin.Requests.Tests/Seam/SeamSurfaceTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Seam/SeamSurfaceTests.cs
@@ -1,0 +1,104 @@
+using System;
+using Jellyfin.Plugin.Requests.Seam;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Seam;
+
+/// <summary>
+/// The names a sibling gets no compiler help with.
+/// <para>
+/// #117 took the handover by name through reflection on 2026-08-28, after a run on both claimed
+/// lines measured the two package options unavailable. What that buys is immunity to two types of
+/// one name; what it costs is that the assembly, the type, the member and the want are strings on
+/// the other side of the seam. Renaming any of them here compiles, passes every other test, ships,
+/// and is met by an operator as a handover that silently stops arriving.
+/// </para>
+/// <para>
+/// So the names are written down once, here, as literals, and compared against what the types
+/// actually say. <see cref="SeamSurface"/> derives its side of that comparison and holds no literal
+/// of its own, which is what makes this a pin rather than two copies agreeing with each other.
+/// Changing a name means changing this file, and the commit that changes it is where the seam
+/// version is raised and the sibling's board is told.
+/// </para>
+/// <para>
+/// This is the half that reds without a server. The other half is the seam probe, which asks the
+/// same questions of a running server from inside a second plugin, and neither stands in for the
+/// other: this one cannot see a load context and that one cannot run on a machine with no container.
+/// </para>
+/// </summary>
+public class SeamSurfaceTests
+{
+    /// <summary>
+    /// The assembly a sibling resolves the seam out of. It is the plugin's own, which is the whole
+    /// of the third option: nothing separate ships, so there is nothing to be a second copy of.
+    /// </summary>
+    [Fact]
+    public void TheAssemblyIsNamedWhatTheSiblingIsToldItIs()
+        => Assert.Equal("Jellyfin.Plugin.Requests", SeamSurface.AssemblyName, StringComparer.Ordinal);
+
+    /// <summary>
+    /// The type a sibling asks the server's container for.
+    /// </summary>
+    [Fact]
+    public void TheSeamTypeIsNamedWhatTheSiblingIsToldItIs()
+        => Assert.Equal("Jellyfin.Plugin.Requests.Seam.IWantHandover", SeamSurface.TypeName, StringComparer.Ordinal);
+
+    /// <summary>
+    /// The want a sibling has to build to make the call. It is named separately from its properties
+    /// because the two fail at different moments: a wrong type name fails before anything is set.
+    /// </summary>
+    [Fact]
+    public void TheWantIsNamedWhatTheSiblingIsToldItIs()
+        => Assert.Equal("Jellyfin.Plugin.Requests.Seam.HandedOverWant", SeamSurface.WantTypeName, StringComparer.Ordinal);
+
+    /// <summary>
+    /// The seam version, which is what a sibling puts in the want and what this side checks it
+    /// against. Raising it is the deliberate act that says the surface below moved.
+    /// </summary>
+    [Fact]
+    public void TheSeamVersionIsTheOneWrittenDown()
+        => Assert.Equal(1, SeamSurface.Version);
+
+    /// <summary>
+    /// The one member, with its parameters and its return type rather than only its name. A member
+    /// that kept its name and changed its shape is met at the same moment and in the same silence as
+    /// one that was renamed, and under reflection it is met one step later, after the sibling has
+    /// already found the type and been handed the implementation.
+    /// <para>
+    /// Joined rather than compared as two sequences, because a collection failure prints the
+    /// difference with the middle elided and the whole surface is what somebody repairing this needs
+    /// to read.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void TheSeamDeclaresExactlyTheMemberWrittenDown()
+        => Assert.Equal(
+            "System.Threading.Tasks.Task`1[System.Boolean] AcceptAsync(Jellyfin.Plugin.Requests.Seam.HandedOverWant, System.Threading.CancellationToken)",
+            string.Join(" | ", SeamSurface.Members),
+            StringComparer.Ordinal);
+
+    /// <summary>
+    /// Every property of the want, by type and name. A sibling with no compile-time reference sets
+    /// each of these by name, so an addition, a removal or a rename is a runtime failure on a
+    /// server and nothing before it.
+    /// <para>
+    /// This is a set of names rather than a copy of the contract. What each field MEANS is fixed on
+    /// the sibling's board, in the contract issue <c>docs/seam.md</c> points at, and neither this
+    /// file nor that document restates it: #11's second condition is what that rule comes from.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void TheWantCarriesExactlyThePropertiesWrittenDown()
+        => Assert.Equal(
+            string.Join(
+                " | ",
+                "Jellyfin.Plugin.Requests.Model.RequestedItemKind Kind",
+                "System.Collections.Generic.IReadOnlyDictionary`2[System.String,System.String] ProviderIds",
+                "System.Guid RequestedByUserId",
+                "System.Guid WantId",
+                "System.Int32 ContractVersion",
+                "System.Nullable`1[System.Int32] Year",
+                "System.String Title"),
+            string.Join(" | ", SeamSurface.WantProperties),
+            StringComparer.Ordinal);
+}

--- a/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
@@ -120,6 +120,14 @@ public sealed class PluginServiceRegistrator : IPluginServiceRegistrator
             provider.GetRequiredService<ILogger<WantHandover>>(),
             WantHandover.DefaultAnswerWithin));
 
+        // The one line an operator reads about the seam, written once at startup. A hosted service
+        // rather than something built when somebody first asks, because the server this exists for
+        // is the one where nobody ever asks: the handover is taken by name through reflection since
+        // #117, so a sibling naming something else is answered with nothing, exactly as a server
+        // with no sibling is, and the two states have to read differently somewhere.
+        serviceCollection.AddHostedService(provider => new SeamAnnouncement(
+            provider.GetRequiredService<ILogger<SeamAnnouncement>>()));
+
         // The record every move leaves behind, which is the server's own activity log rather than
         // anything this plugin keeps. Registered beside the sink below and not instead of it: the
         // sink is a courtesy that may be lost, and this is the line an operator reads afterwards in

--- a/Jellyfin.Plugin.Requests/Seam/SeamAnnouncement.cs
+++ b/Jellyfin.Plugin.Requests/Seam/SeamAnnouncement.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.Requests.Seam;
+
+/// <summary>
+/// The one line this plugin writes at startup about the seam, so that a server with no sibling on it
+/// and a server whose sibling is naming something else do not read the same.
+/// <para>
+/// <b>This is the price of #117's third option, paid where the operator is.</b> The handover is
+/// taken by name through reflection, so a sibling that names a type this side does not declare gets
+/// nothing back from the container - and a server with no sibling installed gets nothing back
+/// either, because nobody asked. Under a compile-time contract those two states differ at build
+/// time. Under this one they are the same silence at runtime, and #117's fourth condition is that an
+/// operator can tell them apart anyway.
+/// </para>
+/// <para>
+/// <b>What separates them is what this line says, not a guess about what went wrong.</b> It reports
+/// whether another Jellyfin plugin is loaded in this process at all, and it prints the four names a
+/// sibling has to get right. On a server with no sibling the line says so and there is nothing to
+/// expect. On a server that has one and is getting nothing, the line is where the operator reads the
+/// exact strings to compare against what the other plugin is asking for. Neither sentence claims a
+/// mismatch was detected: nothing on this side can see what the sibling asked for, that limit is
+/// stated in <c>docs/seam.md</c>, and a line that claimed more would be worth less.
+/// </para>
+/// <para>
+/// <b>It is written once, at startup, at information level.</b> A line per handover would be noise
+/// on a working server and would say nothing at all on the server this exists for, which is the one
+/// where no handover ever arrives.
+/// </para>
+/// </summary>
+public sealed class SeamAnnouncement : IHostedService
+{
+    /// <summary>
+    /// The prefix every Jellyfin plugin assembly carries, which is how one is told from the rest of
+    /// a server process without a list of plugin names nobody could keep.
+    /// </summary>
+    public const string PluginPrefix = "Jellyfin.Plugin.";
+
+    private readonly ILogger _logger;
+    private readonly Func<IEnumerable<string>> _loaded;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SeamAnnouncement"/> class.
+    /// </summary>
+    /// <param name="logger">The server's log, which is where an operator reads this.</param>
+    /// <exception cref="ArgumentNullException">Where the log is missing.</exception>
+    public SeamAnnouncement(ILogger<SeamAnnouncement> logger)
+        : this(logger, () => AppDomain.CurrentDomain.GetAssemblies().Select(assembly => assembly.GetName().Name ?? string.Empty))
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SeamAnnouncement"/> class over a named set of
+    /// loaded assemblies.
+    /// <para>
+    /// The set is a parameter so that both states can be produced without installing a plugin. A
+    /// suite that could only ever observe the state it happens to run in would prove the sentence it
+    /// already gets and nothing about the other one, and the other one is the whole reason this
+    /// class exists.
+    /// </para>
+    /// </summary>
+    /// <param name="logger">The server's log.</param>
+    /// <param name="loaded">What is loaded in this process, by assembly name.</param>
+    /// <exception cref="ArgumentNullException">Where anything it needs is missing.</exception>
+    public SeamAnnouncement(ILogger logger, Func<IEnumerable<string>> loaded)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(loaded);
+
+        _logger = logger;
+        _loaded = loaded;
+    }
+
+    /// <summary>
+    /// What this side offers, in the words an operator compares against the other plugin.
+    /// <para>
+    /// Composed rather than logged directly so the sentence itself can be read by a test. Every name
+    /// in it comes from <see cref="SeamSurface"/>, which reads them off the types, so a rename moves
+    /// this line rather than leaving it describing a seam that is no longer there.
+    /// </para>
+    /// </summary>
+    /// <returns>The offer.</returns>
+    public static string Offered()
+        => string.Format(
+            CultureInfo.InvariantCulture,
+            "This plugin registers the want handover as {0} from assembly {1}, member {2}, want type {3}, seam version {4}. A plugin handing a want across names all of those as strings; there is no shared assembly and nothing checks them until the call is made.",
+            SeamSurface.TypeName,
+            SeamSurface.AssemblyName,
+            SeamSurface.MemberName,
+            SeamSurface.WantTypeName,
+            SeamSurface.Version);
+
+    /// <summary>
+    /// The whole line, for the process it is given.
+    /// </summary>
+    /// <param name="loadedAssemblyNames">What is loaded, by assembly name.</param>
+    /// <returns>The sentence written to the log.</returns>
+    /// <exception cref="ArgumentNullException">Where the set is missing.</exception>
+    public static string Compose(IEnumerable<string> loadedAssemblyNames)
+    {
+        ArgumentNullException.ThrowIfNull(loadedAssemblyNames);
+
+        string[] siblings = [.. loadedAssemblyNames
+            .Where(name => name.StartsWith(PluginPrefix, StringComparison.Ordinal))
+            .Where(name => !name.StartsWith(SeamSurface.AssemblyName, StringComparison.Ordinal))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(name => name, StringComparer.Ordinal)];
+
+        if (siblings.Length == 0)
+        {
+            return Offered()
+                + " No other Jellyfin plugin is loaded on this server, so nothing here is expected to hand one across and no handover arriving is the ordinary state.";
+        }
+
+        return Offered()
+            + string.Format(
+                CultureInfo.InvariantCulture,
+                " Other Jellyfin plugins are loaded on this server: {0}. Whether any of them hands wants across, and what names it asks for, cannot be read from this side. If wants are not arriving from one that should be sending them, compare the names above against what it asks for: under this seam a name that does not match is answered with nothing rather than with an error.",
+                string.Join(", ", siblings));
+    }
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        // Guarded rather than composed unconditionally. The sentence walks every loaded assembly
+        // name, and a server that has turned this level off should not pay for a line nobody will
+        // read; CA1873 refuses the unguarded form for exactly that reason.
+        if (_logger.IsEnabled(LogLevel.Information))
+        {
+            _logger.LogInformation("{Seam}", Compose(_loaded()));
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/Jellyfin.Plugin.Requests/Seam/SeamSurface.cs
+++ b/Jellyfin.Plugin.Requests/Seam/SeamSurface.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+
+namespace Jellyfin.Plugin.Requests.Seam;
+
+/// <summary>
+/// The names a sibling has to get right, derived from the types rather than typed out.
+/// <para>
+/// <b>This is what #117's third option costs, held in one place.</b> The handover is taken by name
+/// through reflection, so nothing a sibling does is checked by a compiler: it names an assembly, a
+/// type, a member and a want type as strings, and a rename on this side turns every one of those
+/// into a lookup that finds nothing at runtime, on a server, silently. <c>docs/seam.md</c> is the
+/// page both boards read those names off, and this class is the tree's copy of the same four
+/// questions answered by the types themselves.
+/// </para>
+/// <para>
+/// <b>Nothing here is a literal, and that is the whole design.</b> A string typed into this file
+/// would go stale with a rename exactly as quietly as the sibling's copy does. Every member below
+/// is read off a type, so a rename moves it; what refuses the rename is
+/// <c>SeamSurfaceTests</c>, which holds the literals and compares them against these, and the seam
+/// probe, which asks the same questions of a running server from another plugin's load context.
+/// </para>
+/// <para>
+/// <b>It is not a second contract.</b> What crosses the seam is fixed on the sibling's board, in the
+/// contract issue <c>docs/seam.md</c> points at. This says what this side answers to, which is a
+/// different question and is this board's to answer.
+/// </para>
+/// </summary>
+public static class SeamSurface
+{
+    /// <summary>
+    /// Gets the assembly a sibling resolves the seam out of.
+    /// </summary>
+    public static string AssemblyName => typeof(IWantHandover).Assembly.GetName().Name ?? string.Empty;
+
+    /// <summary>
+    /// Gets the full name of the type a sibling asks the server's container for.
+    /// </summary>
+    public static string TypeName => typeof(IWantHandover).FullName ?? string.Empty;
+
+    /// <summary>
+    /// Gets the name of the one member a sibling calls.
+    /// </summary>
+    public static string MemberName => nameof(IWantHandover.AcceptAsync);
+
+    /// <summary>
+    /// Gets the full name of the type a sibling has to build to make that call.
+    /// </summary>
+    public static string WantTypeName => typeof(HandedOverWant).FullName ?? string.Empty;
+
+    /// <summary>
+    /// Gets the version of the contract this side answers to.
+    /// <para>
+    /// It is the same number a want carries and is checked against, read off the implementation
+    /// rather than repeated, so the version an operator is told is the version a handover is judged
+    /// by and there is no second place for one of them to move.
+    /// </para>
+    /// </summary>
+    public static int Version => WantHandover.KnownContractVersion;
+
+    /// <summary>
+    /// Gets every member the seam type declares, rendered as the runtime renders it.
+    /// <para>
+    /// The parameter types and the return type are in it rather than only the name, because a member
+    /// that kept its name and changed its shape is the same silent failure as one that was renamed,
+    /// and under reflection it fails one step later rather than one step earlier.
+    /// </para>
+    /// </summary>
+    public static IReadOnlyList<string> Members
+        => [.. typeof(IWantHandover)
+            .GetMembers(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Select(member => member.ToString() ?? string.Empty)
+            .OrderBy(rendered => rendered, StringComparer.Ordinal)];
+
+    /// <summary>
+    /// Gets every property of the want, rendered as a type and a name.
+    /// <para>
+    /// A sibling with no compile-time reference sets these by name, so they are as much of the
+    /// runtime surface as the member is. What each one MEANS is the sibling's contract and is not
+    /// restated here or in <c>docs/seam.md</c>; what is here is the set of names a lookup can miss.
+    /// </para>
+    /// </summary>
+    public static IReadOnlyList<string> WantProperties
+        => [.. typeof(HandedOverWant)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Select(property => string.Format(
+                CultureInfo.InvariantCulture,
+                "{0} {1}",
+                property.PropertyType.ToString(),
+                property.Name))
+            .OrderBy(rendered => rendered, StringComparer.Ordinal)];
+}

--- a/docs/seam.md
+++ b/docs/seam.md
@@ -65,7 +65,7 @@ all.
 means having the type, and whether a second plugin in one server process can name this one was the
 open half of #117. A second plugin installed beside this one, shipping no copy of anything this
 plugin declares, finds the type and is handed the registration by the container, on a server of each
-claimed line. The answer and the commands are under "Where the shared type comes from" below.
+claimed line. The answer and the commands are under "Where the seam type comes from" below.
 Resolving the sink from inside this assembly, which is what the suite does, is still a different
 claim and still says nothing about who else can ask for it.
 
@@ -91,7 +91,7 @@ Giving up is safe here for the same reason a repeat is safe. The want carries an
 other side hands it over again, and a request the abandoned call still managed to write is
 recognised as the repeat it is rather than made twice.
 
-## Where the shared type comes from
+## Where the seam type comes from
 
 Implementing somebody's interface means having the type, so the type has to arrive from somewhere,
 and where it arrives from is the whole of whether this seam works at all. The failure is quiet:
@@ -99,38 +99,111 @@ two assemblies of the same simple name in one process can declare two different 
 full name, nothing fails at build time, and what happens instead is that the container returns no
 implementations, which looks exactly like the sibling not being installed and is a supported state.
 
-**The choice is a contract-only package both sides compile against, with exactly one copy shipped.**
-Taken on #117 on 2026-08-21, and taken before the sibling writes its half, because once the other
-side has written against a type declared in this assembly, moving it is a migration across two
-boards rather than a choice on one.
+**The choice is that no type is shared at all. The sibling names this one by string and takes the
+handover through reflection.** Taken on #117 on 2026-08-28, and taken against the option this
+document carried until that day, because the two options that would have shared a type were both
+measured on a running server of each claimed line and neither of them works. The measurements are
+below, with the commands, before the argument that rests on them.
 
-What it costs, stated rather than implied. It is another artefact with its own version and its own
-publishing route, on a board that does not yet publish a manifest for the plugin itself, so the
-package's release path has to be settled as part of building this and not assumed to follow the
-plugin's. It is versioned independently and changed rarely: a contract package that moves often is
-two plugins that have to be upgraded together, which is the thing a shared type was meant to avoid.
+**Ugly is the fair word for it and immune is the one that matters.** There is no second assembly, so
+there is no second type of the same name, so the failure class this section opens with cannot arise.
+Nothing has to be published, versioned or upgraded in step across two boards, and a server that
+installs one plugin and not the other is unremarkable rather than a case somebody has to have
+thought about.
 
-### The two that were rejected
+**What it costs is the compiler, and the price is paid at runtime on somebody's server.** A sibling
+that names an assembly, a type, a member or a field this side does not declare compiles perfectly,
+installs perfectly, and is answered with nothing. So does this side after a rename nobody thought of
+as a breaking change. That is not a residual risk to be noted and left; it is the whole reason for
+the three paragraphs that follow, and for the two guards that stand behind them.
+
+### This page is the ABI, and a rename is a version
+
+Both boards read the names off this section and treat them as fixed. A change to any of them is a
+breaking change on both boards at once and moves the seam version with it; it is never discovered by
+an operator.
+
+The names are not written out here, because a list in a document drifts against the thing it
+describes and the thing it describes is one `git grep` away. They are derived:
+
+    git grep -n 'public static string AssemblyName\|public static string TypeName\|public static string MemberName\|public static string WantTypeName' -- Jellyfin.Plugin.Requests/Seam/SeamSurface.cs
+    git grep -n 'public const int KnownContractVersion' -- Jellyfin.Plugin.Requests/Seam/WantHandover.cs
+
+`SeamSurface` holds no literal of its own: every member reads its answer off a type, so a rename
+moves what it says instead of leaving it describing a seam that is no longer there. What refuses the
+rename is `SeamSurfaceTests`, which holds the literals and compares them against those types. That is
+the pin, and changing a name means changing that file, in the commit that raises the version and
+tells the other board.
+
+The field set the want carries is NOT fixed here and this document does not restate it. It is the
+sibling's, in the contract issue named at the top of this page, which is the rule #11's second
+condition imposes and which the choice above does not weaken. What the surface test pins is the set
+of NAMES a reflected lookup can miss, which is a different question from what any of them means:
+
+    git grep -n 'TheWantCarriesExactlyThePropertiesWrittenDown' -- Jellyfin.Plugin.Requests.Tests/Seam/SeamSurfaceTests.cs
+
+### The two that were rejected, and the run that killed each
+
+Both were rejected on evidence rather than on taste, and each had been an open option until the run
+that closed it. Both readings come from `.github/workflows/seam-probe.yaml` on
+`seam/117-the-contract-package`, which built a contract-only package for exactly this purpose and is
+not merged.
+
+**A contract-only package both sides compile against, with exactly one copy shipped.** This was the
+choice this document carried from 2026-08-21 until 2026-08-28, and the premise underneath it - that a
+compile-time reference resolves an assembly shipping in another plugin's directory - had never been
+measured. Run `33125497741`, job `98702538786` for the 10.11 line, job `98702538479` for 12.0,
+identical verdicts:
+
+    gh api --allow-escape-sequences repos/Flowfin/jellyfin-plugin-requests/actions/jobs/98702538786/logs \
+      | sed 's/\x1b\[[0-9;]*m//g' | grep -a "SEAM-PROBE" | sed -E 's/.*ContainerReport: //' | sort -u
+    SEAM-PROBE assemblies loaded under the name Jellyfin.Plugin.Requests.Contract: 1
+    SEAM-PROBE one of them is at /config/plugins/Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.Contract.dll
+    SEAM-PROBE the compile-time reference to Jellyfin.Plugin.Requests.Seam.IWantHandover did not bind: System.IO.FileNotFoundException: Could not load file or assembly 'Jellyfin.Plugin.Requests.Contract, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'. The system cannot find the file specified.
+    SEAM-PROBE the container returned 1 implementation(s) of it
+    SEAM-PROBE the type Jellyfin.Plugin.Requests.Seam.IWantHandover is reachable from this plugin
+    SEAM-PROBE result assemblies=1 contract=reachable implementations=1 binding=unbound bound-implementations=0 same-type=no
+
+The type is visible to the second plugin and the reference to it is unresolvable, in one run, at the
+same moment. Neither half cancels the other, and the second half is the option gone: a sibling that
+ships no copy cannot bind what it compiled against.
 
 **A contract-only package both sides compile against and both ship, with the loader deduplicating
-it.** Rejected. It rests on the loader actually merging two copies, and that is the assumption the
-entire handover would then depend on. Nobody has measured it on either claimed line, so the cost of
-this option is an unmeasured premise underneath every call that crosses. One shipped copy removes
-the question instead of answering it.
+it.** Rejected on 2026-08-21 on the grounds that its premise was unmeasured, and the premise is false.
+It is also what a package reference gives a sibling by default, rather than a shape anybody has to
+construct, which is why it had to be measured rather than assumed away. Run `33126052099`, job
+`98704350874` for 10.11, job `98704350837` for 12.0, identical verdicts:
 
-**No shared type at all, with the handover taken by name through reflection.** Rejected, and it is
-the honest fallback if the package turns out to be impractical rather than a bad idea. It is immune
-to this whole error class, because there is no second type to be a different type. What it costs is
-the thing #117's fourth condition is about: a mismatch stops being a compile error and becomes a
-runtime one, so "no sibling installed" and "sibling installed, type did not match" collapse back
-into the same silence. A compile-time contract is what keeps those two states different.
+    SEAM-PROBE assemblies loaded under the name Jellyfin.Plugin.Requests.Contract: 2
+    SEAM-PROBE one of them is at /config/plugins/Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.Contract.dll
+    SEAM-PROBE one of them is at /config/plugins/SeamProbe/Jellyfin.Plugin.Requests.Contract.dll
+    SEAM-PROBE the compile-time reference to Jellyfin.Plugin.Requests.Seam.IWantHandover bound and the container returned 0 implementation(s) for it
+    SEAM-PROBE the container returned 1 implementation(s) of it
+    SEAM-PROBE the type it bound to and the type found by name are two different types
+    SEAM-PROBE result assemblies=2 contract=reachable implementations=1 binding=bound bound-implementations=0 same-type=no
+
+The loader does not merge them. The second plugin binds to its own copy, that copy declares a
+different type of the same full name, and the container hands it nothing. That is not a near-miss of
+the failure the top of this section describes. It is that failure, reproduced on a running server of
+each claimed line, with the same silence an operator meets.
+
+**One cause sits under both, which is why the third option is not a coin toss.** A plugin gets a load
+context of its own. Resolving an assembly by name looks in that plugin's own directory and in what
+the host provides, and never in another plugin's. Ship the contract once and the reference is
+unresolvable; ship it twice and each side resolves its own. Enumerating what the process has loaded
+reaches every plugin's assemblies whatever context they arrived in, which is why the reflected lookup
+answered in both runs and in every run before them.
+
+Whoever reopens this in a year: the experiment is `tools/seam-probe`, it is one job away, and both
+readings above came out of it in one evening. Re-run it rather than re-arguing it.
 
 ### What a server of each line actually does
 
-The choice above rests on a plugin being able to name a type whose assembly ships in another
-plugin's directory. That is a fact about the host rather than about either tree, and the two claimed
-lines are different major versions of it, so an answer taken from one is a claim about the other.
-Both were asked, at `5b96f57`, by `.github/workflows/seam-probe.yaml`:
+The choice above rests on a plugin being able to name a type declared in another plugin's assembly,
+and to call the member it finds. That is a fact about the host rather than about either tree, and the
+two claimed lines are different major versions of it, so an answer taken from one is a claim about
+the other. Both are asked by `.github/workflows/seam-probe.yaml`, on every change to the files the
+measurement is made of, and the reading is the last line each run writes:
 
     gh api repos/Flowfin/jellyfin-plugin-requests/actions/jobs/96989583236/logs | grep -a "SEAM-PROBE" | sed -E 's/.*ContainerReport: //' | sort -u
     SEAM-PROBE assemblies loaded under the name Jellyfin.Plugin.Requests: 1
@@ -138,74 +211,80 @@ Both were asked, at `5b96f57`, by `.github/workflows/seam-probe.yaml`:
     SEAM-PROBE the container returned 1 implementation(s) of it
     SEAM-PROBE the type Jellyfin.Plugin.Requests.Seam.IWantHandover is reachable from this plugin
 
-That job is the 10.11 line. The 12.0 line is job `96989583387` and the same command returns the same
-four lines. Both servers held two plugins while answering, this one and the probe.
+That job is the 10.11 line, taken at `5b96f57`; job `96989583387` is 12.0 and returns the same four
+lines. Both servers held two plugins while answering, this one and the probe, and the probe ships no
+copy of anything this plugin declares.
 
-So one shipped copy is available on both lines. The assembly is loaded once, in a context a second
-plugin can see, and the container hands that second plugin the implementation this one registered.
+**The probe now goes as far as a sibling goes, and that is what the choice made necessary.** Finding
+the type and being handed an implementation says the lookup works. It says nothing about whether the
+call can be made, and under this shape the call is where the remaining risk sits: the member is found
+by name, the want is built out of this plugin's own type by reflection, its properties are set by
+name, and every one of those steps can fail at runtime with nothing failing at build time. So the
+probe makes the call, with a want that names no user - so the implementation runs its own path and
+writes nothing into the queue of a server it does not own - and the verdict carries what became of
+it. Being refused is the answer being measured; a request being made is not.
 
-What it does not say, because the distance between the two is where this would be misread. The probe
-finds the type by name through reflection, so what is measured is that the assembly is loaded once
-and that its type resolves and answers a lookup from elsewhere in the process. Whether the runtime
-binds a compile-time reference to that same loaded assembly is a further step and is not measured
-here. And nothing above installs two copies of one contract assembly, so the premise the first
-rejected option rests on is still unmeasured, which is what that option's own paragraph says.
+    git grep -n 'private async Task<string> CallAsync' -- tools/seam-probe/ContainerReport.cs
 
 ### That answer is refused rather than reported, since 2026-08-26
 
-The run that took the measurement above refused one thing only: a probe that wrote nothing. Both
-answers were results while the three options were open, because each of them decided which options
-were available. They are not both results any more. The choice above rests on the answer the two
-lines gave, so a run that comes back with the other one is a defect and a run that prints it and
-passes tells nobody.
+The run that took the first measurement refused one thing only: a probe that wrote nothing. Every
+answer was a result while the three options were open, because each of them decided which options
+were available. They are not results any more. The choice above rests on the answer the two lines
+give, so a run that comes back with another one is a defect and a run that prints it and passes tells
+nobody.
 
-`scripts/read-seam-probe-answer.sh` reads the one line the probe writes as a verdict and refuses four
-answers, each for its own reason: no assembly of that name loaded, more than one of them, a contract
-type a second plugin cannot reach, and a container that handed back nothing. The last of those is the
-silence #117's fourth condition is about, and it is refused here rather than printed.
+`scripts/read-seam-probe-answer.sh` reads the one line the probe writes as a verdict and refuses five
+answers, each for its own reason: no assembly of that name loaded, more than one of them, a seam type
+a second plugin cannot reach, a container that handed back nothing, and a lookup that worked with a
+call that did not. The fourth of those is the silence #117's fourth condition is about. The fifth
+arrived with this choice and is where a rename lands, in four spellings the reader names one by one.
 
-What made this worth doing before the package exists is that moving the type is what breaks it. The
-probe names the contract by string:
+Every refusal is watched biting in `scripts/prove-seam-probe-refusals.sh`, over one log per answer,
+with the answer the chosen shape produces beside them as the case that has to pass. Two of the
+fixtures are near-misses rather than plain wrong answers: a restart whose SECOND verdict is the bad
+one, which is what a reader using `head` where this one uses `tail` would pass, and the result line
+of the reader before this one, word for word, which is what a reader that matched the first three
+fields and stopped would pass as a working seam. It needs no container and no server, so the reader
+that decides a probe run is checked on machines that cannot run one.
 
-    git grep -n 'OtherAssembly = \|Contract = ' -- tools/seam-probe/ContainerReport.cs
-    tools/seam-probe/ContainerReport.cs:38:    private const string OtherAssembly = "Jellyfin.Plugin.Requests";
-    tools/seam-probe/ContainerReport.cs:39:    private const string Contract = "Jellyfin.Plugin.Requests.Seam.IWantHandover";
+### What the tree does today is the choice, and that is a change
 
-so the day the contract moves into the package neither string names anything that declares it, and
-under the old rule the job stayed green about an assembly that no longer held the type. It now reds
-and names the two constants. The trigger carries the same reasoning: `Jellyfin.Plugin.Requests/Seam/`
-and the service registrator are in the paths that start the job, because the change that breaks the
-measurement arrives through them rather than through the probe's own files. A rename of the assembly
-lives in the project file and is still not covered.
-
-Every refusal above is watched biting in `scripts/prove-seam-probe-refusals.sh`, over one log per
-answer, with the answer both lines gave beside them as the case that has to pass. It needs no
-container and no server, so the reader that decides a probe run is checked on machines that cannot
-run one.
-
-### What the tree does today is not yet the choice above
-
-The type the sibling would name is declared in this plugin's own assembly, and this project
-references no contract package:
+This section said the opposite until 2026-08-29, and said it deliberately: the registration had
+landed before the question was decided, and reading the paragraphs above as a description of what
+ships was the one misreading the document could produce. There is nothing left to build. The type the
+sibling names is declared in this plugin's own assembly, and this project references nothing but the
+host:
 
     git grep -n 'public interface IWantHandover' -- Jellyfin.Plugin.Requests/Seam/IWantHandover.cs
-    Jellyfin.Plugin.Requests/Seam/IWantHandover.cs:30:public interface IWantHandover
-
     git grep -n 'PackageReference Include\|ProjectReference' -- Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.csproj
-    Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.csproj:23:    <PackageReference Include="Jellyfin.Controller" Version="$(JellyfinVersion)">
-    Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.csproj:26:    <PackageReference Include="Jellyfin.Model" Version="$(JellyfinVersion)">
 
-Two references and both are the host's. So the registration landed before the question was decided,
-and the decision above is a thing to build rather than a description of what ships. Reading this
-section as the arrangement being in place is the one misreading it could produce, which is why the
-commands are here.
+What used to be the gap is closed rather than softened. The seam probe resolves this plugin's
+registration from another plugin's load context and calls it, on a running server of each claimed
+line, in the shape that ships - which is the shape, because under this choice there is no second
+shape a package would have introduced.
 
-**Two things #117 asks for are still not done, and neither is softened by the choice being
-taken.** Nothing proves that the sibling's container lookup finds this plugin's implementation in
-the shape that will actually ship, on either line; what the suite resolves is this assembly's own
-registration and what the probe resolves it finds by name, and neither of those is a contract
-package. And nothing separates a container that found no implementation from one that found none
-because the type did not match, so an operator meeting either one meets the same silence.
+### The silence an operator meets, and what is put beside it
+
+This is what the rejected options bought and this one does not, so it is stated as a cost rather than
+as a feature. Under a compile-time contract a sibling naming the wrong type fails to build. Under
+this one it is handed nothing by the container - and a server with no sibling installed is handed
+nothing too, because nobody asked. The container cannot tell those apart, because from where it
+stands there is no difference.
+
+What separates them is one line this plugin writes at startup, in `SeamAnnouncement`. It prints the
+names above, so an operator has the exact strings to compare against what the other plugin asks for,
+and it says whether any other Jellyfin plugin is loaded in this process at all. A server with no
+sibling is told there is nothing to expect. A server that has one is told which one, and that a name
+that does not match is answered with nothing rather than with an error.
+
+**It does not detect a mismatch and does not claim to.** Nothing on this side can see what another
+plugin asked the container for; there is no callback and no read back across this seam, for the
+reasons under "No read crosses back" below. What the line buys is that the two states read
+differently and that the operator holds the strings. That is what #117's fourth condition asks for
+and it is the whole of what is delivered.
+
+    git grep -n 'NoSiblingAndASiblingDoNotReadTheSame' -- Jellyfin.Plugin.Requests.Tests/Seam/SeamAnnouncementTests.cs
 
 ### What the package actually contains, read out of the package
 
@@ -226,9 +305,10 @@ Taken from the run of `037a664567acbd9eb0defa88118ddf6331ff3bed`:
        380928  2026-08-25 19:12   Jellyfin.Plugin.Requests.dll
 
 Two files on each claimed line: this plugin's own assembly and the metadata a server reads. Nothing
-of the other board ships, and nothing that could be a second copy of a shared type ships either,
-which is the baseline the choice above changes: when the contract package exists, exactly one side
-carries it and this listing is where that becomes visible.
+of the other board ships, and nothing that could be a second copy of a shared type ships either.
+That was a baseline about to change while the choice above was a package; since 2026-08-28 it is the
+permanent shape, and this listing is where a shared assembly appearing in the install would be seen.
+A second name in it is the failure the section above measured, not a step towards the seam working.
 
 That list is derived rather than asserted. The same job publishes the plugin and compares what the
 publish leaves behind against the `artifacts:` list in `build.yaml`, ending non-zero on a name in

--- a/scripts/prove-seam-probe-refusals.sh
+++ b/scripts/prove-seam-probe-refusals.sh
@@ -8,10 +8,14 @@
 # everything. It reads a file, so every one of its answers can be handed to it directly.
 #
 # THE ONE THIS EXISTS FOR IS THE LOG WITH NO RESULT LINE IN IT. Until this reader landed, a run
-# passed if the probe wrote any line at all, so a probe reporting that the contract type was NOT
-# reachable was a green job. That is the shape #117 names on 2026-08-25 as the failure to build
-# against: the day the contract type moves into the package it stops being declared by the assembly
-# the probe names, and a run that only refuses silence goes on passing about nothing.
+# passed if the probe wrote any line at all, so a probe reporting that the seam type was NOT
+# reachable was a green job.
+#
+# THE ONES ADDED WITH THE THIRD OPTION ARE THE CALL. #117 took the handover by name through
+# reflection on 2026-08-28, so the member and the want are resolved at runtime by string and a rename
+# fails nothing at build time. The probe makes the call a sibling makes and the reader refuses a run
+# whose lookup worked and whose call did not - and there are four ways for that to read, so each of
+# them is handed over below rather than one of them standing for the set.
 #
 # The near-miss beside it is `head` where the reader has `tail`. A server that restarts its hosted
 # services writes the result line twice, and a reader taking the first one reports the answer of a
@@ -37,13 +41,13 @@ trap 'rm -rf "$work"' EXIT
 log() {
     local file=$1 result=$2
     {
-        printf '[2026-08-26 21:00:00.000 +00:00] [INF] [1] Main: Jellyfin version: 10.11.11\n'
-        printf '[2026-08-26 21:00:01.000 +00:00] [WRN] [9] Jellyfin.Plugin.SeamProbe.ContainerReport: SEAM-PROBE assemblies loaded under the name Jellyfin.Plugin.Requests: 1\n'
-        printf '[2026-08-26 21:00:01.000 +00:00] [WRN] [9] Jellyfin.Plugin.SeamProbe.ContainerReport: SEAM-PROBE one of them is at /config/plugins/Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.dll\n'
+        printf '[2026-08-29 21:00:00.000 +00:00] [INF] [1] Main: Jellyfin version: 10.11.11\n'
+        printf '[2026-08-29 21:00:01.000 +00:00] [WRN] [9] Jellyfin.Plugin.SeamProbe.ContainerReport: SEAM-PROBE assemblies loaded under the name Jellyfin.Plugin.Requests: 1\n'
+        printf '[2026-08-29 21:00:01.000 +00:00] [WRN] [9] Jellyfin.Plugin.SeamProbe.ContainerReport: SEAM-PROBE one of them is at /config/plugins/Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.dll\n'
         if [ -n "$result" ]; then
-            printf '[2026-08-26 21:00:01.000 +00:00] [WRN] [9] Jellyfin.Plugin.SeamProbe.ContainerReport: %s\n' "$result"
+            printf '[2026-08-29 21:00:01.000 +00:00] [WRN] [9] Jellyfin.Plugin.SeamProbe.ContainerReport: %s\n' "$result"
         fi
-        printf '[2026-08-26 21:00:02.000 +00:00] [INF] [1] Main: Startup complete\n'
+        printf '[2026-08-29 21:00:02.000 +00:00] [INF] [1] Main: Startup complete\n'
     } > "$work/$file"
 }
 
@@ -74,57 +78,88 @@ refuses() {
     esac
 }
 
-printf '\n== the answer both claimed lines gave on 2026-08-22 passes\n'
-log clean.log 'SEAM-PROBE result assemblies=1 contract=reachable implementations=1'
+printf '\n== the answer the shape #117 took has to produce passes\n'
+log clean.log 'SEAM-PROBE result assemblies=1 contract=reachable implementations=1 call=answered'
 if out=$("$reader" "$work/clean.log" 2>&1); then
     printf '%s\n' "$out" | sed 's/^/  /'
 else
     printf '%s\n' "$out" | sed 's/^/  /'
-    echo "  REFUSED the answer the tree was built on, which is a reader that refuses everything."
+    echo "  REFUSED the answer the tree is built on, which is a reader that refuses everything."
     failures=$((failures + 1))
 fi
 
 # The trap this reader exists for. The probe ran, said the type was not reachable, and every line it
 # wrote carries the marker the old run grepped for, so this log used to be a green job.
-log missing.log 'SEAM-PROBE result assemblies=1 contract=missing implementations=0'
-refuses "the contract type is not reachable, which used to pass" \
-    "the contract type is not reachable from a second plugin" \
+log missing.log 'SEAM-PROBE result assemblies=1 contract=missing implementations=0 call=notattempted'
+refuses "the seam type is not reachable, which used to pass" \
+    "the seam type is not reachable from a second plugin" \
     -- "$reader" "$work/missing.log"
 
-log two.log 'SEAM-PROBE result assemblies=2 contract=reachable implementations=1'
+log two.log 'SEAM-PROBE result assemblies=2 contract=reachable implementations=1 call=answered'
 refuses "two assemblies of one name in one process" \
-    "Two copies of one contract assembly in one process is the failure this seam exists to avoid" \
+    "Two copies of one assembly in one process is the failure this seam exists to avoid" \
     -- "$reader" "$work/two.log"
 
-log none.log 'SEAM-PROBE result assemblies=0 contract=missing implementations=0'
+log none.log 'SEAM-PROBE result assemblies=0 contract=missing implementations=0 call=notattempted'
 refuses "the plugin under test was not loaded at all" \
     "no assembly named Jellyfin.Plugin.Requests was loaded" \
     -- "$reader" "$work/none.log"
 
-log unanswered.log 'SEAM-PROBE result assemblies=1 contract=reachable implementations=0'
+log unanswered.log 'SEAM-PROBE result assemblies=1 contract=reachable implementations=0 call=notattempted'
 refuses "the container handed back nothing, which is the silence an operator meets" \
-    "the container returned no implementation of the contract" \
+    "the container returned no implementation of the seam" \
     -- "$reader" "$work/unanswered.log"
+
+# The four ways the call can fail. They are one refusal in the reader and four different repairs, so
+# each of them is handed over rather than one standing in for the set: a run that reads any of these
+# as a working seam is a run that measured the lookup and called it the handover.
+log nomember.log 'SEAM-PROBE result assemblies=1 contract=reachable implementations=1 call=nomember'
+refuses "the member was renamed, which nothing catches at build time" \
+    "the lookup worked and the call did not (call=nomember)" \
+    -- "$reader" "$work/nomember.log"
+
+log nowant.log 'SEAM-PROBE result assemblies=1 contract=reachable implementations=1 call=nowant'
+refuses "the want type or one of its properties was renamed" \
+    "the lookup worked and the call did not (call=nowant)" \
+    -- "$reader" "$work/nowant.log"
+
+log failed.log 'SEAM-PROBE result assemblies=1 contract=reachable implementations=1 call=failed'
+refuses "the call was made and did not come back with an answer" \
+    "the lookup worked and the call did not (call=failed)" \
+    -- "$reader" "$work/failed.log"
+
+log notattempted.log 'SEAM-PROBE result assemblies=1 contract=reachable implementations=1 call=notattempted'
+refuses "the lookup answered and nothing tried to call" \
+    "the lookup worked and the call did not (call=notattempted)" \
+    -- "$reader" "$work/notattempted.log"
 
 # The probe threw before it reached an answer. It writes a line, and that line carries the marker, so
 # only a reader looking for the verdict rather than for the marker refuses this.
 log threw.log ''
-printf '[2026-08-26 21:00:01.000 +00:00] [WRN] [9] Jellyfin.Plugin.SeamProbe.ContainerReport: SEAM-PROBE the probe itself failed: System.TypeLoadException: no\n' >> "$work/threw.log"
+printf '[2026-08-29 21:00:01.000 +00:00] [WRN] [9] Jellyfin.Plugin.SeamProbe.ContainerReport: SEAM-PROBE the probe itself failed: System.TypeLoadException: no\n' >> "$work/threw.log"
 refuses "the probe failed before it had an answer" \
     "the probe wrote no result line, so this run measured nothing" \
     -- "$reader" "$work/threw.log"
 
-log shape.log 'SEAM-PROBE result contract=reachable assemblies=1 implementations=1'
+log shape.log 'SEAM-PROBE result contract=reachable assemblies=1 implementations=1 call=answered'
 refuses "a result line whose fields this reader does not know" \
     "does not have the shape this reader knows" \
     -- "$reader" "$work/shape.log"
 
+# The line the previous reader passed, word for word. It carries no call field at all, so a reader
+# that matched the first three fields and stopped would read a run that never called anything as a
+# working seam. This is the one-character mistake somebody makes while widening the pattern.
+log ofthethreefields.log 'SEAM-PROBE result assemblies=1 contract=reachable implementations=1'
+refuses "the result line the reader before this one passed" \
+    "does not have the shape this reader knows" \
+    -- "$reader" "$work/ofthethreefields.log"
+
 # The near-miss: `head` where the reader has `tail`. The server restarted its hosted services, the
 # first answer was the good one and the process that is actually running gave the second.
-log restarted.log 'SEAM-PROBE result assemblies=1 contract=reachable implementations=1'
-printf '[2026-08-26 21:00:30.000 +00:00] [WRN] [9] Jellyfin.Plugin.SeamProbe.ContainerReport: SEAM-PROBE result assemblies=2 contract=reachable implementations=1\n' >> "$work/restarted.log"
+log restarted.log 'SEAM-PROBE result assemblies=1 contract=reachable implementations=1 call=answered'
+printf '[2026-08-29 21:00:30.000 +00:00] [WRN] [9] Jellyfin.Plugin.SeamProbe.ContainerReport: SEAM-PROBE result assemblies=1 contract=reachable implementations=1 call=failed\n' >> "$work/restarted.log"
 refuses "a restart whose second answer is the bad one" \
-    "Two copies of one contract assembly in one process is the failure this seam exists to avoid" \
+    "the lookup worked and the call did not (call=failed)" \
     -- "$reader" "$work/restarted.log"
 
 refuses "a log that was never written" \
@@ -136,4 +171,4 @@ if [ "$failures" -ne 0 ]; then
     echo "$failures of the rules above did not bite." >&2
     exit 1
 fi
-echo "Every refusal the reader claims was watched refusing, and the answer both lines gave passes."
+echo "Every refusal the reader claims was watched refusing, and the answer the chosen shape produces passes."

--- a/scripts/read-seam-probe-answer.sh
+++ b/scripts/read-seam-probe-answer.sh
@@ -4,18 +4,27 @@
 # WHY THIS REFUSES NOW AND DID NOT BEFORE. When the probe was written, both answers were results:
 # #117 listed three options for where the shared contract type comes from, and a shared load context
 # and a separate one each decided which of the three was available. So the run refused silence and
-# nothing else. That is no longer the position. #117 chose one of the three on 2026-08-21 - a
-# contract-only package both sides compile against, with exactly one copy shipped - and `docs/seam.md`
-# carries the choice and says it rests on a plugin being able to name a type whose assembly ships in
-# another plugin's directory. Once a decision rests on an answer, the opposite answer is a defect
-# rather than a result, and a run that prints it and passes tells nobody.
+# nothing else. That is no longer the position. #117 took the third option on 2026-08-28, after the
+# other two were measured unavailable on both claimed lines - no shared type at all, the handover
+# taken by name through reflection - and `docs/seam.md` carries the choice with both measurements.
+# Once a decision rests on an answer, the opposite answer is a defect rather than a result, and a run
+# that prints it and passes tells nobody.
 #
-# WHAT IT IS BUILT AGAINST is written on #117 on 2026-08-25: the contract type moves out of
-# `Jellyfin.Plugin.Requests` the day the package lands, the probe's two constants stop naming
-# anything that declares it, and a run that only refuses silence goes green on a measurement about an
-# assembly that no longer holds the type. Whoever moves the type meets a red job that names the
-# constants instead of discovering months later that the measurement had quietly stopped being about
-# anything.
+# WHAT IT IS BUILT AGAINST HAS CHANGED WITH THE CHOICE, and the direction is worth stating because
+# the old reason is still readable above it. It used to be that the contract type would move OUT of
+# `Jellyfin.Plugin.Requests` into a package on the day that package landed, leaving the probe naming
+# an assembly that no longer held it. There is no package now and the type is not going anywhere, so
+# what this guards is the opposite: the type, the member and the want are named by string on both
+# sides of the seam, so a rename here is what a sibling meets at runtime and nowhere else. This
+# reader is the second half of that; `SeamSurfaceTests` in the suite is the first, and it reds
+# without a server.
+#
+# THE CALL IS PART OF THE ANSWER SINCE THE THIRD OPTION WAS TAKEN. Being handed an implementation
+# says the lookup works. It says nothing about whether the call can be made, and under reflection the
+# call is where the remaining risk sits: the member is found by name, the want is built out of the
+# other plugin's own type, and every one of those steps can fail at runtime with nothing failing at
+# build time. So the probe makes the call a sibling makes, and a run whose lookup succeeded and whose
+# call did not is refused rather than read as a working seam.
 #
 # It reads a file and nothing else: no container, no server, no network. That is what lets
 # `scripts/prove-seam-probe-refusals.sh` watch every refusal here bite, one log at a time.
@@ -42,7 +51,7 @@ fi
 
 # Matched rather than word-split, so a line carrying the fields in some other order, or carrying a
 # field this reader does not know, is refused as unreadable instead of being read as a passing one.
-pattern='SEAM-PROBE result assemblies=([0-9]+) contract=(reachable|missing) implementations=([0-9]+)$'
+pattern='SEAM-PROBE result assemblies=([0-9]+) contract=(reachable|missing) implementations=([0-9]+) call=([a-z]+)$'
 if [[ ! $answer =~ $pattern ]]; then
     echo "read-seam-probe-answer: the result line does not have the shape this reader knows, so nothing about the run can be read from it: ${answer}" >&2
     exit 1
@@ -51,8 +60,9 @@ fi
 assemblies=${BASH_REMATCH[1]}
 contract=${BASH_REMATCH[2]}
 implementations=${BASH_REMATCH[3]}
+call=${BASH_REMATCH[4]}
 
-echo "the probe answered: assemblies=${assemblies} contract=${contract} implementations=${implementations}"
+echo "the probe answered: assemblies=${assemblies} contract=${contract} implementations=${implementations} call=${call}"
 
 if [ "$assemblies" -eq 0 ]; then
     echo "read-seam-probe-answer: no assembly named Jellyfin.Plugin.Requests was loaded, so this is an answer about a server that does not have this plugin in it rather than about what a second plugin can see of it." >&2
@@ -60,18 +70,23 @@ if [ "$assemblies" -eq 0 ]; then
 fi
 
 if [ "$assemblies" -gt 1 ]; then
-    echo "read-seam-probe-answer: ${assemblies} assemblies named Jellyfin.Plugin.Requests were loaded. Two copies of one contract assembly in one process is the failure this seam exists to avoid: the type this plugin registers and the type a sibling names are then different types with the same name, the container returns nothing, and it looks exactly like the sibling not being installed." >&2
+    echo "read-seam-probe-answer: ${assemblies} assemblies named Jellyfin.Plugin.Requests were loaded. Two copies of one assembly in one process is the failure this seam exists to avoid: each plugin resolves its own, the type this plugin registers and the type a sibling reaches are then different types with the same name, and the container returns nothing to the sibling. That was measured on both claimed lines on 2026-08-27 and it is why no shared type ships." >&2
     exit 1
 fi
 
 if [ "$contract" = "missing" ]; then
-    echo "read-seam-probe-answer: the contract type is not reachable from a second plugin. The shape chosen on #117 is one shipped copy of the contract that both sides name, so a type a second plugin cannot reach is that shape gone; if the type moved on purpose, the constants in tools/seam-probe/ContainerReport.cs are what name it and they move with it." >&2
+    echo "read-seam-probe-answer: the seam type is not reachable from a second plugin. Under the shape #117 took there is no package and no second copy, so the type is declared by this plugin and named by string from the other side; a type a second plugin cannot reach means that name no longer resolves, and the constants in tools/seam-probe/ContainerReport.cs are what name it." >&2
     exit 1
 fi
 
 if [ "$implementations" -eq 0 ]; then
-    echo "read-seam-probe-answer: the container returned no implementation of the contract to the second plugin. That is the silence #117's fourth condition is about - an operator cannot tell it from a sibling that was never installed - so it is refused here rather than printed." >&2
+    echo "read-seam-probe-answer: the container returned no implementation of the seam to the second plugin. That is the silence #117's fourth condition is about - an operator cannot tell it from a sibling that was never installed - so it is refused here rather than printed." >&2
     exit 1
 fi
 
-echo "One assembly, the contract reachable from a plugin that ships no copy of it, and ${implementations} implementation(s) handed back by the container. That is the shape docs/seam.md says the choice rests on."
+if [ "$call" != "answered" ]; then
+    echo "read-seam-probe-answer: the lookup worked and the call did not (call=${call}). A seam nobody can call is not a seam, and under the shape #117 took the member and the want are found by name at runtime, so this is exactly where a rename lands: nomember is the member gone, nowant is the want type or one of its properties gone, failed is a call that did not come back with the answer the contract carries, and notattempted means nothing got far enough to try." >&2
+    exit 1
+fi
+
+echo "One assembly, the seam reachable from a plugin that compiles against nothing of this one, ${implementations} implementation(s) handed back by the container, and the call made and answered. That is the shape docs/seam.md says the choice rests on."

--- a/scripts/verify-seam-probe.sh
+++ b/scripts/verify-seam-probe.sh
@@ -9,18 +9,22 @@
 # lines are different major versions of the host, so an answer from one is a claim about the other.
 #
 # WHAT THE PROBE IS AND WHY IT REFERENCES NOTHING. `tools/seam-probe` is a plugin of its own that
-# names this plugin's assembly and its contract by string and compiles against the host alone. An
+# names this plugin's assembly, its seam type, its member and its want by string and compiles
+# against the host alone. That was a convenience while the shape was open and it is the shape itself
+# since 2026-08-28, so what the probe does IS what a sibling does. An
 # assembly reference would fail to resolve before anything could be reported on exactly the servers
 # where the answer is interesting, and a probe that cannot run is a probe that says nothing.
 #
 # THIS REFUSED ONLY SILENCE UNTIL 2026-08-26 AND NOW REFUSES THE ANSWER TOO. While #117 listed three
 # options for where the shared type comes from, a shared load context and a separate one were both
-# results, and each decided which of the three was available. #117 chose one of them on 2026-08-21 -
-# a contract-only package both sides compile against, with exactly one copy shipped - and
-# `docs/seam.md` says that choice rests on a plugin being able to name a type whose assembly ships in
-# another plugin's directory. Once a decision rests on an answer, the opposite answer is a defect and
-# not a result. `scripts/read-seam-probe-answer.sh` is what refuses it and carries the reasons one at
-# a time; `scripts/prove-seam-probe-refusals.sh` is where each of them is watched biting.
+# results, and each decided which of the three was available. #117 took the third option on
+# 2026-08-28 - no shared type at all, the handover taken by name through reflection - after runs of
+# this script measured the other two unavailable on both claimed lines, and `docs/seam.md` carries
+# the choice with both measurements. That choice rests on a plugin being able to name a type declared
+# in another plugin's assembly AND to call the member it finds there, which is what the probe now
+# asks. Once a decision rests on an answer, the opposite answer is a defect and not a result.
+# `scripts/read-seam-probe-answer.sh` is what refuses it and carries the reasons one at a time;
+# `scripts/prove-seam-probe-refusals.sh` is where each of them is watched biting.
 #
 # usage: scripts/verify-seam-probe.sh <image> <target-framework> [host-port]
 #   scripts/verify-seam-probe.sh jellyfin/jellyfin:10.11.11 net9.0  18098

--- a/tools/seam-probe/ContainerReport.cs
+++ b/tools/seam-probe/ContainerReport.cs
@@ -15,9 +15,16 @@ namespace Jellyfin.Plugin.SeamProbe;
 /// where a run can read it.
 /// <para>
 /// It names the other plugin by string and references none of its types, so the probe compiles
-/// against the host alone. That is the point rather than a convenience: if the two plugins do not
-/// share a load context, an assembly reference here would fail before anything could be reported,
-/// and a probe that cannot run is a probe that says nothing.
+/// against the host alone. That was a convenience while the shape was open and it is the shape
+/// itself since 2026-08-28: #117 took the handover by name through reflection, so what this class
+/// does IS what a sibling does, and the measurement stops being an analogy for the seam.
+/// </para>
+/// <para>
+/// It goes as far as a sibling goes. Finding the type and being handed an implementation says the
+/// lookup works; it says nothing about whether the call can be made across the boundary, and a
+/// lookup that returns an object nobody can invoke is not a seam. So the member is called, with a
+/// want built by reflection out of the other plugin's own types, and the answer is part of the
+/// verdict.
 /// </para>
 /// </summary>
 public sealed class ContainerReport : IHostedService
@@ -37,6 +44,10 @@ public sealed class ContainerReport : IHostedService
 
     private const string OtherAssembly = "Jellyfin.Plugin.Requests";
     private const string Contract = "Jellyfin.Plugin.Requests.Seam.IWantHandover";
+    private const string Member = "AcceptAsync";
+    private const string WantType = "Jellyfin.Plugin.Requests.Seam.HandedOverWant";
+    private const string ImplementationType = "Jellyfin.Plugin.Requests.Seam.WantHandover";
+    private const string VersionField = "KnownContractVersion";
 
     private readonly IServiceProvider _services;
     private readonly ILogger<ContainerReport> _logger;
@@ -53,11 +64,11 @@ public sealed class ContainerReport : IHostedService
     }
 
     /// <inheritdoc />
-    public Task StartAsync(CancellationToken cancellationToken)
+    public async Task StartAsync(CancellationToken cancellationToken)
     {
         try
         {
-            Look();
+            await LookAsync().ConfigureAwait(false);
         }
         catch (Exception error)
         {
@@ -65,14 +76,16 @@ public sealed class ContainerReport : IHostedService
             // answers a different question from the one being asked.
             Say("the probe itself failed: {0}: {1}", error.GetType().FullName ?? "?", error.Message);
         }
-
-        return Task.CompletedTask;
     }
 
     /// <inheritdoc />
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
-    private void Look()
+    private static void Set(Type wanted, object want, string property, object value)
+        => (wanted.GetProperty(property)
+            ?? throw new InvalidOperationException("the want type declares no " + property)).SetValue(want, value);
+
+    private async Task LookAsync()
     {
         Assembly[] loaded = AppDomain.CurrentDomain.GetAssemblies()
             .Where(assembly => string.Equals(assembly.GetName().Name, OtherAssembly, StringComparison.Ordinal))
@@ -84,28 +97,154 @@ public sealed class ContainerReport : IHostedService
             Say("one of them is at {0}", string.IsNullOrEmpty(assembly.Location) ? "(no location)" : assembly.Location);
         }
 
+        Assembly? holder = null;
         Type? contract = null;
         foreach (Assembly assembly in loaded)
         {
             contract = assembly.GetType(Contract, throwOnError: false);
             if (contract is not null)
             {
+                holder = assembly;
                 break;
             }
         }
 
-        if (contract is null)
+        if (contract is null || holder is null)
         {
             Say("the type {0} is not reachable from this plugin", Contract);
-            Answer(loaded.Length, reachable: false, implementations: 0);
+            Answer(loaded.Length, reachable: false, implementations: 0, call: "notattempted");
             return;
         }
 
         Say("the type {0} is reachable from this plugin", Contract);
 
-        int returned = _services.GetServices(contract).Count();
-        Say("the container returned {0} implementation(s) of it", returned);
-        Answer(loaded.Length, reachable: true, implementations: returned);
+        object[] implementations = _services.GetServices(contract)
+            .Where(one => one is not null)
+            .Select(one => one!)
+            .ToArray();
+
+        Say("the container returned {0} implementation(s) of it", implementations.Length);
+
+        if (implementations.Length == 0)
+        {
+            Answer(loaded.Length, reachable: true, implementations: 0, call: "notattempted");
+            return;
+        }
+
+        string call = await CallAsync(holder, contract, implementations[0]).ConfigureAwait(false);
+        Answer(loaded.Length, reachable: true, implementations: implementations.Length, call: call);
+    }
+
+    /// <summary>
+    /// Makes the call a sibling makes, over the boundary, with nothing of the other plugin compiled
+    /// in.
+    /// <para>
+    /// The want is deliberately one this side refuses: it names no user, so the implementation runs
+    /// its own path and answers without writing anything into the queue of a server the probe does
+    /// not own. What is being measured is that the call crossed and came back with the answer the
+    /// contract says it carries, not that a request was made.
+    /// </para>
+    /// </summary>
+    /// <param name="holder">The assembly declaring the seam.</param>
+    /// <param name="contract">The seam type.</param>
+    /// <param name="implementation">What the container handed back for it.</param>
+    /// <returns>The word the verdict carries.</returns>
+    private async Task<string> CallAsync(Assembly holder, Type contract, object implementation)
+    {
+        MethodInfo? member = contract.GetMethod(Member);
+        if (member is null)
+        {
+            Say("the seam type declares no member named {0}, so there is nothing to call", Member);
+            return "nomember";
+        }
+
+        Say("the member is {0}", member.ToString() ?? Member);
+
+        object want;
+        try
+        {
+            want = BuildWant(holder);
+        }
+        catch (Exception error)
+        {
+            Say(
+                "a want could not be built out of {0}: {1}: {2}",
+                WantType,
+                error.GetType().FullName ?? "?",
+                error.Message);
+            return "nowant";
+        }
+
+        try
+        {
+            object? returned = member.Invoke(implementation, [want, CancellationToken.None]);
+            if (returned is not Task answering)
+            {
+                Say("the member did not return a task, so the shape that shipped is not the one the contract names");
+                return "failed";
+            }
+
+            await answering.ConfigureAwait(false);
+
+            object? answer = answering.GetType().GetProperty("Result")?.GetValue(answering);
+            Say("the call crossed the boundary and answered {0}", answer ?? "(nothing)");
+            return answer is bool ? "answered" : "failed";
+        }
+        catch (Exception error)
+        {
+            Say(
+                "the call did not come back: {0}: {1}",
+                error.GetType().FullName ?? "?",
+                (error as TargetInvocationException)?.InnerException?.Message ?? error.Message);
+            return "failed";
+        }
+    }
+
+    /// <summary>
+    /// One want, built the way a sibling with no compile-time reference has to build one.
+    /// <para>
+    /// The version is read out of the other plugin rather than typed here. A number typed into this
+    /// file would be this probe's opinion of the seam version, and what is worth measuring is
+    /// whether a sibling can find out what the version is at all.
+    /// </para>
+    /// </summary>
+    /// <param name="holder">The assembly declaring the seam.</param>
+    /// <returns>The want to hand across.</returns>
+    private object BuildWant(Assembly holder)
+    {
+        Type wanted = holder.GetType(WantType, throwOnError: true)
+            ?? throw new InvalidOperationException("the want type is not declared by " + OtherAssembly);
+
+        int version = 0;
+        FieldInfo? declared = holder.GetType(ImplementationType, throwOnError: false)
+            ?.GetField(VersionField, BindingFlags.Public | BindingFlags.Static);
+        if (declared?.GetRawConstantValue() is int found)
+        {
+            version = found;
+            Say(
+                "the seam version this side declares, read out of {0}.{1}: {2}",
+                ImplementationType,
+                VersionField,
+                version);
+        }
+        else
+        {
+            Say("no seam version could be read out of {0}.{1}", ImplementationType, VersionField);
+        }
+
+        object want = Activator.CreateInstance(wanted)
+            ?? throw new InvalidOperationException("the want type could not be constructed");
+
+        Set(wanted, want, "ContractVersion", version);
+        Set(wanted, want, "WantId", Guid.NewGuid());
+        Set(wanted, want, "RequestedByUserId", Guid.Empty);
+        Set(wanted, want, "Title", "what a second plugin can see");
+
+        PropertyInfo kind = wanted.GetProperty("Kind")
+            ?? throw new InvalidOperationException("the want type declares no Kind");
+        kind.SetValue(want, Enum.ToObject(Nullable.GetUnderlyingType(kind.PropertyType) ?? kind.PropertyType, 0));
+
+        return want;
     }
 
     /// <summary>
@@ -119,14 +258,16 @@ public sealed class ContainerReport : IHostedService
     /// <param name="assemblies">How many assemblies of the named simple name were loaded.</param>
     /// <param name="reachable">Whether the contract type resolved out of one of them.</param>
     /// <param name="implementations">How many implementations the container returned for it.</param>
-    private void Answer(int assemblies, bool reachable, int implementations)
+    /// <param name="call">What became of the call across the boundary.</param>
+    private void Answer(int assemblies, bool reachable, int implementations, string call)
     {
         Say(
-            "{0} assemblies={1} contract={2} implementations={3}",
+            "{0} assemblies={1} contract={2} implementations={3} call={4}",
             Result,
             assemblies,
             reachable ? "reachable" : "missing",
-            implementations);
+            implementations,
+            call);
     }
 
     private void Say(string format, params object[] values)


### PR DESCRIPTION
**Superseded by #321 and closed unmerged. Nothing here is wanted at `master`.**

The commit on this branch carries no DCO sign-off, and `DCO sign-off` refused it by name:

    FAIL 9bb597266261be914d52385f56122cfa8cb1641f is missing: Signed-off-by: Nils Lehnen <30603423+iderex@users.noreply.github.com>

The job's own message offers `git rebase --signoff` as the retroactive repair. That rewrites a branch
that has been pushed, and a force-push is refused here with no exception for a branch nobody has
seen. So the correction went out under a new name and this one is abandoned, which costs a branch
name and destroys nothing.

The content of #321 is identical to what was here rather than said to be:

    git diff origin/master 9bb5972 | git patch-id --stable
    44ffbef39cc956866c2dbf86d2df5805a1bfd32c

    git diff origin/master a90529d | git patch-id --stable
    44ffbef39cc956866c2dbf86d2df5805a1bfd32c

Read #321 instead. What was written here about #117 is written there, unchanged.
