### PR TITLE
Print the fifteen contexts the ruleset returns, not the thirteen it returned

### DIFF
--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -48,15 +48,19 @@ This one:
     Analyze (csharp, manual)
     Analyze (javascript-typescript, none)
     lines
+    floor build.yaml
+    floor build-jf12.yaml
 
-**Twelve contexts there against thirteen here, and this sentence read "thirteen
-contexts against three" until 2026-09-02.** Both numbers moved after they were
-written and they moved in opposite directions, so the sentence describing the
-gap outlived the gap closing and then reversing, and a reader who trusts it
-concludes this board is where it was three weeks ago. That is the
-failure this page opens by warning about, arriving in the one place a reader
-has been told to trust over the prose around it: both pastes are presented as
-a command's output, and no reader in this tree resolves either, because
+**Twelve contexts there against fifteen here, and this is the second repair of
+one sentence in one day.** It read "thirteen contexts against three" until the
+morning of 2026-09-02, and the paste above it printed thirteen names until that
+afternoon, when the two floor contexts were added to the required set on
+`master`. A ruleset is a repository setting rather than a file here, so nothing
+in this tree moves when one is edited: the paste stops reproducing, the page
+reads exactly as it did, and the build stays green. That is the failure this
+page opens by warning about, arriving in the one place a reader has been told
+to trust over the prose around it: both pastes are presented as a command's
+output, and no reader in this tree resolves either, because
 `scripts/check-pasted-evidence.sh` reads `path:line:text` lines and an API
 response is not one.
 
@@ -336,16 +340,19 @@ command is right:
     Analyze (csharp, manual)
     Analyze (javascript-typescript, none)
     lines
+    floor build.yaml
+    floor build-jf12.yaml
 
-Thirteen of the fifteen. This paste read five, then six, and then thirteen, and
-no arrival moved anything on this page or on #30 on the day it happened, which
-is both why it goes stale in silence and why it has now gone stale twice. The
-rest of the set above is not applied: a ruleset is a repository setting rather
-than a file in this tree, and nothing in this change touches one.
+All fifteen, and the last two arrived on 2026-09-02. This paste read five, then
+six, then thirteen, and now fifteen; on none of those days did the arrival move
+anything on this page or on #30, which is both why it goes stale in silence and
+why it has now gone stale three times.
 
-Two are missing, and they are the two floor contexts. They carried a matrix
-value until the rename of 2026-09-01, which is the reason they were held back,
-and that reason is gone. Nothing is required that this page has not declared,
+The two that were missing were the two floor contexts. They carried a matrix
+value until the rename of 2026-09-01, which is why they were held back; the
+rename gave them names built out of the packaging file, and a packaging file
+does not change its name when the floor inside it does, so the reason went with
+it. Nothing is required that this page has not declared,
 which
 is the direction worth checking rather than assuming, because a name required
 here and absent above would be a gate nobody wrote a line for:

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -126,8 +126,21 @@ a pull request in which either of those `version:` fields moves without touching
 `CHANGELOG.md` fails the `Deterministic pull request hygiene checks` job, which
 #26 landed.
 
-Two absences the old wording named are still absences and are not softened here.
-The job asks whether `CHANGELOG.md` was touched and never what was written in it,
-so an entry that says nothing passes. And it is not in the required set on
-`master`, so a red one reports rather than holds a merge; whether it becomes
-required is #30's.
+Two absences the old wording named were both absences when it was written. One
+still is: the job asks whether `CHANGELOG.md` was touched and never what was
+written in it, so an entry that says nothing passes, and that is not softened
+here.
+
+**The other one has gone and this paragraph went on asserting it.** It said the
+job was not in the required set on `master`, so that a red one reported rather
+than held a merge, and it named #30 as where that would be decided. It was
+decided, and the job is required today:
+
+    $ gh api repos/iderex/jellyfin-plugin-requests/rules/branches/master         --jq '.[] | select(.type=="required_status_checks")
+              | .parameters.required_status_checks[].context'       | grep -x 'Deterministic pull request hygiene checks'
+    Deterministic pull request hygiene checks
+
+A ruleset is a repository setting rather than a file here, so nothing in this
+tree moved on the day that context was added and the sentence stayed green while
+it stopped being true. The whole required set, and one line per difference from
+the sibling board's, is `docs/quality-parity.md`.


### PR DESCRIPTION
Part of #30. Two documents state which checks hold a merge on `master`, and both had stopped reproducing. This change is also the demonstration the last note on #30 asks for: it is the next change on this board, so its own checks are where the two floor contexts are seen being required.

## What was wrong

A ruleset is a repository setting rather than a file here. On the day a context is added to the required set, nothing in this tree moves - the paste stops reproducing, the page reads exactly as it did, and every check stays green. That has now happened three times to one paste.

Run at `origin/master`, `e514d774db018b3aa04d698f89e26c8febb3f90a`:

    $ git show origin/master:docs/quality-parity.md \
        | sed -n '/^Fifteen contexts/,/^There are no bypass actors/p' \
        | sed -n 's/^    \([^ ].*\)$/\1/p' | sort > declared.txt
    $ gh api repos/Flowfin/jellyfin-plugin-requests/rules/branches/master \
        --jq '.[] | select(.type=="required_status_checks")
              | .parameters.required_status_checks[].context' | sort > live.txt
    $ comm -23 declared.txt live.txt
    $ comm -13 declared.txt live.txt
    $ wc -l < declared.txt ; wc -l < live.txt
    15
    15

Both directions return nothing and both sides are fifteen, while three sentences on that page still described a gap.

## The three sites

**`## What each gate actually requires`.** The `This one:` paste printed thirteen names and the command returns fifteen. The sentence under it read "Twelve contexts there against thirteen here"; the other board's paste still reproduces at twelve, so only this side moved.

    $ gh api repos/iderex/jellyfin-plugin-sso/rules/branches/main \
        --jq '.[] | select(.type=="required_status_checks")
              | .parameters.required_status_checks[].context' | wc -l
    12

**`### What has arrived since this list was written`.** The same paste, again at thirteen, followed by "Thirteen of the fifteen" and "Two are missing, and they are the two floor contexts". The two that were missing are `floor build.yaml` and `floor build-jf12.yaml`, and they went in on 2026-09-02 once the rename of 2026-09-01 had given them names that do not move when a floor does.

**`docs/versioning.md`.** It said the `Deterministic pull request hygiene checks` job is not in the required set, so that a red one reports rather than holds a merge, and named #30 as where that would be decided. It is required:

    $ gh api repos/iderex/jellyfin-plugin-requests/rules/branches/master \
        --jq '.[] | select(.type=="required_status_checks")
              | .parameters.required_status_checks[].context' \
      | grep -x 'Deterministic pull request hygiene checks'
    Deterministic pull request hygiene checks

The absence beside it in the same paragraph - the job asks whether `CHANGELOG.md` was touched and never what is in it - is still an absence and is not softened here.

## Why a second file rather than a second change

#30's `Scope:` line names `docs/quality-parity.md` and not `docs/versioning.md`. Both edits are one topic - a document's statement of what the gate requires, brought back to what the ruleset returns - and the second sentence names #30 as its own address. Splitting it would leave a false sentence in the tree pointing at an issue that had just been closed.

## What is kept rather than deleted

Each corrected sentence keeps what it used to say. A correction that removes the wrong reading leaves the next reader unable to tell a repair from an ordinary edit, and this page has already been corrected twice for the same class.

## Evidence

    $ ./scripts/check-pasted-evidence.sh docs/quality-parity.md docs/versioning.md
    read 0 pasted match lines in 2 document(s)
    check-pasted-evidence: every pasted match line reproduces against the file it names.

    $ ./scripts/check-negative-disclosures.sh docs/quality-parity.md docs/versioning.md
    ran 1 negative disclosure(s) in 2 document(s)
    check-negative-disclosures: every negative disclosure exits as the document says it does.

    $ npx --yes prettier@3.6.2 --check .lfcheck/docs/
    Checking formatting...
    All matched files use Prettier code style!

The markdown was checked as an LF copy made inside the tree, because this checkout is CRLF and the gate reads LF. That copy is not committed.

## Means

Markdown edited in place, in the two files that already hold the claims. Any other means - a generated page, a check that rewrote the paste - would put the live gate in a second place, which is the drift this page opens by warning about.

## What this does not do

**It applies no setting and changes no ruleset.** The fifteen contexts were required before this change and are required after it.

**It adds no context to the required set and takes none out.** The `Fifteen contexts` list under `## The set to require` is untouched.

**Nobody else read it.** There is no second reader on this board tonight, and the commands above are what stands in place of one.
