### PR TITLE
Mint 0.3.0.0 and say what a deleted account actually leaves behind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,16 @@ not need an entry; the git history is where that is read.
   claims from now on, and a packaging run that asks a server for more than the claim is refused
   before a tag can be spent on it. **This does not repair an installed `0.2.0.0`:** that release
   keeps the references it shipped with until a later release replaces it.
-- Deleting a Jellyfin user now takes their requests with them. A request they asked for is removed,
-  a request somebody else asked for that they had joined stays with them off its list, and the
-  switch they may have set about being told is set back to the shipping value. Until now nothing in
-  this plugin was told that an account had gone, so a request record naming a person outlived the
-  account it named until the retention period reached it.
+- Deleting a Jellyfin user now takes that person out of this plugin's records and keeps the records
+  themselves. A request of theirs that was still open or approved is declined, carrying a reason
+  that says the person who asked is gone, and then stays with a marker where their identifier was.
+  A request of theirs that had already finished stays with the same marker. A request somebody
+  else asked for that they had joined stays and they come off its list. The switch they may have
+  set about being told is set back to the shipping value. So the queue goes on saying that a title
+  was asked for on a date without saying by whom, and an administrator answering for what was
+  asked and answered still has it. Until now nothing in this plugin was told that an account had
+  gone, so a request record naming a person outlived the account it named until the retention
+  period reached it.
 - A history entry says what kind of caller made a move instead of naming the person who made it.
   An entry now reads as the requester, an administrator or the plugin itself. A queue file written
   by an earlier version is migrated as it is read and the file is not changed until the next write.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ not need an entry; the git history is where that is read.
 
 ## Unreleased
 
+Nothing has landed since the entries below were collected under `0.3.0.0`.
+
+## 0.3.0.0
+
+One of the entries below changes what a server already doing its work does, which
+is the kind of change the scheme reserves for a `MAJOR` bump. Below `1.0.0.0` a
+`MINOR` bump is allowed to carry one and the entry says so, which is what the
+marked entry does. What each part of a number means is in
+[docs/versioning.md](docs/versioning.md).
+
 - The 10.11 package now installs on every server of the line it claims, and not only on the newest
   one. `0.2.0.0` was compiled against `10.11.11` while its packaging metadata claimed `10.11.0.0`,
   so a server below `10.11.11` downloaded it, failed to bind five assembly references, and reported
@@ -35,7 +45,11 @@ not need an entry; the git history is where that is read.
   by an earlier version is migrated as it is read and the file is not changed until the next write.
   **This costs something and it is permanent:** past decisions can no longer be attributed to an
   individual, in exchange for this plugin not holding identifiers for people who have left the
-  server.
+  server. **A queue file this version has written cannot be read by `0.2.0.0`**, which above
+  `1.0.0.0` would be a `MAJOR` bump; below it, this entry is the notice the scheme asks for. A
+  server put back on `0.2.0.0` after this version has written the file finds a queue that plugin
+  refuses to read: it changes nothing, keeps the bytes as they are, and says so in the server
+  log.
 
 ## 0.2.0.0
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,7 +39,7 @@
              scheme this number follows, what each part of it means to somebody who has the plugin
              installed, and why it starts below one, are in docs/versioning.md. Raising it and
              writing the changelog entry are one change. -->
-        <PluginVersion>0.2.0.0</PluginVersion>
+        <PluginVersion>0.3.0.0</PluginVersion>
         <Version>$(PluginVersion)</Version>
         <AssemblyVersion>$(PluginVersion)</AssemblyVersion>
         <FileVersion>$(PluginVersion)</FileVersion>

--- a/README.md
+++ b/README.md
@@ -108,10 +108,10 @@ an edit to either shows up as a difference between this table and what the
 command prints:
 
     git grep -nE '^(version|targetAbi|framework):' -- build.yaml build-jf12.yaml
-    build-jf12.yaml:13:version: "0.2.0.0"
+    build-jf12.yaml:13:version: "0.3.0.0"
     build-jf12.yaml:15:targetAbi: "12.0.0.0"
     build-jf12.yaml:16:framework: "net10.0"
-    build.yaml:5:version: "0.2.0.0"
+    build.yaml:5:version: "0.3.0.0"
     build.yaml:10:targetAbi: "10.11.0.0"
     build.yaml:11:framework: "net9.0"
 
@@ -121,7 +121,7 @@ disagreement between it and the assembly rather than trusting three copies to be
 edited together:
 
     git grep -n '<PluginVersion>' -- Directory.Build.props
-    Directory.Build.props:42:        <PluginVersion>0.2.0.0</PluginVersion>
+    Directory.Build.props:42:        <PluginVersion>0.3.0.0</PluginVersion>
 
 That test is `PluginVersionMatchesThePackagingMetadata` in
 `Jellyfin.Plugin.Requests.Tests/PackagingMetadataTests.cs`, and

--- a/build-jf12.yaml
+++ b/build-jf12.yaml
@@ -10,7 +10,7 @@ name: "Requests"
 # PackagingMetadataTests.BothPackagesClaimTheSameIdentity refuses them diverging on it.
 guid: "0f9c9107-b31b-459e-81fa-6d35dac25e79"
 imageUrl: "https://raw.githubusercontent.com/Flowfin/jellyfin-plugin-requests/master/img/logo.png"
-version: "0.2.0.0"
+version: "0.3.0.0"
 # The 12.0 line's floor and the runtime it provides.
 targetAbi: "12.0.0.0"
 framework: "net10.0"

--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@
 name: "Requests"
 guid: "0f9c9107-b31b-459e-81fa-6d35dac25e79"
 imageUrl: "https://raw.githubusercontent.com/Flowfin/jellyfin-plugin-requests/master/img/logo.png"
-version: "0.2.0.0"
+version: "0.3.0.0"
 # Packaging metadata for the Jellyfin 10.11 line. The oldest server of that line this package claims
 # to load on, and the runtime that line provides. The project compiles against a newer 10.11.x SDK,
 # so a floor build against this number is what would show that every API the plugin calls also exists

--- a/docs/catalogue.md
+++ b/docs/catalogue.md
@@ -190,10 +190,10 @@ The scheme is one entry per server line, each carrying its line's `targetAbi`. W
 two entries for one line. This board claims two:
 
     grep -nE '^(version|targetAbi|framework):' build.yaml build-jf12.yaml
-    build.yaml:5:version: "0.2.0.0"
+    build.yaml:5:version: "0.3.0.0"
     build.yaml:10:targetAbi: "10.11.0.0"
     build.yaml:11:framework: "net9.0"
-    build-jf12.yaml:13:version: "0.2.0.0"
+    build-jf12.yaml:13:version: "0.3.0.0"
     build-jf12.yaml:15:targetAbi: "12.0.0.0"
     build-jf12.yaml:16:framework: "net10.0"
 


### PR DESCRIPTION
Prepared for #152. This mints `0.3.0.0` and repairs the notes that release would
otherwise carry out. **It pushes no tag, so nothing is published by it.** Cutting
the release is the act #152 already names as the operator's, and it is untouched
here.

Everything below was run at the head of this branch unless it names another commit.

## The changelog said the opposite of what ships, and that is the first commit

The `Unreleased` entry about account deletion read "Deleting a Jellyfin user now
takes their requests with them. A request they asked for is removed". Nothing is
removed. The entry was written on 2026-08-27 and the behaviour moved twice after
it, in changes that touched no changelog:

    git log --oneline 0.2.0.0-stable..origin/master -- CHANGELOG.md
    dbc151b Refuse a package that asks a server for more than its targetAbi claims
    01db8ff Take a deleted account out of the queue, and stop the history naming anybody

`f49159b` of 2026-08-30 keeps a finished request and puts a tombstone where the
person was, `fb33a87` of 2026-09-01 declines an unfinished one instead of removing
it, and neither is in that listing. The source says so about itself:

    git grep -n 'Nothing about a deleted account is removed' -- docs/personal-data.md
    docs/personal-data.md:302:request of a deleted person carries the tombstone by the rule above. Nothing about a deleted account

**What the wrong entry costs is paid by an operator rather than by a reader.** An
administrator who reads that deleting an account removes what that person asked for
concludes the queue gets shorter and that a deletion discharges a request to erase.
Neither is true: every record stays with a marker where the identifier was, and the
open ones arrive in the declined list rather than disappearing from the page.
`docs/personal-data.md` has carried the shipping behaviour since `f49159b`, so the
two documents disagreed and the changelog is the one an operator reads before
updating.

## The number, and why `MINOR`

`0.3.0.0` is what `docs/versioning.md` gives: behaviour was added since
`0.2.0.0-stable` and nothing was removed.

One of the three entries is `MAJOR`-shaped and had no notice. The scheme allows a
`MINOR` bump below `1.0.0.0` to carry one provided the entry says so, and the entry
about the history now says it. The reason is the store's own shape number, which
moved after the tag:

    git show 0.2.0.0-stable:Jellyfin.Plugin.Requests/Storage/FileRequestStore.cs | grep -n 'OnDiskVersion = '
    90:    public const int OnDiskVersion = 1;

    git grep -n 'OnDiskVersion = ' -- Jellyfin.Plugin.Requests/Storage/FileRequestStore.cs
    Jellyfin.Plugin.Requests/Storage/FileRequestStore.cs:90:    public const int OnDiskVersion = 2;

A file at version 2 is refused by a plugin reading at most 1, which is the "stored
request that this version can read and the previous one cannot" the scheme names.
The store logs that refusal and changes nothing, and the entry now says a downgrade
finds a queue the older plugin will not read instead of leaving an operator to meet
it after installing.

## The guard, watched failing for the reason it names

`PluginVersion` and both packaging files move together. With `build.yaml` alone left
at the old number:

    DOTNET_CLI_UI_LANGUAGE=en dotnet test --nologo -f net9.0 --filter FullyQualifiedName~PackagingMetadataTests
    Failed ... PackagingMetadataTests.BothPackagesClaimTheSameIdentity(field: "version")
    Expected: 0.2.0.0
    Actual:   0.3.0.0
    Failed ... PackagingMetadataTests.PluginVersionMatchesThePackagingMetadata(packagingFile: "build.yaml")
    Expected: 0.3.0.0
    Actual:   0.2.0.0
    Failed!  - Failed:     2, Passed:     3, Skipped:     0, Total:     5

and with all three carried:

    Passed!  - Failed:     0, Passed:     5, Skipped:     0, Total:     5

The whole suite on both claimed lines at this head:

    DOTNET_CLI_UI_LANGUAGE=en dotnet test --nologo
    Passed!  - Failed:     0, Passed:   785, Skipped:     0, Total:   785 - (net10.0)
    Passed!  - Failed:     0, Passed:   785, Skipped:     0, Total:   785 - (net9.0)

## The means

Three tracked text files and a changelog. The version is a number three files repeat
because a JPRM metadata file is read by the release path rather than compiled, which
`docs/versioning.md` argues; the means here is therefore the files the release path
already reads, with the existing tests refusing a disagreement between them. No
language, runtime or dependency is added.

## Five pasted lines the mint broke, found by the guard for it

`README.md` and `docs/catalogue.md` each paste the packaging files' `version` lines,
and one pastes `PluginVersion` beside them, so minting a number leaves five pasted
lines the tree no longer produces. The third commit carries them. It was the check
that found them rather than a reading, on the first head of this branch:

    ./scripts/check-pasted-evidence.sh
    README.md:111: pastes build-jf12.yaml:13 as
        version: "0.2.0.0"
      and that line reads
        version: "0.3.0.0"
    ...
    check-pasted-evidence: 5 pasted line(s) the tree does not produce.

and on this head:

    ./scripts/check-pasted-evidence.sh
    read 120 pasted match lines in 24 document(s)
    check-pasted-evidence: every pasted match line reproduces against the file it names.

Only the numbers move in either document.

## What the checks say

Every context this board requires is green at the head, and so are the two floor
contexts it does not require yet, which is #30's. `Works alone, works with the
sibling set` - step 1 of `docs/RELEASING.md` - is green here as `set 10.11` and
`set 12.0`, so the commit this merge produces is one that step is satisfied on.
`CodeQL` reports `neutral`, which is what it reports on this board and is why it is
not in the required set.

## What this does not claim

**No tag was pushed and no release was made.** `0.3.0.0` is a number carried by the
tree and by nothing else until somebody pushes `0.3.0.0-stable`.

**It does not repair an installed `0.2.0.0`.** That release keeps the references it
shipped with, and the entry says so.

**Nothing was installed into a Jellyfin server.** No container was started for this
change, and the downgrade the marked entry describes is read out of the store's
refusal path rather than performed.

**Step 1 of `docs/RELEASING.md` is not discharged here.** It asks that `Works alone,
works with the sibling set` be green on the commit to be released, and the commit to
be released does not exist until this merges.

**Nobody else read it.** No second reader was available on this board tonight, and
the readings above stand in place of one.
