### PR TITLE
Give the bridge failures an address now that they are decided but not built

### DIFF
--- a/docs/operating.md
+++ b/docs/operating.md
@@ -110,11 +110,17 @@ by writing a row, and writing that row is what says that person's account name m
 Matching people by name is refused rather than built and switched off, because it is wrong in the
 direction that credits one person with another's request.
 
-**What each failure looks like.** This is the part no document can answer yet. The service being
-unreachable, refusing the credential, running a version the adapter does not know, and being asked
-about a title it has never heard of each need a decided behaviour, and none of them has one, because
-there is nothing here that could fail. Until that lands, an operator has nothing to read here, and a
-sequence written now would be an account of intentions rather than of behaviour.
+**What each failure looks like.** This is the part no document can answer yet, and the reason moved
+on 2026-08-28. The four failures now have decided behaviours: unreachable is temporary and retried
+with a bound, a refused credential stops the bridge and tells the operator rather than being retried
+until somebody notices, a service version the adapter does not know is surfaced as an incompatibility
+and not retried either, and a title the service has never heard of is a fact about one request and
+never stops the rest. Those are the ruling on issue #86 and they are written here as an address
+rather than as a sequence, because nothing implements them: the only bridge that ships is still the
+one for a server with no service, so none of the four can occur. Issue #315 is the adapter that makes
+them real, and this section is written against what it does on the day it lands. A sequence written
+before then would be an account of intentions rather than of behaviour, which is the one thing
+somebody reading a page like this under pressure cannot afford.
 
 ## When requests stop moving
 


### PR DESCRIPTION
Part of #102. It does not finish that issue, and the paragraph below says why.

## What moved

`docs/operating.md` said that what each failure of an external request service looks like is a part no document can answer yet, because none of the four failures had a decided behaviour. Four of them have one as of 2026-08-28, ruled on #86: unreachable is temporary and retried with a bound, a refused credential stops the bridge and tells the operator rather than being retried until somebody notices, a service version the adapter does not know is surfaced as an incompatibility and not retried either, and a title the service has never heard of is a fact about one request and never stops the rest.

So the reason the section cannot yet be a sequence changed, and the sentence had to change with it. What is missing is no longer a decision. It is the adapter, and that is #315.

## Why the section is an address rather than the sequence

Nothing implements those four behaviours. The only bridge that ships is still the one for a server with no service:

    git grep -n ': IRequestBackend' origin/master -- Jellyfin.Plugin.Requests/
    origin/master:Jellyfin.Plugin.Requests/Bridge/NoRequestBackend.cs:23:public sealed class NoRequestBackend : IRequestBackend

so none of the four can occur, and a sequence written now would be an account of intentions rather than of behaviour. That is the same reason the paragraph gave before the ruling, and the page keeps it rather than softening it: somebody reading a diagnostics section under pressure is the last reader who can afford a page describing what the software is going to do.

What the section carries instead is the ruling, named as a ruling, with the two issues a reader follows to see where it stands.

## The means

Prose in the document this issue's scope names, edited in place. The section already existed and already carried the two halves that are answerable; nothing here adds a file, a format or a tool.

## What this does not close

**The bridge section is still the named remainder of this issue's second condition**, which asks that it cover the credential, the identity mapping and what each failure looks like. The first two are covered by pointing at `docs/bridge.md`, which the reading of 17 August on #102 measured. The third is written when #315 makes the behaviours real, and #102 closes on that rather than on anything further being written now.

**Nothing was read on a running server.** The page's own last paragraph already says the panel, its sentences and the order of the six steps are read off this repository rather than off a running install, and this change does not touch that.
