### PR TITLE
Open a pull request that is meant to be refused, so the merge gate can be watched holding one

### DIFF
--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -911,3 +911,21 @@ The adopted rows that name an issue are decisions, not deliveries. What is
 running is the check list at the top, printed from a run, and an adopted row
 with an open issue beside it is a workflow this repository has decided it wants
 and does not yet have.
+
+## A deliberate formatting violation, so that a red required check can be watched refusing a merge
+
+This section exists to be badly formatted. The third done-when on #30 asks for a
+pull request with one of the required checks red that cannot be merged, shown by
+trying it, and no reading of a ruleset shows that. The block below breaks
+`Check formatting`, which is required on `master`, and nothing else:
+
+
+
+*   the blank run above is three lines where Prettier keeps one
+*  this list uses `*` markers at two different indents
+
+
+
+The branch carrying this is never merged. What it produces is a transcript of a
+merge being refused, which goes onto #30, and the section goes no further than
+that branch.


### PR DESCRIPTION
**This pull request was opened to be refused and is closed unmerged.** It exists to
discharge the third done-when on issue #30, which asks for a pull request with
one of the required checks red that cannot be merged, shown by trying it. That
condition had stood attemptable and unattempted since 17 August, because it
costs a deliberate act rather than falling out of ordinary work, and it is not
something to put inside somebody else's change.

**The merge was attempted and was refused, naming the check.** The full
transcript is on #30. The section this head adds to `docs/quality-parity.md`
never reached the mainline.

    gh api -X PUT repos/Flowfin/jellyfin-plugin-requests/pulls/335/merge -f merge_method=squash
    {"message":"Repository rule violations found\n\nRequired status check \"Check formatting\" is failing.\n\n","documentation_url":"https://docs.github.com/rest/pulls/pulls#merge-a-pull-request","status":"405"}

## What the head does

One file changed. It appends a section whose blank run and list markers break
Prettier and nothing else, so `Check formatting` reds and every other context
reports as it would on any documentation head.

That the committed blob reds the formatter is measured rather than expected. The
working copy on this machine carries CRLF, which makes a local run of the
formatter warn about files the gate is green on, so the check is run against the
blob git holds rather than against the file on disk:

    git show HEAD:docs/quality-parity.md > /tmp/qp-head.md
    npx --yes prettier@3.6.2 --parser markdown --check /tmp/qp-head.md
    Checking formatting...
    [warn] /tmp/qp-head.md
    [warn] Code style issues found in the above file. Run Prettier with --write to fix.
    prettier-rc=1

The same command against the blob at `origin/master` returns the opposite, which
is what makes the redness this head's rather than the page's:

    git show origin/master:docs/quality-parity.md > /tmp/qp-lf.md
    npx --yes prettier@3.6.2 --parser markdown --check /tmp/qp-lf.md
    Checking formatting...
    All matched files use Prettier code style!
    rc=0

## Which contexts are required, read rather than assumed

    gh api repos/iderex/jellyfin-plugin-requests/rules/branches/master \
      --jq '.[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context' | sort
    Audit workflows (zizmor)
    call / build
    call / test
    Check formatting
    DCO sign-off
    dependency-review
    Deterministic pull request hygiene checks
    Enforce greppable invariants
    Reject Trojan Source Unicode

`Check formatting` is one of the nine, so a red one here is a red **required**
one rather than a red check the ruleset does not read.

## Means

Markdown, because the subject is the formatter's own reading of markdown and the
cheapest head that reds exactly one required context is a documentation head.
Nothing is compiled and no code path is touched, so the demonstration cannot be
confused with a change to the plugin.

## What this does not claim

**Nothing about the six contexts that are declared and not required.**
`docs/quality-parity.md` declares fifteen and nine are live; this head says
nothing about the other six and applies no setting. A ruleset is a repository
setting rather than a file in this tree.

**Nothing about the eight required contexts that were green here.** One check was
made to fail and the refusal names that one. A ruleset that reads the other eight
correctly is not shown by this, only that it reads this one.
