### PR TITLE
Keep every line and push a notice task gives a recording double

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Doubles/ASessionManagerThatOnlyDelivers.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/ASessionManagerThatOnlyDelivers.cs
@@ -37,10 +37,22 @@ namespace Jellyfin.Plugin.Requests.Tests.Doubles;
 /// The recorded call keeps the arguments as they were passed, the user list included, because the
 /// claim under test is about who is in that list.
 /// </para>
+/// <para>
+/// <b>Several threads may push through it at once.</b> <c>ServerRequesterNotice</c> and
+/// <c>ServerArrivalNotice</c> each decide one message on a task of their own and call the session
+/// manager from whichever one runs, so two messages handed over without a wait between them reach
+/// this from two threads with nothing above them serialising it. An unguarded
+/// <see cref="List{T}"/> under that traffic loses an entry, keeps one twice or is enumerated
+/// mid-append, and each of those reads in a report as a defect in whatever the test was actually
+/// about. The whole of what the lock buys is that every push made through this double is kept
+/// exactly once, and that a list already handed out does not move under its reader. No order across
+/// threads is promised, because nothing above it promises one.
+/// </para>
 /// </summary>
 #pragma warning disable CS0067 // The event is never used: the host raises these, and nothing here does.
 internal sealed class ASessionManagerThatOnlyDelivers : ISessionManager
 {
+    private readonly object _gate = new object();
     private readonly List<Delivery> _delivered = [];
     private readonly List<Broadcast> _broadcast = [];
 
@@ -72,15 +84,35 @@ internal sealed class ASessionManagerThatOnlyDelivers : ISessionManager
     public IEnumerable<SessionInfo> Sessions => [];
 
     /// <summary>
-    /// Gets every push at a named person this double was asked to make, in order.
+    /// Gets every push at a named person this double was asked to make, in order, as a copy taken
+    /// under the lock.
     /// </summary>
-    public IReadOnlyList<Delivery> Delivered => _delivered;
+    public IReadOnlyList<Delivery> Delivered
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _delivered.ToArray();
+            }
+        }
+    }
 
     /// <summary>
-    /// Gets every push at whoever administers the server, in order. The server decides which
-    /// sessions those are, so there is no list of people to record and the audience is the fact.
+    /// Gets every push at whoever administers the server, in order, as a copy taken under the lock.
+    /// The server decides which sessions those are, so there is no list of people to record and the
+    /// audience is the fact.
     /// </summary>
-    public IReadOnlyList<Broadcast> Broadcasts => _broadcast;
+    public IReadOnlyList<Broadcast> Broadcasts
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _broadcast.ToArray();
+            }
+        }
+    }
 
     /// <summary>
     /// Gets a value indicating whether the one usable call fails instead of delivering.
@@ -101,7 +133,10 @@ internal sealed class ASessionManagerThatOnlyDelivers : ISessionManager
             throw new InvalidOperationException("This session manager was told to fail the push.");
         }
 
-        _delivered.Add(new Delivery(userIds, name, data));
+        lock (_gate)
+        {
+            _delivered.Add(new Delivery(userIds, name, data));
+        }
 
         return Task.CompletedTask;
     }
@@ -118,7 +153,10 @@ internal sealed class ASessionManagerThatOnlyDelivers : ISessionManager
             throw new InvalidOperationException("This session manager was told to fail the push.");
         }
 
-        _broadcast.Add(new Broadcast(name, data));
+        lock (_gate)
+        {
+            _broadcast.Add(new Broadcast(name, data));
+        }
 
         return Task.CompletedTask;
     }

--- a/Jellyfin.Plugin.Requests.Tests/Doubles/RecordingLogger.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Doubles/RecordingLogger.cs
@@ -13,15 +13,42 @@ namespace Jellyfin.Plugin.Requests.Tests.Doubles;
 /// about the log is usually about is what an operator ends up reading. Every level is enabled, so a
 /// line dropped here is a line the code did not write rather than one this double declined to take.
 /// </para>
+/// <para>
+/// <b>Several threads may write to it at once.</b> Every path in <c>Notify/</c> that starts a task
+/// per message writes its failure line from whichever task raises it - the outbound sink, the
+/// switch in front of the requester path and the two server notices - so two messages handed over
+/// without a wait between them reach this from two threads with nothing above them serialising it.
+/// An unguarded <see cref="List{T}"/> under that traffic does not merely reorder: an append racing
+/// another loses an entry, keeps one twice or leaves a hole, and each of those reads in a report as
+/// a defect in whatever the test was actually about. The whole of what the lock buys is that every
+/// line given to this double is kept exactly once.
+/// </para>
+/// <para>
+/// <b>It promises no order across threads, because nothing above it does.</b> Where the lines were
+/// written one after another by one thread, the order kept here is that order, which is what every
+/// leg reading a single path's log reads.
+/// </para>
 /// </summary>
 internal sealed class RecordingLogger : ILogger
 {
+    private readonly object _gate = new object();
     private readonly List<Line> _lines = [];
 
     /// <summary>
-    /// Gets every line written to this logger, in the order it was written.
+    /// Gets every line written to this logger, in the order it was written, as a copy taken under
+    /// the lock. A caller reading this while something is still in flight gets a whole answer of
+    /// some moment rather than a list changing under its own enumeration.
     /// </summary>
-    public IReadOnlyList<Line> Lines => _lines;
+    public IReadOnlyList<Line> Lines
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _lines.ToArray();
+            }
+        }
+    }
 
     /// <inheritdoc />
     public IDisposable? BeginScope<TState>(TState state)
@@ -41,16 +68,25 @@ internal sealed class RecordingLogger : ILogger
     {
         ArgumentNullException.ThrowIfNull(formatter);
 
-        _lines.Add(new Line(logLevel, formatter(state, exception), exception));
+        lock (_gate)
+        {
+            _lines.Add(new Line(logLevel, formatter(state, exception), exception));
+        }
     }
 
     /// <summary>
-    /// Every line at the given level.
+    /// Every line at the given level. Filtered under the lock, so it walks a list nothing is
+    /// appending to rather than one a delivery still in flight is.
     /// </summary>
     /// <param name="level">The level.</param>
     /// <returns>The lines.</returns>
     public IReadOnlyList<Line> At(LogLevel level)
-        => [.. _lines.Where(line => line.Level == level)];
+    {
+        lock (_gate)
+        {
+            return [.. _lines.Where(line => line.Level == level)];
+        }
+    }
 
     /// <summary>
     /// One line as it was written.

--- a/Jellyfin.Plugin.Requests.Tests/Notify/RecordingFromSeveralThreadsTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Notify/RecordingFromSeveralThreadsTests.cs
@@ -6,6 +6,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.Requests.Notify;
 using Jellyfin.Plugin.Requests.Tests.Doubles;
+using MediaBrowser.Model.Session;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Jellyfin.Plugin.Requests.Tests.Notify;
@@ -128,6 +130,181 @@ public sealed class RecordingFromSeveralThreadsTests
         Assert.Single(earlier);
         Assert.Equal(2, recording.Told.Count);
     }
+
+    /// <summary>
+    /// Every line written from several threads at once is kept, exactly once each.
+    /// <para>
+    /// The same claim as the leg above, over the double every one of those background paths writes
+    /// to rather than over the one that only the requester path does. What the count separates is
+    /// the same three ways an unguarded append is wrong, and the text of each line names the thread
+    /// and the position so a short count and a full count with fewer distinct texts are different
+    /// failures.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task EveryLineFromSeveralThreadsAtOnceIsKeptExactlyOnce()
+    {
+        var log = new RecordingLogger();
+        using var ready = new Barrier(Tellers);
+
+        var writing = new Task[Tellers];
+
+        for (var writer = 0; writer < Tellers; writer++)
+        {
+            var mine = writer;
+
+            writing[mine] = Task.Factory.StartNew(
+                () =>
+                {
+                    ready.SignalAndWait();
+
+                    for (var position = 0; position < EachTells; position++)
+                    {
+                        Write(log, mine, position);
+                    }
+                },
+                CancellationToken.None,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default);
+        }
+
+        await Task.WhenAll(writing).ConfigureAwait(true);
+
+        var kept = log.Lines;
+
+        Assert.Equal(Tellers * EachTells, kept.Count);
+        Assert.Equal(
+            Tellers * EachTells,
+            kept.Select(line => line.Message).Distinct(StringComparer.Ordinal).Count());
+    }
+
+    /// <summary>
+    /// What was logged is answered as a copy rather than as the list itself, by both readers.
+    /// <para>
+    /// <see cref="RecordingLogger.At"/> is the reader most of this suite uses and it filters, so it
+    /// hands back a new list either way and the direction that matters there is that it does not
+    /// walk the live one while a delivery is still writing to it. That is the same defect as the
+    /// one this leg names for <see cref="RecordingLogger.Lines"/> and is not decidable from one
+    /// thread, so what is asserted here is the half that is: an answer already handed out does not
+    /// move when the next line arrives.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void WhatWasLoggedIsAnsweredAsACopyRatherThanAsTheListItself()
+    {
+        var log = new RecordingLogger();
+
+        Write(log, 0, 0);
+
+        var earlier = log.Lines;
+
+        Write(log, 0, 1);
+
+        Assert.Single(earlier);
+        Assert.Equal(2, log.Lines.Count);
+    }
+
+    /// <summary>
+    /// Every push made from several threads at once is kept, exactly once each.
+    /// <para>
+    /// <c>ServerRequesterNotice</c> and <c>ServerArrivalNotice</c> each start a task per message and
+    /// call the session manager from whichever one runs, so two messages handed over without a wait
+    /// between them reach this double concurrently. The lists it keeps them in are what every leg
+    /// asserting who was reached reads.
+    /// </para>
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task EveryPushFromSeveralThreadsAtOnceIsKeptExactlyOnce()
+    {
+        var sessions = new ASessionManagerThatOnlyDelivers();
+        using var ready = new Barrier(Tellers);
+
+        var pushing = new Task[Tellers];
+
+        for (var pusher = 0; pusher < Tellers; pusher++)
+        {
+            var mine = pusher;
+
+            pushing[mine] = Task.Factory.StartNew(
+                () =>
+                {
+                    ready.SignalAndWait();
+
+                    for (var position = 0; position < EachTells; position++)
+                    {
+                        Push(sessions, mine, position);
+                    }
+                },
+                CancellationToken.None,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default);
+        }
+
+        await Task.WhenAll(pushing).ConfigureAwait(true);
+
+        var kept = sessions.Delivered;
+
+        Assert.Equal(Tellers * EachTells, kept.Count);
+        Assert.Equal(
+            Tellers * EachTells,
+            kept.Select(delivery => delivery.Payload as string).Distinct(StringComparer.Ordinal).Count());
+    }
+
+    /// <summary>
+    /// What was delivered is answered as a copy rather than as the list itself.
+    /// <para>
+    /// The reader's direction, decidable from one thread, exactly as for the notice double. A leg
+    /// that read this list while a push was still in flight would walk a collection another thread
+    /// is appending to and fail as though the plugin had thrown.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void WhatWasDeliveredIsAnsweredAsACopyRatherThanAsTheListItself()
+    {
+        var sessions = new ASessionManagerThatOnlyDelivers();
+
+        Push(sessions, 0, 0);
+
+        var earlier = sessions.Delivered;
+
+        Push(sessions, 0, 1);
+
+        Assert.Single(earlier);
+        Assert.Equal(2, sessions.Delivered.Count);
+    }
+
+    /// <summary>
+    /// One line, named so that a lost one and a doubled one are different failures.
+    /// </summary>
+    /// <param name="log">The logger to write to.</param>
+    /// <param name="writer">Which thread is writing it.</param>
+    /// <param name="position">Where in that thread's run it sits.</param>
+    private static void Write(RecordingLogger log, int writer, int position)
+    {
+        // Named into a local rather than composed in the call: CA1873 refuses an argument a
+        // disabled logger would have paid for, and this double enables every level anyway.
+        var text = string.Create(CultureInfo.InvariantCulture, $"{writer}/{position}");
+
+        log.Log(LogLevel.Information, default, text, null, static (state, _) => state);
+    }
+
+    /// <summary>
+    /// One push, named the same way and addressed to the one person these doubles allow.
+    /// </summary>
+    /// <param name="sessions">The session manager to push through.</param>
+    /// <param name="pusher">Which thread is pushing it.</param>
+    /// <param name="position">Where in that thread's run it sits.</param>
+    private static void Push(ASessionManagerThatOnlyDelivers sessions, int pusher, int position)
+        => sessions
+            .SendMessageToUserSessions(
+                [Asker],
+                SessionMessageType.GeneralCommand,
+                string.Create(CultureInfo.InvariantCulture, $"{pusher}/{position}"),
+                CancellationToken.None)
+            .GetAwaiter()
+            .GetResult();
 
     /// <summary>
     /// One message, named so that a lost one and a doubled one are different failures.


### PR DESCRIPTION
Closes #371.

Four paths in `Notify/` start a task per message, so whatever their bodies call runs on whichever thread the task got. #330 found that `RecordingRequesterNotice` was written to that way and repaired it. `RecordingLogger` and `ASessionManagerThatOnlyDelivers` sit behind the same boundary and were not looked at; this puts them in the same state and adds the legs that prove it.

### The means

C# in the existing test project, which is where the doubles already live and where the suite that judges them already runs. No language, runtime or dependency is added, and the guard is the same `lock` over the same `List<T>` that #330 landed one file over, so a reader who has met one has met both.

### What the failure was, before

Driven from eight threads at once with 2000 appends each, on `net9.0` at `a5d2b87` with only the legs added:

    dotnet test Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj --configuration Release -f net9.0 --filter "FullyQualifiedName~RecordingFromSeveralThreadsTests"

    EveryLineFromSeveralThreadsAtOnceIsKeptExactlyOnce [FAIL]
    Assert.Equal() Failure: Values differ
    Expected: 16000
    Actual:   6284

    EveryPushFromSeveralThreadsAtOnceIsKeptExactlyOnce [FAIL]
    Assert.Equal() Failure: Values differ
    Expected: 16000
    Actual:   14700

    WhatWasLoggedIsAnsweredAsACopyRatherThanAsTheListItself [FAIL]
    Assert.Single() Failure: The collection contained 2 items

    WhatWasDeliveredIsAnsweredAsACopyRatherThanAsTheListItself [FAIL]
    Assert.Single() Failure: The collection contained 2 items

    Fehler!      : Fehler:     4, erfolgreich:     2, gesamt:     6

Lost entries rather than reordered ones. That run was made three times and was red three times.

### Each guard was watched reddening its own legs alone

The two guards are proved separately rather than together, so neither leg is passing on the other's lock. Same command, `net9.0`, with one file reverted at a time:

    only RecordingLogger's lock removed
    WhatWasLoggedIsAnsweredAsACopyRatherThanAsTheListItself [FAIL]
    EveryLineFromSeveralThreadsAtOnceIsKeptExactlyOnce [FAIL]
    Fehler!      : Fehler:     2, erfolgreich:     4, gesamt:     6

    only ASessionManagerThatOnlyDelivers's lock removed
    EveryPushFromSeveralThreadsAtOnceIsKeptExactlyOnce [FAIL]
    WhatWasDeliveredIsAnsweredAsACopyRatherThanAsTheListItself [FAIL]
    Fehler!      : Fehler:     2, erfolgreich:     4, gesamt:     6

    both in place
    Bestanden!   : Fehler:     0, erfolgreich:     6, gesamt:     6

### The whole suite, at the head being pushed

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
        0 Warnung(en)
        0 Fehler

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler:     0, erfolgreich:   789, uebersprungen:     0, gesamt:   789 - net9.0
    Bestanden!   : Fehler:     0, erfolgreich:   789, uebersprungen:     0, gesamt:   789 - net10.0

785 before, four legs added.

### What this does not do

**It fixes nothing that was failing.** No leg in the suite drives either double concurrently, so nothing on this board was red for this. What it removes is the trap: the natural leg to write next - two failing sends and one assertion about the log - would have raced, and `call / test` is a required check here, so it would have refused a pull request for a reason that pull request had nothing to do with.

**It promises no order across threads, and both doubles now say so.** Where entries were handed over one after another by one thread, the order kept is that order, which is what every leg reading a single path's log or a single push reads today. Two entries decided concurrently arrive in an order nothing decides, and that is not a fact a leg may rest on.

**It does not touch the two doubles that were already right.** `ASinkEndpoint` keeps a concurrent queue and `RecordingRequesterNotice` has #330's lock, and neither is edited here.

**It reaches no double outside that boundary.** `RecordingSink`, `RecordingArrivalNotice`, `RecordingJournal` and `RecordedProgress` are called by the thread that hands the entry over rather than from inside a task, so they carry no lock and are left alone. If one of them later ends up behind a `Task.Run`, it owes the same guard.

**Nothing in the plugin project changed.** The diff is three files, all in the test project:

    git diff --name-only origin/master...HEAD
    Jellyfin.Plugin.Requests.Tests/Doubles/ASessionManagerThatOnlyDelivers.cs
    Jellyfin.Plugin.Requests.Tests/Doubles/RecordingLogger.cs
    Jellyfin.Plugin.Requests.Tests/Notify/RecordingFromSeveralThreadsTests.cs

### What had no second reader

Nobody else read this. Every run quoted above was made before the sentence resting on it, and the two near-miss runs are what make the guards proved rather than asserted.


### Why the head moved after the checks were green

The ruleset was edited on 2026-09-02 and now requires two floor contexts under the names the renamed workflow produces, and `45cd547` was pushed before that rename reached `master`, so the check-runs on it carried the old names and the merge stayed blocked with every check green:

    gh api repos/Flowfin/jellyfin-plugin-requests/rulesets/20463655 --jq '[.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context] | map(select(startswith("floor")))'
    ["floor build.yaml","floor build-jf12.yaml"]
    gh api repos/Flowfin/jellyfin-plugin-requests/commits/45cd547a269f0a2d72a6452dce26d393cd67ce91/check-runs --jq '[.check_runs[].name | select(startswith("floor"))]'
    ["floor 12.0.0.0","floor 10.11.0.0"]

So `master` is merged into this branch as an ordinary merge commit, `39a73b6`, nothing is rewritten, and the diff against `master` is the same three files. The suite at that head:

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
        0 Warnung(en)
        0 Fehler

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
    Bestanden!   : Fehler:     0, erfolgreich:   789, uebersprungen:     0, gesamt:   789 - net9.0
    Bestanden!   : Fehler:     0, erfolgreich:   789, uebersprungen:     0, gesamt:   789 - net10.0
