### PR TITLE
Decide that the notice path promises no order, and stop the legs resting on one

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Doubles/RecordingRequesterNotice.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/RecordingRequesterNotice.cs
@@ -19,18 +19,53 @@ namespace Jellyfin.Plugin.Requests.Tests.Doubles;
 /// <c>RequesterMessage.ForMove</c>'s decision, and a double that repeated that rule would let the
 /// rule pass a test while being absent from the thing that ships.
 /// </para>
+/// <para>
+/// <b>Several threads may tell it at once.</b> <c>QuietedRequesterNotice</c> decides each message on
+/// a task of its own and calls the path underneath from whichever one finishes, so this is written
+/// to from several threads with nothing above it serialising them. An unguarded
+/// <see cref="List{T}"/> under that traffic does not merely reorder: an append racing another can
+/// lose an entry, keep one twice or leave a hole, so a test asserting who was told could fail for a
+/// defect in this file rather than in its subject. The whole of what the lock buys is that every
+/// message given to this double is kept exactly once.
+/// </para>
+/// <para>
+/// <b>It promises no order across threads, because nothing above it does.</b>
+/// <see cref="IRequesterNotice.Tell"/> hands back nothing and starts no ordering, so the sequence
+/// two concurrently decided messages arrive here in is not decided by anything and is not a fact a
+/// test may rest on. Where the messages were handed over one after another by one thread, the order
+/// kept here is that order, which is what the legs asserting a sequence over a synchronous caller
+/// read.
+/// </para>
 /// </summary>
 internal sealed class RecordingRequesterNotice : IRequesterNotice
 {
+    private readonly object _gate = new object();
     private readonly List<RequesterMessage> _told = [];
 
     /// <summary>
-    /// Gets every message, in the order it was given.
+    /// Gets every message, in the order it arrived here, as a copy taken under the lock. A caller
+    /// reading this while something is still in flight gets a whole answer of some moment rather
+    /// than a list changing under its own enumeration.
     /// </summary>
-    public IReadOnlyList<RequesterMessage> Told => _told;
+    public IReadOnlyList<RequesterMessage> Told
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _told.ToArray();
+            }
+        }
+    }
 
     /// <inheritdoc />
-    public void Tell(RequesterMessage message) => _told.Add(message);
+    public void Tell(RequesterMessage message)
+    {
+        lock (_gate)
+        {
+            _told.Add(message);
+        }
+    }
 
     /// <inheritdoc />
     public Task QuietAsync(CancellationToken cancellationToken) => Task.CompletedTask;

--- a/Jellyfin.Plugin.Requests.Tests/Notify/APersonsOwnSwitchTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Notify/APersonsOwnSwitchTests.cs
@@ -20,6 +20,17 @@ namespace Jellyfin.Plugin.Requests.Tests.Notify;
 /// this, default on, and no operator setting overrides it - which is why the leg that has an
 /// administrator try is here rather than in a document.
 /// </para>
+/// <para>
+/// <b>No order is promised over two people, and #330 is where that was decided rather than left
+/// open.</b> Two readings were available: compare what was told as a set, or make
+/// <see cref="QuietedRequesterNotice"/> promise the order its caller handed the messages over in.
+/// The second is refused, because keeping such a promise means holding the second message until the
+/// first person's setting has been read, and reading a setting off the calling thread is the whole
+/// of what that class exists to do. So a caller that has just moved two requests is entitled to have
+/// both people told, exactly once each, and to nothing about which of them hears first. Every leg
+/// below therefore compares <see cref="SortedRecipients"/> rather than the sequence as it arrived,
+/// and a leg that reintroduced a sequence would be asserting something the subject does not offer.
+/// </para>
 /// </summary>
 [SuppressMessage(
     "Design",
@@ -50,7 +61,7 @@ public sealed class APersonsOwnSwitchTests
 
         await switched.QuietAsync(CancellationToken.None).ConfigureAwait(true);
 
-        Assert.Equal([Somebody], inner.Told.Select(message => message.ToUserId).ToArray());
+        Assert.Equal([Somebody], SortedRecipients(inner));
     }
 
     /// <summary>
@@ -68,7 +79,7 @@ public sealed class APersonsOwnSwitchTests
 
         await switched.QuietAsync(CancellationToken.None).ConfigureAwait(true);
 
-        Assert.Equal([Asker, Somebody], inner.Told.Select(message => message.ToUserId).ToArray());
+        Assert.Equal([Asker, Somebody], SortedRecipients(inner));
     }
 
     /// <summary>
@@ -139,7 +150,7 @@ public sealed class APersonsOwnSwitchTests
         switched.Tell(Message(Asker));
         await switched.QuietAsync(CancellationToken.None).ConfigureAwait(true);
 
-        Assert.Equal([Asker], inner.Told.Select(message => message.ToUserId).ToArray());
+        Assert.Equal([Asker], SortedRecipients(inner));
     }
 
     /// <summary>
@@ -171,7 +182,7 @@ public sealed class APersonsOwnSwitchTests
         switched.Tell(Message(Administrator));
         await switched.QuietAsync(CancellationToken.None).ConfigureAwait(true);
 
-        Assert.Equal([Asker], inner.Told.Select(message => message.ToUserId).ToArray());
+        Assert.Equal([Asker], SortedRecipients(inner));
     }
 
     /// <summary>
@@ -237,6 +248,26 @@ public sealed class APersonsOwnSwitchTests
         Assert.Equal(RequestFailureCode.TheStoreCouldNotBeRead, Refused(read).Code);
         Assert.Equal(RequestFailureCode.TheStoreCouldNotBeRead, Refused(written).Code);
     }
+
+    /// <summary>
+    /// Who was told, sorted here rather than left in the order the messages arrived.
+    /// <para>
+    /// The sort is what makes a leg of this class independent of which of two tasks finished first,
+    /// and it is a comparison of sequences rather than of sets on purpose: a message kept twice or
+    /// lost moves the sorted answer as readily as it moves the unsorted one, so the count and the
+    /// membership are still asserted and only the order is given up.
+    /// </para>
+    /// <para>
+    /// The identifiers this class uses differ in their last byte and sort ordinally in the order
+    /// they are declared, so the expectations below read in the obvious order.
+    /// </para>
+    /// </summary>
+    /// <param name="inner">The path that kept what it was told.</param>
+    /// <returns>The people who were told, ordinally by identifier.</returns>
+    private static Guid[] SortedRecipients(RecordingRequesterNotice inner)
+        => [.. inner.Told
+            .Select(message => message.ToUserId)
+            .OrderBy(id => id.ToString(), StringComparer.Ordinal)];
 
     /// <summary>
     /// One message for one person.

--- a/Jellyfin.Plugin.Requests.Tests/Notify/RecordingFromSeveralThreadsTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Notify/RecordingFromSeveralThreadsTests.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Notify;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Notify;
+
+/// <summary>
+/// The suite's own recording double, told by several threads at once.
+/// <para>
+/// This is the half of #330 that is not about an assertion. <c>QuietedRequesterNotice</c> decides
+/// each message on a task of its own and calls the path underneath from whichever one finishes, so
+/// <see cref="RecordingRequesterNotice"/> is written to concurrently by every test that drives that
+/// class, and it is the double most of this suite uses for this interface. An unguarded list under
+/// that traffic loses an entry, keeps one twice or is enumerated mid-append, and each of those
+/// reads in a report as a defect in whatever the test was actually about.
+/// </para>
+/// <para>
+/// <b>These legs are about the double and not about the plugin.</b> A test apparatus that can be
+/// wrong in a way that looks like the subject being wrong is worth a guard of its own, and the
+/// alternative reading - keeping the double unguarded and forbidding the tests to drive it
+/// concurrently - was refused because the concurrency is the subject's, not the suite's.
+/// </para>
+/// <para>
+/// <b>What they can and cannot prove, and the two legs differ.</b> A race is shown by driving it
+/// rather than by asserting an absence, so the first leg's redness without the lock is a matter of
+/// scheduling: it was watched failing on three runs of three, and that is evidence rather than a
+/// certainty. The second leg is decidable from one thread and was watched failing with only the
+/// copy removed, which is a certainty. Greenness of either with the guard in place is not a matter
+/// of scheduling: no interleaving of the guarded code loses, doubles or half-publishes an entry,
+/// and no answer it hands out changes underneath its reader.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class RecordingFromSeveralThreadsTests
+{
+    /// <summary>
+    /// How many threads tell it at once. More than the two a notice path produces, because a race
+    /// that needs a particular interleaving is met by trying many rather than by trying twice.
+    /// </summary>
+    private const int Tellers = 8;
+
+    /// <summary>
+    /// How many messages each of them hands over.
+    /// </summary>
+    private const int EachTells = 2000;
+
+    private static readonly Guid Asker = new Guid("f3000000-0000-0000-0000-000000000001");
+
+    /// <summary>
+    /// Every message given from several threads at once is kept, exactly once each.
+    /// <para>
+    /// The text of each message names the thread and the position, so the assertion separates the
+    /// three ways an unguarded append is wrong: a short count is a lost entry, a full count with
+    /// fewer distinct texts is a doubled one, and a hole would be a null nothing here would find a
+    /// text on.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task EveryMessageFromSeveralThreadsAtOnceIsKeptExactlyOnce()
+    {
+        var recording = new RecordingRequesterNotice();
+        using var ready = new Barrier(Tellers);
+
+        var telling = new Task[Tellers];
+
+        for (var teller = 0; teller < Tellers; teller++)
+        {
+            var mine = teller;
+
+            telling[mine] = Task.Factory.StartNew(
+                () =>
+                {
+                    // Started rather than staggered: the appends have to overlap for the guard to
+                    // be under any pressure at all.
+                    ready.SignalAndWait();
+
+                    for (var position = 0; position < EachTells; position++)
+                    {
+                        recording.Tell(Message(mine, position));
+                    }
+                },
+                CancellationToken.None,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default);
+        }
+
+        await Task.WhenAll(telling).ConfigureAwait(true);
+
+        var kept = recording.Told;
+
+        Assert.Equal(Tellers * EachTells, kept.Count);
+        Assert.Equal(
+            Tellers * EachTells,
+            kept.Select(message => message.Text).Distinct(StringComparer.Ordinal).Count());
+    }
+
+    /// <summary>
+    /// What was told is answered as a copy rather than as the list itself.
+    /// <para>
+    /// The direction the count above cannot reach, and the one a reader meets rather than a writer.
+    /// A caller handed the double's own list walks a collection another thread is still appending
+    /// to, which raises out of the enumeration and reads as the test's subject having thrown. This
+    /// leg is written without a second thread on purpose: whether the answer is a copy is decidable
+    /// from one thread, and a leg that raced for it would only sometimes be the leg it claims to be.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void WhatWasToldIsAnsweredAsACopyRatherThanAsTheListItself()
+    {
+        var recording = new RecordingRequesterNotice();
+
+        recording.Tell(Message(0, 0));
+
+        var earlier = recording.Told;
+
+        recording.Tell(Message(0, 1));
+
+        Assert.Single(earlier);
+        Assert.Equal(2, recording.Told.Count);
+    }
+
+    /// <summary>
+    /// One message, named so that a lost one and a doubled one are different failures.
+    /// </summary>
+    /// <param name="teller">Which thread is handing it over.</param>
+    /// <param name="position">Where in that thread's run it sits.</param>
+    /// <returns>The message.</returns>
+    private static RequesterMessage Message(int teller, int position)
+        => new RequesterMessage
+        {
+            ToUserId = Asker,
+            Header = "Requests",
+            Text = string.Create(CultureInfo.InvariantCulture, $"{teller}/{position}"),
+        };
+}

--- a/Jellyfin.Plugin.Requests/Notify/QuietedRequesterNotice.cs
+++ b/Jellyfin.Plugin.Requests/Notify/QuietedRequesterNotice.cs
@@ -26,6 +26,15 @@ namespace Jellyfin.Plugin.Requests.Notify;
 /// <see cref="ServerRequesterNotice"/> pushes off it: what this interface promises is that a caller
 /// which has just moved a request tells the person and carries on.
 /// </para>
+/// <para>
+/// <b>The order two messages reach the path underneath in is not promised, and that is the price of
+/// the paragraph above.</b> Each message is decided on a task of its own, so two people whose
+/// requests moved one after another are told in whichever order their settings finished being read.
+/// Promising the caller's order instead would mean holding the second message until the first
+/// setting had been read, which is the waiting this class is here to keep off the caller's thread.
+/// What is promised is that every message is decided exactly once and that
+/// <see cref="QuietAsync"/> does not return while one is still being decided.
+/// </para>
 /// </summary>
 public sealed class QuietedRequesterNotice : IRequesterNotice
 {


### PR DESCRIPTION
Closes #330.

Two legs of `APersonsOwnSwitchTests` compared a sequence of recipients against what `QuietedRequesterNotice` had passed on, and nothing decides that sequence. Each message is decided on a task of its own, so which of two people reaches the inner path first is whichever preference read finished first. `call / test` holds a merge on this board, so that leg could refuse a pull request for a reason the pull request had nothing to do with.

## The reading this takes, and why

#330 left two readings open and said the one taken is written down where the change lands. **No order is promised.** The other reading - having `QuietedRequesterNotice` keep the order its caller handed the messages over in - means holding the second message until the first person's setting has been read, and reading a setting off the calling thread is the whole of what that class exists to do. What is promised instead is that every message is decided exactly once and that `QuietAsync` does not return while one is still being decided.

It is written in three places rather than one, because the next person to meet an ordering assertion here reads whichever of the three they arrived at: the class doc of `QuietedRequesterNotice`, the class doc of `RecordingRequesterNotice`, and the class doc of `APersonsOwnSwitchTests`.

## What changed

The multi-recipient assertion now compares recipients sorted ordinally by identifier. It is still a comparison of sequences rather than of sets on purpose: a message kept twice or lost moves the sorted answer as readily as it moves the unsorted one, so the count and the membership are still asserted and only the order is given up. No sequence over arrival order is left in that file:

    git grep -n 'inner.Told' -- Jellyfin.Plugin.Requests.Tests/Notify/APersonsOwnSwitchTests.cs
    107:        Assert.Empty(inner.Told);
    146:        Assert.Empty(inner.Told);
    268:        => [.. inner.Told

The second half is the apparatus rather than the assertion. `RecordingRequesterNotice` appended to a plain `List<T>` from those same threads and handed the list itself out, so a lost entry, a duplicated one or an enumeration raising mid-append was available on top of a reordering - and each of those reads in a report as a defect in whatever the test was actually about. It is the double most of this suite uses for this interface:

    git grep -l 'new RecordingRequesterNotice' -- Jellyfin.Plugin.Requests.Tests/ | wc -l
    22

so this reaches twenty-two test classes rather than the two legs #330 opens with. The append is now under a lock and the answer is a copy taken under it.

## The two guards, watched failing

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler:     0, erfolgreich:   768, uebersprungen:     0, gesamt:   768 - Jellyfin.Plugin.Requests.Tests.dll (net9.0)
    Bestanden!   : Fehler:     0, erfolgreich:   768, uebersprungen:     0, gesamt:   768 - Jellyfin.Plugin.Requests.Tests.dll (net10.0)

**Lock and copy both removed**, which is the file as it stood before this change. Three runs of three, on `net10.0`:

    dotnet test Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj --configuration Release -f net10.0 --filter "FullyQualifiedName~EveryMessageFromSeveralThreadsAtOnceIsKeptExactlyOnce"
    Assert.Equal() Failure: Values differ
    Fehler!      : Fehler:     1, erfolgreich:     0, uebersprungen:     0, gesamt:     1 - Jellyfin.Plugin.Requests.Tests.dll (net10.0)

**Copy removed and the lock kept**, which is the near-miss: somebody keeping the lock and handing the list out anyway.

    dotnet test Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj --configuration Release -f net10.0 --filter "FullyQualifiedName~WhatWasToldIsAnsweredAsACopyRatherThanAsTheListItself"
    Assert.Single() Failure: The collection contained 2 items
    Fehler!      : Fehler:     1, erfolgreich:     0, uebersprungen:     0, gesamt:     1 - Jellyfin.Plugin.Requests.Tests.dll (net10.0)

**The two are not worth the same and the file says so rather than leaving a reader to assume.** The first drives a race, so its redness is a matter of scheduling and three runs of three is evidence rather than a certainty. The second is decidable from one thread and its redness is a certainty. Greenness of either with the guard in place is not a matter of scheduling: no interleaving of the guarded code loses, doubles or half-publishes an entry, and no answer it hands out changes underneath its reader.

## What this does not claim

**I did not reproduce the original failure.** #330 says the same, and what stands behind this change instead is the source: the order is not promised, and the list was not safe to append to from several threads. A green suite after this change is not evidence that the flake is gone, because a green suite was the ordinary outcome before it too.

**The ordering assertion in `TellingTheRequesterTests` is untouched and is a different case.** Those two messages are handed over by one thread with an await between them, so the order there is decided by the caller and is a fact a leg may rest on.

**The `Scope:` line on #330 named three files.** This change adds a fourth, the test file carrying the two guards, and the line on the issue now names it.

## The means

C# in the existing test project, against the doubles and the analyzer posture the tree already carries. The change is an assertion and a lock in code this suite already compiles; anything else would add a runtime for two guards that the existing suite runs on both server lines for nothing.

## Reading

No second person has read this. What stands in place of one is the evidence above: the failure each guard prevents, watched, with the command beside it and with the bound on what the race-driven half proves stated rather than smoothed over.
