### PR TITLE
Name the two settings decisions the setup order left out

### DIFF
--- a/docs/operating.md
+++ b/docs/operating.md
@@ -38,6 +38,20 @@ the order to take them in and what each one costs you later.
   [personal-data.md](personal-data.md).
 - **The address a notice is posted to.** Leave it empty unless you have somewhere to receive one.
   Empty means nothing is sent, and that is a supported way to run rather than a half-configured one.
+- **Which movements go to that address.** Approvals, declines and fulfilments have a switch each and
+  all three are on, so an address typed and nothing else decided posts all three. The one worth
+  deciding on the first evening rather than on the first noisy one is fulfilments: nobody moves a
+  request to fulfilled, the library does, so its volume follows how fast titles are arriving rather
+  than how often anybody works the queue. With the address empty all three say nothing, which is why
+  they are on rather than off.
+- **Whether an administrator is told that a request arrived.** This is off, it is a decision of its
+  own rather than a fourth switch on the list above, and it is the one an operator looking for "tell
+  me when somebody asks" would otherwise conclude does not exist. It needs no address: it sends
+  nothing out of the machine and goes down connections the server already holds to clients already
+  signed in. Read what [notifications.md](notifications.md) measures about it before turning it on,
+  because no Jellyfin client subscribes to the name it goes out under, so switching it on and
+  watching the dashboard shows nothing. What reaches an operator today is the activity entries the
+  dashboard already draws, and the queue.
 
 ### 3. Know that approval is not a switch
 


### PR DESCRIPTION
Part of #102. The guide's setup section names four settings decisions and the configuration class carries nine.

## What was wrong

`docs/operating.md` says what it adds over `configuration.md` is the order to take the settings decisions in and what each one costs you later. It lists the quota, the accepted kinds, the retention period and the notice address. Four of nine:

    git grep -c '^- \*\*' origin/master -- docs/operating.md
    origin/master:docs/operating.md:4

    git grep -nE 'public .* \{ get; set; \}' origin/master -- Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs | wc -l
    9

Five of the nine are covered: `AcceptsMovies` and `AcceptsSeries` are one bullet, and the quota, the retention period and the address are one each. Four are not, and they arrived after the page did:

    git log --format='%h %ad %s' --date=short -S AnnouncesFulfilments --reverse -- Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs | head -1
    d5342c0 2026-08-19 Make the outbound path quiet by default and switchable per event

    git log --format='%h %ad %s' --date=short -S TellsAdministratorsAboutArrivals --reverse -- Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs | head -1
    0a78ab5 2026-08-22 Tell a live administrator that a request arrived

    git log --format='%h %ad %s' --date=short -- docs/operating.md | tail -1
    bcb21f9 2026-08-17 Give an operator the path from an installed plugin to a working queue

## What the omission costs, which is the reason this is worth a change

Two failures, and they are the two this page exists to prevent.

An operator who types an address at the fourth bullet is handed approvals, declines and fulfilments, because all three switches default on. Nobody moves a request to fulfilled - the library does, when the title turns up - so the volume of the third follows how fast titles are arriving rather than how often anybody works the queue. The page that promises what a decision costs you later says nothing about the one whose cost is decided by something other than the operator.

An operator looking for a way to be told that somebody asked reads four bullets, finds nothing about it, and concludes there is no such setting. There is one, it is off on a fresh install, and it is deliberately not a fourth switch on the address list: it sends nothing out of the machine and goes down connections the server already holds to clients already signed in.

## What the change does

Two bullets after the address, in the order the decisions are actually taken. `configuration.md` stays the authority for what each setting is, what it defaults to and what it refuses; these add the order and the cost, which is what this page says it adds. The arrival bullet sends the reader to `notifications.md` before switching it on rather than restating that measurement here, because no Jellyfin client subscribes to the name the document goes out under and an operator who turns it on and watches the dashboard sees nothing.

## The means

Markdown in `docs/`, beside the page being corrected. The artefact is prose an operator reads, the claims in it are backed by the tree rather than by the page, and nothing here needs a language the board does not already carry.

## What was run

    npx --yes prettier@3.6.2 --parser markdown --check <the staged blob of docs/operating.md>
    Checking formatting...
    All matched files use Prettier code style!
    prettier-rc=0

Against the staged blob rather than the working file: this clone carries `core.autocrlf=true`, so the working copy is CRLF and a local run would warn about a file the gate is green on.

    git diff --name-only origin/master...HEAD
    docs/operating.md

## What this does not claim

**Nothing was read on a running server.** The defaults, the switch semantics and the arrival path are read out of `Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs`, `docs/configuration.md` and `docs/notifications.md` in this repository. No Jellyfin server was started and no settings page was opened.

**This does not finish issue 102.** That issue is open on the third thing its second condition names, what each bridge failure looks like, and its address is issue 315. Nothing here touches the bridge section.

**No second person has read this change.** No other reader was available on this board tonight, and the transcripts above stand in place of one.
