### PR TITLE
Say that the floor server refuses a version and not a member, in the three files that describe it

### DIFF
--- a/.github/workflows/abi-floor.yaml
+++ b/.github/workflows/abi-floor.yaml
@@ -6,6 +6,20 @@
 # a MissingMethodException on the oldest server it says it supports. That
 # failure lands on a user and on nothing before them.
 #
+# WHAT THIS JOB CANNOT COVER IS THE ARTEFACT, AND THE FLOOR SERVER HAS ALREADY
+# REFUSED ONE. It compiles the SOURCE against the floor SDK. What ships is
+# compiled against the current SDK, and an assembly's reference table is stamped
+# with the versions of the assemblies it was compiled against, so the published
+# `0.2.0.0` archive asks a `10.11.0` server for `MediaBrowser.Common`,
+# `MediaBrowser.Model`, `MediaBrowser.Controller`, `Jellyfin.Data` and
+# `Jellyfin.Database.Implementations` at `10.11.11.0`, and that server carries
+# all five at `10.11.0.0`. A reference above what the host carries does not
+# bind: the assembly loads, `GetTypes()` throws, and the server reports the
+# plugin `NotSupported`. Nothing has to be called for that to happen, so this
+# job being green says nothing about it and the two are easy to read as one
+# guard. It happened in run `33358848505`, the measurement is on #152, and which
+# of the two numbers moves is decided there rather than here.
+#
 # The lines are not listed here. They are read out of the packaging files at the
 # repository root, one file per package, and each file's own `targetAbi` and
 # `framework` fields decide what its job builds. Adding a line is adding a

--- a/README.md
+++ b/README.md
@@ -73,10 +73,12 @@ the plugin was `Active` at `0.2.0.0`. The server was `10.11.11`.
 says `targetAbi: "10.11.0.0"`, which names the server `10.11.0`, and putting
 `requests_0.2.0.0.zip` on that server reports
 `Requests is NotSupported rather than Active` - run `33358848505`. Jellyfin sets
-that status in one place, on a failure to load the assembly's types, so the
-published build references something that server's shared libraries do not carry.
-Which of the two moves, the claimed floor or the reference, is #152. **Do not
-install this on a `10.11.0` server: it will not run.**
+that status in one place, on a failure to load the assembly's types. What that
+server does not carry is not a member, it is the version: the archive's five
+Jellyfin references are stamped `10.11.11.0` and `10.11.0` carries all five at
+`10.11.0.0`, and a reference above what the host carries does not bind. Which of
+the two moves, the SDK the package is built against or the floor it claims, is
+#152. **Do not install this on a `10.11.0` server: it will not run.**
 
 Two further things neither run covers: the bytes are copied into the plugin
 directory rather than fetched and unpacked by the server itself, and the 12.0

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -107,8 +107,12 @@ files:
   server `10.11.0`. The same archive on that server ends the run at its verdict step with
   `Requests is NotSupported rather than Active`, in run `33358848505`. Jellyfin sets that status in
   exactly one place, catching a `TypeLoadException` or a `ReflectionTypeLoadException` while loading
-  the assembly's types, so the shipped build references something `10.11.0`'s shared libraries do
-  not carry. **The floor build does not cover this and the two are easy to read as one guard.**
+  the assembly's types. **What that server does not carry is not a member, it is the version.** The
+  archive's five Jellyfin references are stamped `10.11.11.0` and the `10.11.0` server carries all
+  five at `10.11.0.0`; a reference above what the host carries does not bind, so nothing has to be
+  called for the load to fail. That measurement, and the type graph resolving clean against the
+  floor's own assemblies, are on #152. **The floor build does not cover this and the two are easy to
+  read as one guard.**
   `abi-floor.yaml` compiles the SOURCE against the floor SDK and was green on the same day; what
   ships is compiled against the current SDK, so a green floor build says the source could be built
   against the floor and nothing about the artefact that went out. #152 holds which of the two


### PR DESCRIPTION
Part of #152. Three paragraphs, in the three files that describe why the floor server refuses the published release.

## What was wrong

**`abi-floor.yaml`'s header names one failure mode and it is not the one that happened.** It says an API added since the floor can be called by the plugin, compile clean, ship, and throw a `MissingMethodException` on the oldest server the package claims. That is real. It is also not what `jellyfin/jellyfin:10.11.0` did to the published `0.2.0.0` archive, and a reader who opens this file to find out what the floor job is for meets an argument for a different failure and no bound at all.

**`docs/compatibility.md` and `README.md` said the shipped build "references something" that server's "shared libraries do not carry".** Nothing is missing from them. An assembly's reference table is stamped with the versions of the assemblies it was compiled against, and the shipping build compiles against the current SDK:

    $ dotnet run assembly-references.cs pkg/Jellyfin.Plugin.Requests.dll | grep -E 'MediaBrowser|Jellyfin'
    MediaBrowser.Common, Version=10.11.11.0
    MediaBrowser.Model, Version=10.11.11.0
    MediaBrowser.Controller, Version=10.11.11.0
    Jellyfin.Database.Implementations, Version=10.11.11.0
    Jellyfin.Data, Version=10.11.11.0

The `10.11.0` server carries all five at `10.11.0.0`. A reference above what the host carries does not bind: the assembly loads, `GetTypes()` throws, and the plugin is reported `NotSupported`, without anything having been called. The full measurement - the twelve-line reader used above, the type graph of the shipped assembly resolving clean against the floor's own assemblies, the reproduction of the binder in both directions, and what none of it claims - is on #152 and is not repeated in any of the three.

## Why the difference is worth saying three times

A missing member sends somebody looking for the API this plugin calls that `10.11.0` does not have, and there is none to find. What is wrong is which SDK the shipped bytes were compiled against, which is two numbers in this tree rather than a search. The workflow paragraph stops a green `floor 10.11.0.0` being read as cover for the artefact. The other two stop the search, and they are two rather than one because the front page is where somebody deciding whether to install reads it and the compatibility page is where somebody deciding what is supported reads it.

## What this does not do

**It decides nothing.** Which of the two numbers moves - the SDK the package is compiled against, or the `targetAbi` it claims - is #152's, and all three paragraphs say so and point there.

**It changes no job, no step and no condition.** The workflow half is comment lines only.

    $ git diff --stat origin/master...HEAD
     .github/workflows/abi-floor.yaml | 14 ++++++++++++++
     README.md                        | 10 ++++++----
     docs/compatibility.md            |  8 ++++++--
     3 files changed, 26 insertions(+), 6 deletions(-)

**Nothing was read on a running server.** The container engine is not running on this machine and I did not start one. The run all three paragraphs name, `33358848505`, is the one already recorded on #152.

**No warning is softened.** `docs/compatibility.md` still says the floor server refuses the published release and still says the floor build does not cover it, and `README.md` still says in bold not to install this on a `10.11.0` server. What changed inside each is the cause, from a member to a version.

## Evidence

    $ dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler:     0, erfolgreich:   777, gesamt:   777  (net9.0)
    Bestanden!   : Fehler:     0, erfolgreich:   777, gesamt:   777  (net10.0)

    $ bash scripts/check-pasted-evidence.sh
    read 116 pasted match lines in 24 document(s)
    check-pasted-evidence: every pasted match line reproduces against the file it names.

    $ bash scripts/check-negative-disclosures.sh
    ran 4 negative disclosure(s) in 24 document(s)
    check-negative-disclosures: every negative disclosure exits as the document says it does.

    $ npx --yes prettier@3.6.2 --parser markdown --check .lfcheck/docs/compatibility.md .lfcheck/README.md
    All matched files use Prettier code style!

The markdown was checked as an LF copy made inside the tree, because this checkout is CRLF and the gate reads LF. The workflow still parses as YAML after the edit, checked with `yaml.safe_load`.

## Means

A comment in the workflow it is about, and a sentence in each passage it is about. A document collecting all three would be a second place saying what the floor job covers, and the two would drift; each correction belongs where the claim it corrects already is.

## Review

There is no second reader on this board tonight. Every command above is reproducible at this head, and the measurement all three rest on is on #152 with the reader it used written out in full.
