### PR TITLE
Say what has actually been released, in the five files that said one thing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,17 +37,36 @@ directly, and carries the fixture it is watched refusing.
 
 ## This is not finished
 
-One release exists, and no plugin catalogue serves it:
+Two releases exist, and a manifest under Flowfin's control serves both:
 
     gh release list --repo Flowfin/jellyfin-plugin-requests --json tagName --jq '.[].tagName'
+    0.2.0.0-stable
     0.1.0.0-stable
 
-[docs/RELEASING.md](docs/RELEASING.md) says the same about itself: a GitHub
-release is the whole output, and nothing feeds a catalogue until a manifest
-generator is added. The archive that release carries is built for the one server
-line `build.yaml` names, so an operator on the other line has nothing to install
-even by hand. The packaged install path has not been tried on any server, on
-either line.
+The address an operator adds, what the entries carry and the checksums read back
+against the archives are in [docs/catalogue.md](docs/catalogue.md), which is the
+authority for all of it. Nothing on this board writes that document: the release
+route here publishes a GitHub release and feeds no catalogue, which
+[docs/RELEASING.md](docs/RELEASING.md) says about itself, and what this tree does
+with the published manifest is read it back against the releases once a day.
+
+Three things belong here rather than behind the link, because they decide whether
+this is worth installing.
+
+**The official Jellyfin catalogue does not carry this and will not.** That list is
+filled by enumerating one organisation's repositories, this repository does not
+move into it, and the price of that decision is that an operator reaches this
+plugin only by being told the address.
+
+**Both published entries carry the 10.11 line's package.** The 12.0 line has none,
+because the release route builds the one server line `build.yaml` names, so a
+server on the 12.0 line is offered the `net9.0` build rather than nothing. That
+comparison is read at the server's own source rather than assumed, on the same
+page.
+
+**The packaged install path has not been tried on any server, on either line.**
+What every recorded run installs is the built assembly copied in, not a package a
+server fetched and unpacked.
 
 Nothing here should be pointed at a server you care about.
 
@@ -58,7 +77,7 @@ wrong, what the evidence is and what has to be true for it to be closed.
 
 Two server generations are claimed, and each gets its own package because a
 plugin compiled for one runtime does not load on the other. Claimed is not
-published: the section above says which of the two the one release carries.
+published: the section above says which of the two the releases carry.
 
 | Line           | Runtime | Packaging metadata | Oldest server claimed |
 | -------------- | ------- | ------------------ | --------------------- |
@@ -70,10 +89,10 @@ an edit to either shows up as a difference between this table and what the
 command prints:
 
     git grep -nE '^(version|targetAbi|framework):' -- build.yaml build-jf12.yaml
-    build-jf12.yaml:13:version: "0.1.0.0"
+    build-jf12.yaml:13:version: "0.2.0.0"
     build-jf12.yaml:15:targetAbi: "12.0.0.0"
     build-jf12.yaml:16:framework: "net10.0"
-    build.yaml:5:version: "0.1.0.0"
+    build.yaml:5:version: "0.2.0.0"
     build.yaml:10:targetAbi: "10.11.0.0"
     build.yaml:11:framework: "net9.0"
 
@@ -83,7 +102,7 @@ disagreement between it and the assembly rather than trusting three copies to be
 edited together:
 
     git grep -n '<PluginVersion>' -- Directory.Build.props
-    Directory.Build.props:11:        <PluginVersion>0.1.0.0</PluginVersion>
+    Directory.Build.props:42:        <PluginVersion>0.2.0.0</PluginVersion>
 
 That test is `PluginVersionMatchesThePackagingMetadata` in
 `Jellyfin.Plugin.Requests.Tests/PackagingMetadataTests.cs`, and

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -93,10 +93,11 @@ files:
   and the server reported `12.0.0`. Listing 12.0 as supported without saying that would be a
   statement about a server nobody has run this on.
 - **The packaged install path has not been tried for this plugin.** What every run installs is the
-  built assembly copied into the container, not a package fetched and unpacked by the server. A
-  release exists, `0.1.0.0-stable`, and no run recorded in this repository installed from it. The
-  sibling in the set is the other way round: it arrives as its own published package, unpacked whole,
-  so the set half of the run does exercise that path and the half about this plugin does not.
+  built assembly copied into the container, not a package fetched and unpacked by the server. Two
+  releases exist, `0.1.0.0-stable` and `0.2.0.0-stable`, and no run recorded in this repository
+  installed from either. The sibling in the set is the other way round: it arrives as its own
+  published package, unpacked whole, so the set half of the run does exercise that path and the half
+  about this plugin does not.
 - **The supported set is one board, and it is not the one the seam is written against.** A board
   joins the set for a line on the day it publishes a release for that line, and every candidate
   besides `jellyfin-plugin-sso` has published nothing. So a green run says nothing about the sibling

--- a/docs/operating.md
+++ b/docs/operating.md
@@ -4,8 +4,8 @@ The path from an installed plugin to a queue somebody can work, and the sequence
 queue stops moving. It is written for an operator who has never seen this plugin and does not want to
 read the rest of `docs/` first.
 
-Read the "This is not finished" section of [../README.md](../README.md) before any of it. One release
-exists, it carries the package for one of the two claimed server lines, and the packaged install path
+Read the "This is not finished" section of [../README.md](../README.md) before any of it. Two releases
+exist, both carry the package for one of the two claimed server lines, and the packaged install path
 has not been tried on a server. Nothing below changes that.
 
 ## From an installed plugin to a queue

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -195,11 +195,12 @@ the same trap #97 names for the hop between shipped plugin versions.
 The version 0 fixture was produced by this tree's own store at `592e517`, the commit before the
 version landed, by adding two requests through `AddAsync` and copying `requests.json` out.
 
-It is not a shipped version's output, and it could not be. One release exists, and the commit it was
-built from carries no store to write anything:
+It is not a shipped version's output, and it could not be. The release that existed when it was
+captured is `0.1.0.0-stable`, and the commit that one was built from carries no store to write
+anything:
 
     gh release list --repo Flowfin/jellyfin-plugin-requests --json tagName,createdAt
-    [{"createdAt":"2026-08-08T09:38:30Z","tagName":"0.1.0.0-stable"}]
+    [{"createdAt":"2026-08-27T06:50:36Z","tagName":"0.2.0.0-stable"},{"createdAt":"2026-08-08T09:38:30Z","tagName":"0.1.0.0-stable"}]
     git rev-parse 0.1.0.0-stable^{commit}
     c44552645f0dba120c49599deedbc0244b59dcec
     git ls-tree -r --name-only c445526 -- Jellyfin.Plugin.Requests/Storage
@@ -210,6 +211,8 @@ built from carries no store to write anything:
 
 The contract and its two exceptions, and no implementation. So the shape that fixture holds is what a
 server running the mainline between `7b62877` and the change that landed the version has on its disk.
+The other release in that listing does ship a store, and its own output is the section below rather
+than a second thing this paragraph is about.
 
 ### The version 1 fixtures, which are a shipped version's output
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -80,12 +80,12 @@ promised from then on is #105.
 
 `0.1.0.0`, and the reading that chose it does not reproduce any more. On the day
 the number was picked the template's `1.0.0.0` claimed a released first version
-and nothing had been released. One release exists now, so the command returns a
+and nothing had been released. Two releases exist now, so the command returns a
 different number and is written here as the current reading rather than as the
 one that decided anything:
 
     $ gh release list --repo Flowfin/jellyfin-plugin-requests --json tagName --jq 'length'
-    1
+    2
 
 A version that said 1.0 to a catalogue, to a dashboard and to an operator, for a
 tree that then held no request API and no store behind it, was a claim it could


### PR DESCRIPTION
Part of #340. Every claim in this tree about what has been released, what the packaging carries and whether a catalogue serves it, re-measured and rewritten.

Everything below was run at `origin/master`, `d169c93feb56b5eb79d336ef33fe619e1dd7c340`, and at the head of this branch where it says so.

## What is true, read before anything was written

    gh release list --repo Flowfin/jellyfin-plugin-requests --json tagName --jq '.[].tagName'
    0.2.0.0-stable
    0.1.0.0-stable

    git grep -nE '^(version|targetAbi|framework):' -- build.yaml build-jf12.yaml
    build-jf12.yaml:13:version: "0.2.0.0"
    build-jf12.yaml:15:targetAbi: "12.0.0.0"
    build-jf12.yaml:16:framework: "net10.0"
    build.yaml:5:version: "0.2.0.0"
    build.yaml:10:targetAbi: "10.11.0.0"
    build.yaml:11:framework: "net9.0"

    git grep -n '<PluginVersion>' -- Directory.Build.props
    Directory.Build.props:42:        <PluginVersion>0.2.0.0</PluginVersion>

    curl -sS https://flowfin.dev/manifest.json \
      | jq -r '.[] | select(.name == "Requests") | .versions[] | [.version, .targetAbi] | @tsv'
    0.2.0.0	10.11.0.0
    0.1.0.0	10.11.0.0

## The population is nine rather than the eight the issue names

The ninth was found while editing the file that carries it, and it is `README.md:61`: the lead-in to the server-lines table said the section above says which of the two lines "the one release" carries. It is corrected with the rest. The issue's count of five sites pasting a command output is unchanged by it, because this one pastes nothing.

## What the change does

**`README.md`, the "This is not finished" section, is rewritten rather than renumbered.** What an installing operator needs from it changed when the manifest arrived, so the section now says where the address is, that the official catalogue will not carry this and why, that both published entries are the 10.11 line's package so a server on the 12.0 line is offered the `net9.0` build rather than nothing, and that the packaged install path has been tried on no server on either line. That last one is the negative the old section carried and it is kept rather than softened.

It points at `docs/catalogue.md` for the address, the entries and the checksums instead of holding a second copy of them, and it says that nothing on this board writes that document - the release route publishes a GitHub release and feeds no catalogue, which `docs/RELEASING.md` already says about itself, and what this tree does with the published manifest is read it back against the releases once a day.

**The four passages outside the README keep the argument each is making** and correct only the release position under it.

`docs/storage.md` is the one to read rather than skim. Its point is that the version 0 fixture could not be a shipped version's output, and it argued that from a count of releases. It now argues it from the release it is about, and the listing beside it returns two entries, so a sentence was added saying the other one does ship a store and pointing at the section below that already covers it. That section was already correct and is untouched.

`docs/compatibility.md` keeps the claim the bullet exists for, that no run recorded in this repository installed from a release, and names both releases instead of one.

`docs/versioning.md` and `docs/operating.md` are a number and a count each.

## What was run at this head

    npx --yes prettier@3.6.2 --check <the five staged blobs>
    Checking formatting...
    All matched files use Prettier code style!
    prettier-rc=0

Against the staged blobs rather than the working files: this clone carries `core.autocrlf=true`, so the working copies are CRLF and a local run would warn about files the gate is green on.

The condition the issue makes derivable:

    git grep -n -i 'one release exists' -- . ; echo "exit=$?"
    exit=1

    git diff --name-only origin/master...HEAD
    README.md
    docs/compatibility.md
    docs/operating.md
    docs/storage.md
    docs/versioning.md

## The means

Markdown, in the files being corrected. The artefact is the prose itself, so there is no other means available, and nothing here adds a language, a runtime or a dependency the board does not carry.

## What this does not claim

**Nothing was installed into a Jellyfin server.** The manifest was fetched over HTTP and the release listing was read from the tracker. No server was started, no repository was added to one, and no install was attempted on either line. The sentence saying the packaged install path has been tried on no server is carried forward on the same evidence the pages already had for it, not on a run made here.

**No archive was downloaded or hashed for this change.** The checksums the README now points at are `docs/catalogue.md`'s, read there on 2026-08-28, and this change neither re-runs nor re-quotes them.

**Nothing is claimed about what a 12.0 server does when offered the `net9.0` build.** The README says it is offered that build, which is the comparison `docs/catalogue.md` reads at the server's own source, and neither page says anybody watched an install take it.

**No second person has read this change.** No other reader was available on this board tonight, and the transcripts above stand in place of one.
