### PR TITLE
Say that the cancelled state was refused, where the page said the question was open

### DIFF
--- a/docs/surface.md
+++ b/docs/surface.md
@@ -169,8 +169,10 @@ operator handing this address to their household should treat it as handing over
 
 **It offers no decision about a request.** Approving and declining need an administrator, and
 cancelling something still open needs a state a request can be withdrawn into, which this plugin does
-not have: whether there is a cancelled state is an open decision on #113. So the page is a thing to
-read, and a control that could not do anything would be worse than none.
+not have: a cancelled state was considered and refused on #113, and the refusal was read against a
+later ruling asking for the opposite and upheld on #337. So the absence is settled rather than
+pending, the page is a thing to read, and a control that could not do anything would be worse than
+none.
 
 **It carries one control, and it is not a decision.** A checkbox that turns off the message this
 plugin pushes at the person reading the page when one of their own requests moves. It belongs there


### PR DESCRIPTION
Closes #365

## What was wrong

`docs/surface.md` gave the reason the user page offers no control for taking a request back, and ended that reason with the question being undecided:

    git grep -n 'open decision on #113' origin/master -- docs/
    origin/master:docs/surface.md:172:not have: whether there is a cancelled state is an open decision on #113. So the page is a thing to

It is decided, and twice. It was refused on #113, and the refusal is written into the model:

    git grep -n 'Cancelled' -- Jellyfin.Plugin.Requests/
    Jellyfin.Plugin.Requests/Model/RequestActor.cs:43:    /// is no state for a user withdrawing, refused with the <c>Cancelled</c> state on #113. The
    Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs:69:/// user withdrawing has no state to move to because <c>Cancelled</c> was refused on #113. An

The ruling of 2026-08-28 asked for the opposite and #337 read the two against each other on 2026-08-30 and upheld the refusal:

    git grep -n 'the refusal stands' -- docs/personal-data.md
    docs/personal-data.md:288:**#337 answered that on 2026-08-30, and the refusal stands.** Closed as withdrawn means the terminal

## What the page says now

That a cancelled state was considered and refused on #113, that the refusal was read against a later ruling asking for the opposite and upheld on #337, and that the absence is settled rather than pending.

## What is NOT claimed

**The absence has not moved and this does not soften it.** The page still says the page carries no such control and still says why one that could do nothing would be worse than none. What changes is the tense of the reason, not the reason.

**Nothing else is edited.** `docs/user-guide.md` and `docs/api.md` already say the settled thing, so the surface page was alone in saying otherwise and both are left exactly as they are:

    git grep -n 'no way to take an ask back' -- docs/user-guide.md
    docs/user-guide.md:21:**There is no way to take an ask back.** A request has no withdrawn state, deliberately, so nothing

    git grep -n 'Cancelling is not here' -- docs/api.md
    docs/api.md:475:detected instead. Cancelling is not here because there is no state to cancel into, refused on #113.

**No source file moved and no behaviour changed.** This is one paragraph of one page.

## The means

Markdown in the page that carried the sentence. The claim was about a decision, so it has no home in source and no check could read it; what stands behind it is the review.

## How the formatting was checked

Every markdown file in this clone carries CRLF from `core.autocrlf`, so a check at the path the workflow globs warns on files nothing has touched. The changed file was checked as an LF copy made inside the tree, where the repository's own `.editorconfig` still applies:

    npx --yes prettier@3.6.2 --check ".lfcheck/*.md"
    Checking formatting...
    All matched files use Prettier code style!

## What had no second reader

Nobody else read this. The defect was found while answering #337 against the tree rather than by anything failing, and every command above was run before the sentence resting on it.
