### PR TITLE
Read the pasted evidence back against the tree, and re-run the thirty-three that had stopped reproducing

### DIFF
--- a/.github/workflows/invariant-lint.yaml
+++ b/.github/workflows/invariant-lint.yaml
@@ -6,6 +6,16 @@
 # invariant, added the first time an invariant is decided rather than in a batch
 # afterwards.
 #
+# ONE OF THE READERS HERE IS NOT A PATTERN, AND IT IS HERE RATHER THAN IN A
+# WORKFLOW OF ITS OWN. `scripts/check-pasted-evidence.sh` resolves the
+# `path:line:text` lines the documents paste as evidence against the files they
+# name, which no pattern can do because it compares two places in the tree
+# against each other. It is the same class of rule - one this board decided, that
+# no compiler states, and that a document could otherwise only ask for - so it
+# runs under the same job. Under a job of its own it would report a context the
+# ruleset does not require, and #30 is where the six contexts already in that
+# position are waiting; this one holds a merge from the day it lands instead.
+#
 # Two steps, and both are needed. The first scans the repository and fails on any
 # finding, which is what makes a rule a gate. The second scans the fixtures and
 # fails unless every declared rule fired on one, because a rule that quietly
@@ -77,3 +87,17 @@ jobs:
 
       - name: Prove every rule still refuses something
         run: ./tools/opengrep/prove-rules-fire.sh
+
+      # The reader is watched refusing before its verdict is read. It passes on a
+      # tree nobody has broken, which is the same output a reader that says yes to
+      # everything produces, and the defect it exists for arrives by accident
+      # rather than on demand.
+      - name: Every refusal the pasted-evidence reader claims, refused for its own reason
+        run: ./scripts/prove-pasted-evidence-refusals.sh
+
+      # Over every tracked document rather than the ones this change touched. A
+      # paste goes stale when the file it cites is edited, which is a change that
+      # need not touch the document at all - so reading only the changed documents
+      # would miss every instance of the thing this refuses.
+      - name: Refuse a pasted line the tree does not produce
+        run: ./scripts/check-pasted-evidence.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,12 @@ What is worth knowing before the first push:
 - Some rules of this tree are patterns rather than prose, in
   `tools/opengrep/rules.yaml`. Each one carries a fixture it is watched refusing,
   so adding a rule means adding the fixture that proves it bites.
+- The documents here argue from commands, and the `path:line:text` lines they
+  paste as evidence are read back against the files they name. Edit a file and a
+  document quoting a line below the edit goes stale without either of them being
+  wrong, so `scripts/check-pasted-evidence.sh` refuses that under the same job.
+  Re-run the command above the block and paste what it prints; do not edit the
+  number to fit. It says what it cannot read at the top of the script.
 
 Run the build and the suite before pushing:
 

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -294,8 +294,8 @@ back in order to render its page. This plugin's own page does exactly that for t
 exist today:
 
     git grep -n "getPluginConfiguration" -- Jellyfin.Plugin.Requests/Configuration/configPage.html
-    Jellyfin.Plugin.Requests/Configuration/configPage.html:145:                                return ApiClient.getPluginConfiguration(RequestsConfig.pluginUniqueId);
-    Jellyfin.Plugin.Requests/Configuration/configPage.html:158:                        ApiClient.getPluginConfiguration(RequestsConfig.pluginUniqueId)
+    Jellyfin.Plugin.Requests/Configuration/configPage.html:220:                                return ApiClient.getPluginConfiguration(RequestsConfig.pluginUniqueId);
+    Jellyfin.Plugin.Requests/Configuration/configPage.html:233:                        ApiClient.getPluginConfiguration(RequestsConfig.pluginUniqueId)
 
 So the protection a credential gets here is the protection the server's data directory gets, and this
 page claims no more than that.

--- a/docs/personal-data.md
+++ b/docs/personal-data.md
@@ -64,6 +64,7 @@ which is the trade taken deliberately on #49 in exchange for not keeping identif
 have gone.
 
     git grep -n 'public RequestArrival? Arrival' -- Jellyfin.Plugin.Requests/Model/RequestHistoryEntry.cs
+    Jellyfin.Plugin.Requests/Model/RequestHistoryEntry.cs:97:    public RequestArrival? Arrival { get; init; }
 
 The value says which surface, and never which caller. A request handed over the seam is filed against
 whoever the calling plugin said asked for it, with no session behind the name, and one asked for over
@@ -104,8 +105,8 @@ and cannot take it back.
 ### Two fields carry free text somebody typed
 
     git grep -nE 'public string\? (RequesterNote|DeclineNote)' -- Jellyfin.Plugin.Requests/Model/MediaRequest.cs
-    Jellyfin.Plugin.Requests/Model/MediaRequest.cs:209:    public string? RequesterNote
-    Jellyfin.Plugin.Requests/Model/MediaRequest.cs:242:    public string? DeclineNote
+    Jellyfin.Plugin.Requests/Model/MediaRequest.cs:210:    public string? RequesterNote
+    Jellyfin.Plugin.Requests/Model/MediaRequest.cs:243:    public string? DeclineNote
 
 `RequesterNote` is what the person asking wrote, and `DeclineNote` is what the operator wrote back.
 Both are bounded in length and neither is bounded in content. Anybody can write a name, an address or
@@ -136,17 +137,23 @@ notices file. The settings file holds no person at all, which is the whole
 of that class rather than a sample:
 
     git grep -nE '^    public (const )?(int|bool|string) ' -- Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs
-    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:52:    public const int MinimumRetentionDays = 30;
-    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:67:    public int OpenRequestsPerUser { get; set; } = 10;
-    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:72:    public bool AcceptsMovies { get; set; } = true;
-    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:83:    public bool AcceptsSeries { get; set; } = true;
-    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:99:    public int FinishedRequestRetentionDays { get; set; } = 365;
-    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:123:    public string OutboundNoticeAddress { get; set; } = string.Empty;
+    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:53:    public const int MinimumRetentionDays = 30;
+    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:68:    public int OpenRequestsPerUser { get; set; } = 10;
+    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:73:    public bool AcceptsMovies { get; set; } = true;
+    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:84:    public bool AcceptsSeries { get; set; } = true;
+    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:100:    public int FinishedRequestRetentionDays { get; set; } = 365;
+    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:120:    public bool TellsAdministratorsAboutArrivals { get; set; }
+    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:152:    public string OutboundNoticeAddress { get; set; } = string.Empty;
+    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:167:    public bool AnnouncesApprovals { get; set; } = true;
+    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:181:    public bool AnnouncesDeclines { get; set; } = true;
+    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:191:    public bool AnnouncesFulfilments { get; set; } = true;
 
-Three numbers, one of them the floor under another, two switches, and one address. Nothing there is
-about anybody. The address is where a notice is posted and is empty until an operator types one; it
-names a machine rather than a person, and what typing one into it sends is the section on what
-leaves the server below.
+Three numbers, one of them the floor under another, six switches, and one address. Nothing there is
+about anybody. Two of the switches say what kinds of thing may be asked for, three say which
+movements are announced outward, and one says whether a live administrator is told that a request
+arrived; [configuration.md](configuration.md) is the authority for each. The address is where a
+notice is posted and is empty until an operator types one; it names a machine rather than a person,
+and what typing one into it sends is the section on what leaves the server below.
 
 `PluginConfigurationTests` refuses a second setting of that shape, so a credential arriving beside
 it is a red suite rather than a thing to notice.
@@ -241,7 +248,8 @@ reading on this board has measured it.
 when an account is deleted and this plugin consumes it:
 
     git grep -n 'IEventConsumer<UserDeletedEventArgs>' -- Jellyfin.Plugin.Requests/
-    Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs:232:        serviceCollection.AddSingleton<IEventConsumer<UserDeletedEventArgs>, RemovedAccounts>();
+    Jellyfin.Plugin.Requests/People/RemovedAccounts.cs:30:public sealed class RemovedAccounts : IEventConsumer<UserDeletedEventArgs>
+    Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs:240:        serviceCollection.AddSingleton<IEventConsumer<UserDeletedEventArgs>, RemovedAccounts>();
 
 There are three rules and they are not one rule.
 
@@ -293,12 +301,12 @@ who is gone.
 and the queue page drew it the same day, while the sentence here went on saying an administrator sees
 a raw identifier. It was found by reading the page against the tree rather than by anything failing:
 
-    git log --format='%h %ad %s' --date=short -1 -- Jellyfin.Plugin.Requests/Web/queue.html
+    git log --format='%h %ad %s' --date=short -S 'queue.movedBy.deleted' --reverse -- Jellyfin.Plugin.Requests/Web/queue.html | head -1
     211b90c 2026-08-27 Draw who last moved a request, and keep a deleted account apart from an unanswered call
 
     git grep -n 'queue.movedBy.deleted' -- Jellyfin.Plugin.Requests/
     Jellyfin.Plugin.Requests/Localisation/Strings/en.json:122:  "queue.movedBy.deleted": "A person who has been deleted",
-    Jellyfin.Plugin.Requests/Web/queue.html:558:                        return RequestsShell.word("queue.movedBy.deleted");
+    Jellyfin.Plugin.Requests/Web/queue.html:564:                        return RequestsShell.word("queue.movedBy.deleted");
 
 What the page draws is an identifier the dashboard's user list does not hold, and it says so only
 where that list was actually read, so a failed call is never reported as a deleted account. The
@@ -358,7 +366,7 @@ There is no metadata lookup either. This plugin calls no metadata source at all,
 rather than a habit:
 
     git grep -n 'id: no-call-to-a-metadata-source' -- tools/opengrep/rules.yaml
-    tools/opengrep/rules.yaml:479:  - id: no-call-to-a-metadata-source
+    tools/opengrep/rules.yaml:529:  - id: no-call-to-a-metadata-source
 
 And nothing reports anything to this project, at any setting, by design and with no opt-in. That is
 recorded in [notifications.md](notifications.md) with the decision behind it.

--- a/docs/queue.md
+++ b/docs/queue.md
@@ -58,7 +58,7 @@ The page does that turning:
 The list behind `people` is asked for once when the page opens:
 
     git grep -n "getUsers" -- Jellyfin.Plugin.Requests/Web/
-    Jellyfin.Plugin.Requests/Web/queue.html:819:                        return ApiClient.getUsers()
+    Jellyfin.Plugin.Requests/Web/queue.html:825:                        return ApiClient.getUsers()
 
 A list that cannot be read leaves the identifier in the cell, which is worse to read rather than
 wrong, and it leaves the queue readable. This is the only call either page makes that is not to this
@@ -262,19 +262,19 @@ row carries the decisions its state admits, from #61, and the two items above ar
 
     git grep -n "cell(row, " -- Jellyfin.Plugin.Requests/Web/queue.html
     Jellyfin.Plugin.Requests/Web/queue.html:382:                    function cell(row, text) {
-    Jellyfin.Plugin.Requests/Web/queue.html:738:                            cell(row, title(request));
-    Jellyfin.Plugin.Requests/Web/queue.html:739:                            cell(row, RequestsShell.named("kind", request.Kind));
-    Jellyfin.Plugin.Requests/Web/queue.html:740:                            cell(row, RequestsShell.named("queue.state", request.State));
-    Jellyfin.Plugin.Requests/Web/queue.html:741:                            cell(row, moment(request.RequestedAt));
-    Jellyfin.Plugin.Requests/Web/queue.html:742:                            cell(row, moment(request.StateChangedAt));
-    Jellyfin.Plugin.Requests/Web/queue.html:743:                            cell(row, movedBy(request));
-    Jellyfin.Plugin.Requests/Web/queue.html:744:                            cell(row, who(request));
-    Jellyfin.Plugin.Requests/Web/queue.html:745:                            cell(row, waitingFor(request));
-    Jellyfin.Plugin.Requests/Web/queue.html:746:                            cell(row, held(request));
-    Jellyfin.Plugin.Requests/Web/queue.html:747:                            cell(row, askedBefore(request)).className = "requestsQueueAskedBefore";
-    Jellyfin.Plugin.Requests/Web/queue.html:748:                            cell(row, request.RequesterNote || "");
-    Jellyfin.Plugin.Requests/Web/queue.html:749:                            cell(row, decided(request));
-    Jellyfin.Plugin.Requests/Web/queue.html:752:                                cell(row, handover(request));
+    Jellyfin.Plugin.Requests/Web/queue.html:744:                            cell(row, title(request));
+    Jellyfin.Plugin.Requests/Web/queue.html:745:                            cell(row, RequestsShell.named("kind", request.Kind));
+    Jellyfin.Plugin.Requests/Web/queue.html:746:                            cell(row, RequestsShell.named("queue.state", request.State));
+    Jellyfin.Plugin.Requests/Web/queue.html:747:                            cell(row, moment(request.RequestedAt));
+    Jellyfin.Plugin.Requests/Web/queue.html:748:                            cell(row, moment(request.StateChangedAt));
+    Jellyfin.Plugin.Requests/Web/queue.html:749:                            cell(row, movedBy(request));
+    Jellyfin.Plugin.Requests/Web/queue.html:750:                            cell(row, who(request));
+    Jellyfin.Plugin.Requests/Web/queue.html:751:                            cell(row, waitingFor(request));
+    Jellyfin.Plugin.Requests/Web/queue.html:752:                            cell(row, held(request));
+    Jellyfin.Plugin.Requests/Web/queue.html:753:                            cell(row, askedBefore(request)).className = "requestsQueueAskedBefore";
+    Jellyfin.Plugin.Requests/Web/queue.html:754:                            cell(row, request.RequesterNote || "");
+    Jellyfin.Plugin.Requests/Web/queue.html:755:                            cell(row, decided(request));
+    Jellyfin.Plugin.Requests/Web/queue.html:758:                                cell(row, handover(request));
 
 The first of those fourteen lines is the function that writes a cell and the rest are the cells one
 row carries. The last of them is indented one level deeper than the others because it is the only
@@ -284,8 +284,8 @@ being a column of blanks about a bridge nobody set up. Beside them is the decisi
 which is #61:
 
     git grep -n "decide(row, request)" -- Jellyfin.Plugin.Requests/Web/queue.html
-    Jellyfin.Plugin.Requests/Web/queue.html:570:                    function decide(row, request) {
-    Jellyfin.Plugin.Requests/Web/queue.html:755:                            decide(row, request);
+    Jellyfin.Plugin.Requests/Web/queue.html:576:                    function decide(row, request) {
+    Jellyfin.Plugin.Requests/Web/queue.html:761:                            decide(row, request);
 
 Read against the six items above, that is all of them. Thirteen cells and thirteen headings, and
 that pairing is checked rather than counted by eye: a row carrying one cell more than the header

--- a/docs/seam.md
+++ b/docs/seam.md
@@ -439,7 +439,7 @@ for somebody to infer from the first.
 `IRequestStore` is public, and the plugin registers it into the container the server hands it:
 
     git grep -n 'AddSingleton<IRequestStore>' -- Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
-    Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs:63:        serviceCollection.AddSingleton<IRequestStore>(provider => new FileRequestStore(
+    Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs:68:        serviceCollection.AddSingleton<IRequestStore>(provider => new FileRequestStore(
 
 That collection is the server's own, not one this plugin keeps to itself, so the registration sits
 where everything else in the process can be resolved from. What the interface answers is not

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -354,9 +354,9 @@ The chosen medium needs nothing that is not already in the runtime. The plugin p
 references are the two Jellyfin assemblies and nothing else, and neither is added by this decision:
 
     git grep -n 'PackageReference Include' -- Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.csproj Directory.Build.props
-    Directory.Build.props:54:        <PackageReference Include="SerilogAnalyzer" Version="0.15.0" PrivateAssets="All" />
-    Directory.Build.props:55:        <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
-    Directory.Build.props:56:        <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" PrivateAssets="All" />
+    Directory.Build.props:85:        <PackageReference Include="SerilogAnalyzer" Version="0.15.0" PrivateAssets="All" />
+    Directory.Build.props:86:        <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
+    Directory.Build.props:87:        <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" PrivateAssets="All" />
     Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.csproj:23:    <PackageReference Include="Jellyfin.Controller" Version="$(JellyfinVersion)">
     Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.csproj:26:    <PackageReference Include="Jellyfin.Model" Version="$(JellyfinVersion)">
 

--- a/scripts/check-pasted-evidence.sh
+++ b/scripts/check-pasted-evidence.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Read every `path:line:text` line this repository's documents paste as evidence, and refuse one that
+# the file it names no longer produces.
+#
+# WHY THIS EXISTS. The documents here argue from commands, and a `git grep -n` paste is the commonest
+# form that argument takes. The text in such a paste is the assertion - this file carries this field,
+# this call, this rule - and the line number beside it is a coordinate that moves whenever anything
+# above it is edited. So the assertion stays true while the evidence for it stops reproducing, and a
+# reader who runs the command gets output that does not match the page. Nothing about that failure is
+# visible: the build is green, the suite is green, and the document reads exactly as it did.
+#
+# WHAT IT MEASURED WHEN IT LANDED. Thirty of seventy-nine pasted match lines across five documents,
+# which is #348. #340 was the same defect one register over - a release position stated in prose in
+# five files that had stopped reproducing - and it was repaired by hand because nothing here reads a
+# document against the tree. This is what reads it.
+#
+# WHAT IT READS. A line that begins a four-space indented block line, splits as `path:number:text`,
+# and whose path is a file this repository tracks. That is the shape `git grep -n` prints and the
+# shape every evidence block in these documents uses.
+#
+# WHAT IT CANNOT READ, said plainly rather than left to be discovered:
+#
+#   - A paste qualified by a ref, `<ref>:<path>:<line>:<text>`. Three documents here paste from
+#     Jellyfin's own repository at a ref, which names a tree this check does not have and must not
+#     guess at, so no ref-qualified paste is read at all - including one naming this tree.
+#   - A paste inside a fenced block. No tracked document uses one for evidence today; every evidence
+#     block here is indented.
+#   - The context lines `git grep -A` and `-B` print, which carry a dash where a match carries a
+#     colon.
+#   - Whether the command written above a block is the command that produced it. The paste is checked
+#     against the file, never against the command, so a block whose command was edited afterwards
+#     passes here and is the reviewer's to catch.
+#
+# usage: scripts/check-pasted-evidence.sh [markdown-file...]
+#   with no argument it reads every tracked markdown file.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+if [ "$#" -gt 0 ]; then
+    docs=("$@")
+else
+    mapfile -t docs < <(git ls-files -- '*.md')
+fi
+
+if [ "${#docs[@]}" -eq 0 ]; then
+    echo "check-pasted-evidence: no markdown file to read. A run with nothing to check is not a run that found nothing." >&2
+    exit 2
+fi
+
+# What decides whether a `path:line:text` line is evidence about this tree, or an ordinary colon in
+# somebody's pasted output, is the first field naming a file that is here. The test is the file
+# system rather than the index, so a document and the file it cites can arrive in one change without
+# the check refusing the document until somebody stages the file.
+#
+# The first segment is read out of the index, because that is what separates a path this tree could
+# have from a timestamp or a JSON key. A tracked top level with nothing behind it is a paste naming a
+# file that has moved or gone, which is a finding rather than something to pass over.
+declare -A toplevel=()
+while IFS= read -r f; do
+    toplevel["${f%%/*}"]=1
+done < <(git ls-files)
+
+# Each named file is read once and held by line, rather than a process spawned per pasted line. A
+# document citing one file forty times is the normal case here, and the slow shape is one somebody
+# would rather not run.
+declare -A line=()
+declare -A length=()
+declare -A loaded=()
+hold() {
+    local p=$1 n=0 l
+    [ -n "${loaded[$p]+x}" ] && return
+    while IFS= read -r l || [ -n "$l" ]; do
+        n=$((n + 1))
+        line["$p:$n"]=${l%$'\r'}
+    done < "$p"
+    length["$p"]=$n
+    loaded["$p"]=1
+}
+
+findings=0
+read_lines=0
+
+for doc in "${docs[@]}"; do
+    if [ ! -f "$doc" ]; then
+        echo "check-pasted-evidence: ${doc} does not exist." >&2
+        exit 2
+    fi
+
+    docline=0
+    while IFS= read -r raw || [ -n "$raw" ]; do
+        docline=$((docline + 1))
+        raw=${raw%$'\r'}
+
+        # Evidence is indented. A prose sentence carrying a colon and a number is not a paste, and
+        # reading one as a paste would make this check refuse ordinary writing.
+        case "$raw" in
+            "    "*) body=${raw#    } ;;
+            *) continue ;;
+        esac
+
+        path=${body%%:*}
+        [ "$path" = "$body" ] && continue
+        rest=${body#*:}
+        num=${rest%%:*}
+        [ "$num" = "$rest" ] && continue
+        case "$num" in
+            '' | *[!0-9]*) continue ;;
+        esac
+        text=${rest#*:}
+
+        if [ ! -f "$path" ]; then
+            # Anything under no tracked top level - a timestamp, a JSON document, another
+            # repository's path behind a ref - is not about this tree and is not this check's.
+            if [ -n "${toplevel[${path%%/*}]+x}" ]; then
+                findings=$((findings + 1))
+                echo "${doc}:${docline}: pastes ${path}:${num}, and this repository has no ${path}."
+            fi
+            continue
+        fi
+
+        read_lines=$((read_lines + 1))
+
+        hold "$path"
+        actual=${line["$path:$num"]-}
+
+        if [ "$actual" != "$text" ]; then
+            findings=$((findings + 1))
+            echo "${doc}:${docline}: pastes ${path}:${num} as"
+            echo "    ${text}"
+            if [ "$num" -gt "${length[$path]}" ]; then
+                echo "  and that file has no line ${num}."
+            else
+                echo "  and that line reads"
+                echo "    ${actual}"
+            fi
+        fi
+    done < "$doc"
+done
+
+echo "read ${read_lines} pasted match lines in ${#docs[@]} document(s)"
+
+if [ "$findings" -gt 0 ]; then
+    echo "check-pasted-evidence: ${findings} pasted line(s) the tree does not produce. Re-run the command above each block and paste what it prints; do not edit the number to fit." >&2
+    exit 1
+fi
+
+echo "check-pasted-evidence: every pasted match line reproduces against the file it names."

--- a/scripts/prove-pasted-evidence-refusals.sh
+++ b/scripts/prove-pasted-evidence-refusals.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Every refusal the pasted-evidence check claims, watched refusing once, over documents written to
+# carry the answer each one names - and the near misses it must not refuse, watched passing.
+#
+# `scripts/check-pasted-evidence.sh` reads the tree and passes on a tree nobody has broken yet. A
+# reader in that position is indistinguishable from one that says yes to everything, for as long as
+# nothing goes wrong, and the thing it guards against - a line number drifting under a document -
+# happens quietly and by accident rather than on demand. So each answer is handed to it here.
+#
+# THE NEAR MISSES ARE HALF OF THIS FILE AND THEY ARE THE EXPENSIVE HALF. A check over prose that
+# refuses too much is worse than none: it makes ordinary writing red, somebody turns it off, and the
+# defect it was built for comes back with the argument that the check cried wolf. The three below are
+# the shapes this repository's documents already contain - a timestamp in a run listing, another
+# repository's path behind a ref, a sentence in prose that carries a colon and a number.
+#
+# The fixtures name files this repository really has, because the check resolves what it reads
+# against the tree and a fixture pointing at nothing would prove only that nothing resolves.
+#
+# usage: scripts/prove-pasted-evidence-refusals.sh
+
+set -euo pipefail
+
+here=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+root=$(cd "$here/.." && pwd)
+checker="$here/check-pasted-evidence.sh"
+
+cd "$root"
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# A real line of a real tracked file, taken from the tree rather than typed, so this file does not
+# become the next thing that goes stale.
+subject="scripts/check-pasted-evidence.sh"
+subject_line=1
+subject_text=$(sed -n "${subject_line}p" "$subject" | sed 's/\r$//')
+
+# usage: doc <name> <line...>
+doc() {
+    local name=$1
+    shift
+    printf '%s\n' "# A fixture" '' 'Evidence:' '' "$@" '' 'End.' > "$work/$name"
+}
+
+failures=0
+
+# usage: refuses <heading> <sentence the refusal must carry> -- <command...>
+refuses() {
+    local heading=$1 sentence=$2
+    shift 3
+    printf '\n== %s\n' "$heading"
+    local out status
+    set +e
+    out=$("$@" 2>&1)
+    status=$?
+    set -e
+    printf '%s\n' "$out" | sed 's/^/  /'
+    if [ "$status" -eq 0 ]; then
+        echo "  ACCEPTED it, so the rule does not bite."
+        failures=$((failures + 1))
+        return
+    fi
+    case "$out" in
+        *"$sentence"*) ;;
+        *)
+            echo "  refused, but for something other than: $sentence"
+            failures=$((failures + 1))
+            ;;
+    esac
+}
+
+# usage: accepts <heading> <sentence the pass must carry> -- <command...>
+accepts() {
+    local heading=$1 sentence=$2
+    shift 3
+    printf '\n== %s\n' "$heading"
+    local out status
+    set +e
+    out=$("$@" 2>&1)
+    status=$?
+    set -e
+    printf '%s\n' "$out" | sed 's/^/  /'
+    if [ "$status" -ne 0 ]; then
+        echo "  REFUSED it, which is a reader that refuses everything."
+        failures=$((failures + 1))
+        return
+    fi
+    case "$out" in
+        *"$sentence"*) ;;
+        *)
+            echo "  accepted, but said nothing about: $sentence"
+            failures=$((failures + 1))
+            ;;
+    esac
+}
+
+# The state a document is in when nobody has broken it.
+doc good.md "    ${subject}:${subject_line}:${subject_text}"
+accepts "a paste the file still produces" \
+    "every pasted match line reproduces" \
+    -- "$checker" "$work/good.md"
+
+# THE ONE IT EXISTS FOR. The assertion is still true - that file does carry that line - and the
+# coordinate beside it has moved, which is what happens every time anything above it is edited.
+doc drifted.md "    ${subject}:$((subject_line + 3)):${subject_text}"
+refuses "the number moved under the text, which is the whole defect" \
+    "and that line reads" \
+    -- "$checker" "$work/drifted.md"
+
+doc rewritten.md "    ${subject}:${subject_line}:#!/usr/bin/env fish"
+refuses "the text at that number is not the text pasted" \
+    "and that line reads" \
+    -- "$checker" "$work/rewritten.md"
+
+doc beyond.md "    ${subject}:999999:${subject_text}"
+refuses "the file has no such line at all" \
+    "has no line 999999" \
+    -- "$checker" "$work/beyond.md"
+
+doc moved.md "    scripts/check-pasted-evidence-that-went-away.sh:1:#!/usr/bin/env bash"
+refuses "the file the paste names has moved or gone" \
+    "this repository has no" \
+    -- "$checker" "$work/moved.md"
+
+# The near misses. Each is a shape a document here already carries, and refusing any of them would
+# make ordinary writing red.
+
+doc timestamp.md "    33246667212	push	success	2026-08-29T09:57:04Z"
+accepts "a run listing carrying a timestamp is not a paste" \
+    "read 0 pasted match lines" \
+    -- "$checker" "$work/timestamp.md"
+
+doc foreign.md "    origin/release-10.11.z:MediaBrowser/Session/ISessionManager.cs:1:namespace Whatever;"
+accepts "another repository's path behind a ref names a tree this check does not have" \
+    "read 0 pasted match lines" \
+    -- "$checker" "$work/foreign.md"
+
+doc prose.md "The file ${subject}:${subject_line}:${subject_text} is discussed here in prose."
+accepts "a sentence in prose is not an evidence block, whatever colons it carries" \
+    "read 0 pasted match lines" \
+    -- "$checker" "$work/prose.md"
+
+doc json.md '    {"Id":"00000000-0000-0000-0000-000000000001","RequestedAt":"2026-03-01T12:00:00Z"}'
+accepts "a JSON document pasted as an example is not a paste of this tree" \
+    "read 0 pasted match lines" \
+    -- "$checker" "$work/json.md"
+
+refuses "a document handed to it that does not exist" \
+    "does not exist" \
+    -- "$checker" "$work/no-such-document.md"
+
+printf '\n'
+if [ "$failures" -ne 0 ]; then
+    echo "$failures of the rules above did not bite." >&2
+    exit 1
+fi
+echo "Every refusal the pasted-evidence check claims was watched refusing, and every near miss it must not refuse was watched passing."


### PR DESCRIPTION
Closes #348.

The documents on this board argue from commands, and a `git grep -n` paste is the commonest form that
argument takes. The text in such a paste is the assertion - this file carries this field, this call,
this rule - and the line number beside it is a coordinate that moves whenever anything above it is
edited. So the assertion stays true while the evidence for it stops reproducing, and nothing about
that failure is visible: the build is green, the suite is green, and the page reads exactly as it did.

Thirty-three of a hundred and five pasted lines across five documents were in that state.

## What the reader is, and what it will not claim

`scripts/check-pasted-evidence.sh` resolves every `path:line:text` line in every tracked markdown file
against the file it names. It reads a line as evidence when it is inside a four-space indented block,
splits as `path:number:text`, and names a file that is here.

Its bounds are at the top of the script rather than only here, because that is where somebody meeting
a refusal will be. It does not read a paste behind a ref - three documents here paste from Jellyfin's
own repository at one, which names a tree this check does not have and must not guess at. It does not
read a fenced block, and no tracked document uses one for evidence today. It does not read the context
lines `-A` and `-B` print. And it never asks whether the command written above a block is the command
that produced it: the paste is checked against the file, so a block whose command was edited afterwards
passes here and is the reviewer's to catch.

## Every refusal watched refusing, and every near miss watched passing

    $ ./scripts/prove-pasted-evidence-refusals.sh

    == a paste the file still produces
      read 1 pasted match lines in 1 document(s)
      check-pasted-evidence: every pasted match line reproduces against the file it names.

    == the number moved under the text, which is the whole defect
      /tmp/tmp.iNvzUpnPtg/drifted.md:5: pastes scripts/check-pasted-evidence.sh:4 as
          #!/usr/bin/env bash
        and that line reads
          #
      read 1 pasted match lines in 1 document(s)
      check-pasted-evidence: 1 pasted line(s) the tree does not produce.

    == the text at that number is not the text pasted
      /tmp/tmp.iNvzUpnPtg/rewritten.md:5: pastes scripts/check-pasted-evidence.sh:1 as
          #!/usr/bin/env fish
        and that line reads
          #!/usr/bin/env bash

    == the file has no such line at all
      /tmp/tmp.iNvzUpnPtg/beyond.md:5: pastes scripts/check-pasted-evidence.sh:999999 as
          #!/usr/bin/env bash
        and that file has no line 999999.

    == the file the paste names has moved or gone
      /tmp/tmp.iNvzUpnPtg/moved.md:5: pastes scripts/check-pasted-evidence-that-went-away.sh:1, and this repository has no scripts/check-pasted-evidence-that-went-away.sh.

    Every refusal the pasted-evidence check claims was watched refusing, and every near miss it must not refuse was watched passing.

**The near misses are half of that file and they are the expensive half.** A check over prose that
refuses too much is worse than none: it makes ordinary writing red, somebody turns it off, and the
defect comes back with the argument that the check cried wolf. The four proved passing are shapes the
documents here already contain - a run listing carrying a timestamp, another repository's path behind
a ref, a sentence in prose carrying a colon and a number, and a JSON document pasted as an example.

## Where it runs, and why not in a workflow of its own

Under the invariant lint, as two steps of `Enforce greppable invariants`. It is the same class of rule
that workflow exists for - one this board decided, that no compiler states, that a document could
otherwise only ask for - and it is not a pattern only because it compares two places in the tree
against each other, which no pattern can do.

A job of its own would report a context the ruleset does not require, and #30 is where the six
contexts already in that position are waiting on a repository setting. Under this job the rule holds a
merge from the day it lands. Nothing in this change edits a ruleset or `docs/quality-parity.md`; the
declared set of fifteen is unchanged and no sixteenth context appears.

It reads every tracked document rather than the ones a change touched. A paste goes stale when the
file it cites is edited, which is a change that need not touch the document at all, so reading only
the changed documents would miss every instance of the thing it refuses.

## The repair, and the two sites the reader cannot see

    $ ./scripts/check-pasted-evidence.sh
    read 105 pasted match lines in 24 document(s)
    check-pasted-evidence: every pasted match line reproduces against the file it names.

Every block was re-run and its real output pasted. The numbers were not edited to fit.

**`docs/personal-data.md` is the one where a count moved and not only a coordinate.** The settings
class was pasted as six settings under the sentence that the settings file holds no person at all,
"which is the whole of that class rather than a sample". It carries ten. The four that had arrived are
the three per-event announce switches and the administrator arrival switch; none of them names
anybody, so the claim stands and its evidence now covers it, and the sentence under the block says six
switches instead of two and says what they are.

`docs/queue.md` is sixteen lines over three blocks of the queue page's own rendering, and the set is
unchanged - fourteen `cell(row, ` lines then as now - so the paragraph counting them is untouched.
`docs/storage.md`, `docs/bridge.md` and `docs/seam.md` are line numbers alone.

Two further sites in `docs/personal-data.md` are outside what this reader can see and are repaired for
the same reason. The `IEventConsumer` block pasted one of the two lines the command returns, so a
reader running it got a class the page did not show. And the block naming when the queue page learned
to draw a deleted account used `git log -1` on that file, which names whatever touched it last rather
than the change being cited; it is the pickaxe form now, which answers the question the paragraph asks
and does not move when the file is edited again.

## The means

Bash, wired into a workflow, because this board already carries that shape: `check-manifest-is-fresh.sh`,
`check-released-package.sh` and three `prove-*-refusals.sh` readers are the same pair of a reader and
its watched refusals. The alternative was a test in the suite, and it fits worse: the suite reasons
about the plugin's behaviour, and this reasons about tracked text and the working tree, which would put
file-system walking and markdown parsing into a project that has neither today.

## Evidence

    $ dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler:     0, erfolgreich:   777, übersprungen:     0, gesamt:   777, Dauer: 25 s - Jellyfin.Plugin.Requests.Tests.dll (net10.0)
    Bestanden!   : Fehler:     0, erfolgreich:   777, übersprungen:     0, gesamt:   777, Dauer: 25 s - Jellyfin.Plugin.Requests.Tests.dll (net9.0)

    $ npx --yes prettier@3.6.2 --check ".lfcheck/**/*.md"
    Checking formatting...
    All matched files use Prettier code style!

The markdown was checked as an LF copy made inside the tree and then removed, because this checkout is
CRLF and the gate reads LF. The suite's summary is quoted as the run printed it, in the language this
machine's toolchain answers in.

## What this does NOT claim

**The runner has now exercised both steps, and this paragraph said it had not.** It said the scripts
had been run only on this machine and that the runner's verdict was unanswered. Run `33374439302` on
this head answers it, and the tree-wide step read the same population there as here:

    Enforce greppable invariants	Refuse a pasted line the tree does not produce	2026-08-31T08:46:05.3143105Z read 105 pasted match lines in 24 document(s)
    Enforce greppable invariants	Refuse a pasted line the tree does not produce	2026-08-31T08:46:05.3143673Z check-pasted-evidence: every pasted match line reproduces against the file it names.

What is still unexercised is a red verdict on the runner. Every refusal was watched refusing on this
machine and inside that run's own proof step, and no head has yet carried a stale paste past it.

**The reader was not watched refusing anything in `tools/opengrep/`.** It reads markdown, and the
opengrep steps beside it are untouched.

**Nothing was read on a running server**, and nothing here needed one.

**This has had no second reader.** Nobody else has read it tonight, and the transcript above stands in
place of one rather than beside it.
