### PR TITLE
Read the sibling's replay marker so an adopted request says it was adopted

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Seam/SeamSurfaceTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Seam/SeamSurfaceTests.cs
@@ -86,6 +86,14 @@ public class SeamSurfaceTests
     /// the sibling's board, in the contract issue <c>docs/seam.md</c> points at, and neither this
     /// file nor that document restates it: #11's second condition is what that rule comes from.
     /// </para>
+    /// <para>
+    /// <b>The replay marker was added here without the seam version moving, and that is the
+    /// sibling's rule rather than a concession made on this side.</b> That contract counts breaking
+    /// changes only and says in as many words that a field a receiver may ignore does not raise the
+    /// number; the field arrived there at version one for that reason and because nothing has
+    /// shipped from that repository yet. Raising it here would refuse every want the sibling writes,
+    /// since a field set whose version this side does not know is refused whole.
+    /// </para>
     /// </summary>
     [Fact]
     public void TheWantCarriesExactlyThePropertiesWrittenDown()
@@ -97,6 +105,7 @@ public class SeamSurfaceTests
                 "System.Guid RequestedByUserId",
                 "System.Guid WantId",
                 "System.Int32 ContractVersion",
+                "System.Nullable`1[System.Boolean] Replay",
                 "System.Nullable`1[System.Int32] Year",
                 "System.String Title"),
             string.Join(" | ", SeamSurface.WantProperties),

--- a/Jellyfin.Plugin.Requests.Tests/Seam/WantHandoverTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Seam/WantHandoverTests.cs
@@ -783,6 +783,112 @@ public class WantHandoverTests
     }
 
     /// <summary>
+    /// A want the other side is replaying is recorded as a replay and not as a live handover.
+    /// <para>
+    /// This is what an operator has instead of the moment somebody asked. A replay lands the whole
+    /// of somebody's history at once, the entry can only carry the moment the replay ran, and
+    /// without this the queue that appeared overnight reads as a morning of people asking. Every
+    /// other field of the entry is asserted beside it, so the marker cannot arrive by something else
+    /// on the row having moved.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AReplayedWantIsRecordedAsAReplayRatherThanAsALiveHandover()
+    {
+        var store = new InMemoryRequestStore();
+
+        Assert.True(await Seam(store).AcceptAsync(Want() with { Replay = true }, CancellationToken.None));
+
+        var made = Assert.Single(await store.GetAllAsync(CancellationToken.None)).Request;
+        var entry = Assert.Single(made.History);
+
+        Assert.Equal(RequestArrival.SeamReplay, entry.Arrival);
+        Assert.Equal(RequestActor.Requester, entry.By);
+        Assert.Equal(Noon, entry.At);
+        Assert.Equal(made.State, entry.From);
+        Assert.Equal(made.State, entry.To);
+        Assert.Null(entry.Reason);
+        Assert.Null(entry.Note);
+    }
+
+    /// <summary>
+    /// The whole of a replayed set is marked, and not only the first want in it.
+    /// <para>
+    /// The queue an operator meets is the set rather than one row, so a marker that reached one
+    /// request and not the rest would answer the question for a sample. Three requests come out of
+    /// these four wants, which is asserted so the comparison cannot pass on a run that made none.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AWholeReplayedSetIsMarkedAsAReplayThroughout()
+    {
+        var store = new InMemoryRequestStore();
+        var handover = Seam(store);
+
+        foreach (var want in WhatTheSiblingRecordedBefore())
+        {
+            Assert.True(await handover.AcceptAsync(want with { Replay = true }, CancellationToken.None));
+        }
+
+        var held = await store.GetAllAsync(CancellationToken.None);
+
+        Assert.Equal(3, held.Count);
+        Assert.All(
+            held,
+            request => Assert.Equal(RequestArrival.SeamReplay, Assert.Single(request.Request.History).Arrival));
+    }
+
+    /// <summary>
+    /// A marker spelled <see langword="false"/> is read as a want being expressed now rather than
+    /// refused.
+    /// <para>
+    /// The sending type refuses that spelling and the reason it gives is that a false and an absence
+    /// are the same want. A receiver that then threw the want away would cost somebody their request
+    /// to make a point the sender has already conceded, so what this side does with anything that is
+    /// not the marker set is treat it as live.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AMarkerSpelledFalseIsReadAsLiveRatherThanRefused()
+    {
+        var store = new InMemoryRequestStore();
+
+        Assert.True(await Seam(store).AcceptAsync(Want() with { Replay = false }, CancellationToken.None));
+
+        var made = Assert.Single(await store.GetAllAsync(CancellationToken.None)).Request;
+
+        Assert.Equal(RequestArrival.Seam, Assert.Single(made.History).Arrival);
+    }
+
+    /// <summary>
+    /// A want somebody expressed live and the other side later replays keeps the live arrival it
+    /// already had.
+    /// <para>
+    /// The history is append-only and the request already exists, so the replay writes nothing at
+    /// all - which is the same rule that makes a replay safe to run twice, read here for what it
+    /// says about the record. The alternative a reader might expect, a row saying the request
+    /// arrived a second time, would say a request arrived after it was made.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AReplayOfAWantSomebodyAlreadyExpressedLiveLeavesTheLiveArrivalStanding()
+    {
+        var store = new InMemoryRequestStore();
+        var handover = Seam(store);
+
+        Assert.True(await handover.AcceptAsync(Want(), CancellationToken.None));
+        Assert.True(await handover.AcceptAsync(Want() with { Replay = true }, CancellationToken.None));
+
+        var made = Assert.Single(await store.GetAllAsync(CancellationToken.None)).Request;
+
+        Assert.Equal(RequestArrival.Seam, Assert.Single(made.History).Arrival);
+    }
+
+    /// <summary>
     /// Somebody joining a request that is already here adds no second arrival. The request arrived
     /// once; what a later person did is join something already in the queue, and the entry is about
     /// the record rather than about each person waiting on it.

--- a/Jellyfin.Plugin.Requests/Model/RequestArrival.cs
+++ b/Jellyfin.Plugin.Requests/Model/RequestArrival.cs
@@ -12,6 +12,13 @@ namespace Jellyfin.Plugin.Requests.Model;
 /// about it.
 /// </para>
 /// <para>
+/// <b>Three values over two surfaces.</b> The seam carries two of them, because a want the other
+/// side recorded earlier and one somebody is expressing now cross on the same call and are
+/// different things to an operator meeting a queue that filled up overnight. Which of the two it is
+/// comes from the marker the contract carries for it and from nothing this side infers; #93 is
+/// where that was asked for and the sibling's own contract note is where the field is fixed.
+/// </para>
+/// <para>
 /// <b>It says how, and never who.</b> Which plugin handed a want over is not recorded, decided on
 /// #118: the contract carries no field naming the caller, and reading one off an assembly name or a
 /// call stack would be this side inventing a value nobody agreed. A history that records an
@@ -35,5 +42,30 @@ public enum RequestArrival
     /// <summary>
     /// Somebody asked over this plugin's own HTTP endpoint, on a session the server authenticated.
     /// </summary>
-    Endpoint = 1
+    Endpoint = 1,
+
+    /// <summary>
+    /// A want the other side had already recorded, handed over the seam when a replay was run rather
+    /// than at the moment somebody expressed it.
+    /// <para>
+    /// It is a third value rather than a flag beside <see cref="Seam"/> because the question an
+    /// operator arrives with is one question - how did this reach the queue - and two fields
+    /// answering it is two fields to read and one of them to forget. The proof position is the
+    /// seam's in both cases and nothing about it is softened here.
+    /// </para>
+    /// <para>
+    /// <b>What it costs to read it as the moment somebody asked.</b> The moment on the entry is when
+    /// the replay ran, because that is the only moment this side ever sees; the other side holds
+    /// when the want was recorded and the contract carries no field for it. So a queue that filled
+    /// up at once reads as a queue that filled up at once, and this value is what says the filling
+    /// was a replay rather than a morning of people asking.
+    /// </para>
+    /// <para>
+    /// A build of the sibling from before the marker existed hands every want over without one, so
+    /// its replays land as <see cref="Seam"/>. That is absence read as absence: the contract's
+    /// marker says the unusual thing and says nothing where it is not sent, so this side records
+    /// what it was told rather than guessing at a replay it has no evidence of.
+    /// </para>
+    /// </summary>
+    SeamReplay = 2
 }

--- a/Jellyfin.Plugin.Requests/Seam/HandedOverWant.cs
+++ b/Jellyfin.Plugin.Requests/Seam/HandedOverWant.cs
@@ -93,4 +93,29 @@ public sealed record HandedOverWant
         get => _providerIds;
         init => _providerIds = value ?? ReadOnlyDictionary<string, string>.Empty;
     }
+
+    /// <summary>
+    /// Gets <see langword="true"/> where the other side is replaying a want it recorded before this
+    /// plugin was installed, and nothing where somebody is expressing one now.
+    /// <para>
+    /// <b>Absence is live, and it is the value every older build sends.</b> The marker says the
+    /// unusual thing rather than the ordinary one, so a sibling built before the field existed hands
+    /// wants over without it and each of them reads as what it is. That is the contract's own
+    /// spelling and not a reading invented here.
+    /// </para>
+    /// <para>
+    /// <b><see langword="false"/> is read as live rather than refused.</b> The sending type refuses
+    /// it, and the reason it gives is that a false and an absence are the same want; a receiver that
+    /// then threw the want away over the redundant spelling would cost somebody their request to
+    /// make a point the sender has already conceded. So this side treats anything that is not
+    /// <see langword="true"/> as a want being expressed now.
+    /// </para>
+    /// <para>
+    /// <b>A field a receiver may ignore does not move the contract version.</b> This one arrived at
+    /// version one on the sibling's board rather than minting a second, which is that board's rule
+    /// applied on that board; <see cref="WantHandover.KnownContractVersion"/> is unchanged for it
+    /// and a want carrying the marker is read by the same version this side already knew.
+    /// </para>
+    /// </summary>
+    public bool? Replay { get; init; }
 }

--- a/Jellyfin.Plugin.Requests/Seam/WantHandover.cs
+++ b/Jellyfin.Plugin.Requests/Seam/WantHandover.cs
@@ -300,7 +300,16 @@ public sealed class WantHandover : IWantHandover
         // decided on #118, and a value read off anything else would be the sender saying who they
         // are. What this side knows is that no session stood behind the person named, and that is
         // what the entry says.
-        incoming = RequestLifecycle.Arriving(incoming, RequestArrival.Seam);
+        //
+        // Which of the two seam values it is comes from the marker the other side sends and from
+        // nothing inferred here. A replay and a live gesture cross on this same call, and an
+        // operator meeting a queue that filled up overnight has no other way to tell them apart:
+        // the moment on the entry is when the replay ran, because that is the only moment this side
+        // ever sees. Anything that is not the marker set is a want being expressed now, which is
+        // what absence means on the contract and what every build from before it sends.
+        incoming = RequestLifecycle.Arriving(
+            incoming,
+            want.Replay == true ? RequestArrival.SeamReplay : RequestArrival.Seam);
 
         Answer<IntakeResult> intake;
 

--- a/docs/seam.md
+++ b/docs/seam.md
@@ -534,16 +534,46 @@ somebody closed a browser, and a replay that can only be run once is one nobody 
 
     git grep -n 'TheWholeSetReplayedTwiceIsTheQueueItMadeTheFirstTime\|AReplayThatStoppedHalfwayIsSafeToRunAgainFromTheStart' -- Jellyfin.Plugin.Requests.Tests/Seam/WantHandoverTests.cs
 
-**What is not answered, and it is the rest of #93.** An adopted request is not distinguishable from
-one that arrived live. Both cross on the same call, so the entry a request now carries says the seam
-for either of them, and the moment on it is the moment the replay ran rather than the moment the
-person asked, because that is the only moment this side ever sees:
+**An adopted request is distinguishable from one that arrived live, and what separates them is a
+field the contract now carries.** Both still cross on the same call, so this side infers nothing: the
+sibling marks a want it is replaying, and a request made from a marked want records the arrival that
+says so.
+
+    git grep -n 'want.Replay == true ? RequestArrival.SeamReplay : RequestArrival.Seam' -- Jellyfin.Plugin.Requests/Seam/WantHandover.cs
+    git grep -n 'SeamReplay = 2' -- Jellyfin.Plugin.Requests/Model/RequestArrival.cs
+
+**Absence is live and the marker says the unusual thing, which is what makes an older sibling
+harmless rather than wrong.** A build from before the field existed hands every want over without it
+and each of them is recorded as a want somebody expressed now. The reverse spelling would have made
+every one of those read as a replay. A marker spelled `false` is read as live too rather than
+refused, because the sending side's own type refuses that spelling on the grounds that a false and an
+absence are the same want, and throwing the want away over the redundant spelling would cost somebody
+their request to make a point the sender has already conceded.
+
+    git grep -n 'AMarkerSpelledFalseIsReadAsLiveRatherThanRefused\|AReplayedWantIsRecordedAsAReplayRatherThanAsALiveHandover\|AWholeReplayedSetIsMarkedAsAReplayThroughout' -- Jellyfin.Plugin.Requests.Tests/Seam/WantHandoverTests.cs
+
+**The seam version did not move for it, and that is the sibling's rule rather than a concession made
+here.** That contract counts breaking changes only and says that a field a receiver may ignore does
+not raise the number; the field arrived there at version one for that reason and because nothing has
+shipped from that repository yet. Raising it on this side would refuse every want the sibling writes,
+because a field set whose version this side does not know is refused whole.
+
+**What the marker does not buy is the moment somebody asked.** The moment on the entry is when the
+replay ran, because that is the only moment this side ever sees and the contract carries no field for
+the other one:
 
     git grep -n 'At = request.RequestedAt' -- Jellyfin.Plugin.Requests/Model/RequestHistoryEntry.cs
 
-So an operator who finds a sudden queue can see that it came over the seam and cannot see that it is
-a replay. Telling the two apart needs something the contract does not carry, which is #93's question
-rather than this section's. What a request does record about having arrived is the section below.
+So a queue that filled up at once still reads as a queue that filled up at once. What the operator
+gains is the account of why, which is what this condition was for. What a request records about
+having arrived is the section below.
+
+**A want somebody expressed live and the sibling later replays keeps the live arrival it already
+had.** The request exists, so the replay writes nothing at all - the same rule that makes a replay
+safe to run twice - and the history is append-only, so there is no second row to disagree with the
+first.
+
+    git grep -n 'AReplayOfAWantSomebodyAlreadyExpressedLiveLeavesTheLiveArrivalStanding' -- Jellyfin.Plugin.Requests.Tests/Seam/WantHandoverTests.cs
 
 ## What this side trusts, and what it checks anyway
 
@@ -604,7 +634,13 @@ plugin's own endpoint carries the other value and means the opposite: the server
 person it is filed against. An operator answering for a request can tell those two apart from the
 record now, which was not possible before this entry existed.
 
-    git grep -n '^    Seam = 0,\|^    Endpoint = 1' -- Jellyfin.Plugin.Requests/Model/RequestArrival.cs
+    git grep -n '^    Seam = 0,\|^    Endpoint = 1,\|^    SeamReplay = 2' -- Jellyfin.Plugin.Requests/Model/RequestArrival.cs
+
+**Three values over two surfaces.** The seam carries two of them, because a want the sibling recorded
+before this plugin was installed and one somebody is expressing now are different things to an
+operator meeting a queue that filled up overnight. Which of the two a request got comes from the
+marker the other side sends and from nothing this side infers, and the section above is where that
+is argued.
 
 **One arrival per request, not one per person.** A want naming something already in the queue joins
 the request that is there, and a want handed over a second time writes nothing at all, so neither


### PR DESCRIPTION
Closes #93.

## What was missing

Two of this issue's three conditions were met on 12 August: a replay creates no second request, proven over the whole set replayed twice and over a replay restarted from the beginning, and `docs/seam.md` states that the replay is the sibling's to initiate. The third was not, and the reason it was not moved twice: first it waited on a history that did not exist, then on the contract gaining a way to say that a want is being replayed.

That field has landed on the sibling's board. Read now, in a clone of `Flowfin/jellyfin-plugin-discover`:

    gh issue view 335 --repo Flowfin/jellyfin-plugin-discover --json number,state,stateReason,title --jq '[.number,.state,.stateReason,.title]|@tsv'
    335     CLOSED  COMPLETED       The contract gains an optional replay field at its next version

So this reads it.

## What this changes

`HandedOverWant` carries the contract's eighth field, `WantHandover` chooses between the two seam arrivals from it, and the enum gains the value that separates them.

    git grep -n 'public bool? Replay { get; init; }' -- Jellyfin.Plugin.Requests/Seam/HandedOverWant.cs
    Jellyfin.Plugin.Requests/Seam/HandedOverWant.cs:120:    public bool? Replay { get; init; }

    git grep -n 'want.Replay == true ? RequestArrival.SeamReplay : RequestArrival.Seam' -- Jellyfin.Plugin.Requests/Seam/WantHandover.cs
    Jellyfin.Plugin.Requests/Seam/WantHandover.cs:312:            want.Replay == true ? RequestArrival.SeamReplay : RequestArrival.Seam);

    git grep -n '^    Seam = 0,\|^    Endpoint = 1,\|^    SeamReplay = 2' -- Jellyfin.Plugin.Requests/Model/RequestArrival.cs
    Jellyfin.Plugin.Requests/Model/RequestArrival.cs:40:    Seam = 0,
    Jellyfin.Plugin.Requests/Model/RequestArrival.cs:45:    Endpoint = 1,
    Jellyfin.Plugin.Requests/Model/RequestArrival.cs:70:    SeamReplay = 2

Nothing is inferred on this side. A replay and a live gesture still cross on the same call, and what tells them apart is the marker the other side sends.

## The version did not move, and that is the sibling's rule rather than a concession

`WantContract` on that board keeps `CurrentVersion = 1` and says why in the file: the contract counts breaking changes only, a field a receiver may ignore does not raise the number, and nothing has shipped from that repository yet. Raising `KnownContractVersion` here would refuse every want the sibling writes, because a field set whose version this side does not know is refused whole.

    git grep -n 'KnownContractVersion = ' -- Jellyfin.Plugin.Requests/Seam/WantHandover.cs
    Jellyfin.Plugin.Requests/Seam/WantHandover.cs:68:    public const int KnownContractVersion = 1;

What does move is the property pin in `SeamSurfaceTests`, which is the deliberate act the reflected surface asks for: under reflection an added field is a name a sibling sets by string, so it is written down here and compared against the type.

## Absence is live, and so is a false

A build of the sibling from before the marker existed hands every want over without it, and each of those is recorded as a want somebody expressed now. The marker says the unusual thing for exactly that reason; the reverse spelling would have made every one of them read as a replay.

A marker spelled `false` is read as live rather than refused. The sending type refuses that spelling, and the reason it gives is that a false and an absence are the same want - so this side throwing the want away over the redundant spelling would cost somebody their request to make a point the sender has already conceded.

## What this does not buy

The moment somebody asked. The entry carries the moment the replay ran, because that is the only moment this side ever sees and the contract carries no field for the other one. A queue that filled up at once still reads as a queue that filled up at once; what an operator gains is the account of why, which is what this condition asked for. That is written into `docs/seam.md` rather than left here.

## The means

C# in the plugin project with xUnit beside it and prose in `docs/`, which is what this tree already carries. The change is a field on an existing record, a value on an existing enum and one branch at one call site; every property it has is refusable by the suite that already covers this seam, every claim below carries the command that produced it, and it adds no language, runtime or dependency. A different means here would be a second apparatus for six legs.

## The guard was watched biting

With the arrival forced back to `RequestArrival.Seam`, two legs red on both claimed target frameworks:

    Jellyfin.Plugin.Requests.Tests.Seam.WantHandoverTests.AReplayedWantIsRecordedAsAReplayRatherThanAsALiveHandover [FAIL]
      Assert.Equal() Failure: Values differ
      Expected: SeamReplay
      Actual:   Seam
    Jellyfin.Plugin.Requests.Tests.Seam.WantHandoverTests.AWholeReplayedSetIsMarkedAsAReplayThroughout [FAIL]
      Assert.All() Failure: 3 out of 3 items in the collection did not pass.

The near-miss is the one somebody would actually write, `is not null` in place of `== true`. It reds one leg and only that one:

    Jellyfin.Plugin.Requests.Tests.Seam.WantHandoverTests.AMarkerSpelledFalseIsReadAsLiveRatherThanRefused [FAIL]

## The suite at this head

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler:     0, erfolgreich:   766, uebersprungen:     0, gesamt:   766, Dauer: 22 s - Jellyfin.Plugin.Requests.Tests.dll (net10.0)
    Bestanden!   : Fehler:     0, erfolgreich:   766, uebersprungen:     0, gesamt:   766, Dauer: 22 s - Jellyfin.Plugin.Requests.Tests.dll (net9.0)

762 before, 766 after, four legs added. The summary line is quoted in the language the machine printed it in, with two vowels transliterated because the tree refuses non-ASCII in tracked text and this body is quoted back into none of it.

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    0 Warnung(en)
    0 Fehler

## One path outside this issue's declared scope

`Scope:` on #93 reads "the seam code, docs/seam.md, the test project", and this change also touches `Jellyfin.Plugin.Requests/Model/RequestArrival.cs`. That is unavoidable rather than an extra topic: the distinction this issue asks for is a value of that enum, and there is nowhere else for it to live. Nothing else in `Model/` moves.

`docs/personal-data.md` describes that same enum and is deliberately NOT touched here, because #102 and #104 are open against the documents tonight and one file under two hands is the collision the sizing rule exists against. Nothing in that page is made false by this change: it says the value names which surface and never which caller, which both seam values do, and it states no count.

## What had no second reader

Nobody else read this change. The commands above stand in place of one, and the run they quote was made at this head rather than recalled from an earlier one.

## One thing found while running the suite, which is not this change's

`APersonsOwnSwitchTests.AnInstallNobodyHasTouchedTellsEverybody` failed once on `net9.0` during a full-suite run here and passed on the run either side of it and when its class is run alone. It asserts an exact order over messages that `QuietedRequesterNotice.Tell` starts on independent tasks, and the double it asserts against appends to an unsynchronised list from those threads. It is on `master` and not introduced here; it has its own issue rather than a paragraph in this body.

## This replaces #328, which carried the same content unsigned

That pull request's single commit had no `Signed-off-by:` trailer, so the DCO gate refused it, and the repair is a new branch rather than a rewritten one: whether anybody has fetched a ref is not knowable from here, so a wrong history is corrected under a new name and the old one abandoned. The content is identical - the commit was amended only to add the trailer - and #328 is closed with that reason in its body.
