### PR TITLE
Say that the floor server refuses the published release, where somebody deciding to install reads it

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,20 @@ page.
 **A published release has been installed on a server once, on the 10.11 line
 only.** Run `33357925338`, at `501a943`, downloaded `requests_0.2.0.0.zip`,
 checked it against the digest published beside it, and the server answered that
-the plugin was `Active` at `0.2.0.0`. Three things that leaves untried: the server
-was `10.11.11` rather than the claimed floor `10.11.0`, the bytes were copied into
-the plugin directory rather than fetched and unpacked by the server itself, and
-the 12.0 line has no release for anybody to install.
+the plugin was `Active` at `0.2.0.0`. The server was `10.11.11`.
+
+**On the floor server it claims, the same release does not load.** `build.yaml`
+says `targetAbi: "10.11.0.0"`, which names the server `10.11.0`, and putting
+`requests_0.2.0.0.zip` on that server reports
+`Requests is NotSupported rather than Active` - run `33358848505`. Jellyfin sets
+that status in one place, on a failure to load the assembly's types, so the
+published build references something that server's shared libraries do not carry.
+Which of the two moves, the claimed floor or the reference, is #152. **Do not
+install this on a `10.11.0` server: it will not run.**
+
+Two further things neither run covers: the bytes are copied into the plugin
+directory rather than fetched and unpacked by the server itself, and the 12.0
+line has no release for anybody to install.
 
 Nothing here should be pointed at a server you care about.
 

--- a/build-jf12.yaml
+++ b/build-jf12.yaml
@@ -18,7 +18,7 @@ overview: "A user asks the server for a film or a series, an administrator answe
 description: >
   A user who cannot find something asks for it from inside Jellyfin rather than through a message to whoever runs the server. The ask lands in a queue an administrator works through, and the person who asked can see what happened to it.
 
-  This is not finished. A user can ask for a title and follow what happened to their own asks, and an administrator answers them in a queue. There is no gesture that finds a title the server does not have unless a browsing sibling plugin supplies one, and nothing here downloads anything: approving a request moves a record, and whatever the operator already runs is what fetches. One published release has been installed on a server of the 10.11 line and answered as active; that is one line of the two, and not at the claimed floor.
+  This is not finished. A user can ask for a title and follow what happened to their own asks, and an administrator answers them in a queue. There is no gesture that finds a title the server does not have unless a browsing sibling plugin supplies one, and nothing here downloads anything: approving a request moves a record, and whatever the operator already runs is what fetches. One published release has been installed on a 10.11.11 server and answered as active. On 10.11.0, the floor this package declares, the same release does not load at all: the server reports it as not supported. Do not install this on a 10.11.0 server.
 category: "General"
 owner: "Flowfin"
 artifacts:

--- a/build.yaml
+++ b/build.yaml
@@ -13,7 +13,7 @@ overview: "A user asks the server for a film or a series, an administrator answe
 description: >
   A user who cannot find something asks for it from inside Jellyfin rather than through a message to whoever runs the server. The ask lands in a queue an administrator works through, and the person who asked can see what happened to it.
 
-  This is not finished. A user can ask for a title and follow what happened to their own asks, and an administrator answers them in a queue. There is no gesture that finds a title the server does not have unless a browsing sibling plugin supplies one, and nothing here downloads anything: approving a request moves a record, and whatever the operator already runs is what fetches. One published release has been installed on a server of the 10.11 line and answered as active; that is one line of the two, and not at the claimed floor.
+  This is not finished. A user can ask for a title and follow what happened to their own asks, and an administrator answers them in a queue. There is no gesture that finds a title the server does not have unless a browsing sibling plugin supplies one, and nothing here downloads anything: approving a request moves a record, and whatever the operator already runs is what fetches. One published release has been installed on a 10.11.11 server and answered as active. On 10.11.0, the floor this package declares, the same release does not load at all: the server reports it as not supported. Do not install this on a 10.11.0 server.
 category: "General"
 owner: "Flowfin"
 artifacts:

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -98,10 +98,21 @@ files:
   checks the archive against the digest published beside it, and puts the unpacked bytes on a server
   of that line. Run `33357925338` at `501a943` did it for `0.2.0.0-stable` on `10.11.11`, and the
   server answered `Requests is Active at 0.2.0.0`. What that still does not cover: the archive is
-  unpacked by the run rather than fetched and unpacked by the server, the server was not the claimed
-  floor `10.11.0`, and the 12.0 line has no release to install at all. The sibling in the set
-  arrives as its own published package and is unpacked whole, so the set half of the run exercises
-  the server's own path and the half about this plugin still does not.
+  unpacked by the run rather than fetched and unpacked by the server, and the 12.0 line has no
+  release to install at all. The sibling in the set arrives as its own published package and is
+  unpacked whole, so the set half of the run exercises the server's own path and the half about this
+  plugin still does not.
+- **The floor server of the 10.11 line refuses the published release, and this is the bullet above
+  it read against the claim.** `build.yaml` declares `targetAbi: "10.11.0.0"`, which names the
+  server `10.11.0`. The same archive on that server ends the run at its verdict step with
+  `Requests is NotSupported rather than Active`, in run `33358848505`. Jellyfin sets that status in
+  exactly one place, catching a `TypeLoadException` or a `ReflectionTypeLoadException` while loading
+  the assembly's types, so the shipped build references something `10.11.0`'s shared libraries do
+  not carry. **The floor build does not cover this and the two are easy to read as one guard.**
+  `abi-floor.yaml` compiles the SOURCE against the floor SDK and was green on the same day; what
+  ships is compiled against the current SDK, so a green floor build says the source could be built
+  against the floor and nothing about the artefact that went out. #152 holds which of the two
+  moves.
 - **The supported set is one board, and it is not the one the seam is written against.** A board
   joins the set for a line on the day it publishes a release for that line, and every candidate
   besides `jellyfin-plugin-sso` has published nothing. So a green run says nothing about the sibling

--- a/docs/operating.md
+++ b/docs/operating.md
@@ -6,8 +6,9 @@ read the rest of `docs/` first.
 
 Read the "This is not finished" section of [../README.md](../README.md) before any of it. Two releases
 exist, both carry the package for one of the two claimed server lines, and one of them has been
-installed on a server of that line once, not at the claimed floor and not by the server's own
-download. Nothing below changes that.
+installed once on `10.11.11` and answered. On `10.11.0`, the floor that same package claims, the
+server refuses to load it. Nothing below changes either half, and none of it applies on a server
+where the plugin does not load at all.
 
 ## From an installed plugin to a queue
 


### PR DESCRIPTION
Part of #152. #345 landed the sentence "a published release has been installed once, and not at the claimed floor". The floor has since been tried and it refuses the package, so that sentence understates the state in the one direction that costs somebody a broken server.

## The measurement

    Status: Downloaded newer image for jellyfin/jellyfin:10.11.0
    {"LocalAddress":"http://172.17.0.2:8096","ServerName":"e344a5822ae7","Version":"10.11.0", ...}
    Name=Requests  Version=0.2.0.0  Status=NotSupported  Id=0f9c9107b31b459e81fa6d35dac25e79
    == verdict
    Requests is NotSupported rather than Active.

Run `33358848505`, on the head of #346. The same archive is `Active` on `10.11.11` in run `33357925338` on the mainline, so the server version is the only difference.

The claim it fails against is read rather than assumed:

    $ git grep -nE '^targetAbi:' origin/master -- build.yaml
    origin/master:build.yaml:10:targetAbi: "10.11.0.0"

`10.11.0.0` names the server `10.11.0`, which is published and is what the run pulled.

## What `NotSupported` means

One place in the whole of Jellyfin sets it:

    $ gh api "search/code?q=repo:jellyfin/jellyfin+PluginStatus.NotSupported" --jq '.items[].path'
    Emby.Server.Implementations/Plugins/PluginManager.cs

    $ gh api "repos/jellyfin/jellyfin/contents/Emby.Server.Implementations/Plugins/PluginManager.cs?ref=v10.11.0" \
        -H "Accept: application/vnd.github.raw" | sed -n '169,177p'
                            // Load all required types to verify that the plugin will load
                            assembly.GetTypes();
                        }
                        catch (SystemException ex) when (ex is TypeLoadException or ReflectionTypeLoadException)
                        {
                            _logger.LogError(ex, "Failed to load assembly {Path}. This error occurs when a plugin references an incompatible version of one of the shared libraries. Disabling plugin", assembly.Location);
                            ChangePluginState(plugin, PluginStatus.NotSupported);
                            break;
                        }

## The part that is easy to read backwards

`abi-floor.yaml` was green on the same day and against the real floor:

    $ gh run view 33358423183 --repo Flowfin/jellyfin-plugin-requests --log \
        | grep 'is published; building against it'
    floor 10.11.0.0	Resolve the floor SDK for this line	The floor 10.11.0 is published; building against it.

It compiles the SOURCE against the floor SDK. What ships is compiled against the current SDK by `publish.yaml`, so a green floor build says the source could be built against the floor and nothing about the artefact that went out. `docs/compatibility.md` now carries that distinction rather than leaving the two guards to be read as one.

## What changed, and where

`README.md`, `docs/operating.md`, `build.yaml` and `build-jf12.yaml` are what somebody reads before deciding to install; each now says the floor server refuses it, in those words. `docs/compatibility.md` gains the bullet with the evidence above.

**No claim moved.** `targetAbi` is untouched in both packaging files. Which of the two moves - the claimed floor, or the reference that breaks - is #152 and is not decided here.

## Evidence

    $ dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler:     0, erfolgreich:   777, gesamt:   777  (net9.0)
    Bestanden!   : Fehler:     0, erfolgreich:   777, gesamt:   777  (net10.0)

    $ npx --yes prettier@3.6.2 --check ".lfcheck/**/*.md"
    All matched files use Prettier code style!

Checked as LF copies inside the tree, because this checkout is CRLF and the gate reads LF.

## What this does NOT claim

**The failing type has not been named.** That needs the server's own log, and `scripts/verify-plugin-loads.sh` does not print it. What is stated is the status the server reported and the one place its own code sets that status.

**No install was made from this change.** It quotes two runs and starts no container; the container engine is not running on the machine this was written on.

**Nothing is said about the 12.0 line.** It has no release, so there is nothing published to refuse or accept.

## Means

Prose in the files that already carry the disclosure, in the formats the gates here already read.

## Review

There is no second reader on this board tonight. Both runs quoted are public and their logs are the evidence in place of one.
