### PR TITLE
Say that one setting is an address and is marked, on the two pages that said none is

### DIFF
--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -255,9 +255,44 @@ a second implementation arriving in the plugin assembly unnamed for the same rea
 
 **There is no credential today and nothing here holds one.** The only implementation of the bridge in
 this tree is the one for a server that has no service, it makes no call, and the configuration
-carries no field for an address or for a secret. Everything below is what will be true the day the
+carries no bridge address and no credential. Everything below is what will be true the day the
 adapter adds one, written now so that it is a position rather than a description written afterwards
 to fit whatever was built.
+
+**One field for an address does exist and it is not this one.** `OutboundNoticeAddress` is where a
+notice about a request is posted, it is empty on every install where nobody has decided otherwise,
+and [`notifications.md`](notifications.md) is what it does. It is named here because a sentence
+saying the configuration holds no address, in a tree that holds one, is the sentence a reader carries
+away.
+
+### The mark such a value would carry is already in force
+
+`SecretAttribute` marks a setting whose value may not appear in anything this plugin writes for
+somebody else to read, and the notice address above carries it:
+
+    git grep -nE '^    (\[Secret\]|public string OutboundNoticeAddress)' -- Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs
+    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:151:    [Secret]
+    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:152:    public string OutboundNoticeAddress { get; set; } = string.Empty;
+
+**The mark refuses nothing on its own**, and that is the part to read before treating it as
+protection. Nothing reads it at run time and no code path behaves differently for a marked property.
+What holds the rule is a lint rule pointed at the mark, and a suite leg refusing a mark that no rule
+names, so the two cannot drift apart:
+
+    git grep -n 'id: no-marked-setting-in-a-message' -- tools/opengrep/rules.yaml
+    tools/opengrep/rules.yaml:789:  - id: no-marked-setting-in-a-message
+
+    git grep -n 'public void EveryMarkedSettingIsNamedByARuleInTheInvariantLint' -- Jellyfin.Plugin.Requests.Tests/Configuration/SecretsStayOutOfTheLogTests.cs
+    Jellyfin.Plugin.Requests.Tests/Configuration/SecretsStayOutOfTheLogTests.cs:147:    public void EveryMarkedSettingIsNamedByARuleInTheInvariantLint()
+
+It is not a redacting type, and that is a decision rather than an omission: the host keeps this
+configuration by serialising it and the settings page edits it the same way, so a value that hands
+out a redaction on those paths is a setting that does not survive a restart. What answers that
+instead is a write-only settings page.
+
+None of that decides anything about a bridge credential. It is written here so that the section
+below argues against what is in force rather than against an empty tree, and where such a credential
+is kept is #85.
 
 ### Where it goes
 

--- a/docs/operating.md
+++ b/docs/operating.md
@@ -103,8 +103,9 @@ paraphrase gets wrong.
 ## Wiring an external request service
 
 **Nothing in this tree talks to one.** The only bridge that ships is the one for a server that has no
-service, it makes no call, and the settings carry no field for an address or a credential. There is
-nothing to wire today.
+service, it makes no call, and the settings carry no bridge address and no credential. There is
+nothing to wire today. The address on the settings page is the one in step 2 above, where a notice
+about a request is posted, and it has nothing to do with a request service.
 
 That is not the same as nothing being decided, and the parts an operator will have to reason about
 are already written down. [bridge.md](bridge.md) is the authority for all three, and this section


### PR DESCRIPTION
Closes #352.

`docs/bridge.md` and `docs/operating.md` both told a reader that this plugin's configuration carries
no field for an address or for a secret. It carries one field that is both:

    git grep -nE '^    (\[Secret\]|public string OutboundNoticeAddress)' -- Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs
    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:151:    [Secret]
    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:152:    public string OutboundNoticeAddress { get; set; } = string.Empty;

Both sentences sit in a paragraph about a bridge to an external request service, and inside it the
reading intended is a bridge address and a bridge credential. Neither says so. `docs/operating.md` is
the worse of the two to read that way, because four bullets earlier it tells the operator to decide
**the address a notice is posted to**.

The class the code gets right is written at the property itself:

    $ git grep -n 'There is no bridge address and no credential' -- Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs
    Jellyfin.Plugin.Requests/Configuration/PluginConfiguration.cs:31:/// There is no bridge address and no credential. The only implementation of the bridge in this tree

Both pages now say bridge address, and each names the notice address beside it, so a reader who has
just met one setting is not left reconciling two sentences on their own.

## The half that was missing rather than wrong

`docs/bridge.md` carries that sentence under the heading deciding where a credential would live and
what may be claimed about it. The mark such a value would carry is already in force on a neighbouring
setting, and before this no document in the tree mentioned it at all:

    $ git grep -in 'secret' -- docs/ ; echo "exit=$?"
    exit=1

That section now carries it: what `SecretAttribute` binds, and what refuses a breach of it, which is
a lint rule pointed at the mark and a suite leg refusing a mark that no rule names, so the two cannot
drift apart. It leads with the sentence that matters most about it - **the mark refuses nothing on
its own** - because a page that names an attribute and stops there is read as protection that is not
there.

**Nothing here decides anything about a bridge credential.** Where one is kept is #85. This only
stops that section arguing against an empty tree, and it says so in the page.

## How it was found

By sweeping every document for claims of the shape that had just been wrong in `SECURITY.md` under
#350 and reading each against the tree. Ten lines of that shape at the base of this change, in six
documents:

    $ git grep -cE 'no outbound|makes no call|nothing leaves|sends nothing|no network|never leaves|no field for an? (address|credential)' 761f807 -- '*.md'
    761f807:SECURITY.md:1
    761f807:docs/bridge.md:3
    761f807:docs/notifications.md:3
    761f807:docs/operating.md:1
    761f807:docs/personal-data.md:1
    761f807:docs/queue.md:1

**The pattern is a net rather than the population**, and it is written here so the ten is not read as
a census: a claim of this shape phrased in words the pattern does not carry was not seen by it, and
whether a sentence asserts one at all is a judgement no grep makes. Two of the ten were wrong, both
for the same reason: a qualifier that was in the writer's head and not in the sentence.

## Evidence

    $ dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler:     0, erfolgreich:   777, übersprungen:     0, gesamt:   777, Dauer: 23 s - Jellyfin.Plugin.Requests.Tests.dll (net10.0)
    Bestanden!   : Fehler:     0, erfolgreich:   777, übersprungen:     0, gesamt:   777, Dauer: 23 s - Jellyfin.Plugin.Requests.Tests.dll (net9.0)

    $ ./scripts/check-pasted-evidence.sh
    read 112 pasted match lines in 24 document(s)
    check-pasted-evidence: every pasted match line reproduces against the file it names.

    $ ./scripts/check-negative-disclosures.sh
    ran 4 negative disclosure(s) in 24 document(s)
    check-negative-disclosures: every negative disclosure exits as the document says it does.

    $ npx --yes prettier@3.6.2 --check ".lfcheck/**/*.md"
    Checking formatting...
    All matched files use Prettier code style!

The markdown was checked as an LF copy made inside the tree and then removed, because this checkout
is CRLF and the gate reads LF. The four new pasted lines are read by the check that landed under
#348, so this section does not go stale silently either.

## What this does NOT claim

**Nothing was measured on a running server.** No settings page was opened and no log was read; every
command above reads this repository.

**The mark was not watched refusing anything here.** The lint rule and the suite leg are named as
existing and as passing, which is a different statement from watching a guard bite, and only the
first is made.

**The other eight lines that pattern returned were read and left alone.** They are correct, and this
does not touch them.

**This has had no second reader.** Nobody else has read it tonight, and the transcript above stands
in place of one rather than beside it.
