### PR TITLE
Keep a deleted person's finished requests and put a tombstone where they were

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/People/AccountRemovalTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/People/AccountRemovalTests.cs
@@ -123,7 +123,7 @@ public sealed class AccountRemovalTests
 
         var report = await Removal(store).RemoveAsync(TheDeletedPerson, CancellationToken.None).ConfigureAwait(true);
 
-        Assert.Equal(new AccountRemovalReport(0, 0, 0), report);
+        Assert.Equal(new AccountRemovalReport(0, 0, 0, 0), report);
 
         var held = Assert.Single(await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true));
 
@@ -147,11 +147,18 @@ public sealed class AccountRemovalTests
             CancellationToken.None).ConfigureAwait(true);
         await store.AddAsync(ARequest(3, SomebodyElse), CancellationToken.None).ConfigureAwait(true);
 
+        // A finished one of theirs, which is the record that now SURVIVES the removal. Without it
+        // this property would be asserted only over shapes that are removed or detached, which is
+        // the half of the store the tombstone was added for.
+        await store.AddAsync(
+            ARequest(4, TheDeletedPerson) with { State = RequestState.Fulfilled },
+            CancellationToken.None).ConfigureAwait(true);
+
         await Removal(store).RemoveAsync(TheDeletedPerson, CancellationToken.None).ConfigureAwait(true);
 
         var held = await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true);
 
-        Assert.Equal(2, held.Count);
+        Assert.Equal(3, held.Count);
         Assert.All(held, one => Assert.NotEqual(TheDeletedPerson, one.Request.RequestedByUserId));
         Assert.All(held, one => Assert.DoesNotContain(TheDeletedPerson, one.Request.JoinedByUserIds));
         Assert.All(held, one => Assert.NotEqual(TheDeletedPerson, one.Request.StateChangedByUserId));
@@ -200,7 +207,7 @@ public sealed class AccountRemovalTests
 
         // Nothing was done to it: the person is not the requester and not a joiner, so the store's
         // own answer to "what names them" does not return it.
-        Assert.Equal(new AccountRemovalReport(0, 0, 0), report);
+        Assert.Equal(new AccountRemovalReport(0, 0, 0, 0), report);
 
         var held = Assert.Single(await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true));
 
@@ -343,6 +350,150 @@ public sealed class AccountRemovalTests
 
         // And nobody else is touched, which is the half a sweep that emptied the file would fail.
         Assert.False(await notices.TellsThemAsync(SomebodyElse, CancellationToken.None).ConfigureAwait(true));
+    }
+
+    /// <summary>
+    /// A finished request the deleted person asked for stays, with the tombstone where they were.
+    /// <para>
+    /// The record surviving is the half this is for. The decision of 2026-08-28 on #49 refuses
+    /// deletion-by-record because an administrator's history of what was asked and answered would go
+    /// with the person, so a test that only asserted the identifier had changed would pass for a
+    /// sweep that removed the row and is not what this asks.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AFinishedRequestTheDeletedPersonAskedForStaysWithTheTombstoneWhereTheyWere()
+    {
+        var store = new InMemoryRequestStore();
+
+        await store.AddAsync(
+            ARequest(1, TheDeletedPerson) with { State = RequestState.Fulfilled },
+            CancellationToken.None).ConfigureAwait(true);
+
+        var report = await Removal(store).RemoveAsync(TheDeletedPerson, CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Equal(new AccountRemovalReport(0, 1, 0, 0), report);
+
+        var held = Assert.Single(await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true));
+
+        Assert.Equal(DeletedPerson.Tombstone, held.Request.RequestedByUserId);
+        Assert.NotEqual(TheDeletedPerson, held.Request.RequestedByUserId);
+
+        // What the record still says, which is the reason it was kept rather than removed.
+        Assert.Equal(RequestState.Fulfilled, held.Request.State);
+        Assert.Equal("Something somebody wanted", held.Request.DisplayTitle);
+        Assert.Equal(Asked, held.Request.RequestedAt);
+    }
+
+    /// <summary>
+    /// An unfinished request of theirs is still removed, which is this change's interim and is
+    /// asserted rather than left to be discovered.
+    /// <para>
+    /// The ruling asks for such a request to be closed as withdrawn instead, and there is no state
+    /// for that: a withdrawn-shaped value was considered and refused on #113. Which of the two
+    /// decisions stands is #337. This test is what a later change answering it has to argue with.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AnUnfinishedRequestOfTheirsIsStillRemoved()
+    {
+        var store = new InMemoryRequestStore();
+
+        await store.AddAsync(
+            ARequest(1, TheDeletedPerson) with { State = RequestState.Approved },
+            CancellationToken.None).ConfigureAwait(true);
+
+        var report = await Removal(store).RemoveAsync(TheDeletedPerson, CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Equal(new AccountRemovalReport(1, 0, 0, 0), report);
+        Assert.Empty(await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true));
+    }
+
+    /// <summary>
+    /// Every finished state is tombstoned and every unfinished one is removed, over the whole of
+    /// <see cref="RequestState"/> rather than over the two values the tests above happen to name.
+    /// <para>
+    /// The partition is <see cref="RetentionSweep.IsFinished"/>'s, and reading it here rather than
+    /// listing states is what stops this test and the sweep meaning different things by the word on
+    /// the day a state is added.
+    /// </para>
+    /// </summary>
+    /// <param name="state">The state the request is in.</param>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Theory]
+    [InlineData(RequestState.Open)]
+    [InlineData(RequestState.Approved)]
+    [InlineData(RequestState.Declined)]
+    [InlineData(RequestState.Fulfilled)]
+    [InlineData(RequestState.Failed)]
+    public async Task WhichOnesStayIsTheSamePartitionTheSweepDraws(RequestState state)
+    {
+        var store = new InMemoryRequestStore();
+        var asked = ARequest(1, TheDeletedPerson) with { State = state };
+
+        await store.AddAsync(asked, CancellationToken.None).ConfigureAwait(true);
+
+        var report = await Removal(store).RemoveAsync(TheDeletedPerson, CancellationToken.None).ConfigureAwait(true);
+        var held = await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true);
+
+        if (RetentionSweep.IsFinished(asked))
+        {
+            Assert.Equal(1, report.Tombstoned);
+            Assert.Equal(DeletedPerson.Tombstone, Assert.Single(held).Request.RequestedByUserId);
+        }
+        else
+        {
+            Assert.Equal(1, report.Removed);
+            Assert.Empty(held);
+        }
+    }
+
+    /// <summary>
+    /// The tombstone is not an identifier a server could have minted, and is not the empty one.
+    /// <para>
+    /// Two different failures. A value a server could mint could collide with a real account, and
+    /// then a tombstoned record would name somebody who never asked for anything. The empty
+    /// identifier already means "nobody" in this plugin, and reusing it would make "a person who is
+    /// gone asked for this" and "no person is named here" the same value.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void TheTombstoneIsNotAnIdentifierAServerCouldMint()
+    {
+        Assert.NotEqual(Guid.Empty, DeletedPerson.Tombstone);
+
+        // Jellyfin mints version 4 identifiers. The version is the high nibble of the seventh byte,
+        // read off the value rather than off its text.
+        Assert.NotEqual(4, DeletedPerson.Tombstone.ToByteArray()[7] >> 4);
+
+        Assert.True(DeletedPerson.Is(DeletedPerson.Tombstone));
+        Assert.False(DeletedPerson.Is(TheDeletedPerson));
+    }
+
+    /// <summary>
+    /// A finished request of the deleted person, an unfinished one, and one of somebody else's they
+    /// had joined are answered by three different rules in one run, and the counts say which was
+    /// which.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task TheThreeRulesAreCountedApartInOneRun()
+    {
+        var store = new InMemoryRequestStore();
+
+        await store.AddAsync(
+            ARequest(1, TheDeletedPerson) with { State = RequestState.Fulfilled },
+            CancellationToken.None).ConfigureAwait(true);
+        await store.AddAsync(ARequest(2, TheDeletedPerson), CancellationToken.None).ConfigureAwait(true);
+        await store.AddAsync(
+            ARequest(3, SomebodyElse) with { JoinedByUserIds = [TheDeletedPerson] },
+            CancellationToken.None).ConfigureAwait(true);
+
+        var report = await Removal(store).RemoveAsync(TheDeletedPerson, CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Equal(new AccountRemovalReport(1, 1, 1, 0), report);
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Requests/People/AccountRemoval.cs
+++ b/Jellyfin.Plugin.Requests/People/AccountRemoval.cs
@@ -17,9 +17,27 @@ namespace Jellyfin.Plugin.Requests.People;
 /// and reaches only finished requests; this is about a person and reaches every request they are on.
 /// </para>
 /// <para>
-/// <b>The two rules, and they are not the same rule.</b> A request the deleted person asked for is
-/// theirs and goes. A request somebody else asked for that they had joined is not theirs, so the
-/// request stays and they come off its list of joiners. That split is the decision recorded on #49.
+/// <b>The three rules, and they are not one rule.</b> A FINISHED request the deleted person asked
+/// for stays, with <see cref="DeletedPerson.Tombstone"/> where their identifier was: the record
+/// then says that somebody who is gone asked for this title on this date, which keeps an
+/// administrator's history of what was asked and answered without keeping a person. An UNFINISHED
+/// one of theirs goes. A request somebody else asked for that they had joined is not theirs, so the
+/// request stays and they come off its list of joiners.
+/// </para>
+/// <para>
+/// <b>The middle rule is an interim and says so.</b> The ruling of 2026-08-28 on #49 asks for an
+/// open request of a deleted person to be closed as withdrawn rather than removed, and there is no
+/// state for that: a withdrawn-shaped value was considered and refused on #113, which
+/// <see cref="Model.RequestLifecycle"/> and <see cref="Model.RequestActor"/> both record. Which of
+/// the two decisions stands is #337. Until it is answered an unfinished request of theirs is
+/// removed, which is what this did for every request of theirs before #336.
+/// </para>
+/// <para>
+/// <b>What finished means is not decided here.</b> It is
+/// <see cref="Storage.RetentionSweep.IsFinished"/>, which is the complement of the partition
+/// <see cref="Model.RequestQuota"/> already draws and is asserted over every value of
+/// <see cref="Model.RequestState"/>. A second reading of the word here would be a rule that can
+/// disagree with the sweep about the same request.
 /// </para>
 /// <para>
 /// <b>What this deliberately does not touch.</b>
@@ -88,9 +106,14 @@ public sealed class AccountRemoval
     private enum Outcome
     {
         /// <summary>
-        /// It was theirs and it is gone.
+        /// It was theirs, unfinished, and it is gone.
         /// </summary>
         Removed,
+
+        /// <summary>
+        /// It was theirs, finished, and it stays with the tombstone where they were.
+        /// </summary>
+        Tombstoned,
 
         /// <summary>
         /// It was somebody else's and they are off it.
@@ -126,6 +149,7 @@ public sealed class AccountRemoval
         }
 
         var removed = 0;
+        var tombstoned = 0;
         var detached = 0;
         var left = 0;
 
@@ -143,6 +167,10 @@ public sealed class AccountRemoval
                     removed++;
                     break;
 
+                case Outcome.Tombstoned:
+                    tombstoned++;
+                    break;
+
                 case Outcome.Detached:
                     detached++;
                     break;
@@ -158,16 +186,17 @@ public sealed class AccountRemoval
         // because the list holds the people who said no and nobody else.
         await _notices.SetAsync(userId, tellsThem: true, cancellationToken).ConfigureAwait(false);
 
-        var report = new AccountRemovalReport(removed, detached, left);
+        var report = new AccountRemovalReport(removed, tombstoned, detached, left);
 
         // At information rather than debug where anything happened: this is the plugin deleting
         // somebody's records without anybody asking it to, and an operator answering for what is
         // held should find that it happened in the log they already read.
-        if ((removed > 0 || detached > 0) && _logger.IsEnabled(LogLevel.Information))
+        if ((removed > 0 || tombstoned > 0 || detached > 0) && _logger.IsEnabled(LogLevel.Information))
         {
             _logger.LogInformation(
-                "A deleted account left {Removed} request(s) of their own, which were removed, and {Detached} request(s) of other people's, which they were taken off.",
+                "A deleted account left {Removed} unfinished request(s) of their own, which were removed, {Tombstoned} finished one(s), which stay with the person taken out of them, and {Detached} request(s) of other people's, which they were taken off.",
                 removed,
+                tombstoned,
                 detached);
         }
 
@@ -207,9 +236,27 @@ public sealed class AccountRemoval
             {
                 if (current.Request.RequestedByUserId == userId)
                 {
-                    return await _store.RemoveAsync(current.Request.Id, current.Revision, cancellationToken).ConfigureAwait(false)
-                        ? Outcome.Removed
-                        : Outcome.Gone;
+                    if (!RetentionSweep.IsFinished(current.Request))
+                    {
+                        return await _store.RemoveAsync(current.Request.Id, current.Revision, cancellationToken).ConfigureAwait(false)
+                            ? Outcome.Removed
+                            : Outcome.Gone;
+                    }
+
+                    // The joiner list is written as well, because a person can be the requester of
+                    // one request and a joiner of the same one only through a store that already
+                    // disagrees with the model. Writing both here costs nothing and means the
+                    // record this leaves cannot name them through the other field.
+                    await _store.ReplaceAsync(
+                        current.Request with
+                        {
+                            RequestedByUserId = DeletedPerson.Tombstone,
+                            JoinedByUserIds = [.. current.Request.JoinedByUserIds.Where(joined => joined != userId)]
+                        },
+                        current.Revision,
+                        cancellationToken).ConfigureAwait(false);
+
+                    return Outcome.Tombstoned;
                 }
 
                 if (!current.Request.JoinedByUserIds.Contains(userId))

--- a/Jellyfin.Plugin.Requests/People/AccountRemovalReport.cs
+++ b/Jellyfin.Plugin.Requests/People/AccountRemovalReport.cs
@@ -3,16 +3,29 @@ namespace Jellyfin.Plugin.Requests.People;
 /// <summary>
 /// What one account removal did, counted so the caller can report it and a test can assert it.
 /// <para>
-/// The three are separate because they read differently to an operator answering for what is held. A
-/// removed request is a record that is gone; a detached one is a record that stays with one fewer
-/// person on it; and a left one is a record that still names a deleted account, which is the only one
-/// of the three that anybody has to act on.
+/// The four are separate because they read differently to an operator answering for what is held. A
+/// removed request is a record that is gone; a tombstoned one is a record that stays with nobody in
+/// it, which is a different answer to "what do you still hold" than either of the other two; a
+/// detached one is a record that stays with one fewer person on it; and a left one is a record that
+/// still names a deleted account, which is the only one of the four that anybody has to act on.
+/// </para>
+/// <para>
+/// Removed and tombstoned are counted apart rather than added together on purpose. An operator
+/// asked what became of a deleted person's requests is answering about records that no longer exist
+/// and records that do, and one number covering both would make the second sound like the first.
 /// </para>
 /// </summary>
-/// <param name="Removed">Requests the deleted account had asked for, which were removed.</param>
+/// <param name="Removed">
+/// Unfinished requests the deleted account had asked for, which were removed. Whether those should
+/// instead be closed as withdrawn is #337.
+/// </param>
+/// <param name="Tombstoned">
+/// Finished requests the deleted account had asked for, which stay with
+/// <see cref="DeletedPerson.Tombstone"/> where the person was.
+/// </param>
 /// <param name="Detached">Requests somebody else had asked for, which the account came off.</param>
 /// <param name="Left">
 /// Requests that still name the account, because they kept moving while the removal ran. Nothing
 /// looks at these again on its own.
 /// </param>
-public readonly record struct AccountRemovalReport(int Removed, int Detached, int Left);
+public readonly record struct AccountRemovalReport(int Removed, int Tombstoned, int Detached, int Left);

--- a/Jellyfin.Plugin.Requests/People/DeletedPerson.cs
+++ b/Jellyfin.Plugin.Requests/People/DeletedPerson.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace Jellyfin.Plugin.Requests.People;
+
+/// <summary>
+/// The identifier a request carries where the person who asked for it has been deleted.
+/// <para>
+/// <b>One fixed constant, and deliberately not a derivation.</b> A pseudonym computed from the
+/// identifier that was there, however it is computed, is the same person written down differently:
+/// two records carrying it say the same account asked for both, and anybody holding the original
+/// identifier can confirm a match by running the computation. This value carries no information
+/// about who was replaced, so the only thing it says is that somebody who is gone asked, which is
+/// exactly what the decision of 2026-08-28 on #49 asks a surviving record to say.
+/// </para>
+/// <para>
+/// <b>It is not any account's identifier.</b> Jellyfin mints a user identifier as a version 4
+/// value, and this is not one: its version nibble is zero, which no minted identifier has. That is
+/// asserted rather than argued, in <c>TheTombstoneIsNotAnIdentifierAServerCouldMint</c>.
+/// </para>
+/// <para>
+/// <b>What it does to a surface is nothing new.</b> The queue page draws a name for an identifier
+/// out of the user list the dashboard already reads, and shows an identifier that list does not
+/// hold as a person this server no longer has. The tombstone is such an identifier, so a
+/// tombstoned request reads as asked for by somebody who is gone without any page being taught a
+/// second rule.
+/// </para>
+/// </summary>
+public static class DeletedPerson
+{
+    /// <summary>
+    /// Gets the identifier that stands in a request for a person the server has deleted.
+    /// </summary>
+    public static Guid Tombstone { get; } = new Guid("00000000-0000-0000-0000-000000000049");
+
+    /// <summary>
+    /// Whether an identifier is the tombstone rather than somebody.
+    /// </summary>
+    /// <param name="userId">The identifier a record carries.</param>
+    /// <returns><see langword="true"/> where it stands for a deleted person.</returns>
+    public static bool Is(Guid userId) => userId == Tombstone;
+}

--- a/Jellyfin.Plugin.Requests/Web/queue.html
+++ b/Jellyfin.Plugin.Requests/Web/queue.html
@@ -530,10 +530,16 @@
                      * requester gets, in the same list, read on the same call.
                      *
                      * An identifier that list does not hold is a person this server no longer has,
-                     * which is what a deleted account leaves behind: #308 removes the requests a
-                     * deleted person asked for and takes them off the ones they joined, and leaves
-                     * this field alone, because clearing it would say that no person moved the
-                     * request rather than that the person who did is gone.
+                     * which is what a deleted account leaves behind. #308 takes a deleted person off
+                     * the requests they had joined, removes the unfinished ones they asked for, and
+                     * leaves this field alone, because clearing it would say that no person moved
+                     * the request rather than that the person who did is gone.
+                     *
+                     * A finished request they asked for is no longer removed either: #336 leaves it
+                     * standing with a tombstone in the requester field, which is deliberately an
+                     * identifier this list cannot hold. So the third case below is reached by two
+                     * different absences now - an account the server deleted, and a constant that
+                     * was never an account - and the cell says the same true thing about both.
                      *
                      * The fourth is the one this function exists for. Where the user list was never
                      * read, no identifier in it means nothing at all, so the cell falls back to the

--- a/docs/personal-data.md
+++ b/docs/personal-data.md
@@ -193,6 +193,11 @@ at startup, in the server's own task list under `Requests`.
 Deleted rather than anonymised. A record stripped of its requester still says a title was asked for
 on this server on that date, and keeping that is not what a retention period is for.
 
+**That is asked to change and has not.** The decision of 2026-08-28 on #49 says age-based stripping
+uses the same tombstone as an account deletion, which is the opposite of the sentence above and of
+the argument `RetentionSweep` carries for it. Nothing has been built either way and the sweep still
+removes; which of the two stands is #337.
+
 **Finished means fulfilled, declined or failed**, which is the same partition the quota already
 draws, and the suite asserts the two agree over every state rather than leaving them to drift. An
 open or approved request is never removed by age, because those are the two somebody still owes an
@@ -238,12 +243,34 @@ when an account is deleted and this plugin consumes it:
     git grep -n 'IEventConsumer<UserDeletedEventArgs>' -- Jellyfin.Plugin.Requests/
     Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs:232:        serviceCollection.AddSingleton<IEventConsumer<UserDeletedEventArgs>, RemovedAccounts>();
 
-There are two rules and they are not the same rule.
+There are three rules and they are not one rule.
 
-**A request they asked for is theirs and is removed.** Record and history together, not stripped of
-its requester: a row that has lost the person who asked still says a title was asked for on this
-server on that date, which is half a record going and reads as deletion in a document without being
-one in the file.
+**A finished request they asked for stays, with a tombstone where they were.** The record keeps its
+title, its date and its answer, and `MediaRequest.RequestedByUserId` holds one fixed constant instead
+of the person:
+
+    git grep -n 'public static Guid Tombstone' -- Jellyfin.Plugin.Requests/People/DeletedPerson.cs
+    Jellyfin.Plugin.Requests/People/DeletedPerson.cs:33:    public static Guid Tombstone { get; } = new Guid("00000000-0000-0000-0000-000000000049");
+
+It is a constant rather than anything computed from the identifier it replaces. A pseudonym derived
+from that identifier is the same person written down differently: two records carrying it say the
+same account asked for both, and anybody holding the original can confirm a match by running the
+derivation. This value carries nothing about who was replaced, so what the record says afterwards is
+that somebody who is gone asked for this title on this date. Deletion-by-record was the alternative
+and loses the administrator's history of what was asked and answered along with the person, which is
+the trade taken on #49 on 28 August.
+
+**An unfinished request they asked for is removed, and that is an interim rather than the answer.**
+The same decision asks for an open request to be closed as withdrawn instead, and there is no state
+for that: a withdrawn-shaped value was considered and refused on #113, and the refusal is written
+into the model in two places:
+
+    git grep -n 'Cancelled' -- Jellyfin.Plugin.Requests/
+    Jellyfin.Plugin.Requests/Model/RequestActor.cs:43:    /// is no state for a user withdrawing, refused with the <c>Cancelled</c> state on #113. The
+    Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs:69:/// user withdrawing has no state to move to because <c>Cancelled</c> was refused on #113. An
+
+Which of the two stands is #337. Until it is answered, an unfinished request of theirs is removed,
+record and history together, which is what happened to every request of theirs before this.
 
 **A request somebody else asked for that they had joined stays, and they come off its list.** The
 request is not theirs, and taking a third party's request away because somebody else deleted their
@@ -260,9 +287,23 @@ deleted administrator's identifier. Clearing it would say something false rather
 empty value there means no person moved the request, so a cleared field would read as this plugin
 having decided somebody else's request on its own. That was answered on #49 on 27 August, and the
 answer is that the value stays and the queue is what shows an identifier nothing resolves as a person
-who is gone. **That rendering is #307 and is not built yet.** Until it is, an administrator reading the queue for
-such a request sees a raw identifier rather than a name, which is what the field always was and is
-not new; what is new is that nothing on the server can turn it into a name any more.
+who is gone.
+
+**That rendering is built, and this page said it was not.** #307 closed as completed on 2026-08-27
+and the queue page drew it the same day, while the sentence here went on saying an administrator sees
+a raw identifier. It was found by reading the page against the tree rather than by anything failing:
+
+    git log --format='%h %ad %s' --date=short -1 -- Jellyfin.Plugin.Requests/Web/queue.html
+    211b90c 2026-08-27 Draw who last moved a request, and keep a deleted account apart from an unanswered call
+
+    git grep -n 'queue.movedBy.deleted' -- Jellyfin.Plugin.Requests/
+    Jellyfin.Plugin.Requests/Localisation/Strings/en.json:122:  "queue.movedBy.deleted": "A person who has been deleted",
+    Jellyfin.Plugin.Requests/Web/queue.html:558:                        return RequestsShell.word("queue.movedBy.deleted");
+
+What the page draws is an identifier the dashboard's user list does not hold, and it says so only
+where that list was actually read, so a failed call is never reported as a deleted account. The
+tombstone above is such an identifier, which is why a tombstoned request reads as asked for by
+somebody who is gone without the page being taught a second rule.
 
 **A second identifier is left standing, and this one is a boundary rather than an answer.** Every
 activity entry written for a move that person made keeps their identifier, and the consumer that


### PR DESCRIPTION
Builds #336. A deleted account took its finished requests with it, and an operator asking what was requested and answered on this server lost that history along with the person. The record stays now, with one fixed constant where the requester was.

Every command below was run at `0cd9d3e`, which is this head, in a clean checkout of it.

## What changed

`AccountRemoval` had two rules and has three. A **finished** request the deleted person asked for stays, with `DeletedPerson.Tombstone` in `RequestedByUserId`. An **unfinished** one of theirs is removed, which is what happened to all of them before. A request somebody else asked for that they had joined is untouched apart from the joiner list, which is unchanged.

The constant is not derived from the identifier it replaces, and that is the whole of why it is a constant:

    git grep -n 'public static Guid Tombstone' -- Jellyfin.Plugin.Requests/People/DeletedPerson.cs
    Jellyfin.Plugin.Requests/People/DeletedPerson.cs:33:    public static Guid Tombstone { get; } = new Guid("00000000-0000-0000-0000-000000000049");

A pseudonym computed from that identifier is the same person written down differently: two records carrying it say the same account asked for both, and anybody holding the original can confirm a match by re-running the computation.

What counts as finished is read rather than restated:

    git grep -n 'RetentionSweep.IsFinished' -- Jellyfin.Plugin.Requests/People/
    Jellyfin.Plugin.Requests/People/AccountRemoval.cs:240:                    if (!RetentionSweep.IsFinished(current.Request))

so the removal and the age sweep cannot come to mean different things by the word.

## Two proofs, each by deleting the thing and watching the suite go red

**The finished branch.** Taking it out, so every request of theirs is removed as before:

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -f net9.0 --filter "FullyQualifiedName~AccountRemovalTests"
       Assert.Equal() Failure: Values differ
    Expected: AccountRemovalReport { Removed = 0, Tombstoned = 1, Detached = 0, Left = 0 }
    Actual:   AccountRemovalReport { Removed = 1, Tombstoned = 0, Detached = 0, Left = 0 }
      Stapelverfolgung:
         at Jellyfin.Plugin.Requests.Tests.People.AccountRemovalTests.AFinishedRequestTheDeletedPersonAskedForStaysWithTheTombstoneWhereTheyWere() in G:\Github\jellyfin-plugin-requests\Jellyfin.Plugin.Requests.Tests\People\AccountRemovalTests.cs:line 376
    --- End of stack trace from previous location ---

    Fehler!      : Fehler:     6, erfolgreich:    15, übersprungen:     0, gesamt:    21, Dauer: 88 ms - Jellyfin.Plugin.Requests.Tests.dll (net9.0)

Six of the twenty-one, and `AnUnfinishedRequestOfTheirsIsStillRemoved` stays green, which is right: that test is about the behaviour the deletion restores.

**The constant.** Weakening it to `Guid.Empty`, which is the value that already means "nobody" in this plugin:

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -f net9.0 --filter "FullyQualifiedName~AccountRemovalTests"
      Fehler Jellyfin.Plugin.Requests.Tests.People.AccountRemovalTests.TheTombstoneIsNotAnIdentifierAServerCouldMint [1 ms]
    Fehler!      : Fehler:     1, erfolgreich:    20, übersprungen:     0, gesamt:    21, Dauer: 102 ms - Jellyfin.Plugin.Requests.Tests.dll (net9.0)

Both files were restored from git afterwards and the head carries neither deletion.

## The suite at this head

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror

```
Bestanden!   : Fehler:     0, erfolgreich:   777, übersprungen:     0, gesamt:   777, Dauer: 30 s - Jellyfin.Plugin.Requests.Tests.dll (net10.0)
Bestanden!   : Fehler:     0, erfolgreich:   777, übersprungen:     0, gesamt:   777, Dauer: 30 s - Jellyfin.Plugin.Requests.Tests.dll (net9.0)
```

777 against the 768 the mainline carried, on both claimed lines.

## Two corrections travel with it, and both were found by reading a page against the tree

**`docs/personal-data.md` said the queue's rendering of a deleted person was not built.** It landed on 2026-08-27, the day #307 closed as completed:

    git log --format='%h %ad %s' --date=short -1 -- Jellyfin.Plugin.Requests/Web/queue.html
    211b90c 2026-08-27 Draw who last moved a request, and keep a deleted account apart from an unanswered call

    git grep -n 'queue.movedBy.deleted' -- Jellyfin.Plugin.Requests/
    Jellyfin.Plugin.Requests/Localisation/Strings/en.json:122:  "queue.movedBy.deleted": "A person who has been deleted",
    Jellyfin.Plugin.Requests/Web/queue.html:558:                        return RequestsShell.word("queue.movedBy.deleted");

That matters here rather than only being wrong: the page draws an identifier its user list does not hold as a person who is gone, and the tombstone is deliberately such an identifier, so a tombstoned request reads correctly with no page taught a second rule.

**The queue page's own comment** said a deleted person's requests are removed. Half of them are now.

## What this does not do, and the line is deliberate

**An open request of a deleted person is still removed rather than closed as withdrawn.** The decision of 2026-08-28 asks for the second, and there is no state for it: a withdrawn-shaped value was considered and refused on #113.

    git grep -n 'Cancelled' -- Jellyfin.Plugin.Requests/
    Jellyfin.Plugin.Requests/Model/RequestActor.cs:43:    /// is no state for a user withdrawing, refused with the <c>Cancelled</c> state on #113. The
    Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs:69:/// user withdrawing has no state to move to because <c>Cancelled</c> was refused on #113. An

**The age sweep is untouched.** It removes a finished request rather than stripping it and argues for that in the file, which the same decision asks to reverse.

Both of those are #337 and neither is guessed at here. `AnUnfinishedRequestOfTheirsIsStillRemoved` writes the interim down as a test, so whichever way #337 goes has to argue with a red suite rather than with a document.

## Means

C#, in the tree's own project and suite, because the change is a branch inside an existing operator and its proof is a ledger row the existing suite already runs. Nothing new is added to the runtime, the dependency set or the languages this repository has to maintain.

## What is unmeasured, said plainly

**No Jellyfin server was started and no account was deleted on one.** What is measured is the removal against the store this plugin ships, on both claimed target frameworks. That the server raises the event and resolves the consumer is the same unrun procedure every other event-driven behaviour here carries.

**No store written by a previous version was migrated or read.** Nothing on disk changes shape: the tombstone is a value in a field that already held a `Guid`, so a store written before this loads unchanged and a record already removed by an earlier deletion is not brought back. That is an argument from the shape rather than a run against an old file.

**There is no second reader on this board tonight.** This body and the two deletions above stand in place of one.
