### PR TITLE
Say what the storage page's four absences have become, instead of the absences

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -57,7 +57,10 @@ What is not decided here, and where it is:
 - The on-disk shape, its version, and the rules for changing it are below.
 - How long a finished request is kept is `FinishedRequestRetentionDays`, and what acts on it is
   `RetentionSweep` beside this store, driven by a scheduled task. What happens to a record when the
-  person it names is deleted is still open and is #49.
+  person it names is deleted was decided on #49 and is built: `RemovedAccounts` under `People/`
+  consumes the server's own deletion event, and it applies three rules rather than one.
+  [personal-data.md](personal-data.md) is the account of them and the authority for them, because
+  they are policy and this page is the store.
 
 ## The three questions the store is asked
 
@@ -394,9 +397,31 @@ looks like. The generated equality on the record is not value equality:
 requests holding the same values compare unequal whenever the dictionaries are two objects, which is
 every time one of them came off disk. A store deciding whether a write changed anything, or a test
 asserting that what was read is what was written, cannot use `==` for it and has to compare the
-dictionary itself. Nothing in the tree does that today; this is written here so the first thing that
-needs to does not discover it as a bug.
+dictionary itself. This was written here so that the first thing needing it would not meet it as a
+bug, and something needed it: the durability leg puts every collection back before comparing the
+record and then compares the map entry by entry, with the same reason written at it.
 
-The harness for those runs is not tracked. It is a console project referencing the plugin, and adding
-one to a tree whose only test project is the suite is a means decision this issue did not take. The
-round trip belongs in the suite when the store exists, which is #46.
+    git grep -n 'ProviderIds = readFull.Value.Request.ProviderIds' -- Jellyfin.Plugin.Requests.Tests/Storage/FileRequestStoreDurabilityTests.cs
+    Jellyfin.Plugin.Requests.Tests/Storage/FileRequestStoreDurabilityTests.cs:109:                ProviderIds = readFull.Value.Request.ProviderIds,
+
+The harness for those runs is not tracked. It was a console project referencing the plugin, and
+adding one to a tree whose only test project was the suite was a means decision that issue did not
+take. **That reason has since been overtaken and the harness is still not here**, which are two
+statements rather than one: the tree now carries such a project, added for a probe that has to run as
+a process of its own rather than to hold a round trip.
+
+    git grep -n '<OutputType>' -- tools/full-disk-probe/FullDiskProbe.csproj
+    tools/full-disk-probe/FullDiskProbe.csproj:4:    <OutputType>Exe</OutputType>
+
+The round trip did not wait for it. The store exists and the round trip is in the suite, which is
+where this page said it belonged and where #46 put it on 2026-08-09, in the same change that built
+the durability this section argues for:
+
+    git grep -n 'class FileRequestStore ' -- Jellyfin.Plugin.Requests/Storage/FileRequestStore.cs
+    Jellyfin.Plugin.Requests/Storage/FileRequestStore.cs:72:public sealed class FileRequestStore : IRequestStore, IDisposable
+
+    git grep -n 'public async Task EveryFieldComesBackFromAStoreOpenedFreshOverTheSameDirectory' -- Jellyfin.Plugin.Requests.Tests/Storage/FileRequestStoreDurabilityTests.cs
+    Jellyfin.Plugin.Requests.Tests/Storage/FileRequestStoreDurabilityTests.cs:67:    public async Task EveryFieldComesBackFromAStoreOpenedFreshOverTheSameDirectory()
+
+So what is left of the paragraph above is the measurement and the trap it recorded, both of which
+still hold. What is gone is the absence it was written against.


### PR DESCRIPTION
Closes #354.

`docs/storage.md` is the argument for the medium this plugin keeps requests in, and its force comes
from being an account of what was measured rather than of what was hoped. Four of its sentences said
the tree lacks something it has. A reader deciding whether to trust the medium met a survey of
absences, every one of which had been filled.

## The four, and what each says now

**The account-deletion question was not still open.** The bullet listing what this page does not
decide said it was:

    $ gh issue view 49 --repo Flowfin/jellyfin-plugin-requests --json state,stateReason,closedAt --jq '"\(.state)/\(.stateReason) \(.closedAt)"'
    CLOSED/COMPLETED 2026-08-27T10:33:40Z

It names the consumer now and sends the reader to `personal-data.md`, which is the authority for the
three rules it applies, because they are policy and this page is the store.

**Something in the tree does compare the provider dictionary.** The paragraph explaining that a
record compares an `IReadOnlyDictionary` by reference ended by saying nothing in the tree compares it
by value, written so the first thing needing it would not meet it as a bug. Something needed it, and
the note did its work:

    git grep -n 'ProviderIds = readFull.Value.Request.ProviderIds' -- Jellyfin.Plugin.Requests.Tests/Storage/FileRequestStoreDurabilityTests.cs
    Jellyfin.Plugin.Requests.Tests/Storage/FileRequestStoreDurabilityTests.cs:109:                ProviderIds = readFull.Value.Request.ProviderIds,

The comment above that line gives the same reason this page gives.

**The tree is no longer one whose only test project is the suite.**

    git grep -n '<OutputType>' -- tools/full-disk-probe/FullDiskProbe.csproj
    tools/full-disk-probe/FullDiskProbe.csproj:4:    <OutputType>Exe</OutputType>

A console project referencing the plugin is exactly what that sentence calls a means decision nobody
had taken, and one has been tracked since 2026-08-23. **The harness for those measurement runs is
still not here**, and the page now says that as two statements rather than one: the reason it was
declined has been overtaken, and the thing itself still does not exist.

**The round trip did not wait for the store.** The page deferred it to the suite "when the store
exists, which is #46". Both halves are answered, and the second is the sharper one:

    $ git log --format='%h %ad %s' --date=short -S 'EveryFieldComesBackFromAStoreOpenedFreshOverTheSameDirectory' --reverse -- Jellyfin.Plugin.Requests.Tests/Storage/FileRequestStoreDurabilityTests.cs | head -1
    7b62877 2026-08-09 Make a write survive being interrupted (#46) (#172)

#46 put the round trip in the suite on 2026-08-09, in the same change that built the durability this
section argues for. So the sentence deferring it was stale from the day the issue it named closed,
and it stood for three weeks.

## What this does not do

**Nothing is decided and nothing is softened.** Each of the four says what is there instead, with the
command that shows it, rather than being deleted and leaving a reader wondering what the paragraph
was for. The measurement the round-trip section records and the trap it found - a record whose
generated equality is not value equality - are untouched, and they still hold.

**`personal-data.md` stays the authority for the deletion rules.** This page names the consumer and
stops.

## How it was found

By resolving every issue number these documents name against the tracker, and reading the sentences
around the closed ones:

    $ git grep -oh '#[0-9]\+' -- '*.md' | sort -u | wc -l
    78

Seventy-eight distinct references. Resolved one by one against the tracker: sixty-seven closed, ten
open, and one that is a pull request rather than an issue. Most of the sixty-seven are provenance -
where a decision was taken - and correctly point at something closed. The ones worth reading are those in a
sentence about the present, and `docs/storage.md` held four of them.

## Evidence

    $ dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler:     0, erfolgreich:   777, übersprungen:     0, gesamt:   777, Dauer: 21 s - Jellyfin.Plugin.Requests.Tests.dll (net10.0)
    Bestanden!   : Fehler:     0, erfolgreich:   777, übersprungen:     0, gesamt:   777, Dauer: 20 s - Jellyfin.Plugin.Requests.Tests.dll (net9.0)

    $ ./scripts/check-pasted-evidence.sh
    read 116 pasted match lines in 24 document(s)
    check-pasted-evidence: every pasted match line reproduces against the file it names.

    $ ./scripts/check-negative-disclosures.sh
    ran 4 negative disclosure(s) in 24 document(s)
    check-negative-disclosures: every negative disclosure exits as the document says it does.

    $ npx --yes prettier@3.6.2 --check ".lfcheck/**/*.md"
    Checking formatting...
    All matched files use Prettier code style!

The markdown was checked as an LF copy made inside the tree and then removed, because this checkout
is CRLF and the gate reads LF. The four new pasted lines are read by the check that landed under
#348.

## What this does NOT claim

**No mechanism refuses the next one of these.** A sentence asserting that the tree lacks something is
a claim about the present in prose, and whether one is being made at all is a judgement about meaning
that no reading of this tree makes. The two readers on this board resolve a paste and re-run a
command; neither can see a sentence like these four. This was found by hand and the next one will be
too.

**Nothing was read on a running server**, and nothing here needed one.

**This has had no second reader.** Nobody else has read it tonight, and the transcript above stands
in place of one rather than beside it.
