### PR TITLE
Decline an open request of a deleted person instead of removing it

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Model/RequestAuthorityTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Model/RequestAuthorityTests.cs
@@ -41,15 +41,22 @@ public class RequestAuthorityTests
     // A decision is an administrator's. An observation is the plugin's. A refused cell admits
     // nobody, which is what makes an illegal move and a move nobody may make one row rather than
     // two rules that can drift apart.
+    //
+    // The two cells into Declined from an unfinished state admit both, and that is the one place
+    // this list is widened rather than derived. The plugin is admitted there so an open request of
+    // a deleted person can be closed rather than removed, which is #337's answer built in #361, and
+    // the lifecycle narrows the widening back to that one move by refusing the reason it carries
+    // from anybody else and every other reason from the plugin. That narrowing has tests of its own
+    // beside this list; what this row asserts is that the widening is here on purpose.
     [InlineData(RequestState.Open, RequestState.Open, RequestActor.None)]
     [InlineData(RequestState.Open, RequestState.Approved, RequestActor.Administrator)]
-    [InlineData(RequestState.Open, RequestState.Declined, RequestActor.Administrator)]
+    [InlineData(RequestState.Open, RequestState.Declined, RequestActor.Administrator | RequestActor.Plugin)]
     [InlineData(RequestState.Open, RequestState.Fulfilled, RequestActor.Plugin)]
     [InlineData(RequestState.Open, RequestState.Failed, RequestActor.None)]
 
     [InlineData(RequestState.Approved, RequestState.Open, RequestActor.None)]
     [InlineData(RequestState.Approved, RequestState.Approved, RequestActor.None)]
-    [InlineData(RequestState.Approved, RequestState.Declined, RequestActor.Administrator)]
+    [InlineData(RequestState.Approved, RequestState.Declined, RequestActor.Administrator | RequestActor.Plugin)]
     [InlineData(RequestState.Approved, RequestState.Fulfilled, RequestActor.Plugin)]
     [InlineData(RequestState.Approved, RequestState.Failed, RequestActor.Plugin)]
 
@@ -281,8 +288,17 @@ public class RequestAuthorityTests
     {
         try
         {
+            // Which reason a decline carries is decided by the caller rather than fixed, because
+            // the lifecycle pairs the two: a caller who is not an administrator may give only the
+            // reason saying the person who asked is gone, and an administrator may give any other.
+            // A fixed reason here would turn that rule into an authority answer and this walk would
+            // report a permission that had not moved.
+            var reason = (by.RolesOn(request) & RequestActor.Administrator) != RequestActor.None
+                ? DeclineReason.NotWanted
+                : DeclineReason.TheRequesterIsGone;
+
             _ = to == RequestState.Declined
-                ? RequestLifecycle.Decline(request, DeclineReason.NotWanted, note: null, MovedAt, by)
+                ? RequestLifecycle.Decline(request, reason, note: null, MovedAt, by)
                 : RequestLifecycle.Move(request, to, MovedAt, by);
 
             return true;

--- a/Jellyfin.Plugin.Requests.Tests/Model/RequestLifecycleTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Model/RequestLifecycleTests.cs
@@ -21,6 +21,11 @@ namespace Jellyfin.Plugin.Requests.Tests.Model;
 public class RequestLifecycleTests
 {
     /// <summary>
+    /// When a move in these tests is made, from a clock a test names rather than the machine's.
+    /// </summary>
+    private static readonly DateTimeOffset MovedAt = new DateTimeOffset(2026, 8, 9, 14, 0, 0, TimeSpan.Zero);
+
+    /// <summary>
     /// Every ordered pair of states has a cell and no pair has two. This is what makes adding a
     /// value to the enumeration a visible piece of work: a sixth state arrives with eleven missing
     /// cells and reds here, instead of quietly being a state nothing can leave or reach.
@@ -347,6 +352,83 @@ public class RequestLifecycleTests
 
     private static string Pair(RequestState from, RequestState to)
         => string.Format(CultureInfo.InvariantCulture, "{0} to {1}", from, to);
+
+    /// <summary>
+    /// The plugin declines an unfinished request for the one reason that is a fact, and for no
+    /// other.
+    /// <para>
+    /// Two cells into <see cref="RequestState.Declined"/> admit the plugin so that an open request
+    /// of a deleted person can be closed rather than removed, which is #337's answer built in #361.
+    /// A cell is coarser than the move it was widened for: on its own it lets the plugin decline
+    /// anything open or approved for any reason on the list, and "not wanted" said by nobody is a
+    /// judgement attributed to a decision that was never taken. This is what narrows the widening
+    /// back to the move it was made for.
+    /// </para>
+    /// </summary>
+    /// <param name="reason">A reason that is somebody's judgement.</param>
+    [Theory]
+    [InlineData(DeclineReason.AlreadyInTheLibrary)]
+    [InlineData(DeclineReason.AlreadyRequested)]
+    [InlineData(DeclineReason.CannotBeObtained)]
+    [InlineData(DeclineReason.NotWanted)]
+    [InlineData(DeclineReason.NoRoomForIt)]
+    [InlineData(DeclineReason.Other)]
+    public void ThePluginDeclinesForTheOneReasonThatIsAFactAndForNoOther(DeclineReason reason)
+    {
+        var open = ARequest();
+
+        Assert.Throws<ArgumentException>(
+            () => RequestLifecycle.Decline(open, reason, note: "Something.", MovedAt, RequestCaller.Plugin));
+
+        var declined = RequestLifecycle.Decline(
+            open,
+            DeclineReason.TheRequesterIsGone,
+            note: null,
+            MovedAt,
+            RequestCaller.Plugin);
+
+        Assert.Equal(RequestState.Declined, declined.State);
+        Assert.Equal(DeclineReason.TheRequesterIsGone, declined.DeclineReason);
+        Assert.Null(declined.StateChangedByUserId);
+        Assert.Equal(RequestActor.Plugin, Assert.Single(declined.History).By);
+    }
+
+    /// <summary>
+    /// An operator may not give the reason saying the person who asked is gone.
+    /// <para>
+    /// The other direction of the same pairing, and the one that keeps the record honest rather than
+    /// the permission narrow. That reason is established when the server reports a deleted account;
+    /// an operator choosing it from a list would write a fact onto the record that nothing
+    /// established, and a surface would then show it beside a requester who is still there.
+    /// </para>
+    /// <para>
+    /// It also holds from <see cref="RequestState.Approved"/>, which is the other cell the widening
+    /// reaches, so the pairing is not a rule about one starting state.
+    /// </para>
+    /// </summary>
+    /// <param name="from">The state the request is in.</param>
+    [Theory]
+    [InlineData(RequestState.Open)]
+    [InlineData(RequestState.Approved)]
+    public void AnOperatorMayNotSayThePersonWhoAskedIsGone(RequestState from)
+    {
+        var request = ARequest() with { State = from };
+        var anOperator = RequestCaller.Administrator(new Guid("2d8f4b16-3a5c-4d97-8e21-7c6b5a4f3e29"));
+
+        Assert.Throws<ArgumentException>(
+            () => RequestLifecycle.Decline(
+                request,
+                DeclineReason.TheRequesterIsGone,
+                note: null,
+                MovedAt,
+                anOperator));
+
+        // And the ordinary decline from the same cell is unaffected, so the refusal above is about
+        // the reason rather than about the move.
+        Assert.Equal(
+            RequestState.Declined,
+            RequestLifecycle.Decline(request, DeclineReason.NotWanted, note: null, MovedAt, anOperator).State);
+    }
 
     /// <summary>
     /// A request with only the fields that have no default, in the state a new one is created in.

--- a/Jellyfin.Plugin.Requests.Tests/People/AccountRemovalTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/People/AccountRemovalTests.cs
@@ -42,21 +42,32 @@ public sealed class AccountRemovalTests
     private static readonly DateTimeOffset Asked = new DateTimeOffset(2026, 8, 27, 8, 0, 0, TimeSpan.Zero);
 
     /// <summary>
-    /// A request the deleted person asked for is gone.
+    /// When the account is deleted, which is after it was asked so a decline this pass makes can be
+    /// told apart from the stamp the request arrived with.
+    /// </summary>
+    private static readonly TestClock Removed = new TestClock(new DateTimeOffset(2026, 8, 29, 21, 0, 0, TimeSpan.Zero));
+
+    /// <summary>
+    /// An open request the deleted person asked for is declined and the record stays.
     /// </summary>
     /// <returns>A task that completes when the assertions have run.</returns>
     [Fact]
-    public async Task ARequestTheDeletedPersonAskedForIsRemoved()
+    public async Task ARequestTheDeletedPersonAskedForIsDeclinedAndStays()
     {
         var store = new InMemoryRequestStore();
         await store.AddAsync(ARequest(1, TheDeletedPerson), CancellationToken.None).ConfigureAwait(true);
 
         var report = await Removal(store).RemoveAsync(TheDeletedPerson, CancellationToken.None).ConfigureAwait(true);
 
-        Assert.Equal(1, report.Removed);
+        Assert.Equal(1, report.Declined);
         Assert.Equal(0, report.Detached);
         Assert.Equal(0, report.Left);
-        Assert.Empty(await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true));
+
+        var held = Assert.Single(await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true));
+
+        Assert.Equal(RequestState.Declined, held.Request.State);
+        Assert.Equal(DeclineReason.TheRequesterIsGone, held.Request.DeclineReason);
+        Assert.Equal(DeletedPerson.Tombstone, held.Request.RequestedByUserId);
     }
 
     /// <summary>
@@ -79,7 +90,7 @@ public sealed class AccountRemovalTests
 
         var report = await Removal(store).RemoveAsync(TheDeletedPerson, CancellationToken.None).ConfigureAwait(true);
 
-        Assert.Equal(0, report.Removed);
+        Assert.Equal(0, report.Declined);
         Assert.Equal(1, report.Detached);
 
         var held = Assert.Single(await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true));
@@ -158,7 +169,9 @@ public sealed class AccountRemovalTests
 
         var held = await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true);
 
-        Assert.Equal(3, held.Count);
+        // Four rather than three: nothing is removed by this pass any more. The open request of
+        // theirs is declined and stays, which is what #337 answered and #361 built.
+        Assert.Equal(4, held.Count);
         Assert.All(held, one => Assert.NotEqual(TheDeletedPerson, one.Request.RequestedByUserId));
         Assert.All(held, one => Assert.DoesNotContain(TheDeletedPerson, one.Request.JoinedByUserIds));
         Assert.All(held, one => Assert.NotEqual(TheDeletedPerson, one.Request.StateChangedByUserId));
@@ -231,25 +244,37 @@ public sealed class AccountRemovalTests
     }
 
     /// <summary>
-    /// A request that moves under the removal is re-read and removed against what the store now
-    /// holds. A sweep that gave up on the first refusal would leave the record it exists to remove.
+    /// A request that moves under the removal is re-read and declined against what the store now
+    /// holds. A sweep that gave up on the first refusal would leave the person on the record it
+    /// exists to take them off.
     /// </summary>
     /// <returns>A task that completes when the assertions have run.</returns>
     [Fact]
-    public async Task ARequestThatMovesUnderTheRemovalIsStillRemoved()
+    public async Task ARequestThatMovesUnderTheRemovalIsStillDeclined()
     {
         var inner = new InMemoryRequestStore();
         await inner.AddAsync(ARequest(1, TheDeletedPerson), CancellationToken.None).ConfigureAwait(true);
 
-        var store = new StoreThatMovesARequestUnderTheRemoval(
+        // The window is now the one between the read and the WRITE, because this pass writes a
+        // decline where it used to remove. A double that intercepted the removal would move nothing
+        // and this test would pass without ever reaching the retry it is about.
+        var store = new StoreThatMovesARequestUnderTheWrite(
             inner,
             moving => moving with { RequesterNote = "Somebody typed something while this ran." });
 
         var report = await Removal(store).RemoveAsync(TheDeletedPerson, CancellationToken.None).ConfigureAwait(true);
 
-        Assert.Equal(1, report.Removed);
+        Assert.Equal(1, report.Declined);
         Assert.Equal(0, report.Left);
-        Assert.Empty(await inner.GetAllAsync(CancellationToken.None).ConfigureAwait(true));
+
+        var held = Assert.Single(await inner.GetAllAsync(CancellationToken.None).ConfigureAwait(true));
+
+        Assert.Equal(RequestState.Declined, held.Request.State);
+        Assert.Equal(DeletedPerson.Tombstone, held.Request.RequestedByUserId);
+
+        // What the writer typed under the removal survives, which is what re-reading is for: a
+        // decline written against the copy read first would have thrown their note away.
+        Assert.Equal("Somebody typed something while this ran.", held.Request.RequesterNote);
     }
 
     /// <summary>
@@ -274,7 +299,7 @@ public sealed class AccountRemovalTests
         var store = new AStoreThatNeverSettles(inner);
         var log = new RecordingLogger();
 
-        var report = await new AccountRemoval(store, new InMemoryNoticePreferences(), log).RemoveAsync(TheDeletedPerson, CancellationToken.None).ConfigureAwait(true);
+        var report = await new AccountRemoval(store, new InMemoryNoticePreferences(), Removed, log).RemoveAsync(TheDeletedPerson, CancellationToken.None).ConfigureAwait(true);
 
         Assert.Equal(1, report.Left);
         Assert.Equal(0, report.Detached);
@@ -299,7 +324,7 @@ public sealed class AccountRemovalTests
         await store.AddAsync(ARequest(1, TheDeletedPerson), CancellationToken.None).ConfigureAwait(true);
 
         var log = new RecordingLogger();
-        await new AccountRemoval(store, new InMemoryNoticePreferences(), log).RemoveAsync(TheDeletedPerson, CancellationToken.None).ConfigureAwait(true);
+        await new AccountRemoval(store, new InMemoryNoticePreferences(), Removed, log).RemoveAsync(TheDeletedPerson, CancellationToken.None).ConfigureAwait(true);
 
         Assert.Contains(
             log.At(LogLevel.Information),
@@ -319,7 +344,7 @@ public sealed class AccountRemovalTests
         await store.AddAsync(ARequest(1, SomebodyElse), CancellationToken.None).ConfigureAwait(true);
 
         var log = new RecordingLogger();
-        await new AccountRemoval(store, new InMemoryNoticePreferences(), log).RemoveAsync(TheDeletedPerson, CancellationToken.None).ConfigureAwait(true);
+        await new AccountRemoval(store, new InMemoryNoticePreferences(), Removed, log).RemoveAsync(TheDeletedPerson, CancellationToken.None).ConfigureAwait(true);
 
         Assert.Empty(log.At(LogLevel.Information));
         Assert.Empty(log.At(LogLevel.Warning));
@@ -343,7 +368,7 @@ public sealed class AccountRemovalTests
         await notices.SetAsync(TheDeletedPerson, tellsThem: false, CancellationToken.None).ConfigureAwait(true);
         await notices.SetAsync(SomebodyElse, tellsThem: false, CancellationToken.None).ConfigureAwait(true);
 
-        await new AccountRemoval(store, notices, new RecordingLogger())
+        await new AccountRemoval(store, notices, Removed, new RecordingLogger())
             .RemoveAsync(TheDeletedPerson, CancellationToken.None).ConfigureAwait(true);
 
         Assert.True(await notices.TellsThemAsync(TheDeletedPerson, CancellationToken.None).ConfigureAwait(true));
@@ -387,17 +412,28 @@ public sealed class AccountRemovalTests
     }
 
     /// <summary>
-    /// An unfinished request of theirs is still removed, which is this change's interim and is
-    /// asserted rather than left to be discovered.
+    /// An unfinished request of theirs is declined rather than removed, and everything the record is
+    /// kept for is on it afterwards.
     /// <para>
-    /// The ruling asks for such a request to be closed as withdrawn instead, and there is no state
-    /// for that: a withdrawn-shaped value was considered and refused on #113. Which of the two
-    /// decisions stands is #337. This test is what a later change answering it has to argue with.
+    /// <b>This replaces <c>AnUnfinishedRequestOfTheirsIsStillRemoved</c>, which asserted the
+    /// opposite.</b> That test was the interim #336 landed deliberately, and it said in its own
+    /// summary that a later change answering #337 would have to argue with it. #337 was answered:
+    /// such a request is closed rather than deleted, and the close is the terminal state this plugin
+    /// already has, carrying <see cref="DeclineReason.TheRequesterIsGone"/>. The interim is
+    /// superseded here rather than deleted, so it is visible that the behaviour was reversed on
+    /// purpose instead of having quietly gone.
+    /// </para>
+    /// <para>
+    /// <b>Four things are asserted and each one is a way the change could be half made.</b> The
+    /// record staying is the whole point of the answer; the state and the reason are what make it
+    /// readable on a surface that renders declines; the tombstone is what makes it hold no person;
+    /// and the history entry saying <see cref="RequestActor.Plugin"/> is what stops an operator
+    /// being answerable for a decision nobody took.
     /// </para>
     /// </summary>
     /// <returns>A task that completes when the assertions have run.</returns>
     [Fact]
-    public async Task AnUnfinishedRequestOfTheirsIsStillRemoved()
+    public async Task AnUnfinishedRequestOfTheirsIsDeclinedRatherThanRemoved()
     {
         var store = new InMemoryRequestStore();
 
@@ -408,11 +444,27 @@ public sealed class AccountRemovalTests
         var report = await Removal(store).RemoveAsync(TheDeletedPerson, CancellationToken.None).ConfigureAwait(true);
 
         Assert.Equal(new AccountRemovalReport(1, 0, 0, 0), report);
-        Assert.Empty(await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true));
+
+        var held = Assert.Single(await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true));
+
+        Assert.Equal(RequestState.Declined, held.Request.State);
+        Assert.Equal(DeclineReason.TheRequesterIsGone, held.Request.DeclineReason);
+        Assert.Equal(DeletedPerson.Tombstone, held.Request.RequestedByUserId);
+        Assert.Equal(Removed.UtcNow, held.Request.StateChangedAt);
+
+        // Nobody decided it, so no person is named as having moved it.
+        Assert.Null(held.Request.StateChangedByUserId);
+
+        var entry = Assert.Single(held.Request.History);
+
+        Assert.Equal(RequestState.Approved, entry.From);
+        Assert.Equal(RequestState.Declined, entry.To);
+        Assert.Equal(RequestActor.Plugin, entry.By);
+        Assert.Equal(DeclineReason.TheRequesterIsGone, entry.Reason);
     }
 
     /// <summary>
-    /// Every finished state is tombstoned and every unfinished one is removed, over the whole of
+    /// Every finished state is tombstoned and every unfinished one is declined, over the whole of
     /// <see cref="RequestState"/> rather than over the two values the tests above happen to name.
     /// <para>
     /// The partition is <see cref="RetentionSweep.IsFinished"/>'s, and reading it here rather than
@@ -438,15 +490,20 @@ public sealed class AccountRemovalTests
         var report = await Removal(store).RemoveAsync(TheDeletedPerson, CancellationToken.None).ConfigureAwait(true);
         var held = await store.GetAllAsync(CancellationToken.None).ConfigureAwait(true);
 
+        // Either way the record stays and holds no person. What the partition decides is whether
+        // this pass ended the request or found it already ended.
+        Assert.Equal(DeletedPerson.Tombstone, Assert.Single(held).Request.RequestedByUserId);
+
         if (RetentionSweep.IsFinished(asked))
         {
             Assert.Equal(1, report.Tombstoned);
-            Assert.Equal(DeletedPerson.Tombstone, Assert.Single(held).Request.RequestedByUserId);
+            Assert.Equal(state, held[0].Request.State);
         }
         else
         {
-            Assert.Equal(1, report.Removed);
-            Assert.Empty(held);
+            Assert.Equal(1, report.Declined);
+            Assert.Equal(RequestState.Declined, held[0].Request.State);
+            Assert.Equal(DeclineReason.TheRequesterIsGone, held[0].Request.DeclineReason);
         }
     }
 
@@ -475,7 +532,7 @@ public sealed class AccountRemovalTests
     /// <summary>
     /// A finished request of the deleted person, an unfinished one, and one of somebody else's they
     /// had joined are answered by three different rules in one run, and the counts say which was
-    /// which.
+    /// which. All three records stay, so the counts are the only thing that tells them apart.
     /// </summary>
     /// <returns>A task that completes when the assertions have run.</returns>
     [Fact]
@@ -502,7 +559,7 @@ public sealed class AccountRemovalTests
     /// <param name="store">Where requests are kept.</param>
     /// <returns>The removal.</returns>
     private static AccountRemoval Removal(IRequestStore store)
-        => new AccountRemoval(store, new InMemoryNoticePreferences(), new RecordingLogger());
+        => new AccountRemoval(store, new InMemoryNoticePreferences(), Removed, new RecordingLogger());
 
     /// <summary>
     /// A request somebody asked for.

--- a/Jellyfin.Plugin.Requests.Tests/Web/DecideFromTheQueueTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Web/DecideFromTheQueueTests.cs
@@ -150,12 +150,23 @@ public sealed class DecideFromTheQueueTests
     }
 
     /// <summary>
-    /// Every reason a decline may carry is one the page offers, and the list opens on none of them.
+    /// Every reason an operator may give is one the page offers, every reason they may not is one it
+    /// does not, and the list opens on none of them.
     /// <para>
     /// The reasons are a closed set in the model and a list of options on the page, which is the
     /// same second-copy problem the decisions above have. A reason added to the model and not here
     /// is one no operator can give; an option here that the model does not know is a decline the
     /// endpoint refuses after the operator has written the sentence beside it.
+    /// </para>
+    /// <para>
+    /// <b>The set is not the enumeration any more, and it is asked of the lifecycle rather than
+    /// listed here.</b> <see cref="DeclineReason.TheRequesterIsGone"/> is a fact the plugin
+    /// establishes when the server reports a deleted account, and
+    /// <see cref="RequestLifecycle.Decline"/> refuses it from an administrator, so offering it would
+    /// be an option that reds the endpoint after the operator has chosen it. Naming it here as an
+    /// exception would put the rule in two places; asking which reasons an administrator may
+    /// actually give keeps one, and a seventh reason arrives on the page or is refused from it by
+    /// the same reading.
     /// </para>
     /// <para>
     /// The option that chooses nothing is required to be the selected one. A list that opens on a
@@ -174,15 +185,59 @@ public sealed class DecideFromTheQueueTests
             .Order(StringComparer.Ordinal)
             .ToArray();
 
-        Assert.Equal(
-            Enum.GetNames<DeclineReason>().Order(StringComparer.Ordinal),
-            offered,
-            StringComparer.Ordinal);
+        var choosable = Enum.GetValues<DeclineReason>()
+            .Where(AnOperatorMayGive)
+            .Select(reason => reason.ToString())
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        // The reading is worth nothing if it answers yes to everything, so the two sets are known to
+        // differ before they are compared.
+        Assert.NotEqual(Enum.GetNames<DeclineReason>().Length, choosable.Length);
+
+        Assert.Equal(choosable, offered, StringComparer.Ordinal);
 
         var opensOn = options.Where(option => option.Selected).ToArray();
 
         Assert.Single(opensOn);
         Assert.Empty(opensOn[0].Value);
+    }
+
+    /// <summary>
+    /// Whether an administrator may decline an open request for this reason, asked of the lifecycle
+    /// rather than decided here.
+    /// </summary>
+    /// <param name="reason">The reason.</param>
+    /// <returns><see langword="true"/> where the move is made rather than refused.</returns>
+    private static bool AnOperatorMayGive(DeclineReason reason)
+    {
+        var open = new MediaRequest
+        {
+            Id = new Guid("00000000-0000-4000-8000-0000000000aa"),
+            RequestedByUserId = new Guid("00000000-0000-4000-8000-0000000000bb"),
+            RequestedAt = new DateTimeOffset(2026, 8, 31, 12, 0, 0, TimeSpan.Zero),
+            Kind = RequestedItemKind.Movie,
+            DisplayTitle = "Something somebody wanted",
+            StateChangedAt = new DateTimeOffset(2026, 8, 31, 12, 0, 0, TimeSpan.Zero)
+        };
+
+        try
+        {
+            // A note beside every reason, because one of them requires it and this reading is not
+            // about that rule.
+            _ = RequestLifecycle.Decline(
+                open,
+                reason,
+                note: "Why this was declined.",
+                new DateTimeOffset(2026, 8, 31, 13, 0, 0, TimeSpan.Zero),
+                RequestCaller.Administrator(new Guid("00000000-0000-4000-8000-0000000000cc")));
+
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Requests/Localisation/Strings/en.json
+++ b/Jellyfin.Plugin.Requests/Localisation/Strings/en.json
@@ -32,6 +32,7 @@
   "declineReason.NoRoomForIt": "No room for it",
   "declineReason.NotWanted": "Not wanted",
   "declineReason.Other": "Another reason",
+  "declineReason.TheRequesterIsGone": "The person who asked is gone",
   "declineReason.withNote": "{0}, {1}",
   "kind.Movie": "Film",
   "kind.Series": "Series",

--- a/Jellyfin.Plugin.Requests/Model/DeclineReason.cs
+++ b/Jellyfin.Plugin.Requests/Model/DeclineReason.cs
@@ -55,5 +55,29 @@ public enum DeclineReason
     /// There is no room for it. Separate from <see cref="NotWanted"/> because it is a fact about the
     /// disk rather than a judgement about the title, and asking again later is reasonable.
     /// </summary>
-    NoRoomForIt = 5
+    NoRoomForIt = 5,
+
+    /// <summary>
+    /// The person who asked for it is gone. Their Jellyfin account was deleted while this request
+    /// was still open, so there is nobody left to give it to and nobody left to tell.
+    /// <para>
+    /// <b>This is the one reason no operator chooses.</b> Every value above is a sentence somebody
+    /// decided; this one is a fact the plugin establishes when the server tells it an account has
+    /// been deleted. <see cref="RequestLifecycle"/> refuses it from an administrator and refuses
+    /// every other reason from the plugin, so which of the two made a decline is readable off the
+    /// reason as well as off the history entry beside it.
+    /// </para>
+    /// <para>
+    /// <b>Why this is a reason on a state that exists rather than a sixth state.</b> The ruling of
+    /// 2026-08-28 on #49 asks for such a request to be closed rather than removed, and #337 answered
+    /// what "closed" is here: the terminal state this plugin already has. A withdrawn-shaped
+    /// <see cref="RequestState"/> was considered and refused on #113, and that refusal stands. What
+    /// the surfaces need is a finished request whose reason says why, and a reason is exactly what
+    /// this list is for - a request declined for this reason reads correctly on every surface that
+    /// already renders a decline, and a sixth state would have needed a cell in
+    /// <see cref="RequestLifecycle.Table"/> against every other state and a rendering rule in each
+    /// surface.
+    /// </para>
+    /// </summary>
+    TheRequesterIsGone = 6
 }

--- a/Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs
+++ b/Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs
@@ -47,13 +47,26 @@ namespace Jellyfin.Plugin.Requests.Model;
 /// already refuses.
 /// </para>
 /// <para>
-/// One line decides every cell's permitted set: <b>a decision is an administrator's and an
+/// One line decides almost every cell's permitted set: <b>a decision is an administrator's and an
 /// observation is the plugin's</b>. Approving, declining, taking either back and sending something
-/// onward again are answers a person gives, and they are the six cells an administrator may make.
+/// onward again are answers a person gives, and they are the cells an administrator may make.
 /// Arriving in the library and failing to arrive are things that happened whether or not anybody
-/// looked, and they are the four cells the plugin may make. A person marking a request fulfilled
+/// looked, and they are the cells the plugin may make. A person marking a request fulfilled
 /// would be making the state say something about the library that the library does not say, and
-/// #42 is where that is detected instead.
+/// #42 is where that is detected instead. The counts those two sentences carried are gone rather
+/// than corrected: a number in a paragraph beside a table is a second copy of the table, and it went
+/// stale the first time a cell was widened.
+/// </para>
+/// <para>
+/// <b>Two cells are neither, and they are the exception the line above admits.</b> Moving an
+/// unfinished request into <see cref="RequestState.Declined"/> is made by an administrator, who
+/// decides, and by the plugin, which acts on a fact outside the request: the account of the person
+/// who asked has been deleted, so there is nobody left to answer. #337 decided that such a request is
+/// closed rather than removed and #361 built it. The widening is held to that one move rather than
+/// left as a general permission - a caller who is not an administrator may give only
+/// <see cref="DeclineReason.TheRequesterIsGone"/>, and an administrator may not give it at all,
+/// because that reason is established by the server reporting a deletion rather than chosen from a
+/// list.
 /// </para>
 /// <para>
 /// <b>A request with no provider identifier may only be declined.</b> It is a title somebody typed,
@@ -185,7 +198,9 @@ public static class RequestLifecycle
     /// Where the table allows the decline and does not admit this caller for it.
     /// </exception>
     /// <exception cref="ArgumentException">
-    /// Where the reason is <see cref="DeclineReason.Other"/> and no note says what happened.
+    /// Where the reason is <see cref="DeclineReason.Other"/> and no note says what happened; where a
+    /// caller who is not an administrator gives any reason but
+    /// <see cref="DeclineReason.TheRequesterIsGone"/>; or where an administrator gives that one.
     /// </exception>
     /// <exception cref="RequestTextTooLongException">Where the note is too long.</exception>
     public static MediaRequest Decline(
@@ -326,9 +341,42 @@ public static class RequestLifecycle
             throw new IllegalRequestTransitionException(cell.From, cell.To, cell.Why);
         }
 
-        if ((cell.Permitted & by.RolesOn(request)) == RequestActor.None)
+        var roles = by.RolesOn(request);
+
+        if ((cell.Permitted & roles) == RequestActor.None)
         {
             throw new RequestMoveNotPermittedException(cell.From, cell.To, cell.Permitted);
+        }
+
+        // WHICH MOVER MAY GIVE WHICH REASON, AND IT IS A BICONDITIONAL RATHER THAN ONE RULE.
+        //
+        // Two cells admit the plugin into Declined so that an open request of a deleted person can
+        // be closed rather than removed, which is #337's answer built in #361. Widening a cell is
+        // coarser than the move it was widened for: on its own it lets the plugin decline anything
+        // open or approved for any reason on the list, and it lets an operator record a fact about
+        // an account that they are in no position to establish. Neither of those is what was
+        // decided, so both are refused here.
+        //
+        // The check is on the ADMINISTRATOR role rather than on the plugin one, because the
+        // requester role rides along on a caller's own request and testing for the plugin by
+        // absence would let an ordinary user through the day a cell admits one.
+        if (to == RequestState.Declined)
+        {
+            var anOperator = (roles & RequestActor.Administrator) != RequestActor.None;
+
+            if (!anOperator && reason != DeclineReason.TheRequesterIsGone)
+            {
+                throw new ArgumentException(
+                    "A decline nobody decided carries the one reason that is a fact rather than a judgement, that the person who asked is gone. Every other reason on the list is somebody's decision and this caller took none.",
+                    nameof(reason));
+            }
+
+            if (anOperator && reason == DeclineReason.TheRequesterIsGone)
+            {
+                throw new ArgumentException(
+                    "The reason saying the person who asked is gone is established when the server reports a deleted account, not chosen. An operator giving it would put a fact on the record that nothing established.",
+                    nameof(reason));
+            }
         }
 
         // Authority before this one, and that order is deliberate too. Whether a request carries an
@@ -386,11 +434,31 @@ public static class RequestLifecycle
         const RequestActor Decision = RequestActor.Administrator;
         const RequestActor Observation = RequestActor.Plugin;
 
+        // The third set, and the paragraph above says that naming one is the moment to say what the
+        // cell has become. These two cells admit an operator, who decides, and the plugin, which
+        // neither decides nor observes the library: it acts on a fact outside the request, that the
+        // account of the person who asked has been deleted. #361 is where that was built and #337 is
+        // where it was decided.
+        //
+        // The widening is exactly that one move rather than a general permission to decline.
+        // `Moved` refuses a decline the plugin makes for any other reason, and refuses
+        // `DeclineReason.TheRequesterIsGone` from anybody else, so the pair is a biconditional
+        // rather than a door left open.
+        //
+        // It reaches these two cells and no others because they are the two unfinished states:
+        // `RequestQuota.CountsAgainstIt` is open or approved, and `RetentionSweep.IsFinished` is its
+        // complement, which is the partition the account removal walks.
+        const RequestActor DecisionOrTheRequesterLeaving = Decision | RequestActor.Plugin;
+
         var table = new List<RequestTransition>
         {
             Refused(RequestState.Open, RequestState.Open, NotAMove),
             Legal(RequestState.Open, RequestState.Approved, Decision, "An operator says yes."),
-            Legal(RequestState.Open, RequestState.Declined, Decision, "An operator says no."),
+            Legal(
+                RequestState.Open,
+                RequestState.Declined,
+                DecisionOrTheRequesterLeaving,
+                "An operator says no, or the person who asked is gone and nothing is left to answer."),
             Legal(
                 RequestState.Open,
                 RequestState.Fulfilled,
@@ -403,8 +471,8 @@ public static class RequestLifecycle
             Legal(
                 RequestState.Approved,
                 RequestState.Declined,
-                Decision,
-                "An operator takes an approval back, and the reason says why. This is the repair for an approval given by mistake."),
+                DecisionOrTheRequesterLeaving,
+                "An operator takes an approval back, and the reason says why. This is the repair for an approval given by mistake. It is also where an approved request goes when the person who asked is gone."),
             Legal(
                 RequestState.Approved,
                 RequestState.Fulfilled,

--- a/Jellyfin.Plugin.Requests/People/AccountRemoval.cs
+++ b/Jellyfin.Plugin.Requests/People/AccountRemoval.cs
@@ -2,8 +2,10 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Model;
 using Jellyfin.Plugin.Requests.Notify;
 using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Time;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.Requests.People;
@@ -21,16 +23,28 @@ namespace Jellyfin.Plugin.Requests.People;
 /// for stays, with <see cref="DeletedPerson.Tombstone"/> where their identifier was: the record
 /// then says that somebody who is gone asked for this title on this date, which keeps an
 /// administrator's history of what was asked and answered without keeping a person. An UNFINISHED
-/// one of theirs goes. A request somebody else asked for that they had joined is not theirs, so the
-/// request stays and they come off its list of joiners.
+/// one of theirs is declined, for the reason saying the person who asked is gone, and then carries
+/// the tombstone too, because declining it makes it finished. A request somebody else asked for that
+/// they had joined is not theirs, so the request stays and they come off its list of joiners.
 /// </para>
 /// <para>
-/// <b>The middle rule is an interim and says so.</b> The ruling of 2026-08-28 on #49 asks for an
-/// open request of a deleted person to be closed as withdrawn rather than removed, and there is no
+/// <b>The middle rule was an interim and is not one any more.</b> The ruling of 2026-08-28 on #49
+/// asks for an open request of a deleted person to be closed rather than removed, and there was no
 /// state for that: a withdrawn-shaped value was considered and refused on #113, which
-/// <see cref="Model.RequestLifecycle"/> and <see cref="Model.RequestActor"/> both record. Which of
-/// the two decisions stands is #337. Until it is answered an unfinished request of theirs is
-/// removed, which is what this did for every request of theirs before #336.
+/// <see cref="RequestLifecycle"/> and <see cref="RequestActor"/> both record. #337 answered which of
+/// the two stands, and it upholds that refusal: the close is the terminal state this plugin already
+/// has, carrying <see cref="DeclineReason.TheRequesterIsGone"/>. So an unfinished request of theirs
+/// is declined rather than removed, and the record stays with the tombstone where they were, which
+/// is what a finished request of a deleted person has carried since #336.
+/// </para>
+/// <para>
+/// <b>The decline is made through the lifecycle and not written into the store.</b> Every other
+/// state change this plugin makes is checked against <see cref="RequestLifecycle.Table"/> and leaves
+/// a history entry, and one that did neither would be the only state change here that an operator
+/// answering a complaint could not read the reason for. Two cells admit the plugin into the declined
+/// state for it, and the lifecycle refuses that reason from an operator and every other reason from
+/// this caller, so the widening is that one move rather than a general permission to decline. The
+/// entry it leaves says <see cref="RequestActor.Plugin"/>, because nobody decided this.
 /// </para>
 /// <para>
 /// <b>What finished means is not decided here.</b> It is
@@ -59,10 +73,12 @@ namespace Jellyfin.Plugin.Requests.People;
 /// </para>
 /// <para>
 /// <b>The case nobody has decided, stated rather than hidden.</b> A request the deleted person asked
-/// for and somebody else joined is removed, because it is theirs, and the joiner loses it. Whether it
-/// should instead pass to the earliest joiner, who did ask for the same title, is a call no issue on
-/// this board has taken. Removal is what the decision as written says, and passing it on would make
-/// the record say somebody asked at a moment they did not.
+/// for and somebody else joined is declined, because it is theirs, and the joiner loses what they
+/// were waiting for. Whether it should instead pass to the earliest joiner, who did ask for the same
+/// title, is a call no issue on this board has taken. Ending it is what the decision as written says,
+/// and passing it on would make the record say somebody asked at a moment they did not. #361 changed
+/// what happens to such a request from removal to a decline and did not touch this question: the
+/// joiner is left with a request they cannot act on either way.
 /// </para>
 /// </summary>
 public sealed class AccountRemoval
@@ -80,6 +96,7 @@ public sealed class AccountRemoval
 
     private readonly IRequestStore _store;
     private readonly INoticePreferences _notices;
+    private readonly IClock _clock;
     private readonly ILogger _logger;
 
     /// <summary>
@@ -87,16 +104,22 @@ public sealed class AccountRemoval
     /// </summary>
     /// <param name="store">Where requests are kept.</param>
     /// <param name="notices">Where the switch a person set about being told is kept.</param>
+    /// <param name="clock">
+    /// What stamps the decline this makes. It is injected for the reason everything else here that
+    /// stamps a record is: a moment read off the machine cannot be asserted about.
+    /// </param>
     /// <param name="logger">Where what was done is written.</param>
     /// <exception cref="ArgumentNullException">Where anything it needs is missing.</exception>
-    public AccountRemoval(IRequestStore store, INoticePreferences notices, ILogger logger)
+    public AccountRemoval(IRequestStore store, INoticePreferences notices, IClock clock, ILogger logger)
     {
         ArgumentNullException.ThrowIfNull(store);
         ArgumentNullException.ThrowIfNull(notices);
+        ArgumentNullException.ThrowIfNull(clock);
         ArgumentNullException.ThrowIfNull(logger);
 
         _store = store;
         _notices = notices;
+        _clock = clock;
         _logger = logger;
     }
 
@@ -106,9 +129,10 @@ public sealed class AccountRemoval
     private enum Outcome
     {
         /// <summary>
-        /// It was theirs, unfinished, and it is gone.
+        /// It was theirs, unfinished, and it is declined with the tombstone where they were. The
+        /// record stays.
         /// </summary>
-        Removed,
+        Declined,
 
         /// <summary>
         /// It was theirs, finished, and it stays with the tombstone where they were.
@@ -148,7 +172,7 @@ public sealed class AccountRemoval
                 nameof(userId));
         }
 
-        var removed = 0;
+        var declined = 0;
         var tombstoned = 0;
         var detached = 0;
         var left = 0;
@@ -163,8 +187,8 @@ public sealed class AccountRemoval
 
             switch (outcome)
             {
-                case Outcome.Removed:
-                    removed++;
+                case Outcome.Declined:
+                    declined++;
                     break;
 
                 case Outcome.Tombstoned:
@@ -186,16 +210,16 @@ public sealed class AccountRemoval
         // because the list holds the people who said no and nobody else.
         await _notices.SetAsync(userId, tellsThem: true, cancellationToken).ConfigureAwait(false);
 
-        var report = new AccountRemovalReport(removed, tombstoned, detached, left);
+        var report = new AccountRemovalReport(declined, tombstoned, detached, left);
 
         // At information rather than debug where anything happened: this is the plugin deleting
         // somebody's records without anybody asking it to, and an operator answering for what is
         // held should find that it happened in the log they already read.
-        if ((removed > 0 || tombstoned > 0 || detached > 0) && _logger.IsEnabled(LogLevel.Information))
+        if ((declined > 0 || tombstoned > 0 || detached > 0) && _logger.IsEnabled(LogLevel.Information))
         {
             _logger.LogInformation(
-                "A deleted account left {Removed} unfinished request(s) of their own, which were removed, {Tombstoned} finished one(s), which stay with the person taken out of them, and {Detached} request(s) of other people's, which they were taken off.",
-                removed,
+                "A deleted account left {Declined} unfinished request(s) of their own, which were declined because the person who asked is gone and stay with the person taken out of them, {Tombstoned} finished one(s), which stay with the person taken out of them, and {Detached} request(s) of other people's, which they were taken off.",
+                declined,
                 tombstoned,
                 detached);
         }
@@ -238,9 +262,27 @@ public sealed class AccountRemoval
                 {
                     if (!RetentionSweep.IsFinished(current.Request))
                     {
-                        return await _store.RemoveAsync(current.Request.Id, current.Revision, cancellationToken).ConfigureAwait(false)
-                            ? Outcome.Removed
-                            : Outcome.Gone;
+                        // Declined first and tombstoned afterwards, in that order. The history entry
+                        // the lifecycle appends records what the caller was on the request it was
+                        // handed, and a request whose requester had already been replaced is one
+                        // this caller is nothing on.
+                        var declined = RequestLifecycle.Decline(
+                            current.Request,
+                            DeclineReason.TheRequesterIsGone,
+                            note: null,
+                            _clock.UtcNow,
+                            RequestCaller.Plugin);
+
+                        await _store.ReplaceAsync(
+                            declined with
+                            {
+                                RequestedByUserId = DeletedPerson.Tombstone,
+                                JoinedByUserIds = [.. declined.JoinedByUserIds.Where(joined => joined != userId)]
+                            },
+                            current.Revision,
+                            cancellationToken).ConfigureAwait(false);
+
+                        return Outcome.Declined;
                     }
 
                     // The joiner list is written as well, because a person can be the requester of

--- a/Jellyfin.Plugin.Requests/People/AccountRemovalReport.cs
+++ b/Jellyfin.Plugin.Requests/People/AccountRemovalReport.cs
@@ -4,20 +4,30 @@ namespace Jellyfin.Plugin.Requests.People;
 /// What one account removal did, counted so the caller can report it and a test can assert it.
 /// <para>
 /// The four are separate because they read differently to an operator answering for what is held. A
-/// removed request is a record that is gone; a tombstoned one is a record that stays with nobody in
-/// it, which is a different answer to "what do you still hold" than either of the other two; a
-/// detached one is a record that stays with one fewer person on it; and a left one is a record that
-/// still names a deleted account, which is the only one of the four that anybody has to act on.
+/// declined request is a record that stays, finished, saying that somebody who is gone asked for
+/// this and was answered by nobody; a tombstoned one is a record that stays as it was decided, with
+/// nobody in it; a detached one is a record that stays with one fewer person on it; and a left one
+/// is a record that still names a deleted account, which is the only one of the four that anybody
+/// has to act on.
 /// </para>
 /// <para>
-/// Removed and tombstoned are counted apart rather than added together on purpose. An operator
-/// asked what became of a deleted person's requests is answering about records that no longer exist
-/// and records that do, and one number covering both would make the second sound like the first.
+/// Declined and tombstoned are counted apart rather than added together on purpose. Both leave a
+/// record behind, and they are not the same record: one was ended by this pass and one was already
+/// finished when the pass reached it, which is the difference between what became of an open
+/// question and what became of an answered one.
+/// </para>
+/// <para>
+/// <b>The first count was called Removed and named a record that no longer existed.</b> Nothing is
+/// removed by this pass any more: #337 answered that an open request of a deleted person is closed
+/// rather than deleted, and #361 built it. The field is renamed rather than kept with a new meaning,
+/// because a count called Removed that counts records still in the store is the worst of the two
+/// available mistakes.
 /// </para>
 /// </summary>
-/// <param name="Removed">
-/// Unfinished requests the deleted account had asked for, which were removed. Whether those should
-/// instead be closed as withdrawn is #337.
+/// <param name="Declined">
+/// Unfinished requests the deleted account had asked for, which were declined for
+/// <see cref="Model.DeclineReason.TheRequesterIsGone"/> and stay with
+/// <see cref="DeletedPerson.Tombstone"/> where the person was.
 /// </param>
 /// <param name="Tombstoned">
 /// Finished requests the deleted account had asked for, which stay with
@@ -28,4 +38,4 @@ namespace Jellyfin.Plugin.Requests.People;
 /// Requests that still name the account, because they kept moving while the removal ran. Nothing
 /// looks at these again on its own.
 /// </param>
-public readonly record struct AccountRemovalReport(int Removed, int Tombstoned, int Detached, int Left);
+public readonly record struct AccountRemovalReport(int Declined, int Tombstoned, int Detached, int Left);

--- a/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs
@@ -236,6 +236,7 @@ public sealed class PluginServiceRegistrator : IPluginServiceRegistrator
         serviceCollection.AddSingleton(provider => new AccountRemoval(
             provider.GetRequiredService<IRequestStore>(),
             provider.GetRequiredService<INoticePreferences>(),
+            provider.GetRequiredService<IClock>(),
             provider.GetRequiredService<ILogger<AccountRemoval>>()));
         serviceCollection.AddSingleton<IEventConsumer<UserDeletedEventArgs>, RemovedAccounts>();
 

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -480,7 +480,7 @@ hope.** Nothing is handed over until an operator has approved it, and an approva
 request carrying no external identifier at all:
 
     git grep -n 'RequestNotIdentifiedException(to)' -- Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs
-    Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs:339:            throw new RequestNotIdentifiedException(to);
+    Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs:387:            throw new RequestNotIdentifiedException(to);
 
 **What that rule does not promise is the one this call needs.** It asks for an identifier and not for
 a TMDB one, so a request identified by an IMDb or a TVDB number alone is approvable here and has no

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -58,12 +58,12 @@ itself, so a sixth state is eleven new cells rather than a silent widening.
 
 - **Open to Open**: refused. A move to the state it is already in is not a move, and appending a history entry saying nothing happened makes the history harder to read rather than more complete.
 - **Open to Approved**: allowed. An operator says yes.
-- **Open to Declined**: allowed. An operator says no.
+- **Open to Declined**: allowed. An operator says no, or the person who asked is gone and nothing is left to answer.
 - **Open to Fulfilled**: allowed. The library already holds what was asked for, so there is nothing left for anybody to decide.
 - **Open to Failed**: refused. Nothing was ever sent onward, so there is nothing that could have failed.
 - **Approved to Open**: refused. Nothing returns to open. A request reading as undecided after somebody decided it hides that decision from the next person to look at the queue.
 - **Approved to Approved**: refused. A move to the state it is already in is not a move, and appending a history entry saying nothing happened makes the history harder to read rather than more complete.
-- **Approved to Declined**: allowed. An operator takes an approval back, and the reason says why. This is the repair for an approval given by mistake.
+- **Approved to Declined**: allowed. An operator takes an approval back, and the reason says why. This is the repair for an approval given by mistake. It is also where an approved request goes when the person who asked is gone.
 - **Approved to Fulfilled**: allowed. It arrived and the person who asked can watch it.
 - **Approved to Failed**: allowed. It was sent onward and did not arrive, so it stops looking like an operator forgot about it.
 - **Declined to Open**: refused. Nothing returns to open. A request reading as undecided after somebody decided it hides that decision from the next person to look at the queue.
@@ -100,6 +100,31 @@ on Wednesday, which is what happened.
 one is a request for the right one, and it is a new request because the old one describes what was
 asked for and got an answer. A library that no longer holds the media is an observation, which the
 `Availability` field on the record already carries with the time it was made.
+
+## The one decline nobody decides
+
+Every cell into `Declined` is an operator's, except that the two out of an unfinished state are also
+the plugin's. That is not an observation in the sense the rest of the table uses the word: nothing
+about the library changed. What changed is outside the request - the Jellyfin account of the person
+who asked was deleted - so there is nobody left to give it to and nobody left to tell, and the
+request is closed rather than removed. #337 decided that and #361 built it.
+
+Widening a cell is coarser than the move it was widened for, so the reason and the mover are paired
+rather than left independent:
+
+    git grep -n 'TheRequesterIsGone = ' -- Jellyfin.Plugin.Requests/Model/DeclineReason.cs
+    Jellyfin.Plugin.Requests/Model/DeclineReason.cs:82:    TheRequesterIsGone = 6
+
+A caller that is not an administrator may give that reason and no other, so the widening does not
+become a general permission for the plugin to decline anything open. An administrator may give every
+other reason and not that one, because it is a fact the server reports rather than a judgement
+anybody makes, and an operator choosing it from a list would write down something nothing
+established. The queue page therefore offers six of the seven, and which six is read off the
+lifecycle by the test rather than listed on the page a second time.
+
+The entry it leaves in the history says the mover was the plugin, and
+`MediaRequest.StateChangedByUserId` is empty on such a request, so nobody is recorded as having taken
+a decision they did not take.
 
 ## What holds the two doors, and what it does not reach
 

--- a/docs/personal-data.md
+++ b/docs/personal-data.md
@@ -257,7 +257,7 @@ when an account is deleted and this plugin consumes it:
 
     git grep -n 'IEventConsumer<UserDeletedEventArgs>' -- Jellyfin.Plugin.Requests/
     Jellyfin.Plugin.Requests/People/RemovedAccounts.cs:30:public sealed class RemovedAccounts : IEventConsumer<UserDeletedEventArgs>
-    Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs:240:        serviceCollection.AddSingleton<IEventConsumer<UserDeletedEventArgs>, RemovedAccounts>();
+    Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs:241:        serviceCollection.AddSingleton<IEventConsumer<UserDeletedEventArgs>, RemovedAccounts>();
 
 There are three rules and they are not one rule.
 
@@ -276,25 +276,44 @@ that somebody who is gone asked for this title on this date. Deletion-by-record 
 and loses the administrator's history of what was asked and answered along with the person, which is
 the trade taken on #49 on 28 August.
 
-**An unfinished request they asked for is removed, and that is the interim rather than the answer.**
-The same decision asks for an open request to be closed as withdrawn instead, and there is no state
+**An unfinished request they asked for is declined, and then carries the tombstone too.** The same
+decision asks for an open request to be closed rather than removed, and there is no separate state
 for that: a withdrawn-shaped value was considered and refused on #113, and the refusal is written
 into the model in two places:
 
     git grep -n 'Cancelled' -- Jellyfin.Plugin.Requests/
     Jellyfin.Plugin.Requests/Model/RequestActor.cs:43:    /// is no state for a user withdrawing, refused with the <c>Cancelled</c> state on #113. The
-    Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs:69:/// user withdrawing has no state to move to because <c>Cancelled</c> was refused on #113. An
+    Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs:82:/// user withdrawing has no state to move to because <c>Cancelled</c> was refused on #113. An
 
-**#337 answered that on 2026-08-30, and the refusal stands.** Closed as withdrawn means the terminal
-state that already exists, carrying a reason that says the requester is gone, rather than a sixth
-`RequestState` value. The argument #113 made is still true - a user withdrawing is a second road to
-finished that an operator does nothing different about - and a landed decision is not re-taken by a
-later sentence that did not name it. What the answer costs is one `DeclineReason` value instead of
-eleven new cells in the lifecycle table and everything that reads it.
+**#337 answered that on 2026-08-30, and the refusal stands.** Closed means the terminal state that
+already exists, carrying a reason that says the requester is gone, rather than a sixth `RequestState`
+value. The argument #113 made is still true - a user withdrawing is a second road to finished that an
+operator does nothing different about - and a landed decision is not re-taken by a later sentence
+that did not name it. What the answer costs is one `DeclineReason` value instead of eleven new cells
+in the lifecycle table and everything that reads it.
 
-**The behaviour has not moved yet, and #361 is where it does.** Until that lands an unfinished
-request of theirs is removed, record and history together, which is what happened to every request
-of theirs before this.
+**The behaviour moved in #361 and this page said it had not.** The reason is on the list:
+
+    git grep -n 'TheRequesterIsGone = ' -- Jellyfin.Plugin.Requests/Model/DeclineReason.cs
+    Jellyfin.Plugin.Requests/Model/DeclineReason.cs:82:    TheRequesterIsGone = 6
+
+So an open or approved request of a deleted person is now declined for that reason and the record
+stays, with the tombstone where the person was, because declining it makes it finished and a finished
+request of a deleted person carries the tombstone by the rule above. Nothing about a deleted account
+is removed from the queue file any more; what changes is what the record says.
+
+**No person is named as having made that decline, because nobody made it.** The move goes through
+the lifecycle rather than being written into the store, so it is checked and it leaves a history
+entry like every other state change here, and the entry says the mover was the plugin.
+`MediaRequest.StateChangedByUserId` is left empty on it, which is the same field the paragraph below
+is about and the opposite case: there it holds an identifier because a person really did move the
+request, and here it holds nothing because none did.
+
+**The lifecycle admits the plugin into exactly that one move.** Two cells were widened for it, and
+the reason and the mover are paired so the widening is not a general permission to decline: a caller
+that is not an administrator may give only this reason, and an administrator may not give it at all.
+The second half is what keeps the record honest, because an operator choosing it from a list would be
+writing down a fact about somebody's account that nothing established.
 
 **A request somebody else asked for that they had joined stays, and they come off its list.** The
 request is not theirs, and taking a third party's request away because somebody else deleted their
@@ -321,7 +340,7 @@ a raw identifier. It was found by reading the page against the tree rather than 
     211b90c 2026-08-27 Draw who last moved a request, and keep a deleted account apart from an unanswered call
 
     git grep -n 'queue.movedBy.deleted' -- Jellyfin.Plugin.Requests/
-    Jellyfin.Plugin.Requests/Localisation/Strings/en.json:122:  "queue.movedBy.deleted": "A person who has been deleted",
+    Jellyfin.Plugin.Requests/Localisation/Strings/en.json:123:  "queue.movedBy.deleted": "A person who has been deleted",
     Jellyfin.Plugin.Requests/Web/queue.html:564:                        return RequestsShell.word("queue.movedBy.deleted");
 
 What the page draws is an identifier the dashboard's user list does not hold, and it says so only

--- a/docs/seam.md
+++ b/docs/seam.md
@@ -500,7 +500,7 @@ cannot. There is no state a request can be withdrawn into, and the model records
 
     git grep -n 'Cancelled' -- Jellyfin.Plugin.Requests/Model/
     Jellyfin.Plugin.Requests/Model/RequestActor.cs:43:    /// is no state for a user withdrawing, refused with the <c>Cancelled</c> state on #113. The
-    Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs:69:/// user withdrawing has no state to move to because <c>Cancelled</c> was refused on #113. An
+    Jellyfin.Plugin.Requests/Model/RequestLifecycle.cs:82:/// user withdrawing has no state to move to because <c>Cancelled</c> was refused on #113. An
 
 **What a person does instead is ask an operator, who declines the request.** That is written here
 rather than left to be found, because it is the one errand this plugin exists to remove, and an


### PR DESCRIPTION
Closes #361.

An open request of a deleted person is now declined and kept, carrying a reason that says the person who asked is gone, instead of being deleted along with its history. #337 answered that on 2026-08-30 and this builds it. The refusal of a withdrawn-shaped `RequestState` recorded on #113 is untouched: the close is the terminal state this plugin already has.

## The fork this issue's note records, and which way it was taken

The note of 31.08. on #361 sets out three ways to make the move and takes none. This takes the first, **widen the two cells and pay the argument the table asks for**, and it narrows the widening afterwards so the argument is about one move rather than a permission.

**Why not the second, writing the record directly as the tombstone does.** That is the cheaper change and it gives up the legality check and the history entry. Every other state change this plugin makes is checked against `RequestLifecycle.Table` and leaves an entry, so a declined request with no entry saying who declined it and why would be the only state change here an operator answering a complaint could not read the reason for. It would also read as data corruption rather than as an answer.

**The third is refused, as the note asks.** No administrator is invented. `StateChangedByUserId` is empty on such a request, and the history entry says `RequestActor.Plugin`.

**The table's own comment says what the first route owes:** a cell needing a third permitted set is a cell that has stopped being either a decision or an observation, and giving the set a name is the moment to say what it is instead. A decline nobody decided is neither, and what it is instead is the plugin acting on a fact outside the request - the Jellyfin account of the person who asked has been deleted. The set is named `DecisionOrTheRequesterLeaving` and the paragraph beside it says that.

**It reaches two cells and not three.** The unfinished states are the ones `RequestQuota.CountsAgainstIt` names, and `Failed` is not among them:

    git grep -n -A2 'public static bool CountsAgainstIt' -- Jellyfin.Plugin.Requests/Model/RequestQuota.cs
    Jellyfin.Plugin.Requests/Model/RequestQuota.cs:37:    public static bool CountsAgainstIt(MediaRequest? request)
    Jellyfin.Plugin.Requests/Model/RequestQuota.cs-38-        => request is not null
    Jellyfin.Plugin.Requests/Model/RequestQuota.cs-39-            && request.State is RequestState.Open or RequestState.Approved;

## What keeps the widening from being a general permission

A widened cell is coarser than the move it was widened for. On its own it would let the plugin decline anything open or approved for any reason on the list, and "not wanted" said by nobody is a judgement attributed to a decision that was never taken. So the reason and the mover are paired in `Moved`, in both directions:

- A caller holding no administrator role may give `TheRequesterIsGone` and no other reason.
- An administrator may give every other reason and not that one, because it is established when the server reports a deleted account rather than chosen from a list. An operator picking it would write a fact onto the record that nothing established.

**The queue page therefore offers six of the seven reasons, and the six are read off the lifecycle rather than listed a second time.** `EveryReasonADeclineMayCarryIsOfferedByThePage` used to compare the options against `Enum.GetNames<DeclineReason>()`; it now asks which reasons an administrator may actually give, and asserts first that the answer is smaller than the enumeration, so a reading that said yes to everything would fail rather than pass quietly.

## Each guard watched failing, for the reason it names

Run on `net9.0` at the head of this branch, with the whole suite each time.

**The move itself.** The decline replaced by the `RemoveAsync` it stood on before:

```
Fehler ... AccountRemovalTests.NoRequestNamesThemAfterwards
Fehler ... AccountRemovalTests.WhichOnesStayIsTheSamePartitionTheSweepDraws(state: Open)
Fehler ... AccountRemovalTests.WhichOnesStayIsTheSamePartitionTheSweepDraws(state: Approved)
Fehler ... AccountRemovalTests.AnUnfinishedRequestOfTheirsIsDeclinedRatherThanRemoved
Fehler ... AccountRemovalTests.ARequestTheDeletedPersonAskedForIsDeclinedAndStays
Fehler ... AccountRemovalTests.ARequestThatMovesUnderTheRemovalIsStillDeclined
Fehler!      : Fehler: 6, erfolgreich: 779, gesamt: 785
```

**The first half of the pairing**, the plugin's reason. That block deleted:

```
Fehler ... RequestLifecycleTests.ThePluginDeclinesForTheOneReasonThatIsAFactAndForNoOther(reason: AlreadyRequested)
Fehler ... (reason: Other)  (reason: NoRoomForIt)  (reason: CannotBeObtained)
Fehler ... (reason: AlreadyInTheLibrary)  (reason: NotWanted)
Fehler!      : Fehler: 6, erfolgreich: 779, gesamt: 785
```

**The second half**, the operator's. That block deleted:

```
Fehler ... RequestLifecycleTests.AnOperatorMayNotSayThePersonWhoAskedIsGone(from: Approved)
Fehler ... RequestLifecycleTests.AnOperatorMayNotSayThePersonWhoAskedIsGone(from: Open)
Fehler ... Web.DecideFromTheQueueTests.EveryReasonADeclineMayCarryIsOfferedByThePage
Fehler!      : Fehler: 3, erfolgreich: 782, gesamt: 785
```

The third of those is the derivation working: with the guard gone the page's offered set and the choosable set stop disagreeing, and the assertion that they must differ from the enumeration is what catches it.

## The done-when, one line each

- **A `DeclineReason` value naming a requester who is gone exists, documented with why it is a reason on an existing state.** `TheRequesterIsGone = 6`, and its documentation carries the argument: a sixth state would have needed a cell against every other state in the table and a rendering rule in each surface.
- **Deleting a user moves each unfinished request into declined with that reason and leaves the record, proven by a test that fails when the move is taken out.** Above.
- **The requester identifier on such a record is the tombstone.** Declining makes the request finished, so it takes the same road a finished one already took. Asserted in three tests.
- **The report counts these apart.** `Removed` is renamed to `Declined` rather than kept with a new meaning: a count called Removed that counts records still in the store is the worse of the two available mistakes. Nothing is removed by this pass any more.
- **`AnUnfinishedRequestOfTheirsIsStillRemoved` is replaced rather than deleted.** Its replacement says in its own summary that it supersedes the interim, and asserts the record, the state, the reason, the tombstone, the stamp, the absent mover and the history entry.
- **The three sentences that called #337 undecided are re-measured**, in `AccountRemoval`, `AccountRemovalReport` and the replaced test, and `docs/personal-data.md` and `docs/lifecycle.md` say what the tree does.

## Three things found on the way, named rather than folded in

**A double stopped standing for anything and was swapped rather than left.** `ARequestThatMovesUnderTheRemoval...` used `StoreThatMovesARequestUnderTheRemoval`, which intercepts `RemoveAsync`. This pass no longer calls it, so that test would have passed without ever reaching the retry it exists for. It uses `StoreThatMovesARequestUnderTheWrite` now, the double this tree already had for the other window, and it asserts that the note somebody typed under the removal survives - which is the re-read actually happening rather than the write being tried once.

**Three pasted evidence lines in `docs/bridge.md`, `docs/personal-data.md` and `docs/seam.md` stopped reproducing**, because they cite lines in `RequestLifecycle.cs` and `PluginServiceRegistrator.cs` below this change. `scripts/check-pasted-evidence.sh` found them; each command above the block was re-run and what it printed was pasted.

**Two counts came out of `RequestLifecycle`'s own class documentation.** It said six cells an administrator may make and four the plugin may. Both moved with this change, and a number in a paragraph beside a table is a second copy of the table, so they are deleted rather than corrected.

## What is NOT claimed here

- **Nothing was run on a real server.** Everything below is the suite on this machine and whatever the checks on this pull request produce. Account deletion reaching this code at all is the server's event, and no container check here deletes a user.
- **The joiner question is untouched and stays open.** A request the deleted person asked for and somebody else joined is ended, and the joiner loses what they were waiting for. Whether it should pass to the earliest joiner is a call no issue on this board has taken; this change moved that request from removal to a decline and answered nothing about it. `AccountRemoval`'s own documentation says so.
- **The age sweep is untouched**, which is what #361 asks: #337 answered that one in the other direction and `RetentionSweep` keeps removing.
- **The pairing is a rule about reasons, not a permission model.** Nothing stops a future caller building `RequestCaller.Plugin` and declining a request for this reason on some other occasion. What refuses that is the review, and the reason's own documentation says it is established by a deletion.

## Scope

`Scope:` on #361 names `Model/`, `People/`, `Tests/People/` and the two documents. Four files outside it are touched and each is a consequence rather than a second topic: `PluginServiceRegistrator.cs` gains one line, because the decline needs the injected clock this class did not have; `Tests/Model/` carries the two guards' tests and the authority list the widened cells moved; `Tests/Web/` carries the page's option list, which was derived from the enumeration and now has to be derived from the lifecycle; and `Localisation/Strings/en.json` gains the word for the new reason, which `PageWordsTests` requires of every value in that enumeration.

## The gate, run here

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler: 0, erfolgreich: 785, übersprungen: 0, gesamt: 785 - net10.0
    Bestanden!   : Fehler: 0, erfolgreich: 785, übersprungen: 0, gesamt: 785 - net9.0

    scripts/check-pasted-evidence.sh      -> every pasted match line reproduces against the file it names
    scripts/check-negative-disclosures.sh  -> every negative disclosure exits as the document says it does
    npx prettier@3.6.2 --check <the changed markdown> -> All matched files use Prettier code style!

## Second reader

There was none on this board tonight. The runs above stand in place of one.
