### PR TITLE
Say that the plugin makes an outbound call, and read every negative disclosure back against the tree

### DIFF
--- a/.github/workflows/invariant-lint.yaml
+++ b/.github/workflows/invariant-lint.yaml
@@ -6,15 +6,18 @@
 # invariant, added the first time an invariant is decided rather than in a batch
 # afterwards.
 #
-# ONE OF THE READERS HERE IS NOT A PATTERN, AND IT IS HERE RATHER THAN IN A
-# WORKFLOW OF ITS OWN. `scripts/check-pasted-evidence.sh` resolves the
+# TWO OF THE READERS HERE ARE NOT PATTERNS, AND THEY ARE HERE RATHER THAN IN
+# WORKFLOWS OF THEIR OWN. `scripts/check-pasted-evidence.sh` resolves the
 # `path:line:text` lines the documents paste as evidence against the files they
-# name, which no pattern can do because it compares two places in the tree
-# against each other. It is the same class of rule - one this board decided, that
-# no compiler states, and that a document could otherwise only ask for - so it
-# runs under the same job. Under a job of its own it would report a context the
-# ruleset does not require, and #30 is where the six contexts already in that
-# position are waiting; this one holds a merge from the day it lands instead.
+# name, and `scripts/check-negative-disclosures.sh` re-runs the blocks that
+# assert something is NOT in the tree and compares the exit code. Neither is
+# expressible as a pattern: one compares two places in the tree against each
+# other, and the other runs a command. They are the same class of rule - one this
+# board decided, that no compiler states, and that a document could otherwise
+# only ask for - so they run under the same job. Under jobs of their own they
+# would report contexts the ruleset does not require, and #30 is where the six
+# contexts already in that position are waiting; here they hold a merge from the
+# day they land instead.
 #
 # Two steps, and both are needed. The first scans the repository and fails on any
 # finding, which is what makes a rule a gate. The second scans the fixtures and
@@ -101,3 +104,13 @@ jobs:
       # would miss every instance of the thing this refuses.
       - name: Refuse a pasted line the tree does not produce
         run: ./scripts/check-pasted-evidence.sh
+
+      # This one runs commands it read out of tracked text, so what it refuses to
+      # run matters as much as what it decides. Two of the cases in the proof
+      # write a sentinel file if a shell ever sees them, and the proof asserts
+      # neither wrote one.
+      - name: Every refusal the negative-disclosure reader claims, refused for its own reason
+        run: ./scripts/prove-negative-disclosure-refusals.sh
+
+      - name: Refuse a negative disclosure the tree does not bear out
+        run: ./scripts/check-negative-disclosures.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,11 @@ What is worth knowing before the first push:
   wrong, so `scripts/check-pasted-evidence.sh` refuses that under the same job.
   Re-run the command above the block and paste what it prints; do not edit the
   number to fit. It says what it cannot read at the top of the script.
+- A block ending `; echo "exit=$?"` is a claim that something is not in the tree,
+  and `scripts/check-negative-disclosures.sh` re-runs it under the same job. It
+  runs `git grep` and nothing else, from a fixed set of options, and a command
+  carrying anything a shell would act on is refused rather than run. Write the
+  claim in that form and it is checked; write it any other way and it is not.
 
 Run the build and the suite before pushing:
 

--- a/Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj
+++ b/Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj
@@ -88,6 +88,11 @@
     <None Include="../CODE_OF_CONDUCT.md" Link="CODE_OF_CONDUCT.md" CopyToOutputDirectory="PreserveNewest" />
     <None Include="../DCO" Link="DCO" CopyToOutputDirectory="PreserveNewest" />
     <None Include="../docs/quality-parity.md" Link="docs/quality-parity.md" CopyToOutputDirectory="PreserveNewest" />
+    <!-- The two the security policy sends a reader to for what leaves the server, for the reason
+         above rather than a new one: the policy names one outbound path and neither describes it,
+         so following the link is what the reader does next. -->
+    <None Include="../docs/personal-data.md" Link="docs/personal-data.md" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="../docs/notifications.md" Link="docs/notifications.md" CopyToOutputDirectory="PreserveNewest" />
     <None Include="../.github/workflows/dco.yml" Link="dco.yml" CopyToOutputDirectory="PreserveNewest" />
     <!-- Every workflow file, next to the suite, so the parity page's enumeration of them is read
          against the directory rather than against a count somebody typed into a sentence. A

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,12 +62,30 @@ There is no telemetry. Nothing about use is collected and nothing is sent
 anywhere for this project's benefit, without exception and without a later
 review of that.
 
-Today the plugin makes no outbound call at all, which is a fact about the tree
-rather than a promise about every version:
+The plugin makes one outbound call and an operator has to turn it on. It is the
+notification sink, and the three lines below are one path rather than three: the
+client, and the socket pipeline it is handed at registration.
 
-    git grep -nE 'HttpClient|WebRequest|WebSocket|Socket' -- Jellyfin.Plugin.Requests ; echo "exit=$?"
-    exit=1
+    git grep -nE 'HttpClient|WebRequest|WebSocket|Socket' -- Jellyfin.Plugin.Requests
+    Jellyfin.Plugin.Requests/Notify/OutboundSink.cs:61:    private readonly HttpClient _client;
+    Jellyfin.Plugin.Requests/Notify/OutboundSink.cs:104:        _client = new HttpClient(handler, disposeHandler: false)
+    Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs:151:            new SocketsHttpHandler(),
 
-That will change when a bridge to an external request service exists. What goes
-to such a service is what the operator configured it to receive, and it is
-documented where that is built.
+It posts nothing until an operator sets `OutboundNoticeAddress`, which is empty
+on every install where nobody has decided otherwise, and there is no other way to
+turn it on. What it posts then is one small document per movement in the queue.
+[docs/notifications.md](docs/notifications.md) writes that document out field by
+field, and [docs/personal-data.md](docs/personal-data.md) is the account of
+everything that leaves the server.
+
+**This section said the plugin makes no outbound call at all, and that stopped
+being true on 2026-08-16.** The sentence is corrected here rather than quietly
+replaced, because somebody who read it and took it for a property of the plugin
+took it from this page. It was never a change in behaviour: the sink landed with
+its switch off and has never been on by default. What was wrong is that this page
+went on asserting the tree of six days earlier, and the pasted command under it
+went on being quoted with an output it no longer produced.
+
+A bridge to an external request service would be a second such path and does not
+exist yet. What goes to one is what the operator configured it to receive, and it
+is documented where that is built.

--- a/scripts/check-negative-disclosures.sh
+++ b/scripts/check-negative-disclosures.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# Re-run the `git grep ... ; echo "exit=$?"` blocks this repository's documents use to assert that
+# something is NOT in the tree, and refuse one whose pasted exit code the command does not produce.
+#
+# WHY THIS EXISTS RATHER THAN BEING COVERED BY THE READER BESIDE IT.
+# `scripts/check-pasted-evidence.sh` resolves a pasted `path:line:text` line against the file it
+# names. A negative disclosure has no such line - that is the whole point of it - so it pastes an exit
+# code and nothing else, and there is nothing in it for that reader to resolve. So the claims this
+# board leans on hardest were the ones nothing read: no socket, no permission call, no reach from the
+# sweep into the activity log.
+#
+# WHAT IT MEASURED WHEN IT LANDED. `SECURITY.md` said the plugin makes no outbound call at all and
+# pasted a command exiting 1. The command exited 0 and had done since 2026-08-16, through two edits of
+# that page. That is #350, and it is why a negative disclosure is not something to take on trust for
+# fifteen days at a time.
+#
+# IT RUNS WHAT THE DOCUMENT SAYS, WHICH IS THE PART TO READ BEFORE TRUSTING IT.
+# Executing text out of the tree is a thing to do narrowly or not at all, so:
+#
+#   - The command is never handed to a shell as a string. It is scanned character by character, and a
+#     character that would mean anything to a shell outside a quoted run - a pipe, a redirection, a
+#     substitution, a backslash, a brace, a glob - makes the block UNREADABLE, which is a refusal
+#     rather than a skip. Inside double quotes the three expansion characters are refused too.
+#   - Only then is it split into words, and the first two must be `git grep`.
+#   - Every option is checked against a fixed set. `git grep -O` runs a pager of the caller's
+#     choosing, which is the one flag of this verb that executes anything, and it is not in the set.
+#   - Nothing is written. `git grep` reads.
+#
+# A block this will not run is reported and fails the run. A check that quietly passed over the
+# commands it could not read would be at its most silent exactly where a document had been written to
+# evade it.
+#
+# WHAT IT DOES NOT DO. It compares the exit code and never the match lines, because the lines are the
+# other reader's subject and two readers refusing one thing is two places to fix it. It reads only the
+# `; echo "exit=$?"` form; a negative stated in prose is a judgement about meaning that no reading of
+# this tree makes.
+#
+# usage: scripts/check-negative-disclosures.sh [markdown-file...]
+#   with no argument it reads every tracked markdown file.
+
+set -uo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+if [ "$#" -gt 0 ]; then
+    docs=("$@")
+else
+    mapfile -t docs < <(git ls-files -- '*.md')
+fi
+
+if [ "${#docs[@]}" -eq 0 ]; then
+    echo "check-negative-disclosures: no markdown file to read. A run with nothing to check is not a run that found nothing." >&2
+    exit 2
+fi
+
+tail_marker='; echo "exit=$?"'
+
+# The letters a bundled short option may carry. Every one of them only selects what is reported.
+short_flags='nclLiwEFvhH'
+
+# The long options this will run, named one by one rather than by a pattern, because a pattern admits
+# whatever git grows next and the point of the set is that it does not.
+long_flags=' --line-number --count --files-with-matches --name-only --files-without-match --ignore-case --word-regexp --extended-regexp --fixed-strings --invert-match --no-color --text --untracked --cached --no-index --full-name '
+
+# safe_to_split <command>
+# Refuses any character that would mean something to a shell outside a quoted run, and the three
+# expansion characters inside double quotes. Returns 0 when the string can be split by word rules
+# alone, with no expansion of any kind left in it.
+safe_to_split() {
+    local s=$1 i c state=plain
+    for ((i = 0; i < ${#s}; i++)); do
+        c=${s:i:1}
+        case "$state" in
+            plain)
+                case "$c" in
+                    "'") state=single ;;
+                    '"') state=double ;;
+                    [A-Za-z0-9_./=:@%,+-] | ' ') ;;
+                    *) return 1 ;;
+                esac
+                ;;
+            single)
+                [ "$c" = "'" ] && state=plain
+                ;;
+            double)
+                case "$c" in
+                    '"') state=plain ;;
+                    '$' | '`' | '\') return 1 ;;
+                esac
+                ;;
+        esac
+    done
+    [ "$state" = plain ]
+}
+
+findings=0
+blocks=0
+
+for doc in "${docs[@]}"; do
+    if [ ! -f "$doc" ]; then
+        echo "check-negative-disclosures: ${doc} does not exist." >&2
+        exit 2
+    fi
+
+    mapfile -t lines < "$doc"
+    n=${#lines[@]}
+
+    for ((k = 0; k < n; k++)); do
+        raw=${lines[k]%$'\r'}
+        case "$raw" in
+            "    "*) body=${raw#    } ;;
+            *) continue ;;
+        esac
+        body=${body#'$ '}
+        case "$body" in
+            *"$tail_marker") ;;
+            *) continue ;;
+        esac
+
+        blocks=$((blocks + 1))
+        docline=$((k + 1))
+        cmd=${body%"$tail_marker"}
+        cmd=${cmd%"${cmd##*[![:space:]]}"}
+
+        # The pasted code, taken from the rest of this block rather than from the next line alone: a
+        # command that matched pastes its matches first and the code last.
+        pasted=
+        for ((j = k + 1; j < n; j++)); do
+            nxt=${lines[j]%$'\r'}
+            case "$nxt" in
+                "    "*) ;;
+                *) break ;;
+            esac
+            [ -z "${nxt//[[:space:]]/}" ] && break
+            case "${nxt#    }" in
+                exit=[0-9]*) pasted=${nxt#    exit=} ;;
+            esac
+        done
+
+        if [ -z "$pasted" ]; then
+            findings=$((findings + 1))
+            echo "${doc}:${docline}: asks for an exit code and pastes none."
+            continue
+        fi
+
+        if ! safe_to_split "$cmd"; then
+            findings=$((findings + 1))
+            echo "${doc}:${docline}: this check will not run it, so it cannot say the claim holds:"
+            echo "    ${cmd}"
+            echo "  It carries a character that means something to a shell outside a quoted run."
+            continue
+        fi
+
+        eval "argv=($cmd)"
+        if [ "${argv[0]-}" != "git" ] || [ "${argv[1]-}" != "grep" ]; then
+            findings=$((findings + 1))
+            echo "${doc}:${docline}: this check runs git grep and nothing else, and this is not one:"
+            echo "    ${cmd}"
+            continue
+        fi
+
+        refused_flag=
+        for ((a = 2; a < ${#argv[@]}; a++)); do
+            tok=${argv[a]}
+            [ "$tok" = "--" ] && break
+            case "$tok" in
+                --*)
+                    case "$long_flags" in
+                        *" $tok "*) ;;
+                        *) refused_flag=$tok ;;
+                    esac
+                    ;;
+                -?*)
+                    rest=${tok#-}
+                    [ -n "${rest//[$short_flags]/}" ] && refused_flag=$tok
+                    ;;
+                *) ;;
+            esac
+            [ -n "$refused_flag" ] && break
+        done
+
+        if [ -n "$refused_flag" ]; then
+            findings=$((findings + 1))
+            echo "${doc}:${docline}: this check will not run it, so it cannot say the claim holds:"
+            echo "    ${cmd}"
+            echo "  ${refused_flag} is not among the options it will pass to git grep."
+            continue
+        fi
+
+        "${argv[@]}" > /dev/null 2>&1
+        actual=$?
+
+        if [ "$actual" != "$pasted" ]; then
+            findings=$((findings + 1))
+            echo "${doc}:${docline}: pastes exit=${pasted} under"
+            echo "    ${cmd}"
+            echo "  and it exits ${actual}."
+        fi
+    done
+done
+
+echo "ran ${blocks} negative disclosure(s) in ${#docs[@]} document(s)"
+
+if [ "$findings" -gt 0 ]; then
+    echo "check-negative-disclosures: ${findings} disclosure(s) the tree does not bear out. A claim that something is not here is worth exactly what re-running it says." >&2
+    exit 1
+fi
+
+echo "check-negative-disclosures: every negative disclosure exits as the document says it does."

--- a/scripts/prove-negative-disclosure-refusals.sh
+++ b/scripts/prove-negative-disclosure-refusals.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Every refusal the negative-disclosure reader claims, watched refusing once, and the two properties
+# that make running text out of the tree defensible, watched holding.
+#
+# `scripts/check-negative-disclosures.sh` re-runs the `git grep ... ; echo "exit=$?"` blocks the
+# documents use to assert that something is NOT here. It passes on a tree nobody has broken, which is
+# the output a reader that says yes to everything also produces, and the defect it exists for - a
+# negative that quietly stopped being true - is one nobody can produce on demand. So every answer is
+# handed to it here.
+#
+# TWO OF THE CASES BELOW ARE ABOUT WHAT IT REFUSES TO RUN, NOT ABOUT WHAT IT DECIDES. A check that
+# executes text out of the tree earns that by being narrow, and narrow is only worth the word if
+# somebody watched it refuse the wide thing. Both write a sentinel file if a shell ever sees them, and
+# both are asserted to have written nothing.
+#
+# usage: scripts/prove-negative-disclosure-refusals.sh
+
+set -euo pipefail
+
+here=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+root=$(cd "$here/.." && pwd)
+checker="$here/check-negative-disclosures.sh"
+
+cd "$root"
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+sentinel="$work/a-shell-ran-this"
+
+# usage: doc <name> <line...>
+doc() {
+    local name=$1
+    shift
+    printf '%s\n' "# A fixture" '' 'Evidence:' '' "$@" '' 'End.' > "$work/$name"
+}
+
+failures=0
+
+# usage: refuses <heading> <sentence the refusal must carry> -- <command...>
+refuses() {
+    local heading=$1 sentence=$2
+    shift 3
+    printf '\n== %s\n' "$heading"
+    local out status
+    set +e
+    out=$("$@" 2>&1)
+    status=$?
+    set -e
+    printf '%s\n' "$out" | sed 's/^/  /'
+    if [ "$status" -eq 0 ]; then
+        echo "  ACCEPTED it, so the rule does not bite."
+        failures=$((failures + 1))
+        return
+    fi
+    case "$out" in
+        *"$sentence"*) ;;
+        *)
+            echo "  refused, but for something other than: $sentence"
+            failures=$((failures + 1))
+            ;;
+    esac
+}
+
+# usage: accepts <heading> <sentence the pass must carry> -- <command...>
+accepts() {
+    local heading=$1 sentence=$2
+    shift 3
+    printf '\n== %s\n' "$heading"
+    local out status
+    set +e
+    out=$("$@" 2>&1)
+    status=$?
+    set -e
+    printf '%s\n' "$out" | sed 's/^/  /'
+    if [ "$status" -ne 0 ]; then
+        echo "  REFUSED it, which is a reader that refuses everything."
+        failures=$((failures + 1))
+        return
+    fi
+    case "$out" in
+        *"$sentence"*) ;;
+        *)
+            echo "  accepted, but said nothing about: $sentence"
+            failures=$((failures + 1))
+            ;;
+    esac
+}
+
+# A string this repository holds and one it does not, both asserted here rather than believed, so a
+# fixture that has quietly stopped being a fixture fails as itself instead of as the rule it feeds.
+#
+# `git grep` searches what is tracked, so a string that is only in the working tree is absent to it.
+# That is a real distinction and it cost a fixture once: this file named its own checker, which was
+# not staged yet, and the broken-negative case passed because the checker was correct about a file
+# git could not see.
+present='usr/bin/env bash'
+absent='NoSuchSymbolIsInThisTreeAnywhereAtAll'
+
+if ! git grep -q -- "$present" -- scripts/; then
+    echo "the fixture is wrong: scripts/ no longer holds ${present}, so nothing here proves a present string is found." >&2
+    exit 2
+fi
+if git grep -q -- "$absent" -- scripts/; then
+    echo "the fixture is wrong: scripts/ now holds ${absent}, so nothing here proves an absent string is missed." >&2
+    exit 2
+fi
+
+# The state a document is in when nobody has broken it: a negative that is still true.
+doc true-negative.md "    git grep -n '${absent}' -- scripts/ ; echo \"exit=\$?\"" '    exit=1'
+accepts "a negative the tree still bears out" \
+    "every negative disclosure exits as the document says it does" \
+    -- "$checker" "$work/true-negative.md"
+
+# THE ONE IT EXISTS FOR, and it is #350 in miniature: the page says the thing is not here, the thing
+# is here, and nothing about the page looks wrong.
+doc broken-negative.md "    git grep -n '${present}' -- scripts/ ; echo \"exit=\$?\"" '    exit=1'
+refuses "the thing the page says is absent is present" \
+    "and it exits 0" \
+    -- "$checker" "$work/broken-negative.md"
+
+doc broken-positive.md "    git grep -n '${absent}' -- scripts/ ; echo \"exit=\$?\"" '    exit=0'
+refuses "the page claims a match and there is none" \
+    "and it exits 1" \
+    -- "$checker" "$work/broken-positive.md"
+
+doc no-code.md "    git grep -n '${absent}' -- scripts/ ; echo \"exit=\$?\""
+refuses "the block asks for an exit code and pastes none" \
+    "pastes none" \
+    -- "$checker" "$work/no-code.md"
+
+# What it will not run, part one: a redirection. If a shell ever sees this line it creates the
+# sentinel, and the assertion after these two cases is that it never did.
+doc redirection.md "    git grep -n foo -- scripts/ > ${sentinel} ; echo \"exit=\$?\"" '    exit=1'
+refuses "a redirection makes the command unreadable rather than skippable" \
+    "means something to a shell outside a quoted run" \
+    -- "$checker" "$work/redirection.md"
+
+# What it will not run, part two: the one flag of this verb that executes a command of the caller's
+# choosing. It survives the character scan, because every character in it is ordinary, and the option
+# set is what stops it.
+doc pager.md "    git grep -O'touch ${sentinel}' -n foo -- scripts/ ; echo \"exit=\$?\"" '    exit=1'
+refuses "git grep -O runs a pager of the caller's choosing and is not in the option set" \
+    "is not among the options it will pass to git grep" \
+    -- "$checker" "$work/pager.md"
+
+printf '\n== neither of those two reached a shell\n'
+if [ -e "$sentinel" ]; then
+    echo "  THE SENTINEL EXISTS. Something ran a command this check says it refuses to run."
+    failures=$((failures + 1))
+else
+    echo "  ${sentinel} does not exist, so neither line was executed."
+fi
+
+doc not-git.md "    ls -l /tmp ; echo \"exit=\$?\"" '    exit=0'
+refuses "a command that is not git grep" \
+    "runs git grep and nothing else" \
+    -- "$checker" "$work/not-git.md"
+
+# The near miss. A document with no such block at all passes and says how many it ran, so a run that
+# read nothing cannot be read as one that read everything and found nothing.
+doc none.md "    Jellyfin.Plugin.Requests/Model/RequestState.cs:22:    Open = 0,"
+accepts "a document carrying no negative disclosure says it ran none" \
+    "ran 0 negative disclosure(s)" \
+    -- "$checker" "$work/none.md"
+
+refuses "a document handed to it that does not exist" \
+    "does not exist" \
+    -- "$checker" "$work/no-such-document.md"
+
+printf '\n'
+if [ "$failures" -ne 0 ]; then
+    echo "$failures of the rules above did not bite." >&2
+    exit 1
+fi
+echo "Every refusal the negative-disclosure check claims was watched refusing, and nothing it declines to run reached a shell."

--- a/scripts/prove-negative-disclosure-refusals.sh
+++ b/scripts/prove-negative-disclosure-refusals.sh
@@ -95,7 +95,13 @@ accepts() {
 # not staged yet, and the broken-negative case passed because the checker was correct about a file
 # git could not see.
 present='usr/bin/env bash'
-absent='NoSuchSymbolIsInThisTreeAnywhereAtAll'
+
+# The absent one is built from two halves so that naming it here does not put it in the tree. Written
+# whole it would be tracked the moment this file is, which is how it broke: it passed on the machine
+# it was written on, where this file was not staged yet, and failed on the runner, where it was.
+absent_head='NoSuchSymbolIsIn'
+absent_tail='ThisTreeAnywhereAtAll'
+absent="${absent_head}${absent_tail}"
 
 if ! git grep -q -- "$present" -- scripts/; then
     echo "the fixture is wrong: scripts/ no longer holds ${present}, so nothing here proves a present string is found." >&2


### PR DESCRIPTION
Closes #350.

`SECURITY.md` told a reader the plugin makes no outbound call at all, and pasted a command exiting 1
to prove it. The command exits 0 and returns three matches, and had done since 2026-08-16 - through
two edits of that page, neither of which re-ran it.

**This is not a vulnerability and it discloses nothing.** The sink has been off by default since it
landed and there is no way to turn it on but an address an operator types. What was wrong is that the
one page a person evaluating this plugin reads first contradicted the two pages that were right.

## What the page says now

    git grep -nE 'HttpClient|WebRequest|WebSocket|Socket' -- Jellyfin.Plugin.Requests
    Jellyfin.Plugin.Requests/Notify/OutboundSink.cs:61:    private readonly HttpClient _client;
    Jellyfin.Plugin.Requests/Notify/OutboundSink.cs:104:        _client = new HttpClient(handler, disposeHandler: false)
    Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs:151:            new SocketsHttpHandler(),

Three lines and one path: the client, and the socket pipeline it is handed at registration, which the
registration's own comment says is the pipeline that client sends through. The section says what
turns it on, that it is empty on every install, and sends the reader to `docs/notifications.md` and
`docs/personal-data.md`, which were already right about all of it.

It also says in as many words what it used to claim and when that stopped being true. Somebody who
read the old sentence and took it for a property of the plugin took it from this page, and a page
that quietly starts saying something else leaves them holding the old one.

**And the claim is now a paste with lines in it**, so the reader added under #348 holds it from here
on. That is the smaller half of the repair and it is deliberate: the shape that could not be checked
became a shape that can.

## The shape nothing was reading

A negative disclosure pastes an exit code and no line, which is the whole point of it, so the reader
from #348 has nothing in one to resolve against a file. Every claim of that shape on this board was
therefore read by nobody, and they are the load-bearing negatives: no socket, no permission call, no
reach from the retention sweep into the server's activity log.

`scripts/check-negative-disclosures.sh` re-runs each block and compares the exit code. Watched
refusing the defect it was built for, against the page exactly as it stood on the mainline:

    $ git show origin/master:SECURITY.md > /tmp/SECURITY-before.md
    $ ./scripts/check-negative-disclosures.sh /tmp/SECURITY-before.md
    /tmp/SECURITY-before.md:68: pastes exit=1 under
        git grep -nE 'HttpClient|WebRequest|WebSocket|Socket' -- Jellyfin.Plugin.Requests
      and it exits 0.
    ran 1 negative disclosure(s) in 1 document(s)
    check-negative-disclosures: 1 disclosure(s) the tree does not bear out.
    rc=1

and passing over the four that are left, which are true:

    $ ./scripts/check-negative-disclosures.sh
    ran 4 negative disclosure(s) in 24 document(s)
    check-negative-disclosures: every negative disclosure exits as the document says it does.

## It runs text out of the tree, which is the part to read before trusting it

Executing what a document says is a thing to do narrowly or not at all. So the command never reaches
a shell as a string: it is scanned character by character, and anything a shell would act on outside
a quoted run - a pipe, a redirection, a substitution, a backslash, a brace, a glob - makes the block
UNREADABLE, which is a refusal rather than a skip. Only then is it split into words. The first two
must be `git grep`. Every option is checked against a fixed set, which is what excludes `-O`, the one
flag of this verb that runs a command of the caller's choosing.

A block it will not run fails the run. A check that quietly passed over what it could not read would
be at its most silent exactly where a document had been written to evade it.

## Every refusal watched refusing, and nothing it declines to run reaching a shell

    $ ./scripts/prove-negative-disclosure-refusals.sh

    == a negative the tree still bears out                     accepted
    == the thing the page says is absent is present            refused: and it exits 0
    == the page claims a match and there is none               refused: and it exits 1
    == the block asks for an exit code and pastes none         refused
    == a redirection makes the command unreadable              refused: means something to a shell
    == git grep -O runs a pager of the caller's choosing       refused: not among the options

    == neither of those two reached a shell
      /tmp/tmp.KfTUEeXMCU/a-shell-ran-this does not exist, so neither line was executed.

    == a command that is not git grep                          refused
    == a document carrying no negative disclosure              accepted: ran 0
    == a document handed to it that does not exist             refused

    Every refusal the negative-disclosure check claims was watched refusing, and nothing it declines to run reached a shell.

The two sentinel cases are the ones that make "narrow" worth the word. Both write a file if a shell
ever sees them, and the run asserts neither did.

**One of its own fixtures silently proved nothing at first, and that is written into the script
rather than only here.** It named this branch's own checker, which was not staged, and `git grep`
searches what is tracked - so the checker was correct about a file git could not see, and the case
passed for the wrong reason. Both fixture strings are asserted against the tree before anything else
runs now.

## A guard that was already here refused this change first

The two links the security page now carries broke `EveryRepositoryPathTheseDocumentsLinkToIsInTheTree`,
which exists so a document cannot send a reader to a file that is not there:

    Assert.Equal() Failure: Collections differ
    Expected: []
    Actual:   ["docs/notifications.md", "docs/personal-data.md"]

The repair is the one that guard's own group in the test project describes - "the link targets are
here too, because following a link is what the reader does next" - so the two documents are copied
beside the suite like `docs/quality-parity.md` already was.

## Where it runs

Two more steps of `Enforce greppable invariants`, beside the reader from #348, for the reason written
in that workflow: a job of its own reports a context the ruleset does not require, and #30 is where
six contexts are already waiting in that position. Nothing here edits a ruleset or
`docs/quality-parity.md`, and no new context appears.

## The means

Bash, for the same reason as #348 and one more: this reader has to execute a command and inspect its
exit code without a shell between the two, which a test in the C# suite would have to reimplement.

## Evidence

    $ dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler:     0, erfolgreich:   777, übersprungen:     0, gesamt:   777, Dauer: 25 s - Jellyfin.Plugin.Requests.Tests.dll (net10.0)
    Bestanden!   : Fehler:     0, erfolgreich:   777, übersprungen:     0, gesamt:   777, Dauer: 25 s - Jellyfin.Plugin.Requests.Tests.dll (net9.0)

    $ ./scripts/check-pasted-evidence.sh
    read 108 pasted match lines in 24 document(s)
    check-pasted-evidence: every pasted match line reproduces against the file it names.

    $ npx --yes prettier@3.6.2 --check ".lfcheck/**/*.md"
    Checking formatting...
    All matched files use Prettier code style!

The markdown was checked as an LF copy made inside the tree and then removed, because this checkout
is CRLF and the gate reads LF. The suite answers in the language this machine's toolchain runs in.

## What this does NOT claim

**The runner has now exercised both steps, and this paragraph said it had not.** Run `33376811855`
on this head, where the sentinel proof holds on the runner's own filesystem and the tree-wide step
reads the same four:

    Enforce greppable invariants   /tmp/tmp.pZ8XiI3QuO/a-shell-ran-this does not exist, so neither line was executed.
    Enforce greppable invariants   ran 4 negative disclosure(s) in 24 document(s)

**The first runner to see this change refused it, and that is written into the branch rather than
tidied out of it.** The absent fixture string was written whole, so it was in the tree the moment the
file holding it was tracked, and the assertion meant to catch a broken fixture caught this one. It
passed here, where the file was not staged. Both directions of that same distinction have now cost
this one file a fixture, and both are recorded at the fixture.

**Four negative disclosures are now read and no more than four exist in that form.** A negative
stated in prose is not read by this and is not claimed to be: whether a sentence asserts one is a
judgement about meaning that no reading of this tree makes.

**Nothing was read on a running server**, and nothing here needed one.

**This has had no second reader.** Nobody else has read it tonight, and the transcript above stands
in place of one rather than beside it.
