### PR TITLE
Refuse a package that asks a server for more than its targetAbi claims

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -205,6 +205,22 @@ jobs:
           ls -l "${ARTIFACT}" "${ARTIFACT}.meta.json"
           unzip -l "${ARTIFACT}"
 
+      - name: Check the package asks a server for no more than its targetAbi claims
+        env:
+          ARTIFACT: ${{ steps.jprm.outputs.artifact }}
+          ABI: ${{ matrix.abi }}
+        # THE ARTEFACT, NOT THE SOURCE. `abi-floor.yaml` compiles the source against the floor SDK
+        # and says nothing about what was packaged; the step above says the archive exists and
+        # nothing about what it asks for. Between the two sat the class that shipped: `0.2.0.0`
+        # asked a `10.11.0` server for five assemblies at `10.11.11.0`, that server carries them at
+        # `10.11.0.0`, the reference does not bind and the server reports the plugin
+        # `NotSupported` after a download that looked like it worked. Every route here was green
+        # while that shipped, which is #360.
+        #
+        # It reads the archive this job just built, so it judges the bytes rather than a publish of
+        # the same source, and it reaches no network and starts no server.
+        run: ./scripts/check-package-abi.sh "${ARTIFACT}" "${ABI}"
+
       - name: Keep the package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -244,3 +260,34 @@ jobs:
           ls -1 "${staged}"
           image=$(./scripts/server-image-for.sh "${FRAMEWORK}")
           PLUGIN_FROM_DIRECTORY="${staged}" ./scripts/verify-plugin-loads.sh "${image}" "${FRAMEWORK}" 18096
+
+  abi-refusals:
+    # The check name a branch ruleset would require. It is matched literally, so renaming this job
+    # removes a requirement instead of renaming one, and it carries no version for the reason
+    # `floor 10.11.0.0` and `floor 12.0.0.0` are not in the required set today: a name that moves
+    # with a matrix stops existing the day the matrix moves.
+    name: the package check refuses what it says it refuses
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+
+    # A job of its own rather than a step inside the matrix. The proof builds the plugin twice and
+    # judges both, which is one answer about the checker rather than one answer per line, and under
+    # the matrix it would be run once per line and prove the same thing twice.
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: |
+            9.0.x
+            10.0.x
+
+      - name: Every answer the package reader gives, watched being given
+        # Beside the check rather than in a workflow of its own, for the reason the floor build's
+        # documentation proof gives: this is where the answer is produced, and a proof that runs on
+        # some other head is a proof of some other file.
+        run: ./scripts/prove-package-abi-refusals.sh

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -264,8 +264,10 @@ jobs:
   abi-refusals:
     # The check name a branch ruleset would require. It is matched literally, so renaming this job
     # removes a requirement instead of renaming one, and it carries no version for the reason
-    # `floor 10.11.0.0` and `floor 12.0.0.0` are not in the required set today: a name that moves
-    # with a matrix stops existing the day the matrix moves.
+    # `package 10.11.0.0` and `package 12.0.0.0` above are not in the required set today: a name
+    # that moves with a matrix stops existing the day the matrix moves. The floor jobs made the
+    # same argument under `floor 10.11.0.0` and `floor 12.0.0.0` until `fc11369`, which renamed
+    # them after the packaging file so they could be required; those two strings no longer report.
     name: the package check refuses what it says it refuses
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -390,6 +390,31 @@ jobs:
         with:
           dotnet-target: ${{ needs.gate.outputs.framework }}
 
+      - name: Check the package asks a server for no more than its targetAbi claims
+        env:
+          ARTIFACT: ${{ steps.jprm.outputs.artifact }}
+        # THE ARTEFACT, NOT THE SOURCE, AND ON THE ROUTE THAT SHIPS IT. `abi-floor.yaml` compiles the
+        # source against the floor SDK and says nothing about what was packaged, so `0.2.0.0` went out
+        # asking a `10.11.0` server for five assemblies at `10.11.11.0` with every route green: that
+        # server carries them at `10.11.0.0`, the reference does not bind, and the server reports the
+        # plugin `NotSupported` after a download that looked like it worked. `package.yaml` runs the
+        # same check on every pull request; this is the copy that stands between a bad build and a tag,
+        # and a tag cannot be spent twice.
+        #
+        # Before the bill of materials and before anything is uploaded, for the reason the step below
+        # gives about itself: a release that exists is never touched again.
+        #
+        # The claim is read out of the packaging file this run put in place for the line the tag names,
+        # which is the file the package was built from.
+        run: |
+          set -euo pipefail
+          abi=$(sed -n 's/^targetAbi: *"\{0,1\}\([^"]*\)"\{0,1\}$/\1/p' build.yaml | head -1)
+          if [ -z "${abi}" ]; then
+            echo "::error::build.yaml declares no targetAbi, so there is no claim for the package's references to be compared against."
+            exit 1
+          fi
+          ./scripts/check-package-abi.sh "${ARTIFACT}" "${abi}"
+
       - name: Write the bill of materials
         id: bom
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ not need an entry; the git history is where that is read.
 
 ## Unreleased
 
+- The 10.11 package now installs on every server of the line it claims, and not only on the newest
+  one. `0.2.0.0` was compiled against `10.11.11` while its packaging metadata claimed `10.11.0.0`,
+  so a server below `10.11.11` downloaded it, failed to bind five assembly references, and reported
+  the plugin `NotSupported` with nothing saying why. The package is built against the floor it
+  claims from now on, and a packaging run that asks a server for more than the claim is refused
+  before a tag can be spent on it. **This does not repair an installed `0.2.0.0`:** that release
+  keeps the references it shipped with until a later release replaces it.
 - Deleting a Jellyfin user now takes their requests with them. A request they asked for is removed,
   a request somebody else asked for that they had joined stays with them off its list, and the
   switch they may have set about being told is set back to the shipping value. Until now nothing in

--- a/Jellyfin.Plugin.Requests.Tests/packages.lock.json
+++ b/Jellyfin.Plugin.Requests.Tests/packages.lock.json
@@ -741,8 +741,8 @@
       "jellyfin.plugin.requests": {
         "type": "Project",
         "dependencies": {
-          "Jellyfin.Controller": "[10.11.11, )",
-          "Jellyfin.Model": "[10.11.11, )"
+          "Jellyfin.Controller": "[10.11.0, )",
+          "Jellyfin.Model": "[10.11.0, )"
         }
       }
     }

--- a/Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.csproj
+++ b/Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.csproj
@@ -9,10 +9,22 @@
          runs. -->
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <RootNamespace>Jellyfin.Plugin.Requests</RootNamespace>
-    <!-- The Jellyfin SDK the plugin compiles against, per target. Overridable from the command line so
-         an ABI floor build can lower it to the targetAbi each package claims and prove that every API
-         the plugin calls also exists on the oldest server of that line. -->
-    <JellyfinVersion Condition="'$(JellyfinVersion)' == '' and '$(TargetFramework)' == 'net9.0'">10.11.11</JellyfinVersion>
+    <!-- The Jellyfin SDK the plugin compiles against, per target, and it is the floor each package
+         claims rather than the newest SDK of that line. An assembly's reference table is stamped
+         with the versions it was compiled against, and a reference above what the host carries does
+         not bind: the assembly loads, GetTypes() throws, and the server reports the plugin
+         NotSupported. Compiling against 10.11.11 while build.yaml claims 10.11.0.0 is what shipped
+         0.2.0.0 unloadable on every 10.11 server below 10.11.11, measured on #152.
+
+         net10.0 stays on the release candidate because 12.0.0 is not published. The reference table
+         that produces is already 12.0.0.0, which is what build-jf12.yaml claims, so that line is at
+         its claim today; the version below it is a package version and never an assembly version.
+
+         Still overridable from the command line, which is what the floor build in abi-floor.yaml
+         uses to resolve the declared floor from the feed rather than trusting this number.
+         scripts/check-package-abi.sh is what refuses the two drifting apart again, on the routes
+         that produce a package. -->
+    <JellyfinVersion Condition="'$(JellyfinVersion)' == '' and '$(TargetFramework)' == 'net9.0'">10.11.0</JellyfinVersion>
     <JellyfinVersion Condition="'$(JellyfinVersion)' == '' and '$(TargetFramework)' == 'net10.0'">12.0.0-rc4</JellyfinVersion>
   </PropertyGroup>
 

--- a/Jellyfin.Plugin.Requests/packages.lock.json
+++ b/Jellyfin.Plugin.Requests/packages.lock.json
@@ -281,28 +281,28 @@
     "net9.0": {
       "Jellyfin.Controller": {
         "type": "Direct",
-        "requested": "[10.11.11, )",
-        "resolved": "10.11.11",
-        "contentHash": "SqlMUBged5A1UsLhiPtJmGhmi8ovKAyRUte39ycrTk577lsv7mg7EHF78ZNajhtdKlBIHy3iJ44QJENN+aW1mA==",
+        "requested": "[10.11.0, )",
+        "resolved": "10.11.0",
+        "contentHash": "WV+PQy9AHdZLvYqUsNq6ZyQoxaiaEWLz0EwZGOiu8xSrepQLFope2U1VFHVCNbARwesg7s/B+9uB03eXDsQw9w==",
         "dependencies": {
           "BitFaster.Caching": "2.5.4",
-          "Jellyfin.Common": "10.11.11",
-          "Jellyfin.MediaEncoding.Keyframes": "10.11.11",
-          "Jellyfin.Model": "10.11.11",
-          "Jellyfin.Naming": "10.11.11",
-          "Microsoft.Extensions.Configuration.Abstractions": "9.0.11",
-          "Microsoft.Extensions.Configuration.Binder": "9.0.11"
+          "Jellyfin.Common": "10.11.0",
+          "Jellyfin.MediaEncoding.Keyframes": "10.11.0",
+          "Jellyfin.Model": "10.11.0",
+          "Jellyfin.Naming": "10.11.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.10",
+          "Microsoft.Extensions.Configuration.Binder": "9.0.10"
         }
       },
       "Jellyfin.Model": {
         "type": "Direct",
-        "requested": "[10.11.11, )",
-        "resolved": "10.11.11",
-        "contentHash": "ijxySPrwVZvMPmsWAwEQXPjFD8E3YE6jSMX5bBLzipLZTgPicRwr2fXiuV4LdVs5yZUOkxqdV0aedoZXG++x1g==",
+        "requested": "[10.11.0, )",
+        "resolved": "10.11.0",
+        "contentHash": "h+61RSXn4sk8fS6Zx9RkDyVnI5VnNbrsR2p8WcvybtNSW2pgU2uZ9pwEv2awD3ifX69weqYpQLMh91f6aidW2A==",
         "dependencies": {
-          "Jellyfin.Data": "10.11.11",
-          "Jellyfin.Extensions": "10.11.11",
-          "Microsoft.Extensions.Logging.Abstractions": "9.0.11"
+          "Jellyfin.Data": "10.11.0",
+          "Jellyfin.Extensions": "10.11.0",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.10"
         }
       },
       "SerilogAnalyzer": {
@@ -360,36 +360,36 @@
       },
       "Jellyfin.Common": {
         "type": "Transitive",
-        "resolved": "10.11.11",
-        "contentHash": "OZkCi8ruuR5TeL+EPXkudTHPJkbLnBolDGj1qKIB9opSePvJ6AJopxO1tPJSw7BgqNZbczYvD/t2oWdI95DJPA==",
+        "resolved": "10.11.0",
+        "contentHash": "TitN7+qWFt2l0V5b+KTRt7ABDCvfZdvSC6qBG1uHS18Y80xrbrSCJ9O6BH/of310h6a4lxKlQjUtTPHCzeG2AA==",
         "dependencies": {
-          "Jellyfin.Model": "10.11.11",
-          "Microsoft.Extensions.Configuration.Abstractions": "9.0.11",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.11"
+          "Jellyfin.Model": "10.11.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.10"
         }
       },
       "Jellyfin.Data": {
         "type": "Transitive",
-        "resolved": "10.11.11",
-        "contentHash": "5rIih9CKDtWyhAR72O6Wi7ln3It+K8oXdgVF1EZEaeXTjFCl4n/+y6B3oYnFA3SeVMMmdcZq5ty+qTDcbyasLA==",
+        "resolved": "10.11.0",
+        "contentHash": "YEz7/85b98Rj14IJJIVqmzJsi69LDOKo4Ox+VHbh1vj3tkWomSPayzvG3kyU8I0yFMrd6+Ta55C20kZ2XC7vQg==",
         "dependencies": {
-          "Jellyfin.Database.Implementations": "10.11.11",
-          "Microsoft.Extensions.Logging": "9.0.11"
+          "Jellyfin.Database.Implementations": "10.11.0",
+          "Microsoft.Extensions.Logging": "9.0.10"
         }
       },
       "Jellyfin.Database.Implementations": {
         "type": "Transitive",
-        "resolved": "10.11.11",
-        "contentHash": "kRfod73YY4EMvMx1dS6+/1dpsOuwJxk+lJ2D3TKAp7T/dz9C20JT3DroldkLursLc5BTXB74YT0/k6uNz/mySg==",
+        "resolved": "10.11.0",
+        "contentHash": "oLblVZzqF9zuLMdfqp8pbusSVQq6b40/RcHjGF1hxYozVNEi+UhiDX8aJipYBOrh33FFAofoQq468BvZixpPcw==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "9.0.11",
-          "Polly": "8.6.5"
+          "Microsoft.EntityFrameworkCore.Relational": "9.0.10",
+          "Polly": "8.6.4"
         }
       },
       "Jellyfin.Extensions": {
         "type": "Transitive",
-        "resolved": "10.11.11",
-        "contentHash": "mR8rQk09R4JRoKI1MWIDSsNbfsg4qsvhXML3QFw5+u+kkwYC1x3iT6Atz9doLKe0iV+odUXVWKwEljsIYS2J3g==",
+        "resolved": "10.11.0",
+        "contentHash": "1ufj+Rm0Bn6C990i2wwiT5UHPZfD65GOtJK6NcDU//DDMbuoGX1LQZxuCx+rhhRg1XdHPWzYASARYyNlFQa6cg==",
         "dependencies": {
           "Diacritics": "4.0.17",
           "ICU4N.Transliterator": "60.1.0-alpha.356"
@@ -397,134 +397,134 @@
       },
       "Jellyfin.MediaEncoding.Keyframes": {
         "type": "Transitive",
-        "resolved": "10.11.11",
-        "contentHash": "/7OxtK1mFEq5jIrNLGJlnxC3p/xKhdI4rbGzTKQ3pWewCUW6vpyonngQlIdm1JLjt58SeLN+OJ8wygu2lAIdFw==",
+        "resolved": "10.11.0",
+        "contentHash": "/OBcg4Qj825elOGNj5bNRfABKzfAf4qNQj0/d/DwhG/+V/wsKuxS0Pc/xOEagVVjXOnqGPZz/+k8D4UvnvMoHw==",
         "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "9.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.10",
           "NEbml": "1.1.0.5"
         }
       },
       "Jellyfin.Naming": {
         "type": "Transitive",
-        "resolved": "10.11.11",
-        "contentHash": "D1/Zts7F+XI0UXt7A1oZ09C2V7e0MWd5tDsDAOjRP1E+/7ZmBEbXOMOq3stG5ZkzGiQOulDg+iNzckL9mWF4vw==",
+        "resolved": "10.11.0",
+        "contentHash": "2++xSbhdFSb1J3XySjC6UU+uII6OdKc0DfkYx/E1oN7mSjoftyZR8eU045kVWBwsAxr+UcMI6t2DYfES2tJkRA==",
         "dependencies": {
-          "Jellyfin.Common": "10.11.11",
-          "Jellyfin.Model": "10.11.11"
+          "Jellyfin.Common": "10.11.0",
+          "Jellyfin.Model": "10.11.0"
         }
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "9.0.11",
-        "contentHash": "lqqV6JEmVv8s0Y/25RnKtYZ6qL+Vz14wEsrBV1ubVUyzDGrOp+10XJ54HNuRLUzdvzVPR2uQ5li/CPrBj0kQHg==",
+        "resolved": "9.0.10",
+        "contentHash": "WjjxVyOTVs85V7SUe+lZjtGOEeVzF4RO8amrqL4adgbyThNq7vGCFzPw8buZj44gHeQYD5V/uZ/6XuqG9Jq+kA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "9.0.11",
-          "Microsoft.EntityFrameworkCore.Analyzers": "9.0.11",
-          "Microsoft.Extensions.Caching.Memory": "9.0.11",
-          "Microsoft.Extensions.Logging": "9.0.11"
+          "Microsoft.EntityFrameworkCore.Abstractions": "9.0.10",
+          "Microsoft.EntityFrameworkCore.Analyzers": "9.0.10",
+          "Microsoft.Extensions.Caching.Memory": "9.0.10",
+          "Microsoft.Extensions.Logging": "9.0.10"
         }
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
-        "resolved": "9.0.11",
-        "contentHash": "MHcdHm7vF71MfqYC68Jx9YfDAjxcuClGBZJk5zcJDRhVO4HgX+QFsOqcAisKWb20aBeF0IN1YkSktnEUf/tmLQ=="
+        "resolved": "9.0.10",
+        "contentHash": "I3TWAs5Lbzmzu8S0T6qXhzBiO3CznYLrfE59W0npkqNHfWGH8CgA66LrHMWxWOXVTD4145QwYqiWNCdLwpJ1Ew=="
       },
       "Microsoft.EntityFrameworkCore.Analyzers": {
         "type": "Transitive",
-        "resolved": "9.0.11",
-        "contentHash": "ccEk88YkXXWV+s5ZS+27UoY5YUVzgx8mq7kl+e05+AgJPGLhtmpQL26LxqBV1StJZEl2KaL8BxzABvXTXBAkoQ=="
+        "resolved": "9.0.10",
+        "contentHash": "mXNl0Gg3l3zGrClLCHepB+b7rYVuFfB9qQJwya0dUSHFuR1T0jMD8KxuNVyhQSfoWIepanhzjcG8TUNGXOcU0Q=="
       },
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "Transitive",
-        "resolved": "9.0.11",
-        "contentHash": "b6A19xFuU2F92C7N70+HSjRcxwDHTYTdZ/1PyLpHmzXt35G6ugCVKTPS+YJVK1u5ArrDFGQNu+EI+UrSRgUwGA==",
+        "resolved": "9.0.10",
+        "contentHash": "IJNrG5vdmFUvHR8FLLFg9AWpuE8qW1DTEN+fNLGbNTu6cnpZzzqU6+aknAGtTSAEVWosJ3BZ3TOO9wpifUvv3A==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "9.0.11",
-          "Microsoft.Extensions.Caching.Memory": "9.0.11",
-          "Microsoft.Extensions.Configuration.Abstractions": "9.0.11",
-          "Microsoft.Extensions.Logging": "9.0.11"
+          "Microsoft.EntityFrameworkCore": "9.0.10",
+          "Microsoft.Extensions.Caching.Memory": "9.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.10",
+          "Microsoft.Extensions.Logging": "9.0.10"
         }
       },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "Transitive",
-        "resolved": "9.0.11",
-        "contentHash": "PRv1SPyrgl/ullMF6eKDuEULRkTc10fVcnWvzFhqIMDA3m5f91znKH9ZNsKZBgu4xVc4ulNt7TEXyyt0rdlB3g==",
+        "resolved": "9.0.10",
+        "contentHash": "cL6iTxgJ4u5zP3eFOdBiDAtmE/B2WKTRhyJfEne7n6qvHpsMwwIDxljs210mWSO1ucBy7lR1Lo7/7kjeZeLcqQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "9.0.11"
+          "Microsoft.Extensions.Primitives": "9.0.10"
         }
       },
       "Microsoft.Extensions.Caching.Memory": {
         "type": "Transitive",
-        "resolved": "9.0.11",
-        "contentHash": "J77oUeVZXdMoiUiCPkL4v13KrNRuMQnSHHw78cTh/2ZidyiMFm8jhu49OUKvNydMUX8ZcuM5g8uohW18YaglMw==",
+        "resolved": "9.0.10",
+        "contentHash": "2iuzwIoCoqZJfH2VLk1xvlQS4PQDEuhj4dWiGb+Qpt1vHFHyffp497cTO6ucsV54W/h4JmM1vzDBv8pVAFazZg==",
         "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "9.0.11",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.11",
-          "Microsoft.Extensions.Logging.Abstractions": "9.0.11",
-          "Microsoft.Extensions.Options": "9.0.11",
-          "Microsoft.Extensions.Primitives": "9.0.11"
+          "Microsoft.Extensions.Caching.Abstractions": "9.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.10",
+          "Microsoft.Extensions.Options": "9.0.10",
+          "Microsoft.Extensions.Primitives": "9.0.10"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "9.0.11",
-        "contentHash": "g23//mPpMa33QdJkLujJICoCRbiLFpiQ4XbROG9JdeDI6/sM+qZPB2t5SmUWNM8GwY8dYW3NucxlZDFe8s3NAQ==",
+        "resolved": "9.0.10",
+        "contentHash": "ad3JxmFj0uxuFa1CT6oxTCC1lQ0xeRuOvzBRFT/I/ofIXVOnNsH/v2GZkAJWhlpZqKUvSexQZzp3EEAB2CdtJg==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "9.0.11"
+          "Microsoft.Extensions.Primitives": "9.0.10"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "Transitive",
-        "resolved": "9.0.11",
-        "contentHash": "iPE1jROL5uK/6iJSRzwpEIJt6BuANN36Io+6bLss67JVjbG6DdVedrMnB9nqsxs+Lx3X9RxvARTgFsUgP0MB0g==",
+        "resolved": "9.0.10",
+        "contentHash": "D6Kng+9I+w1SQPxJybc6wzw9nnnyUQPutycjtI0svv1RHaWOpUk9PPlwIRfhhoQZ3yihejkEI2wNv/7VnVtkGA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "9.0.11"
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.10"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "9.0.11",
-        "contentHash": "UquyDzvz0EneIQrrU67GJkIgynS+VD7t+RDtNv6VgKMOFrLBjldn6hzlXppGGecFMvAkMTqn4T8RYvzw7j7fQA==",
+        "resolved": "9.0.10",
+        "contentHash": "iEtXCkNd5XhjNJAOb/wO4IhDRdLIE2CsPxZggZQWJ/q2+sa8dmEPC393nnsiqdH8/4KV8Xn25IzgKPR1UEQ0og==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.11"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.10"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
-        "resolved": "9.0.11",
-        "contentHash": "+ZxxZzcVU+IEzq12GItUzf/V3mEc5nSLiXijwvDc4zyhbjvSZZ043giSZqGnhakrjwRWjkerIHPrRwm9okEIpw=="
+        "resolved": "9.0.10",
+        "contentHash": "r9waLiOPe9ZF1PvzUT+RDoHvpMmY8MW+lb4lqjYGObwKpnyPMLI3odVvlmshwuZcdoHynsGWOrCPA0hxZ63lIA=="
       },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
-        "resolved": "9.0.11",
-        "contentHash": "PVHYgMmMZFEE3PGpc7oZ9CnoyNonNyT5klrV9pNIzCPxL12FpQ7kNhliXAwowmtaDVBmKnG/1db6d7gqPwDj8g==",
+        "resolved": "9.0.10",
+        "contentHash": "UBXHqE9vyptVhaFnT1R7YJKCve7TqVI10yjjUZBNGMlW2lZ4c031Slt9hxsOzWCzlpPxxIFyf1Yk4a6Iubxx7w==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "9.0.11",
-          "Microsoft.Extensions.Logging.Abstractions": "9.0.11",
-          "Microsoft.Extensions.Options": "9.0.11"
+          "Microsoft.Extensions.DependencyInjection": "9.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.10",
+          "Microsoft.Extensions.Options": "9.0.10"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
-        "resolved": "9.0.11",
-        "contentHash": "UKWFTDwtZQIoypyt1YPVsxTnDK+0sKn26+UeSGeNlkRQddrkt9EC6kP4g94rgO/WOZkz94bKNlF1dVZN3QfPFQ==",
+        "resolved": "9.0.10",
+        "contentHash": "MFUPv/nN1rAQ19w43smm6bbf0JDYN/1HEPHoiMYY50pvDMFpglzWAuoTavByDmZq7UuhjaxwrET3joU69ZHoHQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.11"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.10"
         }
       },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",
-        "resolved": "9.0.11",
-        "contentHash": "HX4M3BLkW1dtByMKHDVq6r7Jy6e4hf8NDzHpIgz7C8BtYk9JQHhfYX5c1UheQTD5Veg1yBhz/cD9C8vtrGrk9w==",
+        "resolved": "9.0.10",
+        "contentHash": "zMNABt8eBv0B0XrWjFy9nZNgddavaOeq3ZdaD5IlHhRH65MrU7HM+Hd8GjWE3e2VDGFPZFfSAc6XVXC17f9fOA==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.11",
-          "Microsoft.Extensions.Primitives": "9.0.11"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.10",
+          "Microsoft.Extensions.Primitives": "9.0.10"
         }
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "9.0.11",
-        "contentHash": "rtUNSIhbQTv8iSBTFvtg2b/ZUkoqC9qAH9DdC2hr+xPpoZrxiCITci9UR/ELUGUGnGUrF8Xye+tGVRhCxE+4LA=="
+        "resolved": "9.0.10",
+        "contentHash": "3pl8D1O5ZwMpDkZAT2uXrhQ6NipkwEgDLMFuURiHTf72TvkoMP61QYH3Vk1yrzVHnHBdNZk3cQACz8Zc7YGNhQ=="
       },
       "NEbml": {
         "type": "Transitive",
@@ -533,16 +533,16 @@
       },
       "Polly": {
         "type": "Transitive",
-        "resolved": "8.6.5",
-        "contentHash": "VqtW2ZE/ALvQMAH1cQY3qZ2cF2OXa3oe/HKMdOv6Q02HCoEW0rsFNfcBONXlHBe1TnjWW1vdRxBEkPeq0/2FHA==",
+        "resolved": "8.6.4",
+        "contentHash": "uuBsDoBw0oYrMe3uTWRjkT2sIkKh+ZZnnDrLb4Z+QANfeA4+7FJacx6E8CY5GAxXRoSgFrvUADEAQ7DPF6fGiw==",
         "dependencies": {
-          "Polly.Core": "8.6.5"
+          "Polly.Core": "8.6.4"
         }
       },
       "Polly.Core": {
         "type": "Transitive",
-        "resolved": "8.6.5",
-        "contentHash": "t+sUVrIwvo7UmsgHGgOG9F0GDZSRIm47u2ylH17Gvcv1q5hNEwgD5GoBlFyc0kh/pebmPyrAgvGsR/65ZBaXlg=="
+        "resolved": "8.6.4",
+        "contentHash": "4AWqYnQ2TME0E+Mzovt1Uu+VyvpR84ymUldMcPw7Mbj799Phaag14CKrMtlJGx5jsvYP+S3oR1QmysgmXoD5cw=="
       },
       "StyleCop.Analyzers.Unstable": {
         "type": "Transitive",

--- a/README.md
+++ b/README.md
@@ -78,7 +78,10 @@ server does not carry is not a member, it is the version: the archive's five
 Jellyfin references are stamped `10.11.11.0` and `10.11.0` carries all five at
 `10.11.0.0`, and a reference above what the host carries does not bind. Which of
 the two moves, the SDK the package is built against or the floor it claims, is
-#152. **Do not install this on a `10.11.0` server: it will not run.**
+answered on #360: the package is built against the floor from now on and the
+floor stands, because moving the claim would drop every server below `10.11.11`
+without saying so. That answer does not reach a release that already exists.
+**Do not install this on a `10.11.0` server: it will not run.**
 
 Two further things neither run covers: the bytes are copied into the plugin
 directory rather than fetched and unpacked by the server itself, and the 12.0

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -308,8 +308,23 @@ configuration. The host decides that and this plugin does not choose it:
     ### MediaBrowser.Common.Configuration.IApplicationPaths  [MediaBrowser.Common.dll]
         System.String get_PluginConfigurationsPath()
 
-Read out of the reference assemblies each target framework compiles against, `jellyfin.common` at
-`10.11.11` on `net9.0` and at `12.0.0-rc4` on `net10.0`, with identical output on both. A plugin that
+Read out of the reference assemblies, `jellyfin.common` at `10.11.11` on `net9.0` and at
+`12.0.0-rc4` on `net10.0`, with identical output on both. **The `net9.0` target compiles against
+`10.11.0` since #360**, which is the floor `build.yaml` claims, and the three members are in that
+package too:
+
+    for v in 10.11.0 10.11.11; do echo "--- jellyfin.common $v ---"; tr -d '\000' < ~/.nuget/packages/jellyfin.common/$v/lib/net9.0/MediaBrowser.Common.dll | grep -oE 'get_ConfigurationFilePath|SaveConfiguration|get_PluginConfigurationsPath' | sort | uniq -c; done
+    --- jellyfin.common 10.11.0 ---
+          1 get_ConfigurationFilePath
+          1 get_PluginConfigurationsPath
+          1 SaveConfiguration
+    --- jellyfin.common 10.11.11 ---
+          1 get_ConfigurationFilePath
+          1 get_PluginConfigurationsPath
+          1 SaveConfiguration
+
+That is a count of the name in the assembly rather than a signature, which is a weaker reading than
+the block above it and is stated as one. A plugin that
 wrote its secret somewhere else would be a plugin whose secret is not in the operator's backup and
 not in their restore, which is a worse failure than the one it would be avoiding.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -115,8 +115,14 @@ files:
   read as one guard.**
   `abi-floor.yaml` compiles the SOURCE against the floor SDK and was green on the same day; what
   ships is compiled against the current SDK, so a green floor build says the source could be built
-  against the floor and nothing about the artefact that went out. #152 holds which of the two
-  moves.
+  against the floor and nothing about the artefact that went out.
+  **Which of the two moves is answered on #360: the package moves to the floor and the claim stands**,
+  because moving the claim would narrow every server this plugin reaches in order to accommodate a
+  packaging accident, silently, for anybody on `10.11.4`. So the plugin compiles against the floor
+  each packaging file names, and `scripts/check-package-abi.sh` refuses a package whose references
+  rise above that claim on both routes that produce one. **This does not repair the published
+  release.** `0.2.0.0` carries the references it shipped with, and the run above stays the answer for
+  it until a later release replaces it, which is #152's.
 - **The supported set is one board, and it is not the one the seam is written against.** A board
   joins the set for a line on the day it publishes a release for that line, and every candidate
   besides `jellyfin-plugin-sso` has published nothing. So a green run says nothing about the sibling

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -360,8 +360,8 @@ references are the two Jellyfin assemblies and nothing else, and neither is adde
     Directory.Build.props:85:        <PackageReference Include="SerilogAnalyzer" Version="0.15.0" PrivateAssets="All" />
     Directory.Build.props:86:        <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
     Directory.Build.props:87:        <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" PrivateAssets="All" />
-    Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.csproj:23:    <PackageReference Include="Jellyfin.Controller" Version="$(JellyfinVersion)">
-    Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.csproj:26:    <PackageReference Include="Jellyfin.Model" Version="$(JellyfinVersion)">
+    Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.csproj:35:    <PackageReference Include="Jellyfin.Controller" Version="$(JellyfinVersion)">
+    Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.csproj:38:    <PackageReference Include="Jellyfin.Model" Version="$(JellyfinVersion)">
 
 The three analyzers are `PrivateAssets="All"` and are build-time only. The two Jellyfin references
 differ in version between the lines, which is what `JellyfinVersion` is for and what makes the point:

--- a/scripts/check-package-abi.sh
+++ b/scripts/check-package-abi.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Does this package ask a server for more than its targetAbi claims?
+#
+# WHY THIS EXISTS. `abi-floor.yaml` compiles the SOURCE against the floor SDK and says nothing about
+# the artefact. `package.yaml` and `publish.yaml` build the artefact and never compared what they
+# produced against the floor the packaging file claims. Between the two sat the class that shipped:
+# `0.2.0.0` went out asking a `10.11.0` server for five assemblies at `10.11.11.0`, that server
+# carries them at `10.11.0.0`, a reference above what the host carries does not bind, and the server
+# reported the plugin `NotSupported`. Nothing has to be called for that to happen, so every route was
+# green while it shipped. The measurement is on #152 and the refusal is #360.
+#
+# WHAT IT READS. The assembly reference table of every assembly the package carries, printed by
+# `tools/package-abi`, against the `targetAbi` of the packaging file the package was built from.
+# Both are in hand at package time. It reaches no network, starts no server and needs no container.
+#
+# WHICH REFERENCES IT JUDGES. The host's own assemblies, which are the ones a server supplies and a
+# package must not out-ask: names beginning `MediaBrowser.` or `Jellyfin.`. A reference to an
+# assembly the package itself carries is not one of those, however it is named, so a plugin that
+# ships a helper assembly of its own is judged on what it asks the SERVER for.
+#
+# A SET IT COULD NOT READ IS A REFUSAL AND NEVER A PASS. An archive with no assembly in it, an
+# assembly the reader cannot open, and an assembly carrying no host reference at all each print the
+# same nothing as a package that is within its claim. A reader that passes on all three is a reader
+# that passes on a broken build, which is the failure this whole check is about arriving one level
+# up.
+#
+# usage: scripts/check-package-abi.sh <package> <targetAbi>
+#   <package> is the built archive or the directory it unpacks to
+#   <targetAbi> is the four part number the packaging file for that line declares
+
+set -euo pipefail
+
+package=${1:?path to the package archive or the directory it unpacks to}
+claim=${2:?the targetAbi the packaging file for this line declares}
+
+here=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+root=$(cd "$here/.." && pwd)
+
+tab=$(printf '\t')
+
+refuse() {
+    echo "check-package-abi: $1" >&2
+    exit 1
+}
+
+case "$claim" in
+    [0-9]*.[0-9]*.[0-9]*.[0-9]*) ;;
+    *) refuse "targetAbi '${claim}' is not four numeric parts, so there is no version for a reference to be compared against." ;;
+esac
+
+if [ ! -e "$package" ]; then
+    refuse "${package} does not exist. This reads what a packaging step actually produced, never what it was expected to produce."
+fi
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+if [ -d "$package" ]; then
+    contents="$package"
+else
+    if ! unzip -q -o "$package" -d "$work/unpacked" 2>/dev/null; then
+        refuse "${package} is not an archive that unpacks, so nothing in it can be read. A server handed this asset cannot install it either."
+    fi
+    contents="$work/unpacked"
+fi
+
+# Depth is not bounded. The packaging tool puts the artefacts at the root of the archive today, and a
+# reader that only looked there would pass a package whose assemblies moved one directory down.
+find "$contents" -type f -name '*.dll' | sort > "$work/assemblies.txt"
+if [ ! -s "$work/assemblies.txt" ]; then
+    refuse "${package} carries no assembly, so it has no reference table to read. A package with nothing in it installs and does nothing, and this check cannot tell that apart from one that is within its claim."
+fi
+
+# What the package brings with it. A reference to one of these is answered by the package itself and
+# is not a demand on the server, whatever the assembly is called.
+while read -r assembly; do
+    basename "$assembly" .dll
+done < "$work/assemblies.txt" | sort -u > "$work/carried.txt"
+
+: > "$work/references.txt"
+while read -r assembly; do
+    if ! dotnet run --project "$root/tools/package-abi" -- "$assembly" > "$work/one.txt" 2> "$work/reader.txt"; then
+        sed 's/^/  /' "$work/reader.txt" >&2
+        refuse "the reference table of ${assembly} could not be read, so what this package asks a server for is unknown. An unknown answer is refused rather than passed."
+    fi
+    awk -v carrier="$(basename "$assembly")" 'BEGIN { OFS = "\t" } { print carrier, $0 }' "$work/one.txt" >> "$work/references.txt"
+done < "$work/assemblies.txt"
+
+# The host's own assemblies, minus anything the package carries under one of those names.
+awk -F'\t' '
+    NR == FNR { carried[$0] = 1; next }
+    $2 ~ /^(MediaBrowser|Jellyfin)\./ && !($2 in carried) { print }
+' "$work/carried.txt" "$work/references.txt" > "$work/host.txt"
+
+if [ ! -s "$work/host.txt" ]; then
+    refuse "no assembly in ${package} references a Jellyfin or MediaBrowser assembly at all. A plugin that asks the server for nothing is a build that went wrong somewhere earlier, and its reference set cannot be compared with a claim of ${claim}."
+fi
+
+# Component by component as integers, never as strings: 10.11.9.0 sorts above 10.11.11.0 in a string
+# comparison and below it in the comparison a runtime makes.
+awk -F'\t' -v claim="$claim" '
+    function part(v, i,   a) { split(v, a, "."); return a[i] + 0 }
+    {
+        for (i = 1; i <= 4; i++) {
+            mine = part($3, i); theirs = part(claim, i)
+            if (mine > theirs) { print; next }
+            if (mine < theirs) { next }
+        }
+    }
+' "$work/host.txt" > "$work/above.txt"
+
+echo "What ${package} asks a server for, against the targetAbi ${claim} it claims:"
+sort -u -t"$tab" -k2,3 "$work/host.txt" | awk -F'\t' '{ printf "  %s references %s at %s\n", $1, $2, $3 }'
+
+if [ -s "$work/above.txt" ]; then
+    while IFS="$tab" read -r carrier name version; do
+        echo "check-package-abi: ${carrier} references ${name} at ${version}, and this package claims targetAbi ${claim}. A server of the claimed floor carries ${name} below ${version}, the reference does not bind, and the server reports the plugin NotSupported after a download that looked like it worked." >&2
+    done < "$work/above.txt"
+    refuse "this package asks a server for more than its targetAbi claims. Build the package against the floor the packaging file declares, or move the claim - and moving the claim narrows every server this plugin reaches."
+fi
+
+echo "check-package-abi: every host reference is at or below ${claim}, so a server of the claimed floor carries all of them."

--- a/scripts/prove-package-abi-refusals.sh
+++ b/scripts/prove-package-abi-refusals.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# Every answer `scripts/check-package-abi.sh` gives, watched being given, over packages built here.
+#
+# THE TWO IT EXISTS FOR ARE THE FIRST TWO. A package built against the floor its packaging file
+# claims is accepted, and the same source built one published version above that floor is refused.
+# Those are the two states the class this check is about actually took: `0.2.0.0` shipped as the
+# second while every route was green, and the reading that found it is on #152.
+#
+# A CHECK THAT HAS NEVER SAID NO IS INDISTINGUISHABLE FROM ONE THAT SAYS YES TO EVERYTHING, which is
+# why the accepting cases are here beside the refusing ones. Two of them are the direction a careless
+# comparison gets wrong: a build BELOW the claim is fine, and a build below the claim that a string
+# comparison would call higher is still fine.
+#
+# WHAT IT COSTS AND WHAT IT REACHES. Two builds of the plugin project and one restore each, so it
+# reaches the package feed, and it resolves the version above the floor from that feed rather than
+# carrying a number that goes stale. It starts no server and downloads no release. Neither build
+# touches the checkout: the outputs and the lock file both go to a temporary directory.
+#
+# usage: scripts/prove-package-abi-refusals.sh
+
+set -euo pipefail
+
+here=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+root=$(cd "$here/.." && pwd)
+reader="$here/check-package-abi.sh"
+
+cd "$root"
+
+# The line build.yaml claims, read rather than written, so this harness follows a floor that moves.
+claim=$(sed -n 's/^targetAbi: *"\{0,1\}\([^"]*\)"\{0,1\}$/\1/p' build.yaml | head -1)
+framework=$(sed -n 's/^framework: *"\{0,1\}\([^"]*\)"\{0,1\}$/\1/p' build.yaml | head -1)
+if [ -z "$claim" ] || [ -z "$framework" ]; then
+    echo "prove-package-abi-refusals: build.yaml declares no targetAbi or no framework, so there is no floor to build against." >&2
+    exit 1
+fi
+floor="${claim%.*}"
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# The next published release of the same line, resolved rather than written down. A number in this
+# file would be a second place that line's history is recorded, and it would go stale the first time
+# the line publishes again.
+published=$(curl -sSfL "https://api.nuget.org/v3-flatcontainer/jellyfin.controller/index.json" | jq -r '.versions[]')
+above=$(printf '%s\n' "$published" | awk -v floor="$floor" '
+    function part(v, i,   a) { split(v, a, "."); return a[i] + 0 }
+    /-/ { next }
+    {
+        if (part($0, 1) != part(floor, 1) || part($0, 2) != part(floor, 2)) { next }
+        if (part($0, 3) > part(floor, 3)) { print; exit }
+    }
+')
+if [ -z "$above" ]; then
+    echo "prove-package-abi-refusals: the line ${floor} has published nothing above it, so the refusing case cannot be built. This harness proves nothing in that state and says so rather than passing." >&2
+    exit 1
+fi
+
+# usage: build <name> <jellyfin-version>
+build() {
+    local name=$1 version=$2
+    echo "  building the plugin against ${version} into ${name}"
+    dotnet build "$root/Jellyfin.Plugin.Requests/Jellyfin.Plugin.Requests.csproj" \
+        --configuration Release \
+        -p:TargetFrameworks="$framework" \
+        -p:JellyfinVersion="$version" \
+        -p:NuGetLockFilePath="$work/$name.lock.json" \
+        -p:BaseOutputPath="$work/$name/" \
+        --verbosity quiet --nologo
+    local built
+    built=$(find "$work/$name" -type f -name 'Jellyfin.Plugin.Requests.dll' | head -1)
+    if [ -z "$built" ]; then
+        echo "prove-package-abi-refusals: the build against ${version} produced no assembly, so there is nothing to judge." >&2
+        exit 1
+    fi
+    mkdir -p "$work/package-$name"
+    cp "$built" "$work/package-$name/"
+}
+
+failures=0
+
+# usage: refuses <heading> <sentence the refusal must carry> -- <command...>
+refuses() {
+    local heading=$1 sentence=$2
+    shift 3
+    printf '\n== %s\n' "$heading"
+    local out status
+    set +e
+    out=$("$@" 2>&1)
+    status=$?
+    set -e
+    printf '%s\n' "$out" | sed 's/^/  /'
+    if [ "$status" -eq 0 ]; then
+        echo "  ACCEPTED it, so the rule does not bite."
+        failures=$((failures + 1))
+        return
+    fi
+    case "$out" in
+        *"$sentence"*) ;;
+        *)
+            echo "  refused, but for something other than: $sentence"
+            failures=$((failures + 1))
+            ;;
+    esac
+}
+
+# usage: accepts <heading> <sentence the pass must carry> -- <command...>
+accepts() {
+    local heading=$1 sentence=$2
+    shift 3
+    printf '\n== %s\n' "$heading"
+    local out status
+    set +e
+    out=$("$@" 2>&1)
+    status=$?
+    set -e
+    printf '%s\n' "$out" | sed 's/^/  /'
+    if [ "$status" -ne 0 ]; then
+        echo "  REFUSED it, which is a reader that refuses everything."
+        failures=$((failures + 1))
+        return
+    fi
+    case "$out" in
+        *"$sentence"*) ;;
+        *)
+            echo "  accepted, but said nothing about: $sentence"
+            failures=$((failures + 1))
+            ;;
+    esac
+}
+
+printf '== the two packages this proof turns on\n'
+printf '  build.yaml claims %s, so the floor is %s, and the next published release of that line is %s\n' \
+    "$claim" "$floor" "$above"
+build floor "$floor"
+build above "$above"
+
+accepts "a package built against the floor its packaging file claims" \
+    "every host reference is at or below ${claim}" \
+    -- "$reader" "$work/package-floor" "$claim"
+
+refuses "the same source built one published version above that floor" \
+    "and this package claims targetAbi ${claim}" \
+    -- "$reader" "$work/package-above" "$claim"
+
+accepts "a package built below a claim that sits above it" \
+    "every host reference is at or below" \
+    -- "$reader" "$work/package-floor" "12.0.0.0"
+
+# The pair a string comparison gets backwards. The patch of the build above the floor is one number,
+# and the claim below is that number plus eight, so the claim's patch has two digits where the
+# build's has one: as strings the build sorts higher, as integers it does not. Both are derived, so
+# this stays the case it is named for while the line keeps publishing.
+accepts "a build below a claim that a string comparison would call higher" \
+    "every host reference is at or below" \
+    -- "$reader" "$work/package-above" "${floor%.*}.$(( ${above##*.} + 8 )).0"
+
+printf '\n== the cases where the answer could not be read, which are refusals rather than passes\n'
+
+printf 'not an archive and not a directory of assemblies\n' > "$work/not-an-archive.zip"
+refuses "an asset that is not an archive" \
+    "is not an archive that unpacks" \
+    -- "$reader" "$work/not-an-archive.zip" "$claim"
+
+mkdir -p "$work/empty"
+printf 'a readme and nothing else\n' > "$work/empty/README.txt"
+refuses "a package with no assembly in it" \
+    "carries no assembly, so it has no reference table to read" \
+    -- "$reader" "$work/empty" "$claim"
+
+mkdir -p "$work/not-an-assembly"
+printf 'this is not a PE image\n' > "$work/not-an-assembly/Jellyfin.Plugin.Requests.dll"
+refuses "an assembly the reader cannot open" \
+    "could not be read, so what this package asks a server for is unknown" \
+    -- "$reader" "$work/not-an-assembly" "$claim"
+
+# An assembly that is real and asks the server for nothing. The reader tool is one: it references the
+# shared framework and no Jellyfin package at all.
+dotnet build "$root/tools/package-abi/PackageAbi.csproj" --configuration Release \
+    -p:BaseOutputPath="$work/reader-build/" --verbosity quiet --nologo
+mkdir -p "$work/no-host-reference"
+cp "$(find "$work/reader-build" -type f -name 'Jellyfin.Plugin.Requests.PackageAbi.dll' | head -1)" \
+    "$work/no-host-reference/"
+refuses "an assembly that asks the server for nothing at all" \
+    "references a Jellyfin or MediaBrowser assembly at all" \
+    -- "$reader" "$work/no-host-reference" "$claim"
+
+refuses "a claim that is not four numeric parts" \
+    "is not four numeric parts" \
+    -- "$reader" "$work/package-floor" "10.11"
+
+printf '\n== a reference the package answers itself is not a demand on the server\n'
+mkdir -p "$work/carries-a-host-name"
+cp "$work/package-above/Jellyfin.Plugin.Requests.dll" "$work/carries-a-host-name/"
+cp "$work/no-host-reference/Jellyfin.Plugin.Requests.PackageAbi.dll" \
+    "$work/carries-a-host-name/MediaBrowser.Common.dll"
+set +e
+carried=$("$reader" "$work/carries-a-host-name" "$claim" 2>&1)
+set -e
+printf '%s\n' "$carried" | sed 's/^/  /'
+case "$carried" in
+    *"check-package-abi: Jellyfin.Plugin.Requests.dll references MediaBrowser.Common at"*)
+        echo "  it still demanded MediaBrowser.Common of the server, and the package carries it."
+        failures=$((failures + 1))
+        ;;
+esac
+case "$carried" in
+    *"references MediaBrowser.Model at"*) ;;
+    *)
+        echo "  it stopped naming MediaBrowser.Model as well, so the exclusion is wider than the one claimed."
+        failures=$((failures + 1))
+        ;;
+esac
+
+printf '\n'
+if [ "$failures" -ne 0 ]; then
+    echo "prove-package-abi-refusals: ${failures} case(s) did not answer as claimed." >&2
+    exit 1
+fi
+echo "prove-package-abi-refusals: every case answered as claimed."

--- a/tools/package-abi/Directory.Build.props
+++ b/tools/package-abi/Directory.Build.props
@@ -1,0 +1,14 @@
+<Project>
+
+    <!-- INHERITANCE STOPS HERE, DELIBERATELY, for the reason the full disk probe's copy of this
+         file gives: MSBuild walks up until it finds one of these, and the repository root's
+         properties belong to the artefact somebody installs. This reader is an instrument. It is
+         built only by the routes that judge a package, it ships to nobody, and inheriting the
+         plugin's version number would make a second thing claim to be that version.
+
+         It also inherits no analyzer posture and no lock file, which matters more here than it does
+         for the probe: this reader is built on the release route, and a restore that reaches a feed
+         for three analyzer packages is three more things that can be unavailable at the moment a
+         tag goes out. -->
+
+</Project>

--- a/tools/package-abi/PackageAbi.csproj
+++ b/tools/package-abi/PackageAbi.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <!-- One target, unlike the plugin and unlike the probe. What this reads is a file: the
+         metadata tables of an assembly say the same thing whichever runtime asks, so a reader per
+         server line would be two builds of one answer. -->
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Jellyfin.Plugin.Requests.PackageAbi</RootNamespace>
+    <AssemblyName>Jellyfin.Plugin.Requests.PackageAbi</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+  </PropertyGroup>
+
+  <!-- No PackageReference at all. System.Reflection.Metadata and System.Reflection.PortableExecutable
+       are in the shared framework, so this builds and runs with nothing fetched from a feed. -->
+
+</Project>

--- a/tools/package-abi/Program.cs
+++ b/tools/package-abi/Program.cs
@@ -1,0 +1,70 @@
+// The assembly reference table of one file, printed and never judged here.
+//
+// WHAT IT IS FOR. A plugin package claims a `targetAbi`, and the assembly inside it carries the
+// versions of the assemblies it was compiled against. Those two are independent: the packaging
+// metadata is edited by hand and the reference table is stamped by the compiler from whatever SDK
+// the build resolved. Where the table sits above the claim, the reference does not bind on a server
+// of the claimed floor - the assembly loads, GetTypes() throws, and the server reports the plugin
+// NotSupported. `0.2.0.0` shipped in exactly that state, which is the measurement on #152.
+//
+// THE COMPARISON IS NOT HERE. This prints `name<TAB>version`, one reference per line, and exits
+// zero. Which names matter and which versions are too high is `scripts/check-package-abi.sh`, so
+// the rule lives in one place that a proof harness can drive over fixtures, and this stays a reader
+// with nothing to get wrong.
+//
+// A FILE IT CANNOT READ IS AN ERROR RATHER THAN AN EMPTY LIST. An unreadable assembly and an
+// assembly that references nothing print the same nothing, and the caller has to be able to tell
+// them apart: a package whose reference set could not be read must be refused, not passed.
+//
+// usage: dotnet run --project tools/package-abi -- <assembly>
+using System;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace Jellyfin.Plugin.Requests.PackageAbi
+{
+    internal static class Program
+    {
+        internal static int Main(string[] args)
+        {
+            if (args.Length != 1)
+            {
+                Console.Error.WriteLine("package-abi: one argument, the assembly to read.");
+                return 2;
+            }
+
+            var path = args[0];
+            if (!File.Exists(path))
+            {
+                Console.Error.WriteLine($"package-abi: {path} does not exist.");
+                return 2;
+            }
+
+            try
+            {
+                using var file = File.OpenRead(path);
+                using var image = new PEReader(file);
+                if (!image.HasMetadata)
+                {
+                    Console.Error.WriteLine($"package-abi: {path} carries no managed metadata, so it has no reference table to read.");
+                    return 2;
+                }
+
+                var metadata = image.GetMetadataReader();
+                foreach (var handle in metadata.AssemblyReferences)
+                {
+                    var reference = metadata.GetAssemblyReference(handle);
+                    Console.WriteLine($"{metadata.GetString(reference.Name)}\t{reference.Version}");
+                }
+            }
+            catch (BadImageFormatException error)
+            {
+                Console.Error.WriteLine($"package-abi: {path} is not an assembly this reader can open: {error.Message}");
+                return 2;
+            }
+
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
Closes #360.

`0.2.0.0` shipped asking a `10.11.0` server for five assemblies at `10.11.11.0` while `build.yaml` claimed `targetAbi: "10.11.0.0"`. A reference above what the host carries does not bind, so that server loads the archive, throws in `GetTypes()` and reports the plugin `NotSupported`. Nothing has to be called for it to happen, and every route here was green while it went out: `abi-floor.yaml` compiles the SOURCE against the floor and says nothing about the artefact, and the two routes that build the artefact never compared it with the claim.

The ruling on this issue was that the package moves to the floor and the claim stands, because moving the claim would drop every server below `10.11.11` in order to accommodate a packaging accident, silently. This is that, plus the refusal that holds it there. The two land together because the check would red the mainline on its own, which the issue body says.

## Half one: the package moves to the floor

The `net9.0` target compiles against `10.11.0` rather than `10.11.11`. That is what claiming that floor already meant, and doing it in the project rather than in the two workflows means the lock file records the graph that ships and every route keeps locked mode.

The reference table before and after, read with the reader this change adds:

    dotnet run --project tools/package-abi -- Jellyfin.Plugin.Requests/bin/Release/net9.0/Jellyfin.Plugin.Requests.dll

at `f4f65a9`, which is what `origin/master` was when I started:

    MediaBrowser.Common	10.11.11.0
    MediaBrowser.Model	10.11.11.0
    MediaBrowser.Controller	10.11.11.0
    Jellyfin.Data	10.11.11.0
    Jellyfin.Database.Implementations	10.11.11.0

and on this head:

    MediaBrowser.Common	10.11.0.0
    MediaBrowser.Model	10.11.0.0
    MediaBrowser.Controller	10.11.0.0
    Jellyfin.Data	10.11.0.0
    Jellyfin.Database.Implementations	10.11.0.0

**The `net10.0` target is untouched, and that is a measurement rather than an omission.** `12.0.0` is not published, the release candidate that line builds against stamps its assemblies `12.0.0.0`, and `build-jf12.yaml` claims `12.0.0.0`. So that line already sits at its claim:

    MediaBrowser.Common	12.0.0.0
    MediaBrowser.Model	12.0.0.0
    MediaBrowser.Controller	12.0.0.0
    Jellyfin.Data	12.0.0.0
    Jellyfin.Database.Implementations	12.0.0.0

Only the 10.11 line was the defect this issue names.

## Half two: the refusal

`scripts/check-package-abi.sh` reads the reference table of every assembly in a built package, through `tools/package-abi`, and refuses a `MediaBrowser.*` or `Jellyfin.*` reference above the `targetAbi` of the packaging file the package was built from, naming the assembly, its version and the claim. It reaches no network, starts no server and needs no container.

It runs on both routes that produce a package - `package.yaml` per claimed line, and `publish.yaml` before the bill of materials and before anything is uploaded, because a release that exists is never touched again and a tag cannot be spent twice.

**A set it could not read is refused rather than passed**, which is the third done-when. An archive that does not unpack, a package with no assembly in it, an assembly the reader cannot open and an assembly with no host reference at all each print the same nothing as a package within its claim.

## Watched refusing

`scripts/prove-package-abi-refusals.sh` builds the plugin at the floor `build.yaml` declares and at the next published release of that line, resolved from the feed rather than written down, and drives both through the check. Run on this head:

    == the two packages this proof turns on
      build.yaml claims 10.11.0.0, so the floor is 10.11.0, and the next published release of that line is 10.11.2
      building the plugin against 10.11.0 into floor
    
    Der Buildvorgang wurde erfolgreich ausgeführt.
        0 Warnung(en)
        0 Fehler
    
    Verstrichene Zeit 00:00:04.28
      building the plugin against 10.11.2 into above
    
    Der Buildvorgang wurde erfolgreich ausgeführt.
        0 Warnung(en)
        0 Fehler
    
    Verstrichene Zeit 00:00:03.87
    
    == a package built against the floor its packaging file claims
      What /tmp/tmp.v06Mb6gQX0/package-floor asks a server for, against the targetAbi 10.11.0.0 it claims:
        Jellyfin.Plugin.Requests.dll references Jellyfin.Data at 10.11.0.0
        Jellyfin.Plugin.Requests.dll references Jellyfin.Database.Implementations at 10.11.0.0
        Jellyfin.Plugin.Requests.dll references MediaBrowser.Common at 10.11.0.0
        Jellyfin.Plugin.Requests.dll references MediaBrowser.Controller at 10.11.0.0
        Jellyfin.Plugin.Requests.dll references MediaBrowser.Model at 10.11.0.0
      check-package-abi: every host reference is at or below 10.11.0.0, so a server of the claimed floor carries all of them.
    
    == the same source built one published version above that floor
      What /tmp/tmp.v06Mb6gQX0/package-above asks a server for, against the targetAbi 10.11.0.0 it claims:
        Jellyfin.Plugin.Requests.dll references Jellyfin.Data at 10.11.2.0
        Jellyfin.Plugin.Requests.dll references Jellyfin.Database.Implementations at 10.11.2.0
        Jellyfin.Plugin.Requests.dll references MediaBrowser.Common at 10.11.2.0
        Jellyfin.Plugin.Requests.dll references MediaBrowser.Controller at 10.11.2.0
        Jellyfin.Plugin.Requests.dll references MediaBrowser.Model at 10.11.2.0
      check-package-abi: Jellyfin.Plugin.Requests.dll references MediaBrowser.Common at 10.11.2.0, and this package claims targetAbi 10.11.0.0. A server of the claimed floor carries MediaBrowser.Common below 10.11.2.0, the reference does not bind, and the server reports the plugin NotSupported after a download that looked like it worked.
      check-package-abi: Jellyfin.Plugin.Requests.dll references MediaBrowser.Model at 10.11.2.0, and this package claims targetAbi 10.11.0.0. A server of the claimed floor carries MediaBrowser.Model below 10.11.2.0, the reference does not bind, and the server reports the plugin NotSupported after a download that looked like it worked.
      check-package-abi: Jellyfin.Plugin.Requests.dll references MediaBrowser.Controller at 10.11.2.0, and this package claims targetAbi 10.11.0.0. A server of the claimed floor carries MediaBrowser.Controller below 10.11.2.0, the reference does not bind, and the server reports the plugin NotSupported after a download that looked like it worked.
      check-package-abi: Jellyfin.Plugin.Requests.dll references Jellyfin.Data at 10.11.2.0, and this package claims targetAbi 10.11.0.0. A server of the claimed floor carries Jellyfin.Data below 10.11.2.0, the reference does not bind, and the server reports the plugin NotSupported after a download that looked like it worked.
      check-package-abi: Jellyfin.Plugin.Requests.dll references Jellyfin.Database.Implementations at 10.11.2.0, and this package claims targetAbi 10.11.0.0. A server of the claimed floor carries Jellyfin.Database.Implementations below 10.11.2.0, the reference does not bind, and the server reports the plugin NotSupported after a download that looked like it worked.
      check-package-abi: this package asks a server for more than its targetAbi claims. Build the package against the floor the packaging file declares, or move the claim - and moving the claim narrows every server this plugin reaches.
    
    == a package built below a claim that sits above it
      What /tmp/tmp.v06Mb6gQX0/package-floor asks a server for, against the targetAbi 12.0.0.0 it claims:
        Jellyfin.Plugin.Requests.dll references Jellyfin.Data at 10.11.0.0
        Jellyfin.Plugin.Requests.dll references Jellyfin.Database.Implementations at 10.11.0.0
        Jellyfin.Plugin.Requests.dll references MediaBrowser.Common at 10.11.0.0
        Jellyfin.Plugin.Requests.dll references MediaBrowser.Controller at 10.11.0.0
        Jellyfin.Plugin.Requests.dll references MediaBrowser.Model at 10.11.0.0
      check-package-abi: every host reference is at or below 12.0.0.0, so a server of the claimed floor carries all of them.
    
    == a build below a claim that a string comparison would call higher
      What /tmp/tmp.v06Mb6gQX0/package-above asks a server for, against the targetAbi 10.11.10.0 it claims:
        Jellyfin.Plugin.Requests.dll references Jellyfin.Data at 10.11.2.0
        Jellyfin.Plugin.Requests.dll references Jellyfin.Database.Implementations at 10.11.2.0
        Jellyfin.Plugin.Requests.dll references MediaBrowser.Common at 10.11.2.0
        Jellyfin.Plugin.Requests.dll references MediaBrowser.Controller at 10.11.2.0
        Jellyfin.Plugin.Requests.dll references MediaBrowser.Model at 10.11.2.0
      check-package-abi: every host reference is at or below 10.11.10.0, so a server of the claimed floor carries all of them.
    
    == the cases where the answer could not be read, which are refusals rather than passes
    
    == an asset that is not an archive
      check-package-abi: /tmp/tmp.v06Mb6gQX0/not-an-archive.zip is not an archive that unpacks, so nothing in it can be read. A server handed this asset cannot install it either.
    
    == a package with no assembly in it
      check-package-abi: /tmp/tmp.v06Mb6gQX0/empty carries no assembly, so it has no reference table to read. A package with nothing in it installs and does nothing, and this check cannot tell that apart from one that is within its claim.
    
    == an assembly the reader cannot open
        package-abi: C:/Users/nils7/AppData/Local/Temp/tmp.v06Mb6gQX0/not-an-assembly/Jellyfin.Plugin.Requests.dll is not an assembly this reader can open: Unknown file format.
      check-package-abi: the reference table of /tmp/tmp.v06Mb6gQX0/not-an-assembly/Jellyfin.Plugin.Requests.dll could not be read, so what this package asks a server for is unknown. An unknown answer is refused rather than passed.
    
    Der Buildvorgang wurde erfolgreich ausgeführt.
        0 Warnung(en)
        0 Fehler
    
    Verstrichene Zeit 00:00:01.04
    
    == an assembly that asks the server for nothing at all
      check-package-abi: no assembly in /tmp/tmp.v06Mb6gQX0/no-host-reference references a Jellyfin or MediaBrowser assembly at all. A plugin that asks the server for nothing is a build that went wrong somewhere earlier, and its reference set cannot be compared with a claim of 10.11.0.0.
    
    == a claim that is not four numeric parts
      check-package-abi: targetAbi '10.11' is not four numeric parts, so there is no version for a reference to be compared against.
    
    == a reference the package answers itself is not a demand on the server
      What /tmp/tmp.v06Mb6gQX0/carries-a-host-name asks a server for, against the targetAbi 10.11.0.0 it claims:
        Jellyfin.Plugin.Requests.dll references Jellyfin.Data at 10.11.2.0
        Jellyfin.Plugin.Requests.dll references Jellyfin.Database.Implementations at 10.11.2.0
        Jellyfin.Plugin.Requests.dll references MediaBrowser.Controller at 10.11.2.0
        Jellyfin.Plugin.Requests.dll references MediaBrowser.Model at 10.11.2.0
      check-package-abi: Jellyfin.Plugin.Requests.dll references MediaBrowser.Model at 10.11.2.0, and this package claims targetAbi 10.11.0.0. A server of the claimed floor carries MediaBrowser.Model below 10.11.2.0, the reference does not bind, and the server reports the plugin NotSupported after a download that looked like it worked.
      check-package-abi: Jellyfin.Plugin.Requests.dll references MediaBrowser.Controller at 10.11.2.0, and this package claims targetAbi 10.11.0.0. A server of the claimed floor carries MediaBrowser.Controller below 10.11.2.0, the reference does not bind, and the server reports the plugin NotSupported after a download that looked like it worked.
      check-package-abi: Jellyfin.Plugin.Requests.dll references Jellyfin.Data at 10.11.2.0, and this package claims targetAbi 10.11.0.0. A server of the claimed floor carries Jellyfin.Data below 10.11.2.0, the reference does not bind, and the server reports the plugin NotSupported after a download that looked like it worked.
      check-package-abi: Jellyfin.Plugin.Requests.dll references Jellyfin.Database.Implementations at 10.11.2.0, and this package claims targetAbi 10.11.0.0. A server of the claimed floor carries Jellyfin.Database.Implementations below 10.11.2.0, the reference does not bind, and the server reports the plugin NotSupported after a download that looked like it worked.
      check-package-abi: this package asks a server for more than its targetAbi claims. Build the package against the floor the packaging file declares, or move the claim - and moving the claim narrows every server this plugin reaches.
    
    prove-package-abi-refusals: every case answered as claimed.

## And deleting the refusal turns the first of those green

The done-when asks for that directly. I deleted the block that compares the versions and left everything else, then put it back. The package is the one built one published version above its floor, at `10.11.2`:

    $ ./scripts/check-package-abi.sh <the 10.11.2 build> 10.11.0.0
    check-package-abi: Jellyfin.Plugin.Requests.dll references Jellyfin.Database.Implementations at 10.11.2.0, and this package claims targetAbi 10.11.0.0. A server of the claimed floor carries Jellyfin.Database.Implementations below 10.11.2.0, the reference does not bind, and the server reports the plugin NotSupported after a download that looked like it worked.
    check-package-abi: this package asks a server for more than its targetAbi claims. Build the package against the floor the packaging file declares, or move the claim - and moving the claim narrows every server this plugin reaches.
    exit=1

with the comparison deleted, the same package and the same claim:

    Jellyfin.Plugin.Requests.dll references MediaBrowser.Controller at 10.11.2.0
    Jellyfin.Plugin.Requests.dll references MediaBrowser.Model at 10.11.2.0
    check-package-abi: every host reference is at or below 10.11.0.0, so a server of the claimed floor carries all of them.
    exit=0

It does not only stop refusing, it prints a sentence that is false about the package in front of it, which is the failure the whole check exists against arriving one level up.

    $ git diff --stat scripts/check-package-abi.sh
    (empty, and the same run afterwards exits 1 again)

## The suite, and the three readers this board runs over its own documents

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror

```
Bestanden!   : Fehler:     0, erfolgreich:   777, übersprungen:     0, gesamt:   777, Dauer: 22 s - Jellyfin.Plugin.Requests.Tests.dll (net9.0)
Bestanden!   : Fehler:     0, erfolgreich:   777, übersprungen:     0, gesamt:   777, Dauer: 22 s - Jellyfin.Plugin.Requests.Tests.dll (net10.0)
```

777 on both targets, with the plugin compiled against the floor rather than against `10.11.11`.

    $ ./scripts/check-pasted-evidence.sh
    read 118 pasted match lines in 24 document(s)
    check-pasted-evidence: every pasted match line reproduces against the file it names.

    $ ./scripts/check-negative-disclosures.sh
    ran 4 negative disclosure(s) in 24 document(s)
    check-negative-disclosures: every negative disclosure exits as the document says it does.

**That reader caught something rather than agreeing with me.** Widening the comment above `JellyfinVersion` moved two line numbers `docs/storage.md` pastes out of the project file, and it named both. They are corrected to what the file now produces rather than deleted.

    $ npx --yes prettier@3.6.2 --check CHANGELOG.md README.md docs/compatibility.md docs/bridge.md docs/storage.md
    Checking formatting...
    All matched files use Prettier code style!

## The documents that said this was undecided

`README.md`, `docs/compatibility.md` and `docs/operating.md` each carried a sentence saying which of the two moves is open. The first two now say which way it went and that the answer does not reach a release that already exists; `docs/operating.md` describes the published release rather than the question, so it is unchanged. **None of them claims the published `0.2.0.0` is repaired**, because it is not: it carries the references it shipped with until a later release replaces it, which is #152's.

`docs/bridge.md` read a member list out of "the reference assemblies each target framework compiles against" and named `10.11.11` for `net9.0`. That sentence would have become untrue, so the page now names the move and carries a reading of the same three members in `jellyfin.common` `10.11.0`, stated as the weaker reading it is - a count of a name in the assembly rather than a signature.

## The means

Bash and a small .NET reader, which is the means this repository already uses for a check that judges an artefact: the packaging routes are shell steps, and reading an assembly's metadata tables needs a managed reader, so `tools/package-abi` is the smallest surface that answers it. It is modelled on `tools/full-disk-probe` down to the `Directory.Build.props` that stops inheritance, it references no package at all - `System.Reflection.Metadata` is in the shared framework - and it prints rather than judges, so the rule lives in one shell script a fixture harness can drive.

## What this does not claim

**No server was started and nothing was installed.** Every reading above is of a file in this repository or of an assembly built from it on this machine. That a package built against the floor now loads on a `10.11.0` server is not measured here; `release-install.yaml` measures the published release, and the published release is unchanged.

**The two new contexts are not required.** `the package check refuses what it says it refuses` is a new check-run name and nothing requires it, for the same reason the six on #30 were not required; a red job here does not by itself hold a merge today.

**The proof builds twice and reaches the package feed.** It is a job of its own in `package.yaml` rather than a step in the matrix, so it costs one pair of builds per run rather than one pair per line.

**I watched no other guard on this board bite.** The suite is named as passing, which is a different statement from a guard watched failing for the reason it names, and only the check this change adds was watched doing that.

**Nobody else has read this.** No second reader was available tonight, and the transcripts above stand in place of one.

## The `Scope:` line

It named `.github/workflows/package.yaml`, `.github/workflows/publish.yaml` and `scripts/`. The answer on this issue - that the package moves to the floor rather than the claim moving to the package - puts the project file and its lock files under it, and the documents that said the question was open follow from the same answer. I have widened the line on the issue to name what the work touches, the way the line on #30 was widened when an answer put a workflow change under it.


## Added after this pull request was opened: the job-name comment points at two contexts that exist

The note of 01.09. on #360 found that the comment above the `abi-refusals` job argues its own name by pointing at `floor 10.11.0.0` and `floor 12.0.0.0` as the contexts kept out of the required set for carrying a matrix value. #368 landed first, as `fc11369126dbc8826065e34307f4895238c1295a`, and renamed those jobs after the packaging file precisely so they could be required, so both strings stopped existing:

    $ git grep -n 'name: floor' a5d2b87 -- .github/workflows/abi-floor.yaml
    a5d2b87:.github/workflows/abi-floor.yaml:143:    name: floor ${{ matrix.abi }}

    $ git grep -n 'name: floor' fc11369 -- .github/workflows/abi-floor.yaml
    fc11369:.github/workflows/abi-floor.yaml:161:    name: floor ${{ matrix.metadata }}

Corrected after this section was first written: it quoted a `git grep -c` whose output I had not run, and the command returns a match rather than the `exit=1` beside it, because the job name still contains `${{ matrix` - what moved is the value inside it. The two readings above are what the files print.

A reader who greps for either now finds nothing, which is where a comment stops being evidence. `e3815a8` moves the evidence and leaves the argument alone: `package 10.11.0.0` and `package 12.0.0.0` are built from the matrix in this same file and are not in the required set on `master`, so they carry the point the floor jobs used to carry, and the rename is named rather than left for a reader to reconstruct.

    $ gh api repos/Flowfin/jellyfin-plugin-requests/rules/branches/master \
        --jq '.[] | select(.type=="required_status_checks")
              | .parameters.required_status_checks[].context' | sort | grep -c '^package'
    0

**It changes one comment and no behaviour.** The diff is four lines of `#` in `.github/workflows/package.yaml`, and every check on this head reports for the same reasons it did before.
