### PR TITLE
Print the required set this board has, not the one it had

### DIFF
--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -20,7 +20,6 @@ The other board:
     build
     ABI floor build
     Package (JPRM) / Build package
-    Package (JPRM) / Generate SBOM
     CodeQL
     Analyze (csharp)
     DCO sign-off
@@ -39,12 +38,31 @@ This one:
     call / build
     call / test
     Reject Trojan Source Unicode
+    Audit workflows (zizmor)
+    Check formatting
+    Deterministic pull request hygiene checks
+    DCO sign-off
+    dependency-review
+    Enforce greppable invariants
+    Analyze (actions, none)
+    Analyze (csharp, manual)
+    Analyze (javascript-typescript, none)
+    lines
 
-Thirteen contexts against three, and the gap is not the same as the gap in what
-runs. Most of the thirteen have a counterpart running here already and are
-simply not required, which is a repository setting rather than a file in this
-tree. What ran on `55f1ad2`, the head of the change that added the invariant
-lint:
+**Twelve contexts there against thirteen here, and this sentence read "thirteen
+contexts against three" until 2026-09-02.** Both numbers moved after they were
+written and they moved in opposite directions, so the sentence describing the
+gap outlived the gap closing and then reversing, and a reader who trusts it
+concludes this board is where it was three weeks ago. That is the
+failure this page opens by warning about, arriving in the one place a reader
+has been told to trust over the prose around it: both pastes are presented as
+a command's output, and no reader in this tree resolves either, because
+`scripts/check-pasted-evidence.sh` reads `path:line:text` lines and an API
+response is not one.
+
+The gap is still not the same as the gap in what runs, and that half is
+unchanged. What ran on `55f1ad2`, the head of the change that added the
+invariant lint:
 
     $ gh api repos/Flowfin/jellyfin-plugin-requests/commits/55f1ad2/check-runs \
         --jq '.check_runs[].name' | sort -u
@@ -66,12 +84,16 @@ lint:
     Reject Trojan Source Unicode
     zizmor
 
-One of the thirteen has no counterpart running here at all, and it is the bill of
-materials, #109. It was four until the hygiene job landed under #26, three until
-the invariant lint landed under #28, and two until the package build landed under
-#108, which is `package-lines` and one `package` job per claimed line rather than
-the single context the other board has. The rest run and are not required, and
-the section below is the set that says which of them should be.
+One context in the other board's set had no counterpart running here at all, and
+it was the bill of materials, #109. It was four until the hygiene job landed
+under #26, three until the invariant lint landed under #28, and two until the
+package build landed under #108, which is `package-lines` and one `package` job
+per claimed line rather than the single context the other board has. It is none
+of the twelve now, because `Package (JPRM) / Generate SBOM` left that board's
+required set rather than because anything here answered it: that context still
+reports there, nothing answering it reports on a pull request here, and #109 is
+where the absence is held. The rest run and are not required, and the section
+below is the set that says which of them should be.
 
 ## The set to require
 
@@ -183,9 +205,18 @@ above read out of this page rather than retyped:
     Analyze (actions, none)
     Analyze (csharp, manual)
     Analyze (javascript-typescript, none)
-    floor 10.11.0.0
-    floor 12.0.0.0
+    floor build-jf12.yaml
+    floor build.yaml
     lines
+
+**The two floor names in that output are the names this page declares today,
+not the names `36eccab` reported.** Only one side of the comparison is pinned:
+`reported.txt` is that head's check runs and cannot move, while `declared.txt`
+is read out of `origin/master`, so the rename of 2026-09-01 changed the output
+of a command whose subject is a head from August. At `36eccab` the two
+contexts that did not report were called `floor 10.11.0.0` and
+`floor 12.0.0.0`. The count, the reason and the six jobs are the same either
+way.
 
 A required context that does not report leaves a pull request pending rather than
 failing it, so requiring those six as they stood would have held every
@@ -298,14 +329,24 @@ command is right:
     Audit workflows (zizmor)
     Check formatting
     Deterministic pull request hygiene checks
+    DCO sign-off
+    dependency-review
+    Enforce greppable invariants
+    Analyze (actions, none)
+    Analyze (csharp, manual)
+    Analyze (javascript-typescript, none)
+    lines
 
-Six of the fifteen. This paste read five until the reading above, and the sixth
-arrived without anything on this page or on #30 moving, which is the way every
-previous one arrived too. The rest of the set above is not applied: a ruleset is
-a repository setting rather than a file in this tree, and nothing in this change
-touches one.
+Thirteen of the fifteen. This paste read five, then six, and then thirteen, and
+no arrival moved anything on this page or on #30 on the day it happened, which
+is both why it goes stale in silence and why it has now gone stale twice. The
+rest of the set above is not applied: a ruleset is a repository setting rather
+than a file in this tree, and nothing in this change touches one.
 
-Nine are missing and nothing is required that this page has not declared, which
+Two are missing, and they are the two floor contexts. They carried a matrix
+value until the rename of 2026-09-01, which is the reason they were held back,
+and that reason is gone. Nothing is required that this page has not declared,
+which
 is the direction worth checking rather than assuming, because a name required
 here and absent above would be a gate nobody wrote a line for:
 
@@ -332,7 +373,10 @@ merge.
   contexts: the lines are read out of the packaging files rather than listed in a
   job. They are not in the set above, because the set is what #30 applies and
   this pair arrived after it was written down.
-- `Package (JPRM) / Generate SBOM` has no counterpart running here; #109.
+- `Package (JPRM) / Generate SBOM` was in that set and is not any more, so it is
+  no longer a difference from it. It still reports there, nothing answering it
+  reports on a pull request here, and the bill of materials this board builds
+  runs on the publish route rather than as a check. #109 holds that.
 - `CodeQL` there is required and is not here, because it is the code-scanning
   tab's check rather than a job, and the three `Analyze` legs are required
   instead.


### PR DESCRIPTION
Part of #30, and it is the repair the note of 01.09. on that issue described and could not land. It changes one document and applies no setting.

## What was wrong

This page opens by saying that it is not the gate, that what the gate requires is printed by the commands below it, and that where the two disagree the commands are right. Three of those pastes returned something else, and the sentence that reads two of them together had inverted. That is the one form on this page a reader has been told to trust over the prose around it, and neither reader in the tree resolves an API response: `scripts/check-pasted-evidence.sh` reads `path:line:text` lines and `scripts/check-negative-disclosures.sh` reads the `; echo "exit=$?"` form.

Everything below was run at `origin/master`, `b9addc3cfea38c3d83ad4f94088438db3f73f6c6`.

**The other board's set printed thirteen and returns twelve.**

    $ gh api repos/iderex/jellyfin-plugin-sso/rules/branches/main \
        --jq '.[] | select(.type=="required_status_checks")
              | .parameters.required_status_checks[].context'
    build
    ABI floor build
    Package (JPRM) / Build package
    CodeQL
    Analyze (csharp)
    DCO sign-off
    Deterministic PR-hygiene checks
    Enforce greppable invariants
    Reject Trojan Source Unicode
    Audit workflows (zizmor)
    prettier
    dependency-review

`Package (JPRM) / Generate SBOM` is the one that left. It still reports on that board, so what moved is the requirement rather than the job:

    $ gh api repos/iderex/jellyfin-plugin-sso/commits/9205595e52d1b82b2e3a6ed1bccb35ca7b731c66/check-runs \
        --jq '.check_runs[].name' | sort -u | grep SBOM
    Package (JPRM) / Generate SBOM

**This board's set printed three and returns thirteen.**

    $ gh api repos/iderex/jellyfin-plugin-requests/rules/branches/master \
        --jq '.[] | select(.type=="required_status_checks")
              | .parameters.required_status_checks[].context'
    call / build
    call / test
    Reject Trojan Source Unicode
    Audit workflows (zizmor)
    Check formatting
    Deterministic pull request hygiene checks
    DCO sign-off
    dependency-review
    Enforce greppable invariants
    Analyze (actions, none)
    Analyze (csharp, manual)
    Analyze (javascript-typescript, none)
    lines

**So "Thirteen contexts against three" is twelve against thirteen.** Both numbers moved after the sentence was written and they moved in opposite directions, so the sentence describing the gap outlived the gap closing and then reversing.

**The live paste under `What has arrived since this list was written` printed six and returns the same thirteen**, so two of the fifteen this page declares are missing rather than nine:

    $ git show origin/master:docs/quality-parity.md \
        | sed -n '/^Fifteen contexts/,/^There are no bypass actors/p' \
        | sed -n 's/^    \([^ ].*\)$/\1/p' | sort > declared.txt
    $ gh api repos/iderex/jellyfin-plugin-requests/rules/branches/master \
        --jq '.[] | select(.type=="required_status_checks")
              | .parameters.required_status_checks[].context' | sort > live.txt
    $ comm -23 declared.txt live.txt
    floor build-jf12.yaml
    floor build.yaml

and the direction worth checking rather than assuming still returns nothing, so nothing is required that this page has not declared:

    $ comm -13 declared.txt live.txt

## The fourth site, which the note of 01.09. did not name

It is drift the floor rename introduced when it landed as `fc11369126dbc8826065e34307f4895238c1295a`. The comparison under `Six of these fifteen could not report on a change that is only markdown` pins one of its two sides and not the other: `reported.txt` is `36eccab`'s check runs and cannot move, while `declared.txt` is read out of `origin/master`. So the output of a command whose subject is an August head changed when the names this page declares changed:

    $ gh api repos/Flowfin/jellyfin-plugin-requests/commits/36eccab/check-runs \
        --jq '.check_runs[].name' | sort -u > reported.txt
    $ comm -23 declared.txt reported.txt
    Analyze (actions, none)
    Analyze (csharp, manual)
    Analyze (javascript-typescript, none)
    floor build-jf12.yaml
    floor build.yaml
    lines

The paste now shows what the command prints, and the paragraph beside it says that `36eccab` reported those two contexts as `floor 10.11.0.0` and `floor 12.0.0.0`. The count, the reason and the six jobs are the same either way.

## What is deliberately untouched

**Every paste anchored at a named commit or run.** `55f1ad2`, `605ed46`, `1a18979`, the run listings in the guard tables and the `31095610752` correction all still reproduce, because a completed run's job names and a commit's check runs do not move. Editing one would be rewriting a measurement to match today, which is what the change that landed the rename said about the same pastes and is kept here.

**The `Fifteen contexts` set itself.** No name was added to it or taken out of it; which contexts this board should require is #30 and is not settled by a page repair.

## What was run

    $ ./scripts/check-pasted-evidence.sh
    read 120 pasted match lines in 24 document(s)
    check-pasted-evidence: every pasted match line reproduces against the file it names.

    $ ./scripts/check-negative-disclosures.sh
    ran 4 negative disclosure(s) in 24 document(s)
    check-negative-disclosures: every negative disclosure exits as the document says it does.

    $ dotnet test Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj --configuration Release -f net10.0 --filter "FullyQualifiedName~RepositoryDocuments"

```
Bestanden!   : Fehler:     0, erfolgreich:    15, übersprungen:     0, gesamt:    15, Dauer: 199 ms - Jellyfin.Plugin.Requests.Tests.dll (net10.0)
```

The formatter is run against git's blob rather than against the file on disk, because this clone carries `core.autocrlf=true` and a local run over the working copy warns about a file the gate is green on:

    $ npx --yes prettier@3.6.2 --parser markdown --check qp-new-lf.md
    Checking formatting...
    All matched files use Prettier code style!

## The means

A markdown document, which is what the artefact already is. Nothing is added to the tree: no language, no runtime, no dependency and no script.

## What this does not do

**It applies nothing.** A ruleset is a repository setting rather than a file in this tree. The two missing contexts, `floor build.yaml` and `floor build-jf12.yaml`, are still declared and not live after this merges, and #30's second condition is where the note of 01.09. left it.

**It watches no guard bite.** The two document readers and the fifteen document tests are named as passing, which is a different statement from a guard watched failing for the reason it names, and this change adds no guard.

**Nothing was read on a running server**, and no package was built.

**Nobody else has read this.** No second reader was available tonight, and the readings above stand in place of one.
