### PR TITLE
Say that a published release has now been installed, in the five files that said it had not

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,13 @@ server on the 12.0 line is offered the `net9.0` build rather than nothing. That
 comparison is read at the server's own source rather than assumed, on the same
 page.
 
-**The packaged install path has not been tried on any server, on either line.**
-What every recorded run installs is the built assembly copied in, not a package a
-server fetched and unpacked.
+**A published release has been installed on a server once, on the 10.11 line
+only.** Run `33357925338`, at `501a943`, downloaded `requests_0.2.0.0.zip`,
+checked it against the digest published beside it, and the server answered that
+the plugin was `Active` at `0.2.0.0`. Three things that leaves untried: the server
+was `10.11.11` rather than the claimed floor `10.11.0`, the bytes were copied into
+the plugin directory rather than fetched and unpacked by the server itself, and
+the 12.0 line has no release for anybody to install.
 
 Nothing here should be pointed at a server you care about.
 

--- a/build-jf12.yaml
+++ b/build-jf12.yaml
@@ -18,7 +18,7 @@ overview: "A user asks the server for a film or a series, an administrator answe
 description: >
   A user who cannot find something asks for it from inside Jellyfin rather than through a message to whoever runs the server. The ask lands in a queue an administrator works through, and the person who asked can see what happened to it.
 
-  This is not finished. A user can ask for a title and follow what happened to their own asks, and an administrator answers them in a queue. There is no gesture that finds a title the server does not have unless a browsing sibling plugin supplies one, and nothing here downloads anything: approving a request moves a record, and whatever the operator already runs is what fetches. The packaged install has not been tried on a server on either claimed line.
+  This is not finished. A user can ask for a title and follow what happened to their own asks, and an administrator answers them in a queue. There is no gesture that finds a title the server does not have unless a browsing sibling plugin supplies one, and nothing here downloads anything: approving a request moves a record, and whatever the operator already runs is what fetches. One published release has been installed on a server of the 10.11 line and answered as active; that is one line of the two, and not at the claimed floor.
 category: "General"
 owner: "Flowfin"
 artifacts:

--- a/build.yaml
+++ b/build.yaml
@@ -13,7 +13,7 @@ overview: "A user asks the server for a film or a series, an administrator answe
 description: >
   A user who cannot find something asks for it from inside Jellyfin rather than through a message to whoever runs the server. The ask lands in a queue an administrator works through, and the person who asked can see what happened to it.
 
-  This is not finished. A user can ask for a title and follow what happened to their own asks, and an administrator answers them in a queue. There is no gesture that finds a title the server does not have unless a browsing sibling plugin supplies one, and nothing here downloads anything: approving a request moves a record, and whatever the operator already runs is what fetches. The packaged install has not been tried on a server on either claimed line.
+  This is not finished. A user can ask for a title and follow what happened to their own asks, and an administrator answers them in a queue. There is no gesture that finds a title the server does not have unless a browsing sibling plugin supplies one, and nothing here downloads anything: approving a request moves a record, and whatever the operator already runs is what fetches. One published release has been installed on a server of the 10.11 line and answered as active; that is one line of the two, and not at the claimed floor.
 category: "General"
 owner: "Flowfin"
 artifacts:

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -92,12 +92,16 @@ files:
 - **The 12.0 evidence is against a release candidate.** The image was `jellyfin/jellyfin:12.0-rc4`
   and the server reported `12.0.0`. Listing 12.0 as supported without saying that would be a
   statement about a server nobody has run this on.
-- **The packaged install path has not been tried for this plugin.** What every run installs is the
-  built assembly copied into the container, not a package fetched and unpacked by the server. Two
-  releases exist, `0.1.0.0-stable` and `0.2.0.0-stable`, and no run recorded in this repository
-  installed from either. The sibling in the set is the other way round: it arrives as its own
-  published package, unpacked whole, so the set half of the run does exercise that path and the half
-  about this plugin does not.
+- **A published release has been installed once, and not the way a server installs.** This bullet
+  said no run recorded here had installed from either release. One has since #152:
+  `.github/workflows/release-install.yaml` downloads the newest release of every claimed line,
+  checks the archive against the digest published beside it, and puts the unpacked bytes on a server
+  of that line. Run `33357925338` at `501a943` did it for `0.2.0.0-stable` on `10.11.11`, and the
+  server answered `Requests is Active at 0.2.0.0`. What that still does not cover: the archive is
+  unpacked by the run rather than fetched and unpacked by the server, the server was not the claimed
+  floor `10.11.0`, and the 12.0 line has no release to install at all. The sibling in the set
+  arrives as its own published package and is unpacked whole, so the set half of the run exercises
+  the server's own path and the half about this plugin still does not.
 - **The supported set is one board, and it is not the one the seam is written against.** A board
   joins the set for a line on the day it publishes a release for that line, and every candidate
   besides `jellyfin-plugin-sso` has published nothing. So a green run says nothing about the sibling

--- a/docs/operating.md
+++ b/docs/operating.md
@@ -5,8 +5,9 @@ queue stops moving. It is written for an operator who has never seen this plugin
 read the rest of `docs/` first.
 
 Read the "This is not finished" section of [../README.md](../README.md) before any of it. Two releases
-exist, both carry the package for one of the two claimed server lines, and the packaged install path
-has not been tried on a server. Nothing below changes that.
+exist, both carry the package for one of the two claimed server lines, and one of them has been
+installed on a server of that line once, not at the claimed floor and not by the server's own
+download. Nothing below changes that.
 
 ## From an installed plugin to a queue
 

--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -738,7 +738,7 @@ arrived after that head, so their green runs are their own and carry their own h
 | `sibling-set.yaml`            | 32624752477, `surface/66-a-view-of-your-own-requests`, both lines red at `Alone, then with the set`, on the alone half rather than the collision half | 32603611260               |
 | `user-isolation.yaml`         | 32560880189, `proof/67-the-queue-is-not-closed-to-everybody`, both lines red at the queue step                                                        | 32603611273               |
 | `manifest-freshness.yaml`     | none of this kind, below                                                                                                                              | 33246667212, at `12182bf` |
-| `release-install.yaml`        | none of this kind, below                                                                                                                              | pending, below            |
+| `release-install.yaml`        | none of this kind, below                                                                                                                              | 33357925338, at `501a943` |
 | `full-disk.yaml`              | 32623464033, `throwaway/46-a-mount-nobody-limited`, both lines red at `Does a full disk reach the caller` with nothing measured                       | 32623457801, at `d154ab3` |
 
 The job and step of each red run are read off the run rather than off a log:
@@ -768,9 +768,11 @@ being unable to take it back. There is no red run of the kind that column holds 
 going to be one. What stands in its place is its `prove` job, which hands
 `scripts/check-released-package.sh` every answer it refuses over files rather than over a download,
 and which has itself been watched failing: with the reader replaced by a script that exits zero it
-reports `11 of the rules above did not bite` and reds. The green cell is filled by the first run of
-the `install` job, which downloads the newest release of every claimed line that has one and installs
-it, rather than by a run that only proved the reader.
+reports `11 of the rules above did not bite` and reds. The green cell is the first run of the
+`install` job on the mainline rather than one that only proved the reader: it downloaded
+`requests_0.2.0.0.zip`, checked it against the digest published beside it, and the server answered
+`Requests is Active at 0.2.0.0`. It covered one claimed line of two, and it says so on its own last
+two lines rather than leaving that to be worked out.
 
 ### The two cells that were wrong
 


### PR DESCRIPTION
Part of #152. The check landed in #344; this is the five files that still say it has not happened.

## What is now true

    $ gh run view 33357925338 --repo Flowfin/jellyfin-plugin-requests --json conclusion,headSha \
        --jq '"conclusion=\(.conclusion) head=\(.headSha)"'
    conclusion=success head=501a94371df653754f1c171ba4e9bc865be107bd

That run downloaded `requests_0.2.0.0.zip`, checked it against the digest published beside it, put the unpacked bytes on `jellyfin/jellyfin:10.11.11`, and read the server back:

    Requests is Active at 0.2.0.0, id 0f9c9107b31b459e81fa6d35dac25e79
    GET /web/ConfigurationPage?name=Requests -> 200
    OpenRequestsPerUser=7 and FinishedRequestRetentionDays=90 read back after the save
    Requests loaded and answered on jellyfin/jellyfin:10.11.11 (net9.0)
    note: the jf12 line (targetAbi 12.0.0.0) has no release, so no install was attempted for it.
    1 claimed line(s) had a release, and the published asset of each loaded on a server of its line.

## The five files

`README.md`, `docs/operating.md`, `docs/compatibility.md`, `build.yaml` and `build-jf12.yaml` each said the packaged install had never been tried. Each now says what happened and, in the same sentence, what it still does not cover:

- the archive is unpacked by the run rather than fetched and unpacked by the server itself
- the server was `10.11.11`, not the claimed floor `10.11.0`
- the 12.0 line has no release, so nothing published exists to install for it

**No disclosure became an assurance.** Every one of the three bounds above is new text; what was removed is only the part that had stopped being true.

`docs/quality-parity.md` fills the green cell that landed as `pending, below` with `33357925338, at 501a943`, and its paragraph now says what that run covered rather than what it would cover.

## A second sentence that was already wrong

`docs/compatibility.md` said "what every run installs is the built assembly copied into the container". That has not been true of the packaging route since 2026-08-21:

    $ git log --format='%h %ad %s' --date=short -1 origin/master -- .github/workflows/package.yaml
    5d86b9c 2026-08-21 Install the package the gate just built on a server of its line

    $ git grep -n 'PLUGIN_FROM_DIRECTORY' origin/master -- .github/workflows/package.yaml
    origin/master:.github/workflows/package.yaml:246:          PLUGIN_FROM_DIRECTORY="${staged}" ./scripts/verify-plugin-loads.sh "${image}" "${FRAMEWORK}" 18096

It understated what was covered, which is the milder direction, and it is corrected here rather than left because the bullet it sits in is the one a reader uses to decide what has been tried. Found by reading the page against the tree while writing this change, not by anything failing.

## Evidence

    $ dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler:     0, erfolgreich:   777, gesamt:   777  (net9.0)
    Bestanden!   : Fehler:     0, erfolgreich:   777, gesamt:   777  (net10.0)

    $ npx --yes prettier@3.6.2 --check ".lfcheck/**/*.md"
    All matched files use Prettier code style!

The markdown was checked as LF copies made inside the tree, because this checkout is CRLF and the gate reads LF.

## What this does NOT claim

**Nothing was run on a server by this change.** It quotes the run that #344's check made and changes no code. **Nothing was installed on this machine**; the container engine is not running here.

## Means

Prose in files that already exist, in the formats the gates on this board already read.

## Review

There is no second reader on this board tonight. The run quoted above is public and its log is the evidence in place of one.
