### PR TITLE
Make the mark-against-lint guard read the patterns rather than the whole file

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Configuration/SecretsStayOutOfTheLogTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Configuration/SecretsStayOutOfTheLogTests.cs
@@ -123,7 +123,7 @@ public sealed class SecretsStayOutOfTheLogTests
     }
 
     /// <summary>
-    /// Every property carrying the mark is named by a rule in the invariant lint.
+    /// Every property carrying the mark is named by a pattern in the invariant lint.
     /// <para>
     /// The mark lives on the property and the name it refuses lives in the rule file, which is two
     /// homes for one fact. Neither file can see the other, so this is what stops them drifting: a
@@ -133,6 +133,14 @@ public sealed class SecretsStayOutOfTheLogTests
     /// <para>
     /// It reads the marks off the type rather than out of the source, so a mark added by any route
     /// is in the population.
+    /// </para>
+    /// <para>
+    /// <b>It reads the patterns of that file and not the whole of it, and the difference was
+    /// measured rather than supposed.</b> Until #85 this leg searched the file as one string, and
+    /// with the entire <c>no-marked-setting-in-a-message</c> rule deleted it still passed, because
+    /// the prose above that rule spells the marked property twice. A guard satisfied by a comment
+    /// about a refusal is a guard that does not bite for the reason it names, and this is the
+    /// narrowing that makes it bite.
     /// </para>
     /// </summary>
     [Fact]
@@ -149,10 +157,37 @@ public sealed class SecretsStayOutOfTheLogTests
         var path = Path.Combine(AppContext.BaseDirectory, "tools", "opengrep", "rules.yaml");
         Assert.True(File.Exists(path), FormattableString.Invariant($"{path} was not copied next to the suite."));
 
-        var rules = File.ReadAllText(path);
+        var refusing = RefusingLines(File.ReadAllLines(path));
 
-        Assert.All(marked, name => Assert.Contains(name, rules, StringComparison.Ordinal));
+        Assert.All(
+            marked,
+            name => Assert.True(
+                refusing.Any(line => line.Contains(name, StringComparison.Ordinal)),
+                FormattableString.Invariant(
+                    $"{name} carries [Secret] and no pattern in tools/opengrep/rules.yaml names it. A comment naming it is not a refusal.")));
     }
+
+    /// <summary>
+    /// The lines of the rule file that decide what is refused.
+    /// <para>
+    /// A comment is not a refusal, so it is not in the population a marked setting has to be named
+    /// by. What is left is the pattern entries, which are the lines opengrep matches source against.
+    /// </para>
+    /// <para>
+    /// <b>The bound, written rather than discovered.</b> It reads a line at a time, so a pattern
+    /// broken across lines would hide a name from it. Nothing in that file is written that way
+    /// today, and a rule that was would fail this leg loudly rather than passing it quietly, which
+    /// is the direction to fail in.
+    /// </para>
+    /// </summary>
+    /// <param name="lines">The rule file, line by line.</param>
+    /// <returns>The pattern lines, with their leading space removed.</returns>
+    private static List<string> RefusingLines(IEnumerable<string> lines)
+        => lines
+            .Select(line => line.TrimStart())
+            .Where(line => line.StartsWith("pattern", StringComparison.Ordinal)
+                || line.StartsWith("- pattern", StringComparison.Ordinal))
+            .ToList();
 
     /// <summary>
     /// Everything one line of the log carries that a reader would end up with.


### PR DESCRIPTION
Refs #85.

`EveryMarkedSettingIsNamedByARuleInTheInvariantLint` is the only thing that keeps the `[Secret]` mark
on a property and the invariant-lint rule refusing that property from drifting apart. It did not bite
for the reason it names.

## What it read

The whole rule file, as one string:

```
git show 3adaab7:Jellyfin.Plugin.Requests.Tests/Configuration/SecretsStayOutOfTheLogTests.cs | sed -n '152,155p'
        var rules = File.ReadAllText(path);

        Assert.All(marked, name => Assert.Contains(name, rules, StringComparison.Ordinal));
    }
```

The one marked property is spelled four times in that file, and two of the four are prose:

```
grep -n "OutboundNoticeAddress" tools/opengrep/rules.yaml
775:  # `nameof(PluginConfiguration.OutboundNoticeAddress)`, because an operator has
780:  # miss `_settings.Current.OutboundNoticeAddress`, the spelling the one reader
800:          - pattern-regex: '(?s)(string\.Format|\.Log[A-Z][A-Za-z]*)\([^;]{0,800}?(?<!nameof\(PluginConfiguration)\.OutboundNoticeAddress'
801:          - pattern-regex: '\$"[^"]*\{[^}"]*(?<!nameof\(PluginConfiguration)\.OutboundNoticeAddress'
```

So a comment **about** a refusal satisfied the leg whose whole job is to say a refusal **exists**.

## Why that matters rather than being untidy

The failure it stands against is a marked setting whose rule is gone or misspelled: the mark then
refuses nothing, and the suite reports that every mark is covered. That is the state the second
marked setting arrives in - the credential #85 is about - because whoever adds it copies the rule
that is already there.

## The change

The population is narrowed to the pattern lines, which are what opengrep matches source against.
Comments are out of it. The bound is written at the helper rather than left to be discovered: it
reads a line at a time, so a pattern broken across lines would hide a name from it, and nothing in
that file is written that way today.

## Proof that it bites, and proof that it did not

Four runs. Everything below is `dotnet test` in this checkout; B, C and D are `net9.0` with a filter
on the one leg.

**A. As it stands, whole suite, both claimed target frameworks.**

```
dotnet test Jellyfin.Plugin.Requests.sln
Bestanden!   : Fehler:     0, erfolgreich:   766, gesamt:   766 - Jellyfin.Plugin.Requests.Tests.dll (net9.0)
Bestanden!   : Fehler:     0, erfolgreich:   766, gesamt:   766 - Jellyfin.Plugin.Requests.Tests.dll (net10.0)
```

**B. The `no-marked-setting-in-a-message` rule deleted outright, the two comments left.**

```
sed -i '789,806d' tools/opengrep/rules.yaml
grep -c "OutboundNoticeAddress" tools/opengrep/rules.yaml
2
dotnet test ... --filter "FullyQualifiedName~EveryMarkedSettingIsNamedByARuleInTheInvariantLint"
  Fehlermeldung:
     Error: OutboundNoticeAddress carries [Secret] and no pattern in tools/opengrep/rules.yaml names it. A comment naming it is not a refusal.
Fehler!      : Fehler:     1, erfolgreich:     0, gesamt:     1
```

**C. The near-miss: one character dropped from the property name in the two pattern lines only, the
comments untouched.**

```
sed -i "800,801s/OutboundNoticeAddress/OutboundNoticeAddres/g" tools/opengrep/rules.yaml
dotnet test ... --filter "FullyQualifiedName~EveryMarkedSettingIsNamedByARuleInTheInvariantLint"
  Fehlermeldung:
     Error: OutboundNoticeAddress carries [Secret] and no pattern in tools/opengrep/rules.yaml names it. A comment naming it is not a refusal.
Fehler!      : Fehler:     1, erfolgreich:     0, gesamt:     1
```

**D. The leg as it stood on `3adaab7`, against the same near-miss as C.** This is the run that makes
the change a repair rather than a preference:

```
git stash push -- Jellyfin.Plugin.Requests.Tests/Configuration/SecretsStayOutOfTheLogTests.cs
dotnet test ... --filter "FullyQualifiedName~EveryMarkedSettingIsNamedByARuleInTheInvariantLint"
Bestanden!   : Fehler:     0, erfolgreich:     1, gesamt:     1
```

`tools/opengrep/rules.yaml` was restored with `git checkout --` after each of B, C and D, and A was
re-run at the head being pushed.

## What this does NOT do

**It does not move either of #85's open conditions.** Both quantify over a credential that is not in
the tree: there is one implementation of the bridge and it is the one for a server with no service.
This is the mechanism the first condition will be carried by on the day the credential lands, not the
condition itself.

**It does not make the mark refuse anything at run time.** `SecretAttribute` refuses nothing on its
own and this changes none of that; what holds the rule is the lint and this leg, which is what the
attribute's own documentation says.

**The invariant lint itself was not run here.** `opengrep` is not installed on this machine, and the
gate on this pull request is where it runs. What was measured locally is the suite, which is what this
change touches.

## Choosing the means

The existing xUnit suite and a private helper beside the leg it serves. No new file, no new
dependency, nothing added to what the lint runs, and the assertion message carries the sentence a
reader needs at the moment it fails.

## Second reader

There was none. The runs above stand in place of one, and each was made before the sentence that
rests on it.
