### PR TITLE
Report the ABI floor and the code scan on a documentation head, and read the head rather than filter it

### DIFF
--- a/.github/workflows/abi-floor.yaml
+++ b/.github/workflows/abi-floor.yaml
@@ -17,6 +17,18 @@
 # than a file in this tree, and #30 is where it is written down and applied, so
 # a red job here does not by itself hold a merge today.
 #
+# IT RUNS ON EVERY HEAD, INCLUDING ONE THAT CHANGES ONLY MARKDOWN, and that is
+# what makes the three contexts below requirable at all. A `paths-ignore` filter
+# stood here and declined such a head, so no check run appeared for it, and a
+# required context that never reports leaves a pull request pending rather than
+# failing it - no red check to point at and nothing on the page that looks wrong
+# to the person waiting. `build.yaml` carries the same trap at its own trigger
+# and names it there. Rather than drop these contexts from the set or pay an ABI
+# build on every typo fix, the jobs report on every head and ask
+# `scripts/head-changes-only-documentation.sh` whether there is anything to
+# build. A documentation head costs the checkout and the reading; every other
+# head costs what it always did.
+#
 # The floor SDK version is resolved from the feed rather than assumed to exist.
 # A `targetAbi` of `A.B.C.D` names the server version `A.B.C`, and the package
 # that goes with it is `A.B.C` when that has been released. WHERE IT HAS NOT,
@@ -32,12 +44,8 @@ name: ABI floor
 on:
   push:
     branches: [master]
-    paths-ignore:
-      - '**/*.md'
   pull_request:
     branches: ['**']
-    paths-ignore:
-      - '**/*.md'
   workflow_dispatch:
 
 # Explicit deny-all at workflow level; each job grants only what it needs.
@@ -56,12 +64,42 @@ jobs:
       contents: read
     outputs:
       matrix: ${{ steps.read.outputs.matrix }}
+      documentation_only: ${{ steps.scope.outputs.documentation_only }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # No step pushes via git, so do not persist the GITHUB_TOKEN in .git/config.
           persist-credentials: false
+          # The whole history, because the step below compares two commits, and a
+          # shallow clone holds neither their merge base nor, on a branch that
+          # was cut a while ago, the base itself.
+          fetch-depth: 0
+
+      - name: Every answer the documentation reader gives, watched being given
+        # Beside the reading rather than in a workflow of its own, because this
+        # job is where the answer is produced, and a proof that runs on some
+        # other head is a proof of some other file. It builds its own repository
+        # and reaches no network, so it costs seconds and runs on every head -
+        # including the documentation heads whose floor jobs it is the warrant
+        # for.
+        run: ./scripts/prove-documentation-only-decisions.sh
+
+      - name: Decide whether this head changes anything to build
+        id: scope
+        env:
+          # Out of the event rather than off the checkout. A pull request is
+          # built at a merge commit this repository never held, so the pair the
+          # event names is the only honest one to compare, and a push says what
+          # it moved from. An event that names neither leaves both empty, and the
+          # reader answers that case by building.
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          answer=$(./scripts/head-changes-only-documentation.sh "$BASE_SHA" "$HEAD_SHA")
+          echo "documentation_only=$answer"
+          echo "documentation_only=$answer" >> "$GITHUB_OUTPUT"
 
       - name: Read the claimed lines out of the packaging metadata
         id: read
@@ -101,12 +139,25 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.lines.outputs.matrix) }}
 
+    # Every step below is guarded rather than the job itself. A job skipped by an
+    # `if:` reports a conclusion of its own, and what a ruleset makes of that
+    # conclusion is a rule nobody on this board has read; a job that runs and
+    # does nothing reports `success`, which has one reading.
     steps:
+      - name: Say that this head has nothing for this job to build
+        if: needs.lines.outputs.documentation_only == 'true'
+        env:
+          ABI: ${{ matrix.abi }}
+        run: |
+          echo "::notice::This head changes nothing but markdown, so there is no build to prove against the $ABI floor. The lines job read the change and said so; no filter decided it."
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: needs.lines.outputs.documentation_only != 'true'
         with:
           persist-credentials: false
 
       - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        if: needs.lines.outputs.documentation_only != 'true'
         with:
           # Both SDKs, because which one this job needs is decided by the
           # packaging file it was handed and not by this file.
@@ -115,6 +166,7 @@ jobs:
             10.0.x
 
       - name: Resolve the floor SDK for this line
+        if: needs.lines.outputs.documentation_only != 'true'
         id: resolve
         env:
           ABI: ${{ matrix.abi }}
@@ -157,6 +209,7 @@ jobs:
           echo "version=$use_controller" >> "$GITHUB_OUTPUT"
 
       - name: Build the plugin against the floor
+        if: needs.lines.outputs.documentation_only != 'true'
         env:
           FRAMEWORK: ${{ matrix.framework }}
           FLOOR: ${{ steps.resolve.outputs.version }}
@@ -180,6 +233,7 @@ jobs:
             -p:TargetFrameworks="$FRAMEWORK" -p:JellyfinVersion="$FLOOR"
 
       - name: Show what was built
+        if: needs.lines.outputs.documentation_only != 'true'
         env:
           FRAMEWORK: ${{ matrix.framework }}
         run: find . -path "*/bin/Release/$FRAMEWORK/Jellyfin.Plugin.Requests.dll" -print

--- a/.github/workflows/scan-codeql.yaml
+++ b/.github/workflows/scan-codeql.yaml
@@ -16,17 +16,30 @@
 # The query suite is security-extended. The default suite trades recall for
 # precision, and the finding this is meant to catch is the one nobody was
 # looking for.
+#
+# IT RUNS ON EVERY HEAD, INCLUDING ONE THAT CHANGES ONLY MARKDOWN, and that is
+# what makes the three `Analyze` contexts requirable at all. A `paths-ignore`
+# filter stood under `on:` and declined such a head, so no check run appeared for
+# it, and a required context that never reports leaves a pull request pending
+# rather than failing it - no red check to point at and nothing on the page that
+# looks wrong to the person waiting. Rather than drop those contexts from the set
+# `docs/quality-parity.md` declares, or pay a full scan on every typo fix, the
+# job reports on every head and asks
+# `scripts/head-changes-only-documentation.sh` whether there is anything to
+# analyse. A markdown-only head changes no source a query could read, so the
+# analysis it would produce is the analysis already uploaded; every other head
+# costs what it always did.
+#
+# THE `paths-ignore` UNDER `init:` IS A DIFFERENT ONE and stays. That filters what
+# CodeQL reads inside a run; the one that was removed decided whether a run
+# happened at all.
 name: '🔬 Run CodeQL'
 
 on:
   push:
     branches: ['**']
-    paths-ignore:
-      - '**/*.md'
   pull_request:
     branches: ['**']
-    paths-ignore:
-      - '**/*.md'
   schedule:
     - cron: '24 2 * * 4'
   workflow_dispatch:
@@ -62,13 +75,44 @@ jobs:
           - language: actions
             build-mode: none
 
+    # The steps below are guarded rather than the job. A job skipped by an `if:`
+    # reports a conclusion of its own, and what a ruleset makes of that
+    # conclusion is a rule nobody on this board has read; a job that runs and
+    # does nothing reports `success`, which has one reading.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # No step pushes via git, so do not persist the GITHUB_TOKEN in .git/config.
           persist-credentials: false
+          # The whole history, because the step below compares two commits, and a
+          # shallow clone holds neither their merge base nor, on a branch that
+          # was cut a while ago, the base itself.
+          fetch-depth: 0
 
-      - if: matrix.language == 'csharp'
+      - name: Decide whether this head changes anything to analyse
+        id: scope
+        env:
+          # Out of the event rather than off the checkout. A pull request is
+          # built at a merge commit this repository never held, so the pair the
+          # event names is the only honest one to compare, and a push says what
+          # it moved from. A schedule and a manual run name neither, which leaves
+          # both empty, and the reader answers that case by analysing.
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          answer=$(./scripts/head-changes-only-documentation.sh "$BASE_SHA" "$HEAD_SHA")
+          echo "documentation_only=$answer"
+          echo "documentation_only=$answer" >> "$GITHUB_OUTPUT"
+
+      - name: Say that this head has nothing for this language to read
+        if: steps.scope.outputs.documentation_only == 'true'
+        env:
+          LANGUAGE: ${{ matrix.language }}
+        run: |
+          echo "::notice::This head changes nothing but markdown, so the $LANGUAGE analysis would read the same sources as the one already uploaded. The change was read rather than a filter deciding it, and every other head is analysed in full."
+
+      - if: steps.scope.outputs.documentation_only != 'true' && matrix.language == 'csharp'
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           # Both claimed lines, so the analysis sees the same code the gate
@@ -78,16 +122,18 @@ jobs:
             10.0.x
 
       - name: Initialise CodeQL
+        if: steps.scope.outputs.documentation_only != 'true'
         uses: github/codeql-action/init@18420e3271f74589575af831a523c833acda327f # codeql-bundle-v2.26.2
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-extended
-          # Path filtering for the ANALYSIS. The paths-ignore under `on:` above
-          # decides when this workflow runs, not what CodeQL reads, so without
-          # this block the generated sources under obj/ are analysed too. They
-          # are not in the tree, nobody can change them, and the source
-          # generator that writes them does not follow these rules.
+          # Path filtering for the ANALYSIS, which is a different question from
+          # whether this workflow runs at all - that one is the step above, and
+          # it used to be a `paths-ignore` under `on:`. Without this block the
+          # generated sources under obj/ are analysed too. They are not in the
+          # tree, nobody can change them, and the source generator that writes
+          # them does not follow these rules.
           config: |
             paths-ignore:
               - "**/obj/**"
@@ -97,12 +143,13 @@ jobs:
         # Manual rather than autobuild, so the analysis is over what this
         # repository's own gate builds: every claimed target framework, restored
         # from the committed lockfiles.
-        if: matrix.language == 'csharp'
+        if: steps.scope.outputs.documentation_only != 'true' && matrix.language == 'csharp'
         run: |
           dotnet restore Jellyfin.Plugin.Requests.sln --locked-mode
           dotnet build Jellyfin.Plugin.Requests.sln --configuration Release --no-restore
 
       - name: Analyze
+        if: steps.scope.outputs.documentation_only != 'true'
         uses: github/codeql-action/analyze@18420e3271f74589575af831a523c833acda327f # codeql-bundle-v2.26.2
         with:
           category: /language:${{ matrix.language }}

--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -147,28 +147,15 @@ can read. The jobs behind those two, the three `Analyze` legs and
 `Audit workflows (zizmor)`, are in the list instead, and they are the ones that
 go red for a reason this repository wrote.
 
-### Six of these fifteen cannot report on a change that is only markdown
+### Six of these fifteen could not report on a change that is only markdown
 
-This is the `Scorecard analysis` failure above arriving from a second direction,
-and the list was written without it. `abi-floor.yaml` and `scan-codeql.yaml` both
-decline a change that touches nothing but markdown:
-
-    $ git grep -n -A 1 "^    paths-ignore:" origin/master -- .github/workflows/abi-floor.yaml .github/workflows/scan-codeql.yaml
-    origin/master:.github/workflows/abi-floor.yaml:35:    paths-ignore:
-    origin/master:.github/workflows/abi-floor.yaml-36-      - '**/*.md'
-    --
-    origin/master:.github/workflows/abi-floor.yaml:39:    paths-ignore:
-    origin/master:.github/workflows/abi-floor.yaml-40-      - '**/*.md'
-    --
-    origin/master:.github/workflows/scan-codeql.yaml:24:    paths-ignore:
-    origin/master:.github/workflows/scan-codeql.yaml-25-      - '**/*.md'
-    --
-    origin/master:.github/workflows/scan-codeql.yaml:28:    paths-ignore:
-    origin/master:.github/workflows/scan-codeql.yaml-29-      - '**/*.md'
-
-So the six contexts those two produce never appear on such a head. Measured at
-`36eccab`, the head of a pull request that changed one markdown file and nothing
-else, against the list above read out of this page rather than retyped:
+**This section described a live obstacle and now describes how it was removed.**
+It was the `Scorecard analysis` failure above arriving from a second direction,
+and the list was written without it: `abi-floor.yaml` and `scan-codeql.yaml` both
+declined a change that touched nothing but markdown, so the six contexts those
+two produce never appeared on such a head. Measured at `36eccab`, the head of a
+pull request that changed one markdown file and nothing else, against the list
+above read out of this page rather than retyped:
 
     $ git show origin/master:docs/quality-parity.md \
         | sed -n '/^Fifteen contexts/,/^There are no bypass actors/p' \
@@ -184,11 +171,59 @@ else, against the list above read out of this page rather than retyped:
     lines
 
 A required context that does not report leaves a pull request pending rather than
-failing it, so requiring those six as they stand would hold every markdown-only
-change on this board open. Two repairs exist and this page takes neither: drop
-the six from the set, or take the `paths-ignore` off those two workflows and pay
-their runtime on every change. That is #30's to decide, and nothing here applies
-either of them.
+failing it, so requiring those six as they stood would have held every
+markdown-only change on this board open, with no red check to point at and
+nothing on the page that looks wrong to the person waiting.
+
+Three repairs were available and the third is the one taken. Dropping the six
+from the set weakens the parity this page exists for, because an ABI floor that
+reds on a head that changed code would then stop nothing. Taking the filter off
+and leaving it there buys the six contexts at the price of a full code scan and
+two floor builds re-measuring an unchanged tree on every documentation head. The
+third keeps both halves: the filter comes off, so the jobs report on every head,
+and each job asks first whether the head changed anything it could read.
+
+    $ git grep -n "^    paths-ignore:" -- .github/workflows/abi-floor.yaml .github/workflows/scan-codeql.yaml ; echo "exit=$?"
+    exit=1
+
+The anchor is the same one the paste above used, and it is what separates the two
+filters that share a name: the one under `on:` decided whether a run happened at
+all, and the one CodeQL is handed under `init:` decides what it reads inside a
+run. The second is untouched and is still there.
+
+    $ git grep -l 'head-changes-only-documentation.sh' -- .github/workflows/
+    .github/workflows/abi-floor.yaml
+    .github/workflows/scan-codeql.yaml
+
+**One reader with one home, and every answer it gives is watched being given.**
+Both workflows ask the same script and neither carries a copy of the rule, which
+would become a second rule the first time either was edited. What it answers
+decides whether an ABI floor build and a full code scan happen at all, and it is
+green on an ordinary head either way, so the proof drives it over a repository
+built for each case: a suffix in the other case, markdown in the middle of a
+name, a path a default listing would quote, a base the clone does not hold, and
+a documentation branch whose base moved on underneath it. That last one is the
+one it exists for, because a two-dot comparison reports the code such a branch
+does not have as a change the branch makes.
+
+    $ git grep -c 'prove-documentation-only-decisions.sh' -- .github/workflows/abi-floor.yaml
+    .github/workflows/abi-floor.yaml:1
+
+It runs in `lines`, which runs on every head, including the documentation heads
+whose floor jobs it is the warrant for.
+
+**The steps are guarded rather than the jobs.** A job skipped by an `if:` reports
+a conclusion of its own, and what a ruleset makes of that conclusion is a rule
+nobody on this board has read. A job that runs and does nothing reports
+`success`, which has one reading.
+
+**What this does not show.** No markdown-only head has been through the new
+route. The change that carries it touches workflows, scripts and this page, so
+its own run is the full-price one, and that the six report green on a
+documentation head is a claim until the first such pull request produces them.
+Applying the ruleset remains a repository setting rather than a file in this
+tree, and #30 still carries the application and the demonstration that a red
+required check refuses a merge.
 
 ### What has arrived since this list was written
 

--- a/scripts/head-changes-only-documentation.sh
+++ b/scripts/head-changes-only-documentation.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Does this head change nothing but markdown?
+#
+# WHY A READER EXISTS RATHER THAN A `paths-ignore`. A workflow that declines a head produces no
+# check run for it, and a required context that never reports leaves a pull request pending rather
+# than failing it - no red check to point at, and nothing on the page that looks wrong to the person
+# waiting. `.github/workflows/build.yaml` carries the same trap at its own `pull_request` trigger and
+# names it there. The ABI floor build and the code scan were the two workflows on this board still
+# declining a markdown-only head, which is why six of the fifteen contexts `docs/quality-parity.md`
+# declares could not be required. They report on every head now and ask this reader whether there is
+# anything to do, so the context costs seconds where nothing changed and full price where it did.
+#
+# ONE HOME FOR THE RULE. Two workflows ask the question and neither carries a copy of it. A second
+# copy is a second rule the moment either one is edited, and the answer decides whether an ABI floor
+# build and a full code scan happen at all.
+#
+# IT FAILS TOWARD DOING THE WORK. Every case it cannot resolve - a missing reference, an argument it
+# was not given, a comparison that returns nothing - answers `false`, which spends runtime. The
+# opposite default answers `true` on a head nobody compared, and a scan skipped on a head that
+# changed code is a scan nobody notices is missing.
+#
+# WHAT `.md` MEANS HERE IS THE SUFFIX AND NOTHING ELSE, matched case-sensitively, which is what the
+# `**/*.md` filter it replaces matched. `README.MD` and `notes.md.cs` are both code as far as this
+# reader is concerned, and both answers are the safe direction rather than an accident.
+#
+# THE COMPARISON IS THREE-DOT, so it is the merge base of the two references against the head. On a
+# pull request that is the change the head proposes rather than everything the base branch has done
+# since. On a push whose `before` is an ancestor of its `after` the merge base is `before`, so the
+# two readings agree; where a rewrite makes it something older the comparison widens, which is the
+# direction that spends runtime rather than the one that skips work.
+#
+# usage: scripts/head-changes-only-documentation.sh <base-ref> <head-ref>
+#   prints `true` or `false` on standard output and exits 0. The reason for a `false` goes to
+#   standard error, so a run log says which case it met.
+
+set -euo pipefail
+
+base=${1-}
+head=${2-}
+
+answer() {
+    printf '%s\n' "$1"
+    exit 0
+}
+
+decline() {
+    printf 'head-changes-only-documentation: %s Building.\n' "$1" >&2
+    answer false
+}
+
+zero='0000000000000000000000000000000000000000'
+
+if [ -z "$base" ] || [ -z "$head" ]; then
+    decline "no pair of references to compare was given, so nothing says what this head changed."
+fi
+
+if [ "$base" = "$zero" ] || [ "$head" = "$zero" ]; then
+    decline "one side of the comparison is the empty reference, which is a branch with no before."
+fi
+
+for ref in "$base" "$head"; do
+    if ! git rev-parse --verify --quiet "${ref}^{commit}" >/dev/null; then
+        decline "${ref} is not a commit this clone holds, so no comparison can be made against it."
+    fi
+done
+
+if ! git merge-base "$base" "$head" >/dev/null 2>&1; then
+    decline "${base} and ${head} share no history, so there is no change between them to read."
+fi
+
+# -z rather than the default listing: a path with a space, a quote or a byte outside ASCII is quoted
+# and escaped by the default output, and a reader that unquoted it would be a second parser nobody
+# asked for. It goes to a file rather than into a variable, because a command substitution cannot
+# hold the separator this asked for.
+changed=$(mktemp)
+trap 'rm -f "$changed"' EXIT
+git diff --name-only -z "${base}...${head}" > "$changed"
+
+if [ ! -s "$changed" ]; then
+    decline "${base}...${head} changes no file at all, which is not a head anybody wrote documentation on."
+fi
+
+while IFS= read -r -d '' path; do
+    case "$path" in
+        *.md) ;;
+        *) decline "${path} is not markdown." ;;
+    esac
+done < "$changed"
+
+answer true

--- a/scripts/prove-documentation-only-decisions.sh
+++ b/scripts/prove-documentation-only-decisions.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Every answer the documentation-only reader gives, watched being given once, over a repository
+# written to carry the case it names.
+#
+# `scripts/head-changes-only-documentation.sh` decides whether an ABI floor build and a full code
+# scan happen at all. On an ordinary head it answers `false` and everything runs, which is what the
+# two workflows did before it existed - so a reader that had never answered `true` would look exactly
+# like one that works, for as long as nobody pushed documentation. And a reader that answered `true`
+# too readily skips a scan on a head that changed code, which is the failure nobody sees at all.
+#
+# It takes two references and reads them with git, so every case below is a repository built here
+# rather than a head anybody pushed. No network, no runner and no pull request.
+#
+# THE ONE IT EXISTS FOR IS THE MERGE BASE, and it is the last case below. A documentation branch cut
+# from a master that has since taken a code change is the ordinary shape of a slow-moving branch. A
+# two-dot comparison of that pair reports the code the branch does not have as a change the branch
+# makes, so the reader answers `false` and the head pays for a build it did not ask for; a three-dot
+# comparison reports what the branch actually changed. Both readings are green on a branch nobody
+# waited on, which is why this case is written down rather than trusted.
+#
+# usage: scripts/prove-documentation-only-decisions.sh
+
+set -euo pipefail
+
+here=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+reader="$here/head-changes-only-documentation.sh"
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+repo="$work/repo"
+mkdir -p "$repo"
+cd "$repo"
+git init --quiet .
+# The identity and the signing setting are this throwaway repository's own. Nothing here is pushed
+# anywhere and no commit below leaves this directory; what is being built is an input to a reader,
+# in the same sense as the JSON documents the manifest proofs write.
+git config user.email "proof@example.invalid"
+git config user.name "Documentation only proof"
+git config commit.gpgsign false
+# The line endings this fixture writes are its own too. A clone configured to translate them would
+# otherwise decide what these commits hold, and what is being proved is a reader of paths.
+git config core.autocrlf false
+
+# usage: commit_with <message> -- then the files already written
+commit_with() {
+    git add -A .
+    git commit --quiet --allow-empty -m "$1"
+    git rev-parse HEAD
+}
+
+write() {
+    mkdir -p "$(dirname "$1")"
+    printf '%s\n' "$2" > "$1"
+}
+
+failures=0
+
+# usage: answers <expected> <heading> <base> <head>
+answers() {
+    local expected=$1 heading=$2 base=${3-} head=${4-}
+    printf '\n== %s\n' "$heading"
+    local out err status
+    err="$work/stderr"
+    set +e
+    out=$("$reader" "$base" "$head" 2>"$err")
+    status=$?
+    set -e
+    [ -s "$err" ] && sed 's/^/  /' "$err"
+    printf '  %s -> %s\n' "$expected" "$out"
+    if [ "$status" -ne 0 ]; then
+        echo "  EXITED $status, and this reader answers on standard output rather than through a status."
+        failures=$((failures + 1))
+        return
+    fi
+    if [ "$out" != "$expected" ]; then
+        echo "  ANSWERED $out where $expected is the whole point of this case."
+        failures=$((failures + 1))
+    fi
+}
+
+write README.md "the first line"
+write Jellyfin.Plugin.Requests/Plugin.cs "namespace X;"
+base=$(commit_with "a tree with a document and a source file")
+
+write README.md "a second line"
+write docs/operating.md "a page"
+only_markdown=$(commit_with "two markdown files and nothing else")
+
+git checkout --quiet -b mixed "$base"
+write docs/operating.md "a page"
+write Jellyfin.Plugin.Requests/Plugin.cs "namespace X; // and a change"
+mixed=$(commit_with "a markdown file beside a source file")
+
+git checkout --quiet -b code "$base"
+write Jellyfin.Plugin.Requests/Plugin.cs "namespace X; // moved"
+code=$(commit_with "a source file and no markdown")
+
+git checkout --quiet -b renamed "$base"
+git mv README.md README.cs
+renamed=$(commit_with "a markdown file that stopped being markdown")
+
+git checkout --quiet -b shouting "$base"
+# A path of its own rather than README.md in the other case: on a filesystem that ignores case the
+# two are one file, and the case this proves would quietly become the first case again.
+write docs/SHOUTING.MD "a document whose suffix is not the one the filter matched"
+shouting=$(commit_with "a suffix in the other case")
+
+git checkout --quiet -b lookalike "$base"
+write notes.md.cs "not a document"
+lookalike=$(commit_with "markdown in the middle of a name rather than at the end")
+
+git checkout --quiet -b spaced "$base"
+write "docs/a page with spaces.md" "a page"
+spaced=$(commit_with "a path a default listing would quote")
+
+git checkout --quiet -b removed "$base"
+git rm --quiet README.md
+removed=$(commit_with "a document deleted rather than written")
+
+git checkout --quiet --orphan stranger
+git rm --quiet -rf . >/dev/null 2>&1 || true
+write OTHER.md "a tree with no shared history"
+stranger=$(commit_with "an unrelated history")
+
+# The case this file exists for. Master takes a source change after the documentation branch is cut,
+# and the branch is compared against master's tip.
+git checkout --quiet -b moved-on "$base"
+write Jellyfin.Plugin.Requests/Plugin.cs "namespace X; // master moved on"
+moved_on=$(commit_with "a source change the documentation branch does not have")
+git checkout --quiet -b slow-document "$base"
+write docs/catalogue.md "a page written while master moved on"
+slow_document=$(commit_with "documentation cut before that source change")
+
+answers true  "only markdown changed"                                   "$base" "$only_markdown"
+answers false "markdown beside a source file"                           "$base" "$mixed"
+answers false "a source file and no markdown"                           "$base" "$code"
+answers false "a markdown file renamed to a source file"                "$base" "$renamed"
+answers false "a suffix in the other case"                              "$base" "$shouting"
+answers false "markdown in the middle of a name"                        "$base" "$lookalike"
+answers true  "a path a default listing would quote"                    "$base" "$spaced"
+answers true  "a document deleted rather than written"                  "$base" "$removed"
+answers false "no references at all"
+answers false "the empty reference on one side"                         "0000000000000000000000000000000000000000" "$only_markdown"
+answers false "a base this clone does not hold"                         "1111111111111111111111111111111111111111" "$only_markdown"
+answers false "the same commit on both sides"                           "$base" "$base"
+answers false "two histories that share nothing"                        "$stranger" "$only_markdown"
+answers true  "a documentation branch whose base moved on underneath"   "$moved_on" "$slow_document"
+
+printf '\n'
+if [ "$failures" -ne 0 ]; then
+    echo "$failures of the cases above did not get the answer they are written for."
+    exit 1
+fi
+echo "Every case above got the answer it is written for."


### PR DESCRIPTION
Part of #30. This takes the third repair of the six contexts that could not report on a markdown-only head, decided on that issue on 28.08.

## What was wrong

`docs/quality-parity.md` declares fifteen contexts to require. Six of them - `lines`, `floor 10.11.0.0`, `floor 12.0.0.0` and the three `Analyze` legs - come out of two workflows that declined a head touching nothing but markdown, so those contexts never appeared on such a head at all. Requiring them as they stood would have left every documentation change pending rather than failing: no red check to point at, and nothing on the page that looks wrong to the person waiting. `.github/workflows/build.yaml` already carries that trap at its own `pull_request` trigger and names it there.

The two other repairs are worse. Dropping the six leaves the ABI floor and the code scanning ungated, which is what they are today. Taking the filter off and leaving it there pays a full CodeQL run and two floor builds to re-measure an unchanged tree on every typo fix.

## What this does

The trigger filter comes off `abi-floor.yaml` and `scan-codeql.yaml`, so the six report on every head, and each job asks first whether the head changed anything it could read.

    $ git grep -n "^    paths-ignore:" -- .github/workflows/abi-floor.yaml .github/workflows/scan-codeql.yaml ; echo "exit=$?"
    exit=1

The anchor is the one that separates the two filters sharing a name. The `paths-ignore` CodeQL is handed under `init:` decides what it reads inside a run, and it is untouched.

`scripts/head-changes-only-documentation.sh` is the whole rule, in one place, asked by both workflows. It fails toward doing the work: no pair of references, the empty reference, a commit the clone does not hold, two histories that share nothing, and an empty comparison all answer `false`. The comparison is three-dot, so a documentation branch cut before master took a code change is read as the change it makes rather than as the change it lacks. `.md` means the suffix and nothing else, matched case-sensitively, which is what `**/*.md` matched.

Every step is guarded rather than each job. A job skipped by an `if:` reports a conclusion of its own, and what a ruleset makes of that conclusion is a rule nobody on this board has read; a job that runs and does nothing reports `success`, which has one reading.

## The proof, and it was watched biting

`scripts/prove-documentation-only-decisions.sh` builds its own git repository per case and reaches no network. It runs in the `lines` job, which runs on every head - including the documentation heads whose floor jobs it is the warrant for.

    $ ./scripts/prove-documentation-only-decisions.sh | tail -1
    Every case above got the answer it is written for.

Fourteen cases. Two deletions, each watched reddening only what it is about.

Deleting the suffix refusal, so every changed path counts as documentation:

    $ ./scripts/prove-documentation-only-decisions.sh | grep -E '^  ANSWERED|of the cases'
      ANSWERED true where false is the whole point of this case.
      ANSWERED true where false is the whole point of this case.
      ANSWERED true where false is the whole point of this case.
      ANSWERED true where false is the whole point of this case.
      ANSWERED true where false is the whole point of this case.
    5 of the cases above did not get the answer they are written for.

Turning the three-dot comparison into two dots, which is the near-miss this file exists for, because both readings are green on a branch nobody waited on:

    $ ./scripts/prove-documentation-only-decisions.sh | grep -B1 -E '^  ANSWERED|of the cases'
    == a documentation branch whose base moved on underneath
      ANSWERED false where true is the whole point of this case.
    1 of the cases above did not get the answer they are written for.

Both runs are on this branch at `9c9efe4`, with the file edited in the working tree and restored afterwards.

## The means

Shell beside the two workflows that ask it, rather than a step in each of them or a C# tool. The subject is a pair of git references and a list of paths, which is what git prints; the tree already holds seven readers of this shape under `scripts/`, each with a proof beside it and each driven by a workflow, so this adds no language, no runtime and no apparatus. A copy in each workflow would be a second rule the first time either was edited, and what the rule decides is whether a code scan happens at all.

## What this does not claim

**No markdown-only head has been through the new route.** This change touches workflows, scripts and a document, so its own run is the full-price one and proves the ordinary path rather than the cheap one. That the six report green on a documentation head is a claim until the first such pull request produces them.

**Nothing here applies a ruleset.** The required set is a repository setting rather than a file in this tree. #30's remaining conditions - the nine contexts still not required, and the demonstration that a red required check refuses a merge - are untouched by this and stay where that issue leaves them.

**This board has no second reader tonight.** What stands in place of one is the transcript above, the fourteen cases, and the two deletions watched reddening exactly the cases they are about.

**The `Scope:` line on #30 predates the decision that ordered this.** It names `docs/quality-parity.md`, and the answer of 28.08. put the workflow change under the same issue; the line is corrected on the issue in the same breath as this.
