### PR TITLE
Keep the outbound address out of everything this plugin writes, and refuse its return

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Configuration/SecretsStayOutOfTheLogTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Configuration/SecretsStayOutOfTheLogTests.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Configuration;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Notify;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Configuration;
+
+/// <summary>
+/// A setting marked <see cref="SecretAttribute"/> against everything this plugin writes for somebody
+/// else to read.
+/// <para>
+/// Operators paste logs into issue trackers, so the log has to be safe to paste, and since #318 the
+/// settings page cannot show the outbound address back at all - a log line would be the only place
+/// it could be read. The two ways it left were measured on #100 and they are different in kind: one
+/// is a sentence this tree writes, and one is a sentence the platform writes, which no wording here
+/// can fix.
+/// </para>
+/// <para>
+/// The address used below is not the one the other suites use. It carries a host nothing else in
+/// this repository contains, so a leg that finds it in a log has found the value rather than a word
+/// that happens to appear.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class SecretsStayOutOfTheLogTests
+{
+    private const string Host = "sink-nobody-else-names.invalid";
+    private const string Address = "https://" + Host + "/hook?token=THE-PART-THAT-AUTHENTICATES";
+
+    private static readonly Guid Asker = new Guid("7a000000-0000-0000-0000-000000000001");
+    private static readonly DateTimeOffset Noon = new DateTimeOffset(2026, 8, 29, 12, 0, 0, TimeSpan.Zero);
+
+    /// <summary>
+    /// A send that fails writes nothing of the address, at any level, in a message or in an
+    /// exception carried beside one.
+    /// <para>
+    /// This is the half no sentence in this tree could fix. Nothing on the sink's failure path names
+    /// the address; the platform writes the host and the port into the exception it raises, and
+    /// handing that object to the logger writes it into the log. The endpoint double refuses the
+    /// connection the same way, naming the destination in its own message, so this leg asserts
+    /// against the shape the field produces rather than against a friendlier one.
+    /// </para>
+    /// <para>
+    /// The logger takes every level, so what is read here is the log at its most verbose rather than
+    /// what a default level would have kept.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AFailedSendWritesNoPartOfTheAddressAtAnyLevel()
+    {
+        var endpoint = ASinkEndpoint.ThatRefusesTheConnection();
+        var log = new RecordingLogger();
+        using var sink = Sink(endpoint, Address, log);
+
+        sink.Announce(Notice());
+        await sink.QuietAsync(CancellationToken.None).ConfigureAwait(true);
+
+        // The failure did reach the log. Without this the leg passes on a sink that reported nothing
+        // at all, which is the wrong way to keep an address out of one.
+        Assert.Contains(log.Lines, line => line.Message.Contains("could not deliver", StringComparison.Ordinal));
+
+        Assert.All(log.Lines, line => Assert.DoesNotContain(Host, Written(line), StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// The class of the failure is what reaches the log instead, because that is what an operator
+    /// acts on: a refused connection, a name that does not resolve and a certificate that did not
+    /// verify are three different things to go and look at.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AFailedSendSaysWhatKindOfFailureItWas()
+    {
+        var endpoint = ASinkEndpoint.ThatRefusesTheConnection();
+        var log = new RecordingLogger();
+        using var sink = Sink(endpoint, Address, log);
+
+        sink.Announce(Notice());
+        await sink.QuietAsync(CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Contains(
+            log.Lines,
+            line => line.Message.Contains(nameof(HttpRequestException), StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// A refusal of the configuration names the setting and never quotes the value back.
+    /// <para>
+    /// That sentence becomes the message of the exception thrown out of a save and out of every read
+    /// of a stored configuration, and where the host takes such an exception is not something this
+    /// repository can read. The setting name has to survive, because it is how an operator is told
+    /// which box is wrong, and <c>ConfigurationRulesTests</c> holds that half.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void ARefusedAddressIsNamedAsASettingAndNeverQuotedBack()
+    {
+        var configuration = new PluginConfiguration { OutboundNoticeAddress = Host + "/hook" };
+
+        var problems = ConfigurationRules.Problems(configuration);
+
+        Assert.Contains(problems, problem => problem.Setting == nameof(PluginConfiguration.OutboundNoticeAddress));
+        Assert.All(problems, problem => Assert.DoesNotContain(Host, problem.Why, StringComparison.OrdinalIgnoreCase));
+
+        var refused = Assert.Throws<InvalidConfigurationException>(
+            () => ConfigurationRules.RefuseWhatCannotWork(configuration));
+
+        Assert.DoesNotContain(Host, refused.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Every property carrying the mark is named by a rule in the invariant lint.
+    /// <para>
+    /// The mark lives on the property and the name it refuses lives in the rule file, which is two
+    /// homes for one fact. Neither file can see the other, so this is what stops them drifting: a
+    /// second setting marked as a secret with no rule pointed at it reds the suite here rather than
+    /// being a mark that refuses nothing.
+    /// </para>
+    /// <para>
+    /// It reads the marks off the type rather than out of the source, so a mark added by any route
+    /// is in the population.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void EveryMarkedSettingIsNamedByARuleInTheInvariantLint()
+    {
+        var marked = typeof(PluginConfiguration)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(property => property.GetCustomAttribute<SecretAttribute>() is not null)
+            .Select(property => property.Name)
+            .ToList();
+
+        Assert.NotEmpty(marked);
+
+        var path = Path.Combine(AppContext.BaseDirectory, "tools", "opengrep", "rules.yaml");
+        Assert.True(File.Exists(path), FormattableString.Invariant($"{path} was not copied next to the suite."));
+
+        var rules = File.ReadAllText(path);
+
+        Assert.All(marked, name => Assert.Contains(name, rules, StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Everything one line of the log carries that a reader would end up with.
+    /// </summary>
+    /// <param name="line">The line.</param>
+    /// <returns>The message and whatever was reported beside it.</returns>
+    private static string Written(RecordingLogger.Line line)
+        => line.Message + (line.Exception?.ToString() ?? string.Empty);
+
+    private static OutboundSink Sink(HttpMessageHandler endpoint, string address, RecordingLogger log)
+        => new OutboundSink(
+            new FakeInstallSettings(new PluginConfiguration { OutboundNoticeAddress = address }),
+            endpoint,
+            log,
+            OutboundSink.DefaultAnswerWithin);
+
+    private static OutboundNotice Notice()
+        => OutboundNotice.For(
+            new MediaRequest
+            {
+                Id = new Guid("7a000000-0000-0000-0000-0000000000aa"),
+                RequestedByUserId = Asker,
+                RequestedAt = Noon,
+                Kind = RequestedItemKind.Movie,
+                DisplayTitle = "Stalker",
+                DisplayYear = 1979,
+                ProviderIds = new Dictionary<string, string> { ["Imdb"] = "tt0079944" },
+                State = RequestState.Approved,
+                StateChangedAt = Noon
+            },
+            NoticeEvent.Approved);
+}

--- a/Jellyfin.Plugin.Requests.Tests/Doubles/ASinkEndpoint.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/ASinkEndpoint.cs
@@ -100,7 +100,15 @@ internal sealed class ASinkEndpoint : HttpMessageHandler
 
         if (_answers is not HttpStatusCode answer)
         {
-            throw new HttpRequestException("There is nothing listening at that address.");
+            // The message names the host and the port, because that is what the platform puts into
+            // this exception when a connection is refused - measured on #100 against a loopback port
+            // nothing answers on, in a program outside this repository, so nothing was sent
+            // anywhere. A double whose refusal carried no address would let a leg asserting that no
+            // address reaches the log pass over code that writes one, which is the whole thing that
+            // leg is for.
+            throw new HttpRequestException(
+                FormattableString.Invariant(
+                    $"There is nothing listening at that address. ({request.RequestUri?.Host}:{request.RequestUri?.Port})"));
         }
 
         return new HttpResponseMessage(answer);

--- a/Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj
+++ b/Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj
@@ -71,6 +71,11 @@
     <None Include="../scripts/verify-plugin-loads.sh" Link="scripts/verify-plugin-loads.sh" CopyToOutputDirectory="PreserveNewest" />
     <None Include="../scripts/verify-user-isolation.sh" Link="scripts/verify-user-isolation.sh" CopyToOutputDirectory="PreserveNewest" />
     <None Include="../scripts/verify-full-disk.sh" Link="scripts/verify-full-disk.sh" CopyToOutputDirectory="PreserveNewest" />
+    <!-- The invariant lint's rule set, so the mark on a configuration property and the rule pointed
+         at it can be read against each other. The mark lives on the property and the name it
+         refuses lives in that file, neither can see the other, and a suite that opens both is what
+         stops the two drifting apart. -->
+    <None Include="../tools/opengrep/rules.yaml" Link="tools/opengrep/rules.yaml" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.Requests/Configuration/ConfigurationRules.cs
+++ b/Jellyfin.Plugin.Requests/Configuration/ConfigurationRules.cs
@@ -93,11 +93,15 @@ public static class ConfigurationRules
         {
             problems.Add(new ConfigurationProblem
             {
+                // The value is deliberately not quoted back. This sentence becomes the message of
+                // the exception thrown out of Plugin.UpdateConfiguration and out of every read of a
+                // stored configuration, and where that message then goes is the host's business
+                // rather than this repository's - a log an operator pastes into a tracker among
+                // them. The setting is marked a secret, so what an operator is told is which field
+                // is wrong and what it has to be, which is what they need to fix it; the value is
+                // in the box they just typed it into. #100.
                 Setting = nameof(PluginConfiguration.OutboundNoticeAddress),
-                Why = string.Format(
-                    CultureInfo.InvariantCulture,
-                    "OutboundNoticeAddress is \"{0}\", which is not a complete http or https address. It has to be one a notice can be posted to, scheme included, or empty to send nothing at all.",
-                    configuration.OutboundNoticeAddress)
+                Why = "OutboundNoticeAddress is not a complete http or https address. It has to be one a notice can be posted to, scheme included, or empty to send nothing at all."
             });
         }
 

--- a/Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs
@@ -139,7 +139,16 @@ public class PluginConfiguration : BasePluginConfiguration
     /// in this plugin's configuration file, in the settings page's markup and in every log line that
     /// ever prints the address.
     /// </para>
+    /// <para>
+    /// <b>It is marked as a secret, so it may not appear in anything this plugin writes for
+    /// somebody else to read.</b> An operator pastes a log into a tracker, and the host and port of
+    /// the place their server posts to is exactly the kind of thing that then sits in a public
+    /// issue. Since #318 the settings page cannot show the value back either, so a log line would
+    /// be the only place it could be read at all. <see cref="SecretAttribute"/> says what the mark
+    /// binds and what refuses a breach of it.
+    /// </para>
     /// </summary>
+    [Secret]
     public string OutboundNoticeAddress { get; set; } = string.Empty;
 
     /// <summary>

--- a/Jellyfin.Plugin.Requests/Configuration/SecretAttribute.cs
+++ b/Jellyfin.Plugin.Requests/Configuration/SecretAttribute.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace Jellyfin.Plugin.Requests.Configuration;
+
+/// <summary>
+/// Marks a setting whose value may not appear in anything this plugin writes for somebody else to
+/// read.
+/// <para>
+/// <b>Operators paste logs into issue trackers.</b> That is not a habit anybody is going to change,
+/// so the log has to be safe to paste, and the same goes for an error message, an activity entry and
+/// any diagnostic. #100 is where that was decided.
+/// </para>
+/// <para>
+/// <b>What the mark is, and what it is not.</b> It is a name a rule can be pointed at: the invariant
+/// lint refuses a marked setting reaching a message, and the suite refuses a mark this attribute
+/// carries that no rule names, so the two cannot drift apart. It is not a redacting type, and that
+/// is a decision rather than an omission - the host keeps this configuration by serialising it and
+/// the settings page edits it the same way, so a value that hands out a redaction on those paths is
+/// a setting that does not survive a restart. Decision 9 on #113 answered that with a write-only
+/// settings page instead, which #318 built.
+/// </para>
+/// <para>
+/// <b>So this attribute refuses nothing on its own.</b> Nothing reads it at run time and no code
+/// path behaves differently for a marked property. What holds the rule is the lint and the suite,
+/// and this is the thing they both read, which is why it is one mark rather than a list in each of
+/// them.
+/// </para>
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class SecretAttribute : Attribute
+{
+}

--- a/Jellyfin.Plugin.Requests/Notify/OutboundSink.cs
+++ b/Jellyfin.Plugin.Requests/Notify/OutboundSink.cs
@@ -194,10 +194,23 @@ public sealed class OutboundSink : IOutboundSink, IDisposable
             // request is unaffected. Catching by name instead would leave whichever exception nobody
             // listed to surface out of a task nothing observes, and the failure this sink exists to
             // avoid is exactly a notification path deciding what happens to a request.
+            //
+            // WHAT IS LOGGED IS THE CLASS OF THE FAILURE AND NEVER THE EXCEPTION ITSELF. The
+            // platform puts the destination of a request into the message of the exception it
+            // raises for it - `HttpRequestException` names the host and the port it could not reach
+            // - and the address is a marked secret, so handing the object to the logger writes it
+            // into a log an operator pastes into a tracker. Nothing in this method composes that
+            // sentence, so it cannot be fixed by writing a more careful one; what stops it is not
+            // passing the object. #100.
+            //
+            // WHAT THAT COSTS IS THE STACK AND THE PLATFORM'S OWN WORDING, and the type name is
+            // what an operator actually acts on: a refused connection, a name that does not
+            // resolve, a timeout and a certificate that did not verify are four different type
+            // names and four different things to go and look at.
             _logger.LogError(
-                reason,
-                "The notification sink could not deliver the notice about request {RequestId}. The request is unaffected and nothing will be retried.",
-                notice.RequestId);
+                "The notification sink could not deliver the notice about request {RequestId}: {Failure}. The request is unaffected and nothing will be retried. The failure is named by class rather than reported in full, because the address it was posted to is a secret and the platform writes it into the exception.",
+                notice.RequestId,
+                reason.GetType().Name);
         }
     }
 

--- a/tools/opengrep/fixtures/secrets/WritesAMarkedSettingIntoTheLog.cs
+++ b/tools/opengrep/fixtures/secrets/WritesAMarkedSettingIntoTheLog.cs
@@ -1,0 +1,58 @@
+// Fixture for no-marked-setting-in-a-message and for
+// an-outbound-failure-is-logged-by-class. This file is in no project and is
+// never compiled; it exists so both rules can be watched refusing the mistakes
+// they name.
+//
+// The near-miss in both cases is the sentence somebody writes while trying to
+// be helpful. A refusal that quotes the value back is the obvious way to write
+// a validation message, and handing the caught exception to the logger is the
+// obvious way to report a failed send - it is what every other failure path in
+// this plugin does, correctly, because their exceptions carry a local path and
+// no marked value.
+
+namespace Jellyfin.Plugin.Requests.Tests.Fixtures;
+
+internal sealed class WritesAMarkedSettingIntoTheLog
+{
+    // Legal neighbours, left here on purpose, because a rule that also refused
+    // these would make the mark unusable and the rule has to stay quiet on
+    // them. Naming the setting is how an operator is told which box is wrong,
+    // and reading the value in order to validate it is what the rules do.
+    public static ConfigurationProblem NamesTheSettingAndNotTheValue(PluginConfiguration configuration)
+    {
+        if (IsSomewhereANoticeCanBePosted(configuration.OutboundNoticeAddress))
+        {
+            return null;
+        }
+
+        return new ConfigurationProblem
+        {
+            Setting = nameof(PluginConfiguration.OutboundNoticeAddress),
+            Why = "OutboundNoticeAddress is not a complete http or https address."
+        };
+    }
+
+    // The regression: the value reaching a composed message, in the three
+    // spellings somebody would actually reach for.
+    public static void QuotesItBack(PluginConfiguration configuration, ILogger logger)
+    {
+        var why = string.Format(
+            CultureInfo.InvariantCulture,
+            "OutboundNoticeAddress is \"{0}\", which is not a complete http or https address.",
+            configuration.OutboundNoticeAddress);
+
+        logger.LogWarning("Posting to {Address} was refused.", configuration.OutboundNoticeAddress);
+
+        logger.LogDebug($"The sink is set to {configuration.OutboundNoticeAddress} on this install.");
+    }
+
+    // The regression the rule above cannot see: nothing here names the address,
+    // and the exception carries it anyway.
+    public static void HandsOverThePlatformsException(Exception reason, Guid requestId)
+    {
+        _logger.LogError(
+            reason,
+            "The notification sink could not deliver the notice about request {RequestId}.",
+            requestId);
+    }
+}

--- a/tools/opengrep/rules.yaml
+++ b/tools/opengrep/rules.yaml
@@ -763,3 +763,80 @@ rules:
         - "**/*.xml"
         - "**/*.yaml"
         - "**/*.yml"
+
+  # Invariant (configuration, #100): a setting marked `[Secret]` in
+  # PluginConfiguration may not be read into anything this plugin writes for
+  # somebody else to read. Operators paste logs into issue trackers, and since
+  # #318 the settings page cannot show the outbound address back at all, so a
+  # log line would be the only place it could be read.
+  #
+  # WHAT SEPARATES A READ FROM A MENTION is one spelling. A message legitimately
+  # NAMES the setting, and a problem record legitimately carries
+  # `nameof(PluginConfiguration.OutboundNoticeAddress)`, because an operator has
+  # to be told which box is wrong; what is refused is the VALUE. So the
+  # expression below refuses the member access anywhere inside a composed
+  # message and excepts exactly that one spelling of the mention, rather than
+  # trying to tell an instance from a type by its capital letter - which would
+  # miss `_settings.Current.OutboundNoticeAddress`, the spelling the one reader
+  # of this value in the tree actually uses.
+  #
+  # THE NAME IS IN THIS FILE AND ALSO ON THE PROPERTY, AND THE SUITE REFUSES THE
+  # TWO DRIFTING APART. `SecretsStayOutOfTheLogTests` reads the marked
+  # properties off the type by reflection and requires each one to appear here,
+  # so a second mark added with no rule reds the suite rather than being a rule
+  # nobody wrote. That is the whole of what keeps the two homes in step, and it
+  # is a test rather than a mechanism in this file.
+  - id: no-marked-setting-in-a-message
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      Do not read a setting marked `[Secret]` into a message. The value ends up
+      in a log an operator pastes into a tracker, and the settings page cannot
+      show it back, so this would be the only place it can be read. Name the
+      setting if the reader needs to know which one is wrong, and leave the
+      value out (#100).
+    patterns:
+      - pattern-either:
+          - pattern-regex: '(?s)(string\.Format|\.Log[A-Z][A-Za-z]*)\([^;]{0,800}?(?<!nameof\(PluginConfiguration)\.OutboundNoticeAddress'
+          - pattern-regex: '\$"[^"]*\{[^}"]*(?<!nameof\(PluginConfiguration)\.OutboundNoticeAddress'
+    paths:
+      include:
+        - "Jellyfin.Plugin.Requests/**/*.cs"
+        - "tools/opengrep/fixtures/secrets/**/*.cs"
+
+  # Invariant (configuration, #100), the half the rule above cannot see. The
+  # outbound sink posts to a marked address, and the platform writes the
+  # destination it could not reach into the message of the exception it raises -
+  # `HttpRequestException` names the host and the port. So a failure path that
+  # hands that object to the logger writes the address into the log without any
+  # sentence in this tree naming it, which is exactly the leak a rule over what
+  # a message says cannot reach. What is logged instead is the class of the
+  # failure, which is what an operator acts on.
+  #
+  # THE FIRST ARGUMENT IS THE TEST. Every ILogger extension that takes an
+  # exception takes it first, and a message template is always a literal, so a
+  # first argument that opens with neither a quotation mark nor the dollar of an
+  # interpolated one is an exception being handed over.
+  #
+  # WHAT IT DOES NOT REACH, said here rather than discovered: the subject is the
+  # one file in this tree that makes an outbound call with a marked address. A
+  # second such caller - the adapter #315 asks for is the next one - is outside
+  # this rule until its path is added below, and nothing refuses forgetting to
+  # add it. The alternative is refusing an exception reaching the logger
+  # everywhere, which would refuse the store, the seam and the library watcher,
+  # where the exception carries a local path and no marked value and is the
+  # whole diagnostic.
+  - id: an-outbound-failure-is-logged-by-class
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      Do not hand the exception from an outbound send to the logger. The
+      platform puts the address it could not reach into that exception's own
+      message, and the address is a marked secret, so no wording of the sentence
+      beside it can keep the value out. Log the failure's type name (#100).
+    patterns:
+      - pattern-regex: '\.Log[A-Z][A-Za-z]*\(\s*[^"$\s]'
+    paths:
+      include:
+        - "Jellyfin.Plugin.Requests/Notify/OutboundSink.cs"
+        - "tools/opengrep/fixtures/secrets/**/*.cs"


### PR DESCRIPTION
Closes #100.

## The two ways a marked value left, and they are different in kind

The reading of 17 August on that issue measured both and they need different repairs.

**The configuration refusal quoted the value back.** That sentence becomes the message of the exception thrown out of `Plugin.UpdateConfiguration` and out of every read of a stored configuration, and where the host takes such an exception is not something this repository can read. It now names the setting and not the value, which is what an operator needs in order to fix it - the value is in the box they just typed it into.

**The notification sink named nothing at all and leaked anyway.** The platform writes the destination it could not reach into the message of the exception it raises, and that object was handed to the logger. No wording of the sentence beside it could have fixed that, because nothing in this tree writes the sentence that leaks. What is logged now is the class of the failure. That costs the stack and the platform's own wording, and it keeps the thing an operator acts on: a refused connection, a name that does not resolve, a timeout and a certificate that did not verify are four different type names and four different things to go and look at.

## The mark

`[Secret]`, on `OutboundNoticeAddress`. The tree carried none, and the first condition quantifies over one.

It refuses nothing at run time and it is **not** a redacting type. That is a decision rather than an omission: the host keeps this configuration by serialising it and the settings page edits it the same way, so a value that hands out a redaction on those paths is a setting that does not survive a restart. Decision 9 on #113 answered that with a write-only page instead, which #318 built. So the mark is a name a rule can be pointed at, and the rules are what hold it.

## The two rules, and what each cannot see

`no-marked-setting-in-a-message` refuses a marked setting read into a composed message, and excepts exactly one spelling: `nameof(PluginConfiguration.OutboundNoticeAddress)`, because an operator has to be told which box is wrong. It does that with an exception for that literal rather than by telling an instance from a type by its capital letter, which would have missed `_settings.Current.OutboundNoticeAddress` - the spelling the one reader of this value in the tree actually uses.

`an-outbound-failure-is-logged-by-class` refuses the sink handing an exception to the logger, which is the half the first rule cannot reach. Its subject is the one file in this tree that makes an outbound call with a marked address, and its own comment says so: a second such caller is outside it until its path is added, and nothing refuses forgetting to add it. Refusing an exception reaching the logger everywhere would refuse the store, the seam and the library watcher, where the exception carries a local path and no marked value and is the whole diagnostic.

**Both rules were watched biting on the code that was on the mainline this morning**, run against `origin/master` rather than against a fixture written to be caught:

    rule 1 on the mainline ConfigurationRules.cs: ['l.",\n                    configuration.OutboundNoticeAddress']
    rule 2 on the mainline OutboundSink.cs: ['.LogError(\n                r']

`tools/opengrep/fixtures/secrets/WritesAMarkedSettingIntoTheLog.cs` is where the gate watches them, with the legal neighbours beside the regressions so a rule that also refused those would red there.

## The mark and the rule are two homes for one fact

Neither file can see the other. `EveryMarkedSettingIsNamedByARuleInTheInvariantLint` reads the marks off the type by reflection and requires each one to appear in the rule set, so a second setting marked with no rule pointed at it reds the suite rather than being a mark that refuses nothing.

## Watched biting

The suite is 762 green on `net9.0` at `bcfd289`. Each guard was deleted on its own and the suite watched going red, and the tree restored after each.

The sink guard, put back to handing the exception over:

    Assert.Contains() Failure: Filter not matched in collection
    Assert.All() Failure: 1 out of 1 items in the collection did not pass.
      Error: Assert.DoesNotContain() Failure: Sub-string found
    Fehler!      : Fehler:     2, erfolgreich:     2, uebersprungen:     0, gesamt:     4

The configuration guard, put back to quoting the value:

    Assert.All() Failure: 1 out of 1 items in the collection did not pass.
      Error: Assert.DoesNotContain() Failure: Sub-string found
    Fehler!      : Fehler:     1, erfolgreich:     3, uebersprungen:     0, gesamt:     4

The drift guard, in both directions - the rule stopping naming the setting, and the mark coming off the property:

    Assert.All() Failure: 1 out of 1 items in the collection did not pass.
      Error: Assert.Contains() Failure: Sub-string not found
    Fehler!      : Fehler:     1, erfolgreich:     0, uebersprungen:     0, gesamt:     1

    Assert.NotEmpty() Failure: Collection was empty
    Fehler!      : Fehler:     1, erfolgreich:     0, uebersprungen:     0, gesamt:     1

**And the near-miss, which is the one worth reading.** `ASinkEndpoint.ThatRefusesTheConnection` used to throw an exception naming no address, so a leg asserting that no address reaches the log passed over the code that wrote one. With the leak restored **and** the double put back:

    Bestanden!   : Fehler:     0, erfolgreich:     1, uebersprungen:     0, gesamt:     1

The double now names the host and the port in its own message, the way the platform does - measured on #100 on 17 August against a loopback port nothing answers on, in a program outside this repository, so nothing was sent anywhere.

## The means

C# in the two projects that already hold this code, plus a rule in the invariant lint the issue's own first condition names, plus a fixture in the register that already proves every other rule. No language, runtime or dependency is added, and every part is judged by a suite that already exists. The one thing considered and rejected is a redacting type, for the reason above, which is a decision taken on #113 rather than here.

## The three conditions

**The first is met.** A value marked as a secret exists, and a rule in the invariant lint refuses it being written by a logging call - two rules, because one shape of the leak names the value and one does not.

**The second is met for both paths a marked value can reach.** `RecordingLogger` enables every level, so what the legs read is the log at its most verbose rather than what a default level would have kept, and they read the exception carried beside a line as well as the message. The two paths are the two the issue measured; nothing else in this tree reads the value at all, which the change leaves as it found it:

    git grep -n 'OutboundNoticeAddress' -- Jellyfin.Plugin.Requests/

returns the configuration class, the rules that validate it, and the sink that posts to it.

**The third is met by refusal rather than by a type, and that is worth reading carefully.** "By construction rather than by remembering" is delivered here as a machine that refuses the value re-entering a message, not as a value that cannot render itself. A redacting type is the other reading and it is refused on #113 for a reason this change cannot overturn. If that is not what the condition asks for, this closes wrongly and reopening costs a click.

## What this does not claim

**Nothing was run on a server.** No configuration was saved through a running host, no notice was posted anywhere, and no log written by a Jellyfin server was read. Every leg runs in this process against the sink's own client and handler pipeline, which is the headless rule in `docs/testing.md`.

**The configuration endpoint still serialises the whole object.** #318 disclosed that bound and `docs/configuration.md` carries it: the value still reaches anybody who may read the server's own plugin-configuration endpoint. This change is about what the plugin writes for support purposes and does not touch that.

**A second outbound caller is outside the second rule.** Its path has to be added when the adapter #315 asks for arrives, and nothing refuses forgetting. That is written at the rule rather than only here.

**This board has no second reader tonight.** What stands in place of one is the transcripts above: five deletions, each watched reddening only what it is about, and the two rules watched matching the code that was on the mainline this morning.
