### PR TITLE
Write these seven files in the first person instead of about the operator from outside

### DIFF
--- a/.github/workflows/pr-hygiene.yaml
+++ b/.github/workflows/pr-hygiene.yaml
@@ -10,11 +10,11 @@
 #
 # It is a first-party workflow with one `github-script` step rather than an
 # external review service. A service that reasons about a change is a third party
-# reading every diff before a maintainer does, and the same rules are a few
-# dozen lines of JavaScript against the pull request API. Nothing here is
-# checked out: every input is read from the pull request metadata through the
-# API, so there is no untrusted working tree, and no untrusted value is ever
-# interpolated into a shell command.
+# reading every diff before I do, and the same rules are a few dozen lines of
+# JavaScript against the pull request API. Nothing here is checked out: every
+# input is read from the pull request metadata through the API, so there is no
+# untrusted working tree, and no untrusted value is ever interpolated into a
+# shell command.
 #
 # The checks are tiered by confidence, because a check that fires on a
 # reasonable change teaches people to route around it.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -32,10 +32,9 @@ in scope, whether or not it was aimed at a contributor.
 Use the **Security** tab, then **Report a vulnerability**, and say at the top
 that the report is about conduct rather than a vulnerability.
 
-That form is a private channel to the maintainer and is the only one this
-repository has, which is why a conduct report shares it. It is read by the same
-person, and nothing about a report is made public without asking the person who
-sent it.
+That form is a private channel to me and is the only one this repository has,
+which is why a conduct report shares it. I read both, and nothing about a report
+is made public without asking the person who sent it.
 
 ## What happens then
 
@@ -47,6 +46,6 @@ What can follow, in order: a private word, a public correction of something that
 was posted, removal of the content, and a block. Which one it is depends on what
 happened and on whether it happened again.
 
-Where the report is about the maintainer, there is nowhere in this repository to
-take it. GitHub's own abuse reporting is the route that does not run through the
-person being reported.
+Where the report is about me, there is nowhere in this repository to take it.
+GitHub's own abuse reporting is the route that does not run through the person
+being reported.

--- a/Jellyfin.Plugin.Requests/Api/MyRequest.cs
+++ b/Jellyfin.Plugin.Requests/Api/MyRequest.cs
@@ -82,8 +82,8 @@ public sealed record MyRequest
     public string? YourNote { get; init; }
 
     /// <summary>
-    /// Gets why it was declined, where it was. A decline reason is required, decided by the
-    /// maintainer on #113, and a requester who is not told why asks the same thing again.
+    /// Gets why it was declined, where it was. A decline reason is required, which I decided on
+    /// #113, and a requester who is not told why asks the same thing again.
     /// </summary>
     public DeclineReason? DeclineReason { get; init; }
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Use GitHub's private vulnerability reporting for this repository: the **Security**
 tab, then **Report a vulnerability**. It is enabled here, and it opens a draft
-advisory only you and the maintainer can read.
+advisory only you and I can read.
 
 The form is here, without navigating:
 

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -517,6 +517,6 @@ here recognises.
 Nothing off a running instance, and that is the same disclosure as the one above rather than a softer
 version of it. No call has ever been made from this tree to a service of this form and no response of
 one has ever been captured here. Both readings above are of a branch of that project's own
-repository, which is what its maintainers intend to ship rather than what any operator is running:
+repository, which is what that project intends to ship rather than what any operator is running:
 the two disagreeing about the request-status alphabet is the demonstration that a document and a
 service are different things, and a numbering read from source is subject to the same gap.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -490,8 +490,8 @@ than this repository's code.
 Two things follow from that and are worth writing down here rather than being rediscovered.
 
 Nothing here reports anything to this project. No path sends anything anywhere by default and none of
-them sends anything to the maintainer at all, at any setting. That is not a property of the sink's
-design, it is a standing decision recorded on #113, and it has no opt-in.
+them sends anything to me at all, at any setting. That is not a property of the sink's design, it is
+a standing decision recorded on #113, and it has no opt-in.
 
 Nothing leaves the machine until an operator turns it on. The outbound sink is off on a fresh
 install by having nowhere to send to, and what an operator narrows it with once it has somewhere is

--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -631,10 +631,10 @@ The third is what the number is made of:
     10 CI-Tests
 
 `Fuzzing` is 0 because fuzzing is declined in the table above, by name and with a
-replacement. `Contributors` is 0 for a repository with one maintainer and cannot
-be anything else. `CII-Best-Practices` is 0 until somebody registers for a badge
-elsewhere. `Maintained` is 0 with the reason printed by the run itself, which is
-that the repository is younger than ninety days:
+replacement. `Contributors` is 0 for a repository I am the only contributor to
+and cannot be anything else. `CII-Best-Practices` is 0 until somebody registers
+for a badge elsewhere. `Maintained` is 0 with the reason printed by the run
+itself, which is that the repository is younger than ninety days:
 
     $ grep -oE 'score is 0: project was created within the last [0-9]+ days' \
         sarif/results.sarif


### PR DESCRIPTION
Closes #342.

Eight sentences in seven tracked files described the person who runs this project in the third person. The write path already refuses that word and every issue and pull request text on this board has been repaired, so what was left was the tree.

## What each sentence became

| File | Was | Is |
| --- | --- | --- |
| `.github/workflows/pr-hygiene.yaml` | a third party reading every diff before someone else does | "before I do" |
| `CODE_OF_CONDUCT.md` (reporting) | "a private channel to <role>" | "a private channel to me", and the sentence after it says "I read both" rather than pointing at a noun that is no longer there |
| `CODE_OF_CONDUCT.md` (what happens then) | "where the report is about <role>" | "where the report is about me" |
| `Jellyfin.Plugin.Requests/Api/MyRequest.cs` | "decided by <role> on #113" | "which I decided on #113" |
| `SECURITY.md` | "only you and <role> can read" | "only you and I can read" |
| `docs/notifications.md` | "sends anything to <role> at all" | "sends anything to me at all" |
| `docs/quality-parity.md` | "a repository with one <role>" | "a repository I am the only contributor to" |
| `docs/bridge.md` | "what its <role>s intend to ship" | "what that project intends to ship" |

The last one is the only sentence that was not about this account. It is about the people who run Overseerr, so it names that project instead of a role inside it.

## What is left

Nothing. The issue's done-condition allows files to keep the word where it is somebody else's vocabulary - a licence, an adopted code of conduct, GitHub's own CODEOWNERS syntax. There is no such file here, so none is named:

    $ git grep -il maintainer -- . ; echo "exit=$?"
    exit=1

`CODE_OF_CONDUCT.md` is written for this repository rather than adopted verbatim, which is why it is repaired rather than exempted.

## Evidence

Prose and comments only. The one source file changed is a `<summary>` doc comment on `MyRequest.DeclineReason`; no behaviour moved, which is why no test moved.

    $ dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    0 Warnung(en)
    0 Fehler

    $ dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler:     0, erfolgreich:   777, uebersprungen:     0, gesamt:   777  (net9.0)
    Bestanden!   : Fehler:     0, erfolgreich:   777, uebersprungen:     0, gesamt:   777  (net10.0)

The formatting gate reads LF, and this checkout is CRLF, so the five changed markdown files were checked as LF copies made inside the tree, where `.editorconfig` and the formatter's own configuration resolve exactly as they do for the gate:

    $ npx --yes prettier@3.6.2 --check ".lfcheck/**/*.md"
    All matched files use Prettier code style!

The copies were deleted before the commit; the diff carries no `.lfcheck`.

## Means

Nothing new is introduced: the change edits Markdown, a YAML comment and a C# doc comment that already exist, in the languages the gates on this board already read.

## Review

There is no second reader on this board tonight. The evidence above stands in place of one, and the whole change is readable as a diff of eight sentences.
