### PR TITLE
Install the release an operator downloads onto a server of the line it claims

### DIFF
--- a/.github/workflows/release-install.yaml
+++ b/.github/workflows/release-install.yaml
@@ -1,0 +1,181 @@
+# Does the release an operator downloads install into a server of the line it claims?
+#
+# #152's last condition, and the one thing about a release nothing here measured. Two other routes
+# come close and neither answers it. `.github/workflows/package.yaml` installs a package on a server
+# of its line, but the package is the one that run just built, so a publish that attached the wrong
+# bytes passes it. `.github/workflows/manifest-freshness.yaml` reads the document a server fetches
+# against the releases that exist, and says of itself that it hashes no archive and installs nothing.
+# What is left between them is the asset itself: downloaded the way an operator downloads it, checked
+# against the digest published beside it, and put on a server of the line its own metadata names.
+#
+# EVERY CLAIMED LINE THAT HAS A RELEASE, AND A NOTE FOR EVERY LINE THAT HAS NONE. The lines are read
+# out of the packaging files at the root, the releases out of the tracker, and a claimed line with no
+# release is reported rather than passed over: a line with nothing published cannot fail an install,
+# and a run that had nothing to cover must not read afterwards as one that covered it.
+#
+# WHAT IT DOES NOT DO, SAID HERE RATHER THAN DISCOVERED. It does not install the way a server
+# installs. A server fetches the archive named in a manifest and unpacks it itself; this puts the
+# unpacked bytes in the plugin directory, which is what every container check in this repository
+# does. So it answers whether the published bytes are a plugin that loads, and not whether the
+# server's own download-and-unpack path works on them.
+#
+# It also raises nothing an operator sees. A failed scheduled run sits in a run list, which is the
+# same bound `manifest-freshness.yaml` names for itself and the same issue answers it: #111's third
+# condition.
+#
+# THIS IS NOT A REQUIRED CHECK. The required set is a repository setting rather than a file in this
+# tree, and #30 is where it is written down and applied.
+name: Released package installs
+
+on:
+  schedule:
+    # Once a day, away from the hours the other scheduled readings take. What this bounds is how
+    # long a release nobody can install stays unreported, and a release is not published on a
+    # schedule, so a day is short against the time such a thing has previously gone unnoticed.
+    - cron: '41 3 * * *'
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'scripts/check-released-package.sh'
+      - 'scripts/prove-released-install-refusals.sh'
+      - 'scripts/server-under-test.sh'
+      - 'scripts/verify-plugin-loads.sh'
+      - 'scripts/server-lines.tsv'
+      - '.github/workflows/release-install.yaml'
+      - 'build.yaml'
+      - 'build-*.yaml'
+  push:
+    branches: [master]
+    paths:
+      - 'scripts/check-released-package.sh'
+      - 'scripts/prove-released-install-refusals.sh'
+      - 'scripts/server-under-test.sh'
+      - 'scripts/verify-plugin-loads.sh'
+      - 'scripts/server-lines.tsv'
+      - '.github/workflows/release-install.yaml'
+      - 'build.yaml'
+      - 'build-*.yaml'
+
+# Explicit deny-all at workflow level; each job grants only what it needs.
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prove:
+    # The reader that decides whether an asset is installable at all, handed every answer it refuses,
+    # one triple of files at a time. It downloads nothing and starts no server, so it answers in
+    # seconds and it answers on a machine with no network.
+    name: the released-package reader refuses what it says it refuses
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Every answer the reader refuses, refused for its own reason
+        run: |
+          set -euo pipefail
+          ./scripts/prove-released-install-refusals.sh
+
+  install:
+    name: the published release loads on a server of its line
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Take the newest release of every claimed line, install it, and read the server back
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          # The tag names the line since #110: `X.Y.Z.W-stable` is the line build.yaml carries and
+          # `X.Y.Z.W-<line>-stable` is build-<line>.yaml. The newest tag per line is asked of the
+          # tracker rather than derived from a list here, and `gh release list` answers newest first.
+          gh release list --repo "${GITHUB_REPOSITORY}" --limit 200 \
+            --json tagName --jq '.[].tagName' > "${RUNNER_TEMP}/releases.txt"
+          echo "releases:"
+          cat "${RUNNER_TEMP}/releases.txt"
+
+          covered=0
+          port=18096
+
+          for packaging in build.yaml build-*.yaml; do
+            [ -f "${packaging}" ] || continue
+            abi=$(sed -n 's/^targetAbi: *"\([^"]*\)".*/\1/p' "${packaging}" | head -1)
+            case "${packaging}" in
+              build.yaml)
+                suffix=""
+                named="the line build.yaml names"
+                ;;
+              *)
+                line=${packaging#build-}
+                line=${line%.yaml}
+                suffix="-${line}"
+                named="the ${line} line"
+                ;;
+            esac
+
+            tag=$(grep -E "^[0-9]+(\.[0-9]+)+${suffix}-stable$" "${RUNNER_TEMP}/releases.txt" | head -1 || true)
+            if [ -z "${tag}" ]; then
+              # SILENT ABOUT THE LINE RATHER THAN GREEN ABOUT IT. A claimed line with nothing
+              # published cannot fail an install, so there is nothing here to refuse; saying so is
+              # the difference between a run that covered the line and one that had nothing to cover.
+              echo "note: ${named} (targetAbi ${abi}) has no release, so no install was attempted for it."
+              continue
+            fi
+
+            echo "::group::${named}: ${tag}"
+            assets="${RUNNER_TEMP}/assets-${tag}"
+            rm -rf "${assets}"
+            mkdir -p "${assets}"
+            gh release download "${tag}" --repo "${GITHUB_REPOSITORY}" --dir "${assets}" \
+              --pattern '*.zip' --pattern '*.sha256' --pattern '*.zip.meta.json'
+            ls -1 "${assets}"
+
+            archive=$(ls -1 "${assets}"/*.zip | head -1)
+            ./scripts/check-released-package.sh \
+              "${archive}" "${archive%.zip}.sha256" "${archive}.meta.json" "${assets}/answers"
+            cat "${assets}/answers"
+            # Written by the reader above out of the release's own metadata and this repository's
+            # packaging files. Nothing here re-derives them, so there is one derivation and not two.
+            # shellcheck disable=SC1090
+            . "${assets}/answers"
+
+            staged="${assets}/unpacked"
+            rm -rf "${staged}"
+            mkdir -p "${staged}"
+            unzip -o "${archive}" -d "${staged}"
+            ls -1 "${staged}"
+
+            image=$(./scripts/server-image-for.sh "${framework}")
+            # The version the server must report is the release's, not this tree's: the archive was
+            # built by a publish that may be several versions behind the working branch.
+            PLUGIN_FROM_DIRECTORY="${staged}" EXPECTED_PLUGIN_VERSION="${version}" \
+              ./scripts/verify-plugin-loads.sh "${image}" "${framework}" "${port}"
+            echo "::endgroup::"
+
+            covered=$((covered + 1))
+            port=$((port + 1))
+          done
+
+          # A run that installed nothing is not a run in which everything installed. The releases
+          # exist or they do not, and either way the last line says which of the two happened.
+          if [ "${covered}" -eq 0 ]; then
+            echo "::error::No claimed line has a release, so nothing was installed. This job did not find a problem; it had nothing to look at."
+            exit 1
+          fi
+          echo "${covered} claimed line(s) had a release, and the published asset of each loaded on a server of its line."

--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -423,6 +423,7 @@ longer tracks it.
 | `full-disk.yaml`          | adopted, landed   | What a caller sees when the volume the store writes to runs out of room, on a mount with a hard size, on the runtime of each line. The suite cannot ask it: filling a filesystem needs one to fill, and the headless rule refuses a test that needs a container engine. #46.                                                                                                                                                                                                               |
 | `manifest.yaml`           | adopted, landed   | The manifest generator watched refusing what it says it refuses, over one manifest per defect, with a clean pair of packages beside them. A generator that has never said no writes a manifest for a clean pair, which is also what a generator with no rules does. #110.                                                                                                                                                                                                                  |
 | `manifest-freshness.yaml` | adopted, landed   | The document a server fetches, read back against the releases that exist, once a day and on its own files. It is not the publish checking itself: the incident behind #111 is a publish whose manifest write failed while the run stayed green, so the step that failed would have been the step reporting it. A claimed line with no release is reported rather than passed over. It raises nothing an operator sees, which is #111's third condition and waits on the fleet sweep. #111. |
+| `release-install.yaml`    | adopted, landed   | The archive a published release attaches, downloaded, checked against the digest published beside it, and installed on a server of the line its own metadata names. `package.yaml` installs the package the run just built, so a publish that attached the wrong bytes passes it, and `manifest-freshness.yaml` hashes no archive and installs nothing. A claimed line with no release is reported rather than passed over. #152.                                                          |
 | `changelog.yaml`          | declined, deleted | It drafts a release changelog against a version scheme this repository has not fixed, and nothing covers that risk here because there is nothing to release yet; #107.                                                                                                                                                                                                                                                                                                                     |
 | `command-dispatch.yaml`   | declined, deleted | It turns issue comments into workflow runs, which is a surface this repository does not use, and nothing here needs covering because nothing depends on it.                                                                                                                                                                                                                                                                                                                                |
 | `command-rebase.yaml`     | declined, deleted | Same comment-driven surface, the half that rewrites pull request branches on command, and the same absence.                                                                                                                                                                                                                                                                                                                                                                                |
@@ -737,6 +738,7 @@ arrived after that head, so their green runs are their own and carry their own h
 | `sibling-set.yaml`            | 32624752477, `surface/66-a-view-of-your-own-requests`, both lines red at `Alone, then with the set`, on the alone half rather than the collision half | 32603611260               |
 | `user-isolation.yaml`         | 32560880189, `proof/67-the-queue-is-not-closed-to-everybody`, both lines red at the queue step                                                        | 32603611273               |
 | `manifest-freshness.yaml`     | none of this kind, below                                                                                                                              | 33246667212, at `12182bf` |
+| `release-install.yaml`        | none of this kind, below                                                                                                                              | pending, below            |
 | `full-disk.yaml`              | 32623464033, `throwaway/46-a-mount-nobody-limited`, both lines red at `Does a full disk reach the caller` with nothing measured                       | 32623457801, at `d154ab3` |
 
 The job and step of each red run are read off the run rather than off a log:
@@ -758,6 +760,17 @@ every answer it refuses over files rather than over a fetch, and which has itsel
 failing: with the reader replaced by a script that exits zero it reports `12 of the rules above did
 not bite` and reds. The green cell is the first run of it on the mainline, which fetched the live
 document and compared it rather than only proving the reader.
+
+**`release-install.yaml` has the same shape and the same two reasons.** Its `install` job reds when
+an asset a release has already published does not install, and a release is immutable, so arranging
+that on purpose means publishing a broken release to everybody who has added this repository and
+being unable to take it back. There is no red run of the kind that column holds and there is not
+going to be one. What stands in its place is its `prove` job, which hands
+`scripts/check-released-package.sh` every answer it refuses over files rather than over a download,
+and which has itself been watched failing: with the reader replaced by a script that exits zero it
+reports `11 of the rules above did not bite` and reds. The green cell is filled by the first run of
+the `install` job, which downloads the newest release of every claimed line that has one and installs
+it, rather than by a run that only proved the reader.
 
 ### The two cells that were wrong
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -398,6 +398,16 @@ The plugin is copied into the container after the server has started, because `/
 and a copy made before that lands where the running server never looks. The server is then
 restarted, because plugins are read at start.
 
+**What it installs is decided by the caller, and there are three callers.** Handed nothing, it
+publishes the project and installs the assembly, which is the run recorded below.
+`.github/workflows/package.yaml` names `PLUGIN_FROM_DIRECTORY` and installs the package that run
+just built, so the bytes an artifact list actually produces are the ones under test.
+`.github/workflows/release-install.yaml` names it too, and what it points at is a package downloaded
+from a published release, checked against the digest published beside it by
+`scripts/check-released-package.sh` first. That third one also names `EXPECTED_PLUGIN_VERSION`,
+because the version a months-old release reports is not the version this tree holds and comparing it
+against the tree would red a check for a disagreement it is not about.
+
 ### The recorded run
 
 Run on `e574918775c69640139ee1ecc1f2202efeff27aa`, 2026-08-06, against these images:

--- a/scripts/check-manifest-is-fresh.sh
+++ b/scripts/check-manifest-is-fresh.sh
@@ -24,7 +24,7 @@
 # WHAT IT DOES NOT DO. It does not install anything and it does not hash an archive. Whether the
 # bytes behind an entry are the bytes the entry promises is the manifest generator's own rule, proven
 # in `scripts/prove-manifest-refusals.sh`, and whether a released asset installs into a server is
-# #152 and is not measured anywhere yet.
+# `scripts/check-released-package.sh` and the workflow that runs it, which arrived for #152.
 #
 # usage: scripts/check-manifest-is-fresh.sh <manifest-json> <releases-file>
 #   the releases file holds one release tag per line, in any order - the shape

--- a/scripts/check-released-package.sh
+++ b/scripts/check-released-package.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Is a published release asset a thing a server of a claimed line could install, and which line is
+# it for?
+#
+# WHY THIS EXISTS. `scripts/check-manifest-is-fresh.sh` reads the document a server fetches against
+# the releases that exist, and says of itself that it does not hash an archive and does not install
+# anything. `.github/workflows/package.yaml` installs a package on a server, but the package it
+# installs is the one the run just built, which is not the one an operator downloads. Between the
+# two sits the thing #152's last condition is about: the bytes that are actually published. This is
+# the reader for those, and the install itself is the step after it.
+#
+# IT TAKES ITS INPUTS AS FILES AND REACHES NO NETWORK. The download is the workflow's, so every
+# answer this can give is one `scripts/prove-released-install-refusals.sh` hands it directly, with no
+# release and no network. A reader nobody has watched saying no is a reader that might say yes to
+# everything, and this one is green for as long as nothing goes wrong with a publish - which is the
+# situation the incident behind #111 arose in.
+#
+# WHAT IT DECIDES, IN ORDER:
+#
+#   * the three files it was handed exist
+#   * the archive is an archive a server could unpack
+#   * the archive's digest is the digest the release published beside it
+#   * the release metadata names a version
+#   * the release metadata names a targetAbi some packaging file at the root claims
+#
+# THE LINE IS DERIVED AND NEVER WRITTEN HERE. The published metadata names a `targetAbi` and no
+# framework, so the framework comes from the packaging file at the root that claims that `targetAbi`.
+# That is the same derivation `check-manifest-is-fresh.sh` makes for the same reason: adding a line
+# is adding a packaging file, and a list in this script would be the copy that disagrees first.
+#
+# WHAT IT DOES NOT DO. It does not start a server and it does not fetch anything. Whether the plugin
+# loads is `scripts/verify-plugin-loads.sh`, which this answers the arguments for.
+#
+# usage: scripts/check-released-package.sh <archive> <checksum-file> <metadata-file> <answers-file>
+#   the checksum file is the `.sha256` sidecar the publish attaches, in `sha256sum` shape
+#   the metadata file is the `.zip.meta.json` sidecar the publish attaches
+#   the answers file is written, not read: `version=`, `targetAbi=` and `framework=`, one per line
+
+set -euo pipefail
+
+archive=${1:?path to the released archive}
+checksum=${2:?path to the .sha256 the release published beside it}
+metadata=${3:?path to the .zip.meta.json the release published beside it}
+answers=${4:?path to write the answers to}
+
+here=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+root=$(cd "$here/.." && pwd)
+
+for f in "$archive" "$checksum" "$metadata"; do
+    if [ ! -f "$f" ]; then
+        echo "check-released-package: ${f} does not exist. This reads what a download actually returned, never what it was expected to return." >&2
+        exit 1
+    fi
+done
+
+# AN ASSET THAT IS NOT AN ARCHIVE FAILS SEVERAL STEPS LATER AND ABOUT SOMETHING ELSE. A publish that
+# attached an error page, a truncated upload, or a file that was never zipped all reach a server as
+# an install that does not happen, and the server's own message for it is not about the release.
+if ! unzip -t "$archive" >/dev/null 2>&1; then
+    echo "check-released-package: ${archive} is not an archive that unpacks. A server handed this asset cannot install it, whatever the manifest says about it." >&2
+    exit 1
+fi
+
+# THE DIGEST IS COMPARED RATHER THAN RECOMPUTED INTO THE ANSWER. What the sidecar promises and what
+# the archive is are two published facts, and a release where they disagree is one an operator
+# checking the download would reject. The sidecar is `sha256sum` output, so the name in it is the
+# name the publish gave the file; the archive is compared by its bytes rather than by that name,
+# because a download saved under another name is still the same asset.
+published_digest=$(awk 'NR == 1 { print $1 }' "$checksum" | tr -d '\r')
+if [ -z "$published_digest" ]; then
+    echo "check-released-package: ${checksum} carries no digest on its first line, so there is nothing the archive can be compared against." >&2
+    exit 1
+fi
+actual_digest=$(sha256sum "$archive" | awk '{ print $1 }')
+if [ "$actual_digest" != "$published_digest" ]; then
+    echo "check-released-package: ${archive} hashes to ${actual_digest} and the release publishes ${published_digest} beside it. An operator who checks the download rejects it, and one who does not installs bytes nobody attested." >&2
+    exit 1
+fi
+
+version=$(jq -r '.version // empty' "$metadata" | tr -d '\r')
+if [ -z "$version" ]; then
+    echo "check-released-package: ${metadata} names no version. A catalogue entry with no version is one a server cannot order against what it already has." >&2
+    exit 1
+fi
+
+abi=$(jq -r '.targetAbi // empty' "$metadata" | tr -d '\r')
+if [ -z "$abi" ]; then
+    echo "check-released-package: ${metadata} names no targetAbi, so the server line this package was built for cannot be told from any other and there is no floor to install it at." >&2
+    exit 1
+fi
+
+# Every line this repository claims, derived from the packaging files rather than listed here.
+framework=""
+claimed=""
+for packaging in "$root"/build.yaml "$root"/build-*.yaml; do
+    [ -f "$packaging" ] || continue
+    packaged_abi=$(sed -n 's/^targetAbi: *"\([^"]*\)".*/\1/p' "$packaging" | head -1)
+    packaged_framework=$(sed -n 's/^framework: *"\([^"]*\)".*/\1/p' "$packaging" | head -1)
+    [ -n "$packaged_abi" ] || continue
+    claimed="${claimed}${claimed:+, }${packaged_abi}"
+    if [ "$packaged_abi" = "$abi" ]; then
+        framework=$packaged_framework
+    fi
+done
+
+if [ -z "$framework" ]; then
+    echo "check-released-package: the release names targetAbi ${abi} and no packaging file at the root claims it. The lines this repository claims today are ${claimed:-none}. Either a release went out for a line that was dropped, or the packaging file was removed while its releases still stand." >&2
+    exit 1
+fi
+
+{
+    printf 'version=%s\n' "$version"
+    printf 'targetAbi=%s\n' "$abi"
+    printf 'framework=%s\n' "$framework"
+} > "$answers"
+
+echo "$(basename "$archive") unpacks, hashes to the digest published beside it, and names version ${version} at targetAbi ${abi}, which is the line ${framework} packages for."

--- a/scripts/prove-released-install-refusals.sh
+++ b/scripts/prove-released-install-refusals.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# Every refusal `scripts/check-released-package.sh` claims, watched refusing once, over archives and
+# sidecars written here to carry the answer each one names.
+#
+# The reader it proves runs against what a publish actually attached to a release, which is a thing
+# nobody can produce on demand and which is green for as long as nothing goes wrong with a publish.
+# A reader that had never said no would look exactly like one that says yes to everything, for
+# exactly as long as that lasts.
+#
+# It takes its inputs as files, so every answer is handed to it directly here: no network, no
+# release, and no server.
+#
+# THE ONE IT EXISTS FOR IS THE THIRD CASE. An archive that unpacks, beside a sidecar promising a
+# different digest, is a release where the attestation and the bytes disagree - and an operator who
+# checks the download is the only party who finds out, because everything else about such a release
+# reads as correct.
+#
+# usage: scripts/prove-released-install-refusals.sh
+
+set -euo pipefail
+
+here=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+root=$(cd "$here/.." && pwd)
+reader="$here/check-released-package.sh"
+
+cd "$root"
+
+# The line this repository claims under build.yaml, read rather than written, so a fixture that
+# should be accepted stays accepted on the day a floor moves.
+base_abi=$(sed -n 's/^targetAbi: *"\([^"]*\)".*/\1/p' build.yaml | head -1)
+base_framework=$(sed -n 's/^framework: *"\([^"]*\)".*/\1/p' build.yaml | head -1)
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# An archive a server could unpack, built rather than committed: what matters about it is that it is
+# a real zip, and a committed one would be bytes nobody can see the shape of in a review.
+archive() {
+    python3 - "$work/$1" <<'PY'
+import sys, zipfile
+with zipfile.ZipFile(sys.argv[1], "w") as bundle:
+    bundle.writestr("Jellyfin.Plugin.Requests.dll", "not an assembly, and nothing here loads it")
+    bundle.writestr("meta.json", "{}")
+PY
+}
+
+# usage: sidecar <file> <archive-it-names>
+sidecar() {
+    sha256sum "$work/$2" | sed "s@$work/@@" > "$work/$1"
+}
+
+# usage: metadata <file> <json>
+metadata() {
+    printf '%s\n' "$2" > "$work/$1"
+}
+
+failures=0
+
+# usage: refuses <heading> <sentence the refusal must carry> -- <command...>
+refuses() {
+    local heading=$1 sentence=$2
+    shift 3
+    printf '\n== %s\n' "$heading"
+    local out status
+    set +e
+    out=$("$@" 2>&1)
+    status=$?
+    set -e
+    printf '%s\n' "$out" | sed 's/^/  /'
+    if [ "$status" -eq 0 ]; then
+        echo "  ACCEPTED it, so the rule does not bite."
+        failures=$((failures + 1))
+        return
+    fi
+    case "$out" in
+        *"$sentence"*) ;;
+        *)
+            echo "  refused, but for something other than: $sentence"
+            failures=$((failures + 1))
+            ;;
+    esac
+}
+
+# usage: accepts <heading> <sentence the pass must carry> -- <command...>
+accepts() {
+    local heading=$1 sentence=$2
+    shift 3
+    printf '\n== %s\n' "$heading"
+    local out status
+    set +e
+    out=$("$@" 2>&1)
+    status=$?
+    set -e
+    printf '%s\n' "$out" | sed 's/^/  /'
+    if [ "$status" -ne 0 ]; then
+        echo "  REFUSED it, which is a reader that refuses everything."
+        failures=$((failures + 1))
+        return
+    fi
+    case "$out" in
+        *"$sentence"*) ;;
+        *)
+            echo "  accepted, but said nothing about: $sentence"
+            failures=$((failures + 1))
+            ;;
+    esac
+}
+
+archive good.zip
+sidecar good.sha256 good.zip
+metadata good.json "{\"version\":\"1.2.3.4\",\"targetAbi\":\"${base_abi}\"}"
+
+accepts "the shape a publish attaches is read and answers which line it is for" \
+    "which is the line ${base_framework} packages for" \
+    -- "$reader" "$work/good.zip" "$work/good.sha256" "$work/good.json" "$work/answers.txt"
+
+# The answers are what the install step is handed, so a reader that passed and wrote nothing usable
+# would leave the step after it installing at a floor nobody derived.
+printf '\n== what the accepted run wrote for the step after it\n'
+if [ ! -f "$work/answers.txt" ]; then
+    echo "  it wrote no answers file at all, so the step after it has no floor to install at."
+    failures=$((failures + 1))
+else
+    sed 's/^/  /' "$work/answers.txt"
+    for expected in "version=1.2.3.4" "targetAbi=${base_abi}" "framework=${base_framework}"; do
+        if ! grep -qxF "$expected" "$work/answers.txt"; then
+            echo "  the answers file does not carry ${expected}."
+            failures=$((failures + 1))
+        fi
+    done
+fi
+
+# The trap. The bytes and the attestation published beside them disagree, and nothing else about the
+# release looks wrong.
+metadata other.json "{\"version\":\"1.2.3.4\",\"targetAbi\":\"${base_abi}\"}"
+printf '%s  good.zip\n' "0000000000000000000000000000000000000000000000000000000000000000" > "$work/wrong.sha256"
+refuses "the archive is not what the release publishes a digest for" \
+    "and the release publishes 0000000000000000000000000000000000000000000000000000000000000000 beside it" \
+    -- "$reader" "$work/good.zip" "$work/wrong.sha256" "$work/other.json" "$work/answers.txt"
+
+printf 'not a zip, and no server unpacks it\n' > "$work/plain.zip"
+sidecar plain.sha256 plain.zip
+refuses "the asset attached is not an archive at all" \
+    "is not an archive that unpacks" \
+    -- "$reader" "$work/plain.zip" "$work/plain.sha256" "$work/good.json" "$work/answers.txt"
+
+metadata no-abi.json '{"version":"1.2.3.4"}'
+refuses "the release metadata names no server line" \
+    "names no targetAbi" \
+    -- "$reader" "$work/good.zip" "$work/good.sha256" "$work/no-abi.json" "$work/answers.txt"
+
+metadata unclaimed.json '{"version":"1.2.3.4","targetAbi":"99.9.9.9"}'
+refuses "the release names a line no packaging file at the root claims" \
+    "no packaging file at the root claims it" \
+    -- "$reader" "$work/good.zip" "$work/good.sha256" "$work/unclaimed.json" "$work/answers.txt"
+
+metadata no-version.json "{\"targetAbi\":\"${base_abi}\"}"
+refuses "the release metadata names no version" \
+    "names no version" \
+    -- "$reader" "$work/good.zip" "$work/good.sha256" "$work/no-version.json" "$work/answers.txt"
+
+printf '' > "$work/empty.sha256"
+refuses "the sidecar carries no digest to compare against" \
+    "carries no digest on its first line" \
+    -- "$reader" "$work/good.zip" "$work/empty.sha256" "$work/good.json" "$work/answers.txt"
+
+refuses "the archive was never downloaded" \
+    "does not exist" \
+    -- "$reader" "$work/no-such.zip" "$work/good.sha256" "$work/good.json" "$work/answers.txt"
+
+refuses "the sidecar was never downloaded" \
+    "does not exist" \
+    -- "$reader" "$work/good.zip" "$work/no-such.sha256" "$work/good.json" "$work/answers.txt"
+
+refuses "the metadata was never downloaded" \
+    "does not exist" \
+    -- "$reader" "$work/good.zip" "$work/good.sha256" "$work/no-such.json" "$work/answers.txt"
+
+printf '\n'
+if [ "$failures" -ne 0 ]; then
+    echo "$failures of the rules above did not bite." >&2
+    exit 1
+fi
+echo "Every refusal the released-package reader claims was watched refusing, and the shape a publish attaches passes."

--- a/scripts/server-under-test.sh
+++ b/scripts/server-under-test.sh
@@ -17,6 +17,9 @@
 # built by the gate is put on a server: the bytes a person would install are the ones under test,
 # and a publish is a different set of files from a package.
 #
+# `EXPECTED_PLUGIN_VERSION` names the version the server must report, for a caller installing bytes
+# this tree did not build. Unset, the number comes from `Directory.Build.props` as it always did.
+#
 # What a caller gets, after `server_start`:
 #
 #   $BASE       the address to call, on the loopback interface
@@ -209,8 +212,18 @@ for plugin in json.load(sys.stdin):
     # The number is read out of the one place that holds it rather than written here, so this adds no
     # copy of it. Exactly one value, or the test below ends the run: two would make which one is
     # meant a guess, and none would compare against the empty string and pass on any server at all.
+    #
+    # A CALLER INSTALLING SOMETHING OTHER THAN THIS TREE NAMES THE NUMBER, and the released-package
+    # check is the caller that has to. What it installs is an archive a publish attached months ago,
+    # so the tree's own version is the wrong thing to compare it against: the first version bump
+    # after a release would redden that check for a disagreement it is not about. Every other caller
+    # passes nothing and gets the reading it had before.
     local expected_version
-    expected_version=$(grep -o '<PluginVersion>[^<]*' "$repo_root/Directory.Build.props" | cut -d'>' -f2)
+    if [ -n "${EXPECTED_PLUGIN_VERSION:-}" ]; then
+        expected_version=$EXPECTED_PLUGIN_VERSION
+    else
+        expected_version=$(grep -o '<PluginVersion>[^<]*' "$repo_root/Directory.Build.props" | cut -d'>' -f2)
+    fi
     test "$(printf '%s' "$expected_version" | grep -c '^')" = "1"
 
     PLUGIN_ID=$(printf '%s' "$plugins" | python3 -c '


### PR DESCRIPTION
Part of #152, and the half of its done-when that no reading of this board could ever meet: no run recorded here had installed a published asset.

## What was missing, and why the two neighbouring routes do not cover it

`.github/workflows/package.yaml` installs a package on a server of its line - but the package is the one that run just built. A publish that attached the wrong bytes, or attached them beside a digest they do not match, passes it.

`.github/workflows/manifest-freshness.yaml` reads the document a server fetches against the releases that exist, and says so about itself in its own comment:

    $ git grep -n 'It does not install anything and it does not hash an archive' origin/master -- scripts/check-manifest-is-fresh.sh
    origin/master:scripts/check-manifest-is-fresh.sh:24:# WHAT IT DOES NOT DO. It does not install anything and it does not hash an archive. Whether the

That comment ended with "whether a released asset installs into a server is #152 and is not measured anywhere yet". It now points at the reader this change adds, because the sentence stopped being true.

## What this adds

**`scripts/check-released-package.sh`** reads the three files a publish attaches - the archive, the `.sha256` and the `.zip.meta.json` - and answers which line the release is for. It refuses five things, each a real state a publish can leave behind:

| Refusal | The failure it prevents |
| --- | --- |
| the asset does not unpack | an error page, a truncated upload or a file that was never zipped reaches a server as an install that does not happen, and the server's message for it is not about the release |
| the archive's digest is not the one published beside it | an operator who checks the download rejects it, and one who does not installs bytes nobody attested |
| the metadata names no version | a catalogue entry a server cannot order against what it already has |
| the metadata names no targetAbi | the line the package was built for cannot be told from any other, so there is no floor to install it at |
| the metadata names a targetAbi no packaging file at the root claims | a release went out for a line that was dropped, or the packaging file was removed while its releases still stand |

It reaches no network and takes its inputs as files, which is what makes the proof below possible.

**`scripts/prove-released-install-refusals.sh`** hands it each of those directly, plus the shape a publish actually attaches, plus the check that an accepted run writes the answers the install step is handed. It needs no release, no download and no server.

**`.github/workflows/release-install.yaml`** takes the newest release of every claimed line, downloads it, hands it to the reader, and installs the unpacked bytes on a server of the line the release's own metadata names. A claimed line with no release is reported rather than passed over, and a run that installed nothing at all ends non-zero, because a run with nothing to cover must not read afterwards as one that covered it.

**`scripts/server-under-test.sh`** gains `EXPECTED_PLUGIN_VERSION`. The version a months-old release reports is not the version this tree holds, and comparing it against `Directory.Build.props` would red this check for a disagreement it is not about. Unset, every other caller gets the reading it had before.

## The guard was watched failing

The reader replaced by a script that exits zero, on this machine, at the head being pushed:

    $ printf '#!/usr/bin/env bash\nexit 0\n' > scripts/check-released-package.sh
    $ ./scripts/prove-released-install-refusals.sh
    ...
    == the metadata was never downloaded

      ACCEPTED it, so the rule does not bite.

    11 of the rules above did not bite.
    rc=1

and restored:

    $ ./scripts/prove-released-install-refusals.sh | tail -1
    Every refusal the released-package reader claims was watched refusing, and the shape a publish attaches passes.

The reader was also run against what is actually published today, rather than only against fixtures:

    $ gh release download 0.2.0.0-stable --repo Flowfin/jellyfin-plugin-requests
    $ ./scripts/check-released-package.sh requests_0.2.0.0.zip requests_0.2.0.0.sha256 \
        requests_0.2.0.0.zip.meta.json ./answers
    requests_0.2.0.0.zip unpacks, hashes to the digest published beside it, and names version 0.2.0.0 at targetAbi 10.11.0.0, which is the line net9.0 packages for.

## Evidence

    $ dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    0 Warnung(en)
    0 Fehler

    $ dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler:     0, erfolgreich:   777, gesamt:   777  (net9.0)
    Bestanden!   : Fehler:     0, erfolgreich:   777, gesamt:   777  (net10.0)

The formatting gate reads LF and this checkout is CRLF, so the two changed markdown files were checked as LF copies made inside the tree:

    $ npx --yes prettier@3.6.2 --check ".lfcheck/**/*.md"
    All matched files use Prettier code style!

## What this does NOT claim

**Nothing was installed on this machine.** The container engine is not running here, so the install step has never been executed locally. Its first execution is the `install` job of this pull request, and until that job is green this change is a check nobody has watched pass.

**It does not install the way a server installs.** A server fetches the archive named in a manifest and unpacks it itself; this puts the unpacked bytes into the plugin directory, which is what every container check in this repository does. It answers whether the published bytes are a plugin that loads, and not whether the server's own download-and-unpack path works on them. The workflow says so in its own header.

**It covers one claimed line of two.** The 12.0 line has no release, so the run reports it and installs nothing for it. That is the same bound `check-manifest-is-fresh.sh` prints for the same reason.

**It raises nothing an operator sees.** A failed scheduled run sits in a run list. That is the same bound `manifest-freshness.yaml` names for itself, and #111's third condition is where it is answered.

**The green cell in `docs/quality-parity.md` is `pending, below` and is filled by the first green `install` run**, not by this pull request being merged.

## Means

Bash and a workflow, which is what every other container check on this board is made of: the thing under test is a server in a container reached over HTTP, and `scripts/server-under-test.sh` already carries the procedure. Adding a language for this would be a second apparatus beside the one that exists.

## Review

There is no second reader on this board tonight. The evidence above stands in place of one.
