### PR TITLE
Read the form's own description so the adapter's wire shape is measured rather than guessed

### DIFF
--- a/Jellyfin.Plugin.Requests/Bridge/BackendAccounts.cs
+++ b/Jellyfin.Plugin.Requests/Bridge/BackendAccounts.cs
@@ -24,7 +24,7 @@ namespace Jellyfin.Plugin.Requests.Bridge;
 /// </para>
 /// <para>
 /// Where the table is kept, and how an operator edits it, arrives with the adapter that reads it.
-/// There is no adapter in this tree and no issue on this board asks for one, so nothing on this side
+/// There is no adapter in this tree and #315 is the issue that asks for one, so nothing on this side
 /// reads the table yet and a settings field for it now would be somewhere to type something nothing
 /// uses. <c>docs/bridge.md</c> carries the decision, the two shapes it was chosen over, what each of
 /// them costs, and where the question of an adapter stands.

--- a/Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs
@@ -30,7 +30,7 @@ namespace Jellyfin.Plugin.Requests.Configuration;
 /// <para>
 /// There is no bridge address and no credential. The only implementation of the bridge in this tree
 /// is the one for a server that has none, so a field for an address would be a place to type
-/// something nothing reads. No issue on this board asks for the adapter that would need one, and
+/// something nothing reads. #315 is the issue that asks for the adapter that would need one, and
 /// #85 decides where a credential is kept and what may be claimed about it once there is one.
 /// </para>
 /// </summary>

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -469,10 +469,42 @@ in the alphabet that document gives the listing filter:
             completed,
           ]
 
-So both rows are confirmed as words the service knows, at the only place anything here has read, and
-the numbers they arrive as are written down nowhere in that document. `FAILED` is the row that
-matters, because it is the one word that moves a request on evidence only the service holds, and the
-number behind it is the first thing an adapter has to learn from an instance.
+So both rows are words the service knows, at the only place in that document they appear, and the
+numbers they arrive as are written down nowhere in it.
+
+**The numbers are in the implementation instead, and the description above is behind it.** The same
+repository declares both alphabets as enumerations, and the request-status one has five members where
+the description names three:
+
+    curl -sS -o media.ts -w "http=%{http_code} bytes=%{size_download}\n" \
+      https://raw.githubusercontent.com/sct/overseerr/develop/server/constants/media.ts
+    http=200 bytes=272
+
+    export enum MediaRequestStatus {
+      PENDING = 1,
+      APPROVED,
+      DECLINED,
+      FAILED,
+      COMPLETED,
+    }
+
+    export enum MediaStatus {
+      UNKNOWN = 1,
+      PENDING,
+      PROCESSING,
+      PARTIALLY_AVAILABLE,
+      AVAILABLE,
+      DELETED,
+    }
+
+A member of a TypeScript numeric enumeration that carries no value of its own takes one more than its
+predecessor, so the request statuses run `PENDING` 1, `APPROVED` 2, `DECLINED` 3, `FAILED` 4,
+`COMPLETED` 5, and the media statuses run `UNKNOWN` 1 through `DELETED` 6.
+
+**That is the number-to-word step's data and it is not this table's.** Every word in the mapping above
+is accounted for, `FAILED` being 4 and `COMPLETED` 5 rather than absent, so the row that moves a
+request on evidence only the service holds has a number behind it. Where the step that reads it lives
+is still the decision named above, and it is still not taken here.
 
 **Five of the six media values have no row**, and the rule for an unseen word is what makes that safe
 rather than silently wrong: `UNKNOWN`, `PENDING`, `PROCESSING`, `PARTIALLY_AVAILABLE` and `DELETED`
@@ -483,5 +515,8 @@ here recognises.
 ### What was not read
 
 Nothing off a running instance, and that is the same disclosure as the one above rather than a softer
-version of it. No call has ever been made from this tree to a service of this form, no response of
-one has ever been captured here, and the numbers behind `FAILED` and `COMPLETED` are unknown.
+version of it. No call has ever been made from this tree to a service of this form and no response of
+one has ever been captured here. Both readings above are of a branch of that project's own
+repository, which is what its maintainers intend to ship rather than what any operator is running:
+the two disagreeing about the request-status alphabet is the demonstration that a document and a
+service are different things, and a numbering read from source is subject to the same gap.

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -12,12 +12,13 @@ server without a service runs is
 over is below, and what happens when the service misbehaves is a separate question this page does not
 answer. Where a credential lives is answered at the end of it.
 
-**There is no adapter in this tree, and no issue on this board asks for one.** #82 closed as
+**There is no adapter in this tree, and #315 is the issue that asks for one.** #82 closed as
 completed on 2026-08-23 having built the submission path behind the interface, and it did not produce
 a client that speaks to a service: the only implementation of the interface is still the one for a
-server without one. Whether such an adapter is written on this board at all is an open call, recorded
-on #113. So every sentence below that says something arrives with the adapter is waiting on that
-call, and not on an issue somebody can pick up.
+server without one. Whether such an adapter is written on this board at all was an open call recorded
+on #113, and that call is taken: one is written here, as its own module. So every sentence below that
+says something arrives with the adapter is waiting on work somebody can pick up rather than on a
+decision nobody has taken.
 
 ## The mapping
 
@@ -147,9 +148,9 @@ under the service's own account, so the service is told that a request was made 
 Attribution is turned on one person at a time, by writing a row, and writing the row is what says
 that person's account name may leave.
 
-Where the table is kept and how it is edited arrives with the adapter that reads it, and no issue on
-this board asks for that adapter. Nothing on this side reads the table today, so a settings field for
-it now would be somewhere to type something nothing uses.
+Where the table is kept and how it is edited arrives with the adapter that reads it, which is #315.
+Nothing on this side reads the table today, so a settings field for it now would be somewhere to type
+something nothing uses.
 
 ### What leaves the server when a bridge is configured
 
@@ -327,10 +328,160 @@ quantify over a value that does not exist. They land with the adapter and not be
 
 The words above are the ones issue #81 names for the Overseerr form, which is the form the first
 adapter is written against, decided on #113. **They were not read off a running service, and nothing
-in this tree can read one.** No fixture here was captured from a service, no schema was fetched, and
-the suite makes no outbound call.
+in this tree can read one.** No fixture here was captured from a service and the suite makes no
+outbound call.
 
-So the list is this board's own statement of the vocabulary rather than a measurement of it, and the
-rule for an unseen word is what stands between that and a wrong answer. Whoever writes the adapter is
-the first person in a position to compare the two, and a word that arrives from a real service and is
-not here is a row this table is missing rather than a fault in the service.
+What has been read is that form's own published description, and the comparison against it is the
+section below. That is a weaker reading than a running service and a stronger one than this table had
+before it, and it leaves the sentence above exactly as it stands: a document describing a service is
+not the service, and a description can be behind the implementation it describes.
+
+So the list is still this board's own statement of the vocabulary rather than a measurement of a
+running one, and the rule for an unseen word is what stands between that and a wrong answer. Whoever
+writes the adapter against an instance is the first person in a position to compare the two against
+the thing itself, and a word that arrives from a real service and is not here is a row this table is
+missing rather than a fault in the service.
+
+## The form's own description, read
+
+Fetched on 2026-08-30 from the form's own repository, which is the only description of it anything
+here has read:
+
+    curl -sS -o overseerr-api.yml -w "http=%{http_code} bytes=%{size_download}\n" \
+      https://raw.githubusercontent.com/sct/overseerr/develop/overseerr-api.yml
+    http=200 bytes=177902
+
+Everything below is quoted out of that file rather than summarised, so a reader can disagree with the
+source rather than with this page. Nothing in this repository fetches it and no check compares this
+page against it, so these quotations go stale in silence, and the command above is what a later reader
+re-runs rather than trusting them.
+
+### Where the calls go, and what carries the credential
+
+    servers:
+      - url: '{server}/api/v1'
+
+    securitySchemes:
+      cookieAuth:
+        type: apiKey
+        name: connect.sid
+        in: cookie
+      apiKey:
+        type: apiKey
+        in: header
+        name: X-Api-Key
+
+**The credential travels in a header rather than in a query string**, and that is what makes one of
+the four claims above cheap to keep true instead of impossible. A transport failure names its
+destination in the exception the platform raises, which is the half of the leak no wording of this
+plugin's own log lines can fix; with the key in a header that exception carries the address and not
+the credential. The cookie scheme beside it is how to get this wrong, and an adapter that ever
+authenticated by a route putting the value in a URL would put the leak back where it started.
+
+### The four operations, against the four this side has
+
+`IRequestBackend` has four and no more, and each one lands on a path item in that document.
+
+| This side             | The form                      | What it answers                                   |
+| --------------------- | ----------------------------- | ------------------------------------------------- |
+| `CheckReachableAsync` | `GET /status`                 | that the service is up, and nothing about the key |
+| `SubmitAsync`         | `POST /request`               | `201` with the request the service created        |
+| `ReportAsync`         | `GET /request/{requestId}`    | `200` with that request                           |
+| `WithdrawAsync`       | `DELETE /request/{requestId}` | `204` and no body                                 |
+
+**`/status` is answered without a credential**, and for the first row that is a problem rather than a
+convenience:
+
+    /status:
+      get:
+        summary: Get Overseerr status
+        security: []
+
+A green answer from it says the service is up and says nothing about whether the key is accepted, so
+`Reachable` read off `/status` alone reports a working bridge on an install whose credential is
+wrong. Which call answers the second question is #86's and is not decided here.
+
+**A submission has two required fields and every other one is optional:**
+
+    mediaType:
+      type: string
+      enum: [movie, tv]
+      example: movie
+    mediaId:
+      type: number
+      example: 123
+
+    required:
+      - mediaType
+      - mediaId
+
+This side has a kind and a title. What a `mediaId` is over there, and where an adapter gets one, is
+the question that answer opens, and this page does not close it.
+
+**A withdrawal can be refused for a reason that is about the credential rather than about the
+request**, which that document says in prose and not in a status code:
+
+    delete:
+      summary: Delete request
+      description: Removes a request. If the user has the `MANAGE_REQUESTS` permission, any request can be removed. Otherwise, only pending requests can be removed.
+
+Everything this plugin hands over has already been approved here, and a request that side has
+approved is not pending, so the ordinary withdrawal is exactly the one a caller without that
+permission may not make.
+
+### The two alphabets are numbers, and this table is words
+
+    status:
+      type: number
+      example: 0
+      description: Status of the request. 1 = PENDING APPROVAL, 2 = APPROVED, 3 = DECLINED
+      readOnly: true
+
+    status:
+      type: number
+      example: 0
+      description: Availability of the media. 1 = `UNKNOWN`, 2 = `PENDING`, 3 = `PROCESSING`, 4 = `PARTIALLY_AVAILABLE`, 5 = `AVAILABLE`, 6 = `DELETED`
+
+**A number-to-word step exists and lives nowhere.** The table above is data so that two adapters
+cannot disagree about what a word means with nothing saying which is right. An adapter that turns `3`
+into `DECLINED` on its own moves that argument one layer down, where the table stops being the place
+it is settled. Where the step lives is a decision the adapter has to take rather than discover.
+
+**Two of the five request words this table holds are absent from those three, and the same document
+shows the service using both.** `FAILED` and `COMPLETED` are not among `1`, `2` and `3`, and they are
+in the alphabet that document gives the listing filter:
+
+    - in: query
+      name: filter
+      schema:
+        type: string
+        nullable: true
+        enum:
+          [
+            all,
+            approved,
+            available,
+            pending,
+            processing,
+            unavailable,
+            failed,
+            deleted,
+            completed,
+          ]
+
+So both rows are confirmed as words the service knows, at the only place anything here has read, and
+the numbers they arrive as are written down nowhere in that document. `FAILED` is the row that
+matters, because it is the one word that moves a request on evidence only the service holds, and the
+number behind it is the first thing an adapter has to learn from an instance.
+
+**Five of the six media values have no row**, and the rule for an unseen word is what makes that safe
+rather than silently wrong: `UNKNOWN`, `PENDING`, `PROCESSING`, `PARTIALLY_AVAILABLE` and `DELETED`
+move nothing and are reported as unseen. `DELETED` is the one to look at before an adapter ships,
+because media a service no longer holds is a fact this side may want, and today it is a word nothing
+here recognises.
+
+### What was not read
+
+Nothing off a running instance, and that is the same disclosure as the one above rather than a softer
+version of it. No call has ever been made from this tree to a service of this form, no response of
+one has ever been captured here, and the numbers behind `FAILED` and `COMPLETED` are unknown.


### PR DESCRIPTION
Refs #315.

Two things about the bridge adapter that this tree said wrongly or did not say at all.

## Three sentences said no issue asks for the adapter, and one does

`#315` asks for it. Read at `origin/master` `62e8fe9`:

```
git grep -n "no issue on this board asks\|No issue on this board asks" origin/master
origin/master:Jellyfin.Plugin.Requests/Bridge/BackendAccounts.cs:27:/// There is no adapter in this tree and no issue on this board asks for one, so nothing on this side
origin/master:Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:33:/// something nothing reads. No issue on this board asks for the adapter that would need one, and
origin/master:docs/bridge.md:15:**There is no adapter in this tree, and no issue on this board asks for one.** #82 closed as
```

```
gh issue view 315 --repo Flowfin/jellyfin-plugin-requests --json number,state,title,milestone --jq '[.number,.state,.milestone.title,.title]|@tsv'
315     OPEN    M10 The bridge to an external request service    Build the adapter against the Overseerr form
```

`docs/bridge.md` also said the question of whether an adapter is written here at all is an open call
recorded on `#113`. That call is taken, and the sentence now says so instead.

The failure this prevents is the one `#296` already had to repair once on the same subject: somebody
who wants to write the adapter meets three sentences telling them nobody has asked for it and either
believes them or has to go to the tracker to find out which of the two is current.

## The form's description has now been read, and the page says what it settles

The closing section of `docs/bridge.md` said that the words in the mapping table were never compared
against the service, that **no schema was fetched**, and that whoever writes the adapter is the first
person able to make that comparison. The description is fetched here and quoted rather than
summarised:

```
curl -sS -o overseerr-api.yml -w "http=%{http_code} bytes=%{size_download}\n" \
  https://raw.githubusercontent.com/sct/overseerr/develop/overseerr-api.yml
http=200 bytes=177902
```

What the new section records, each of it quoted out of that file on the page:

- The base path is `{server}/api/v1` and the credential travels in an `X-Api-Key` **header**, not in
  a query string. That is what keeps the exception a transport failure raises carrying the address
  and not the secret, which is the half of the leak `SecretsStayOutOfTheLogTests` measured for the
  outbound sink and that no wording of this plugin's own log lines can fix. The cookie scheme beside
  it is how to get it wrong.
- The four operations of `IRequestBackend` land on `GET /status`, `POST /request`,
  `GET /request/{requestId}` and `DELETE /request/{requestId}`. `/status` carries `security: []`, so
  a green answer from it says the service is up and nothing about whether the key is accepted -
  reachability read off it alone reports a working bridge on an install whose credential is wrong.
- A submission requires `mediaType` and `mediaId` and nothing else. What a `mediaId` is over there,
  and where an adapter gets one, is the question that opens; the page says so rather than guessing.
- A withdrawal is refused for a caller without `MANAGE_REQUESTS` on anything that is not pending, and
  everything this plugin hands over has already been approved, so the ordinary withdrawal is exactly
  the case that can fail for a reason about the credential.
- Both of the service's alphabets are **numbers** while the table here is **words**, so a
  number-to-word step exists and has no home. Where it lives is a decision the adapter has to take;
  an adapter that turns `3` into `DECLINED` on its own moves the argument one layer below the table
  that exists to settle it.
- `FAILED` and `COMPLETED`, the two rows absent from the request-status description, appear in the
  listing filter's alphabet in the same document, so both are words the service knows.

## The numbers behind the words, which that description does not carry

The second commit adds them. The implementation declares both alphabets as enumerations, and it
disagrees with its own published description about how many request statuses there are:

```
curl -sS -o media.ts -w 'http=%{http_code} bytes=%{size_download}' https://raw.githubusercontent.com/sct/overseerr/develop/server/constants/media.ts
http=200 bytes=272

cat media.ts
export enum MediaRequestStatus {
  PENDING = 1,
  APPROVED,
  DECLINED,
  FAILED,
  COMPLETED,
}

export enum MediaStatus {
  UNKNOWN = 1,
  PENDING,
  PROCESSING,
  PARTIALLY_AVAILABLE,
  AVAILABLE,
  DELETED,
}
```

A member carrying no value of its own takes one more than its predecessor, so `PENDING` is 1,
`APPROVED` 2, `DECLINED` 3, `FAILED` 4 and `COMPLETED` 5, and the media statuses run `UNKNOWN` 1
through `DELETED` 6. Every word in the mapping table now has a number behind it.

`FAILED` is the one that matters: it is the only word in that table that moves a request on evidence
only the service holds, and an adapter that put the wrong number on it would move requests to failed
for a state that is not a failure, which reads in the queue and in the history exactly like a state
somebody chose.

Five of the six media values still have no row, which the rule for an unseen word makes safe rather
than silently wrong. `DELETED`, now known to be 6, is the one to look at before an adapter ships.

## What is NOT claimed

**Nothing was read off a running instance.** No call has ever been made from this tree to a service
of this form and no response of one has ever been captured here. Both readings are of a branch of
that project's own repository, which is what its maintainers intend to ship rather than what any
operator is running - and the two of them disagreeing about the request-status alphabet is itself the
demonstration that a document and a service are different things. The page states that twice, once
where the old sentence stood and once at the end of the new section, rather than softening either
into a claim that the vocabulary is now measured against a service.

**Nothing in this repository fetches either document and no check compares the page against them**,
so these quotations go stale in silence. The section hands the reader the commands rather than asking
them to trust the pastes.

**#315 is not finished by this.** Its done-when asks for a round trip against a real instance with the
transcript in the pull request body, and this repository still stands nothing up that could serve
one. What this removes is the part its own note said must not be guessed.

## Choosing the means

Markdown in `docs/`, beside the code it describes, as every other document here is. What changed is
prose about an artefact rather than an artefact, so nothing new is added to build or to test, and the
two comment edits sit in the files that carried the stale claims, which is where a reader meets them.

## Evidence

```
dotnet test Jellyfin.Plugin.Requests.sln
Bestanden!   : Fehler:     0, erfolgreich:   766, gesamt:   766 - Jellyfin.Plugin.Requests.Tests.dll (net10.0)
Bestanden!   : Fehler:     0, erfolgreich:   766, gesamt:   766 - Jellyfin.Plugin.Requests.Tests.dll (net9.0)
```

766 on both claimed target frameworks, run again after the second commit, which includes
`BackendStateMappingTests` and `NoBackendCompletenessTests` - the two that read `docs/bridge.md`
between its markers. Neither marker block is touched by this change.

```
npx prettier@3.6.2 --end-of-line auto --check "**/*.{html,css,js,md}"
All matched files use Prettier code style!
```

`--end-of-line auto` is on that local run only: this checkout has CRLF working files under
`core.autocrlf=true`, so without it every markdown file in the tree reports a style issue for its
line endings alone. The runner checks out LF and needs no such flag.

The invariant lint was not run here; `opengrep` is not installed on this machine, and the gate on this
pull request is where it runs.

## Second reader

There was none. The commands above stand in place of one, and each was run before the sentence that
rests on it.
