### PR TITLE
Walk a request onto a running Jellyseerr beside a real server of each line

### DIFF
--- a/.github/workflows/bridge-round-trip.yaml
+++ b/.github/workflows/bridge-round-trip.yaml
@@ -1,0 +1,117 @@
+# A request made here arrives on a running service that speaks the Overseerr form, on a real server
+# of each claimed line.
+#
+# #315 asks for the adapter and, as its last clause, for a round trip against a real instance rather
+# than a stub alone. The suite drives the adapter through an in-process double, which is the
+# headless rule in `docs/testing.md`, and every answer that double gives is a shape quoted out of the
+# form's description. A description is not a service, and `docs/bridge.md` says twice what the gap
+# between the two is worth. This job is the reading of the service.
+#
+# So it starts a Jellyfin of each line with the plugin installed, starts Jellyseerr beside it on a
+# network of their own, walks Jellyseerr's own first sign-in against an administrator account made on
+# that Jellyfin, reads the key Jellyseerr issued, points the plugin at it, has a person ask for a film
+# and an operator approve it, and reads the request back out of Jellyseerr's own list with the status
+# the mapping table predicts. Then it runs the reconciliation task and reads the request here again.
+# `scripts/verify-bridge-round-trip.sh` is the procedure and says what is asserted and what is not.
+#
+# THE SERVICE IS JELLYSEERR AND NOT OVERSEERR PROPER. Both speak the form; Overseerr's only described
+# route that creates the first user takes a Plex account token, which nobody on this board holds and
+# nothing here should hold. Jellyseerr's takes a Jellyfin username and password, so the credential
+# lives and dies with the containers. The image is pinned by tag and by digest in the script.
+#
+# It runs on a pull request or a push that touches the bridge, the procedure or the shared server
+# scripts, and nightly. Not on every pull request, because it pulls a third party's image and
+# Jellyseerr fetches the film's metadata from TMDB, which are two outbound dependencies more than the
+# other container checks carry, and a defect this job catches is in the paths it names. The cost is
+# two containers per line.
+name: A request arrives on a running service
+
+on:
+  pull_request:
+    paths:
+      - "Jellyfin.Plugin.Requests/Bridge/**"
+      - "Jellyfin.Plugin.Requests/Configuration/**"
+      - "scripts/verify-bridge-round-trip.sh"
+      - "scripts/server-under-test.sh"
+      - "scripts/server-image-for.sh"
+      - "scripts/server-lines.tsv"
+      - ".github/workflows/bridge-round-trip.yaml"
+  push:
+    paths:
+      - "Jellyfin.Plugin.Requests/Bridge/**"
+      - "Jellyfin.Plugin.Requests/Configuration/**"
+      - "scripts/verify-bridge-round-trip.sh"
+      - "scripts/server-under-test.sh"
+      - "scripts/server-image-for.sh"
+      - "scripts/server-lines.tsv"
+      - ".github/workflows/bridge-round-trip.yaml"
+  schedule:
+    - cron: "23 5 * * *"
+  workflow_dispatch:
+
+# Explicit deny-all at workflow level; the job grants what it needs.
+permissions: {}
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  round-trip:
+    name: round trip ${{ matrix.line }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: read
+
+    strategy:
+      # Both lines run whatever the other one does. A failure on one is a fact about that line, and
+      # cancelling the other would leave nobody knowing whether it is a fact about both.
+      fail-fast: false
+      matrix:
+        include:
+          # The server image is not written here. It is one half of a pair several checks need, and
+          # two copies of that pair disagree the first time a line moves, so it lives in
+          # `scripts/server-lines.tsv` and the step below asks for it by framework. The service
+          # image is the script's own: one service, one place it is pinned.
+          - line: "10.11"
+            framework: "net9.0"
+            port: "18102"
+            service_port: "15055"
+          - line: "12.0"
+            framework: "net10.0"
+            port: "18103"
+            service_port: "15056"
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Nothing here pushes, so do not leave the token in .git/config.
+          persist-credentials: false
+
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: |
+            9.0.x
+            10.0.x
+
+      - name: Restore in locked mode
+        run: dotnet restore Jellyfin.Plugin.Requests.sln --locked-mode
+
+      - name: Does a request made here arrive on the service
+        # The matrix values arrive as environment variables rather than as expressions inside the
+        # script. They are written in this file and are not somebody's input, so nothing here is
+        # injectable today; what the shape buys is that it stays that way when a later matrix takes
+        # a value from somewhere else.
+        env:
+          FRAMEWORK: ${{ matrix.framework }}
+          PORT: ${{ matrix.port }}
+          SERVICE_PORT: ${{ matrix.service_port }}
+        run: |
+          set -euo pipefail
+          IMAGE=$(./scripts/server-image-for.sh "$FRAMEWORK")
+          ./scripts/verify-bridge-round-trip.sh "$IMAGE" "$FRAMEWORK" "$PORT" "$SERVICE_PORT"

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -19,8 +19,11 @@ implementation every server resolves; with no address written it hands every cal
 opens with. #82 built the submission path behind the interface, #113 decided the form and that an
 adapter is written here as its own module, and #315 asked for it. What the adapter sends, what it
 makes of what comes back, and what it refuses before sending anything are in the section on it
-below. **Nothing in this tree has ever called a running service**, and the section at the end says
-what a reading of the form's description is worth against a reading of an instance.
+below. **One procedure in this tree calls a running service, and nothing in the suite does.**
+`scripts/verify-bridge-round-trip.sh` walks one request onto a Jellyseerr started beside a server of
+each claimed line, and `.github/workflows/bridge-round-trip.yaml` runs it; the section on the adapter
+says what that run measured on 2026-09-03 and what it did not, and the section at the end says what a
+reading of the form's description is worth against a reading of an instance.
 
 ## The mapping
 
@@ -222,10 +225,13 @@ gave a moment ago.
 **On the ordinary install this does nothing and costs one call.** Most servers have no service, the
 run ends at the reachability check, and it says nothing above debug.
 
-**What is not claimed.** No run of this task on a server has been watched, and no service was
-reached: what the suite measures is the reconciliation against a double, on both claimed target
-frameworks. Which failures an adapter tells apart, and what each of them then does, is #86 and is
-not decided here. And **the person who asked is not told when their request fails this way** - no
+**What is not claimed.** One run of this task on a server has been watched, against a running
+Jellyseerr, in the round trip the adapter's section below records: it asked about one approved
+request, was answered `APPROVED`, and left the request as it was. That is the inert row and nothing
+else; no run against a service has ever moved a request, because no service has ever answered
+`DECLINED` or `FAILED` here, and what the suite measures for those is the reconciliation against a
+double, on both claimed target frameworks. Which failures an adapter tells apart, and what each of
+them then does, is #86 and is not decided here. And **the person who asked is not told when their request fails this way** - no
 sentence is written for that state, so they find out on their own page. That is a gap rather than a
 decision, and `RequesterMessage.ForMove` is where it is written down.
 
@@ -459,12 +465,45 @@ left as it is. Which of those failures are told apart, and what a bound retry is
 say: that route takes no credential, so a green answer is a service that is up and nothing about
 whether the key is accepted.
 
+**One request has made the round trip against a running service, on both claimed lines.**
+`scripts/verify-bridge-round-trip.sh` starts Jellyseerr `2.7.3`, pinned by digest in the script,
+beside a server of each line, walks its own first sign-in against an administrator made on that
+server, reads the key it issued, points the plugin at it through the server's configuration route,
+has a person ask for a film by TMDB number and an operator approve it, and reads the request back out
+of the service's own list; then it runs `ReconciliationTask` and reads the request here again. Run
+`33731657684` on this board, jobs `100572739356` for 10.11 and `100572739618` for 12.0, is the first
+green one, and the two lines that carry the measurement read the same on both:
+
+    id=1  type=movie  status=2  media.tmdbId=550  media.status=3  requestedBy.id=1
+    state=Approved  backend={"Service": "overseerr", "Id": "1"}  handoverFailedAt=None
+
+So the submission's field names are the ones a real service takes, the number it answers with is the
+one this side keeps, the status it reports is `2`, which `OverseerrWords` turns into `APPROVED` and
+the table above holds as inert, and the request stays approved here after the reconciliation. The
+media status `3` beside it is `PROCESSING` in the form's own enumeration below and is read by
+nothing here, as the paragraph above says.
+
+**What that run does not say.** It is Jellyseerr and not Overseerr proper, because Overseerr's only
+described route creating the first user takes a Plex account token, and Jellyseerr's takes a Jellyfin
+username and password the job makes and forgets; whether Overseerr proper behaves the same is not
+measured. The service has no download client, so its own log says the request is skipped rather than
+fetched, and nothing downstream of the service is exercised. No failure path is walked: a refused
+key, a service that goes away and a word the table has not seen are the suite's legs and #86's
+question. And one server setting is turned on for the service on the 12.0 line: Jellyseerr `2.7.3`
+names its client in the `X-Emby-Authorization` header, which a 12.0 server reads only while
+`EnableLegacyAuthorization` is on, and it is off there by default. The first run of the procedure met
+that as a `400` on the service's sign-in, the procedure now turns the switch on where the server has
+it and prints what it found, and an operator running that pair of versions meets the same wall.
+
 ## Where the list of words came from
 
 The words above are the ones issue #81 names for the Overseerr form, which is the form the first
 adapter is written against, decided on #113. **They were not read off a running service, and nothing
-in this tree can read one.** No fixture here was captured from a service and the suite makes no
-outbound call.
+in the suite can read one.** No fixture here was captured from a service and the suite makes no
+outbound call. One of the six has since been met on a running Jellyseerr, in the round trip the
+adapter's section above records: the service reported `2` and `OverseerrWords` turned it into
+`APPROVED`. The other five have not been seen from a service, and the rule below is what stands
+between that and a wrong answer.
 
 What has been read is that form's own published description, and the comparison against it is the
 section below. That is a weaker reading than a running service and a stronger one than this table had
@@ -710,9 +749,11 @@ here recognises.
 
 ### What was not read
 
-Nothing off a running instance, and that is the same disclosure as the one above rather than a softer
-version of it. No call has ever been made from this tree to a service of this form and no response of
-one has ever been captured here. Every reading above is of a branch of that project's own
-repository, which is what that project intends to ship rather than what any operator is running:
-the two disagreeing about the request-status alphabet is the demonstration that a document and a
-service are different things, and a numbering read from source is subject to the same gap.
+Nothing in this section is off a running instance. Every reading above is of a branch of that
+project's own repository, which is what that project intends to ship rather than what any operator
+is running: the two disagreeing about the request-status alphabet is the demonstration that a
+document and a service are different things, and a numbering read from source is subject to the
+same gap. What has been read off an instance is the round trip in the adapter's section above, and
+its reach is exactly the calls it makes: one submission, one report answering `2`, and the status
+route. No response of a service is captured in this tree; the run's log is where the answers are,
+and the section above quotes the two lines that carry the measurement.

--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -801,9 +801,10 @@ workflow that ran on it succeeded:
     32603611353  success  110abde  🧾 PR hygiene
 
 Two names appear twice because two triggers fired on one head, and two of the sixteen belong to the
-inherited section above rather than to this one. Three workflows do not appear at all: `mutation.yaml`
-runs on a schedule, `seam-probe.yaml` on a push that touches the probe, and `full-disk.yaml`
-arrived after that head, so their green runs are their own and carry their own head.
+inherited section above rather than to this one. Four workflows do not appear at all: `mutation.yaml`
+runs on a schedule, `seam-probe.yaml` on a push that touches the probe, and `full-disk.yaml` and
+`bridge-round-trip.yaml` arrived after that head, so their green runs are their own and carry their
+own head.
 
 | Workflow                      | Red run                                                                                                                                               | Green run                 |
 | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
@@ -822,6 +823,7 @@ arrived after that head, so their green runs are their own and carry their own h
 | `manifest-freshness.yaml`     | none of this kind, below                                                                                                                              | 33246667212, at `12182bf` |
 | `release-install.yaml`        | none of this kind, below                                                                                                                              | 33357925338, at `501a943` |
 | `full-disk.yaml`              | 32623464033, `throwaway/46-a-mount-nobody-limited`, both lines red at `Does a full disk reach the caller` with nothing measured                       | 32623457801, at `d154ab3` |
+| `bridge-round-trip.yaml`      | 33732017937, `throwaway/315-a-submission-in-the-wrong-field`, both lines red at `Does a request made here arrive on the service`, at the approval     | 33731657684, at `234daed` |
 
 The job and step of each red run are read off the run rather than off a log:
 

--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -457,12 +457,12 @@ Thirteen files here map onto a file there and are placed by the table above:
 `dco.yml`, `dependency-review.yml`, `invariant-lint.yaml`, `mutation.yaml`,
 `package.yaml`, `prettier.yml`, `pr-hygiene.yaml`,
 `publish-failure-alert.yaml`, `publish.yaml`, `scan-codeql.yaml`,
-`scorecard.yml`, `unicode-guard.yml` and `zizmor.yml`. Eleven of the rows below
-name a file that is present, and thirteen plus eleven is what the directory
+`scorecard.yml`, `unicode-guard.yml` and `zizmor.yml`. Twelve of the rows below
+name a file that is present, and thirteen plus twelve is what the directory
 holds:
 
     $ ls .github/workflows/ | wc -l
-    24
+    25
 
 THIS PARAGRAPH SAID TWELVE AND NINE AND PASTED 21 WHILE THE DIRECTORY HELD 23,
 and it was found by running the pasted command before adding a file to that
@@ -501,6 +501,7 @@ longer tracks it.
 | `gate.yaml`               | adopted, landed   | The build and test legs, in this repository rather than called from another organisation, because a called workflow knows nothing about this tree's lockfiles.                                                                                                                                                                                                                                                                                                                                           |
 | `seam-probe.yaml`         | adopted, landed   | What a second plugin in the same server process can see of this one, measured on a real server of each line with `tools/seam-probe` as the second plugin. It records an answer rather than holding a merge, so what reds it is a run that produced no answer at all. #117.                                                                                                                                                                                                                               |
 | `user-isolation.yaml`     | adopted, landed   | Two ordinary accounts on a real server of each line, each asking for something and reading back what they are given, with the queue asked as somebody who is not an administrator. The server's own evaluation of a policy is the half no double here reaches. #67.                                                                                                                                                                                                                                      |
+| `bridge-round-trip.yaml`  | adopted, landed   | A request made here walked onto a running Jellyseerr beside a real server of each line, read back out of the service's own list with the status the mapping table predicts, and read back here again by the reconciliation task. The suite drives the adapter through a double whose answers are quoted from the form's description; this is the reading of an instance, which #315's last clause asks for. Jellyseerr rather than Overseerr proper, because its first sign-in takes no Plex token.      |
 | `full-disk.yaml`          | adopted, landed   | What a caller sees when the volume the store writes to runs out of room, on a mount with a hard size, on the runtime of each line. The suite cannot ask it: filling a filesystem needs one to fill, and the headless rule refuses a test that needs a container engine. #46.                                                                                                                                                                                                                             |
 | `manifest.yaml`           | adopted, landed   | The manifest generator watched refusing what it says it refuses, over one manifest per defect, with a clean pair of packages beside them. A generator that has never said no writes a manifest for a clean pair, which is also what a generator with no rules does. #110.                                                                                                                                                                                                                                |
 | `manifest-freshness.yaml` | adopted, landed   | The document a server fetches, read back against the releases that exist, once a day and on its own files. It is not the publish checking itself: the incident behind #111 is a publish whose manifest write failed while the run stayed green, so the step that failed would have been the step reporting it. A claimed line with no release is reported rather than passed over. What it finds is raised by `publish-failure-alert.yaml`, which sweeps every workflow here rather than this one. #111. |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -93,7 +93,11 @@ which posts a document to the one address an operator typed and reads a status b
 `Jellyfin.Plugin.Requests.Tests/Doubles/AnOverseerrService.cs` stands in front of the bridge adapter,
 which reads a body back, so the two cases #35 named and nothing here could reach before - a body that
 is not JSON, and JSON of the wrong shape - are answers that double gives and legs the adapter is held
-to. Neither double was captured from a running service, and nothing here has ever called one.
+to. Neither double was captured from a running service. What does call one is outside the suite,
+in the shape of the first-load procedure below: `scripts/verify-bridge-round-trip.sh` starts a
+Jellyseerr beside a server of each claimed line and walks one request onto it, and
+`.github/workflows/bridge-round-trip.yaml` runs it on the paths it names and nightly. `docs/bridge.md`
+carries what that run measured and what it did not.
 
 This paragraph named an issue rather than a file until #251, and went on saying the double did not
 exist for as long as it took somebody to read both.

--- a/scripts/verify-bridge-round-trip.sh
+++ b/scripts/verify-bridge-round-trip.sh
@@ -119,13 +119,22 @@ else:
     sys.exit("no {0} in {1}".format(name, sorted(holder)))
 '
 
-# The same lookup, as a prelude the verdicts below start with.
+# The same lookup, as a prelude the verdicts below start with, and beside it the one for a field the
+# server leaves out when it is null: the failed-handover mark and the reference are both absent
+# from a row that has neither, and absent is the answer rather than a missing field.
 PYFIELD='
 def field(holder, name):
     for key, value in holder.items():
         if key.lower() == name.lower():
             return value
     raise SystemExit("no {0} in {1}".format(name, sorted(holder)))
+
+
+def optional(holder, name):
+    for key, value in holder.items():
+        if key.lower() == name.lower():
+            return value
+    return None
 '
 
 # One call to the service with the key it issued. The key is a header and nothing else, which is the
@@ -371,7 +380,7 @@ api GET "$prefix/Health" | python3 -c "$PYFIELD"'
 import json, sys
 health = json.load(sys.stdin)
 bridge = field(health, "bridge")
-print("Bridge={0}  BridgeLastReachableAt={1}".format(bridge, field(health, "bridgeLastReachableAt")))
+print("Bridge={0}  BridgeLastReachableAt={1}".format(bridge, optional(health, "bridgeLastReachableAt")))
 if str(bridge).lower() != "reachable":
     sys.exit("the plugin reports the bridge as {0!r} with the service up and configured.".format(bridge))
 '
@@ -420,9 +429,9 @@ row = json.load(sys.stdin)
 state = field(row, "state")
 if str(state).lower() != "approved":
     sys.exit("the request is {0!r} after approval.".format(state))
-if field(row, "handoverFailedAt") is not None:
-    sys.exit("the handover failed at {0}: the approval stands and the service has nothing.".format(field(row, "handoverFailedAt")))
-backend = field(row, "backend")
+if optional(row, "handoverFailedAt") is not None:
+    sys.exit("the handover failed at {0}: the approval stands and the service has nothing.".format(optional(row, "handoverFailedAt")))
+backend = optional(row, "backend")
 if not backend:
     sys.exit("the approval carries no reference, so nothing was handed over and nothing failed either, which is the answer a server with no bridge gives.")
 if str(field(backend, "service")).lower() != "overseerr":
@@ -506,8 +515,8 @@ if len(rows) != 1:
     sys.exit("the queue holds {0} row(s) for the request.".format(len(rows)))
 row = rows[0]
 state = field(row, "state")
-backend = field(row, "backend") or {}
-print("state={0}  backend={1}  handoverFailedAt={2}".format(state, json.dumps(backend), field(row, "handoverFailedAt")))
+backend = optional(row, "backend") or {}
+print("state={0}  backend={1}  handoverFailedAt={2}".format(state, json.dumps(backend), optional(row, "handoverFailedAt")))
 if str(state).lower() != "approved":
     sys.exit("the request is {0!r} after the reconciliation, and APPROVED moves nothing.".format(state))
 if str(field(backend, "id")) != os.environ["REFERENCE"]:
@@ -516,8 +525,8 @@ if str(field(backend, "id")) != os.environ["REFERENCE"]:
 api GET "$prefix/Health" | python3 -c "$PYFIELD"'
 import json, sys
 health = json.load(sys.stdin)
-print("Bridge={0}  BridgeLastReachableAt={1}".format(field(health, "bridge"), field(health, "bridgeLastReachableAt")))
-if field(health, "bridgeLastReachableAt") is None:
+print("Bridge={0}  BridgeLastReachableAt={1}".format(field(health, "bridge"), optional(health, "bridgeLastReachableAt")))
+if optional(health, "bridgeLastReachableAt") is None:
     sys.exit("nothing recorded the service as reachable, after the health endpoint and the reconciliation both asked it.")
 '
 

--- a/scripts/verify-bridge-round-trip.sh
+++ b/scripts/verify-bridge-round-trip.sh
@@ -1,0 +1,481 @@
+#!/usr/bin/env bash
+# A request made here arrives on a running service that speaks the Overseerr form, and what that
+# service says about it comes back through the mapping table.
+#
+# #315 asks for an adapter against the Overseerr form and, as its last clause, for a round trip
+# against a real instance rather than a stub alone. The suite drives the adapter through an
+# in-process double whose answers are the shapes docs/bridge.md quotes out of the form's description,
+# which is the headless rule in docs/testing.md and is exactly as strong as that description. This is
+# the other reading: a Jellyfin of one claimed line with this plugin installed, a service of the form
+# in a second container beside it, and one request walked from a person here to a row over there and
+# back.
+#
+# THE SERVICE IS JELLYSEERR, PINNED BY TAG AND DIGEST BELOW, AND NOT OVERSEERR PROPER. Both speak
+# the form; the difference is the door. Overseerr's only described route that creates the first user
+# takes a Plex account token, which is a credential somebody would have to hold as a secret on this
+# board. Jellyseerr's `/auth/jellyfin` creates it from a Jellyfin username and password instead, so
+# the account the service signs in with is one this script makes on the throwaway server and forgets
+# with it. Nothing here holds a credential of anybody's. Whether Overseerr proper behaves the same is
+# not measured by this and is not claimed.
+#
+# WHAT IS ASSERTED, in the order it is walked:
+#
+#   - the service is up, and the plugin's health endpoint reports the bridge reachable once pointed
+#     at it;
+#   - an approval here answers with the service's own number for the request, which is what the
+#     adapter keeps to ask about later;
+#   - the service holds a request under that number, of the kind and the TMDB identifier that were
+#     asked for here, and its status is the number the mapping table's `APPROVED` row is written
+#     for. The request arrives under the service's own account, which holds `ADMIN` there, and the
+#     form's description says such a request is approved on arrival;
+#   - the reconciliation task, run on the server, asks the service and leaves the request approved,
+#     which is what the table says `APPROVED` does.
+#
+# WHAT IS NOT. Nothing downstream of the service: it has no download client configured, so its own
+# log says the request is skipped rather than fetched, and no library here ever fills. The failure
+# paths - a refused key, a service that goes away, a word the table has not seen - are the suite's
+# and #86's, not this script's.
+#
+# The server, the install, the wizard and the administrator account are scripts/server-under-test.sh,
+# which the other container checks source too. Everything else is this script's own, lives for the
+# length of two containers, and is reachable only from loopback ports.
+#
+# usage: scripts/verify-bridge-round-trip.sh <image> <target-framework> [host-port] [service-port]
+#   scripts/verify-bridge-round-trip.sh jellyfin/jellyfin:10.11.11 net9.0  18102 15055
+#   scripts/verify-bridge-round-trip.sh jellyfin/jellyfin:12.0-rc4  net10.0 18103 15056
+
+set -euo pipefail
+
+image=${1:?server image, for example jellyfin/jellyfin:10.11.11}
+framework=${2:?target framework, for example net9.0}
+port=${3:-18102}
+service_port=${4:-15055}
+
+# The service, by tag and by digest. The tag says which release a reader should expect and the
+# digest is what a run actually pulls, so a tag moved underneath this check is a pull that fails
+# rather than a different service measured under the same name.
+SERVICE_IMAGE="fallenbagel/jellyseerr:2.7.3@sha256:4538137bc5af902dece165f2bf73776d9cf4eafb6dd714670724af8f3eb77764"
+
+# The two containers find each other by these names on a network of their own. Names without dots,
+# because the target framework has one and a name with a dot is a name a resolver may treat as fully
+# qualified.
+SERVER_ALIAS=jellyfin
+SERVICE_ALIAS=jellyseerr
+
+# One film the form's own TMDB client can look up, because the form fetches the title's metadata
+# from TMDB before it holds a request for it. The number is what the adapter sends and what the
+# service is asked to hold; the title here is only what a person would have typed.
+TMDB_ID=550
+TITLE="Fight Club"
+YEAR=1999
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+# shellcheck source=scripts/server-under-test.sh
+. "$repo_root/scripts/server-under-test.sh"
+
+NETWORK="bridge-check-$framework"
+SERVICE="jellyseerr-bridge-check-$framework"
+SERVICE_BASE="http://127.0.0.1:$service_port"
+SERVICE_KEY=""
+
+cookies=$(mktemp)
+
+# What the two sides wrote about the handover, read before either container is removed, so a red
+# run carries the reason and a green one carries the service's own account of what it did. The
+# plugin's lines name the address and never the key, which docs/bridge.md claims and the suite holds.
+cleanup() {
+    set +e
+    step "what the plugin wrote about the bridge"
+    dk exec "${CONTAINER:-}" sh -c 'grep -h "external request service\|handed to\|econciliation" /config/log/*.log' 2>/dev/null | tail -n 40
+    step "what the service wrote"
+    dk logs --tail 60 "$SERVICE" 2>&1 | grep -v 'Warning: '
+    server_stop
+    dk rm --force "$SERVICE" >/dev/null 2>&1
+    dk network rm "$NETWORK" >/dev/null 2>&1
+    rm -f "$cookies"
+}
+trap cleanup EXIT
+
+# One field out of a JSON object on stdin, matched without regard to case, so a reader here does not
+# fix a spelling this check is not about. Which casing the server's serialiser hands a plugin's own
+# shapes back in is a property the suite asserts against the bytes.
+FIELD='
+import json, sys
+
+name = sys.argv[1]
+holder = json.load(sys.stdin)
+for key, value in holder.items():
+    if key.lower() == name.lower():
+        print(value if not isinstance(value, (dict, list)) else json.dumps(value))
+        break
+else:
+    sys.exit("no {0} in {1}".format(name, sorted(holder)))
+'
+
+# The same lookup, as a prelude the verdicts below start with.
+PYFIELD='
+def field(holder, name):
+    for key, value in holder.items():
+        if key.lower() == name.lower():
+            return value
+    raise SystemExit("no {0} in {1}".format(name, sorted(holder)))
+'
+
+# One call to the service with the key it issued. The key is a header and nothing else, which is the
+# one shape the adapter is held to as well; --fail-with-body so a refusal prints what it refused.
+service() {
+    local method=${1:?method} path=${2:?path} body=${3:-}
+
+    if [ -n "$body" ]; then
+        curl --silent --fail-with-body --max-time 60 -X "$method" "$SERVICE_BASE/api/v1$path" \
+            -H 'Content-Type: application/json' \
+            -H "X-Api-Key: $SERVICE_KEY" \
+            -d "$body"
+    else
+        curl --silent --fail-with-body --max-time 60 -X "$method" "$SERVICE_BASE/api/v1$path" \
+            -H "X-Api-Key: $SERVICE_KEY"
+    fi
+}
+
+# One call to the service as the signed-in administrator, before a key is known. Only the setup
+# uses it: the session is what the sign-in route hands out, and the key is read through it once.
+service_session() {
+    local method=${1:?method} path=${2:?path} body=${3:-}
+
+    if [ -n "$body" ]; then
+        curl --silent --fail-with-body --max-time 60 -X "$method" "$SERVICE_BASE/api/v1$path" \
+            -H 'Content-Type: application/json' \
+            -b "$cookies" -c "$cookies" \
+            -d "$body"
+    else
+        curl --silent --fail-with-body --max-time 60 -X "$method" "$SERVICE_BASE/api/v1$path" \
+            -b "$cookies" -c "$cookies"
+    fi
+}
+
+# One authenticated call as somebody other than the administrator.
+as() {
+    local token=${1:?token} method=${2:?method} path=${3:?path} body=${4:-}
+
+    if [ -n "$body" ]; then
+        curl --silent --fail-with-body --max-time 30 -X "$method" "$BASE$path" \
+            -H 'Content-Type: application/json' \
+            -H "Authorization: $AUTH_HEADER, Token=\"$token\"" \
+            -d "$body"
+    else
+        curl --silent --fail-with-body --max-time 30 -X "$method" "$BASE$path" \
+            -H "Authorization: $AUTH_HEADER, Token=\"$token\""
+    fi
+}
+
+# An account on the server, created by the administrator and authenticated as itself. Prints the
+# identifier and the token, separated by a space. The password is generated by the caller rather
+# than written here: it exists for the length of one container on a loopback port.
+account() {
+    local name=${1:?account name} password=${2:?password} authenticated
+
+    api POST /Users/New "$(printf '{"Name": "%s", "Password": "%s"}' "$name" "$password")" >/dev/null
+
+    authenticated=$(curl --silent --fail --max-time 30 -X POST "$BASE/Users/AuthenticateByName" \
+        -H 'Content-Type: application/json' \
+        -H "Authorization: $AUTH_HEADER" \
+        -d "$(printf '{"Username": "%s", "Pw": "%s"}' "$name" "$password")")
+
+    printf '%s' "$authenticated" | python3 -c '
+import json, sys
+
+answer = json.load(sys.stdin)
+token = answer.get("AccessToken")
+identifier = (answer.get("User") or {}).get("Id")
+if not token or not identifier:
+    sys.exit("the server authenticated that account and named no token or no user.")
+print(identifier, token)
+'
+}
+
+server_start "$image" "$framework" "$port" "jellyfin-bridge-check-$framework"
+
+prefix=/MediaRequests/v1
+
+step "put the server on a network the service can reach it on"
+# A network of its own rather than the default one, because on the default network containers
+# reach each other by address only, and the address the service is told has to survive a restart.
+dk network rm "$NETWORK" >/dev/null 2>&1 || true
+dk network create "$NETWORK" >/dev/null
+dk network connect --alias "$SERVER_ALIAS" "$NETWORK" "$CONTAINER"
+echo "$CONTAINER is $SERVER_ALIAS on $NETWORK"
+
+step "start the service from $SERVICE_IMAGE"
+dk rm --force "$SERVICE" >/dev/null 2>&1 || true
+dk run --detach --name "$SERVICE" \
+    --network "$NETWORK" --network-alias "$SERVICE_ALIAS" \
+    --publish "127.0.0.1:$service_port:5055" \
+    --env LOG_LEVEL=info \
+    "$SERVICE_IMAGE" >/dev/null
+
+step "wait for the service to answer"
+# Three answers in a row, for the reason the server is waited for the same way: a port that accepts
+# while the process is still coming up is not a service that is ready.
+status="" settled=0
+for _ in $(seq 1 120); do
+    if status=$(curl --silent --fail --max-time 5 "$SERVICE_BASE/api/v1/status" 2>/dev/null); then
+        settled=$((settled + 1))
+        if [ "$settled" -ge 3 ]; then
+            break
+        fi
+        sleep 1
+        continue
+    fi
+    settled=0
+    status=""
+    sleep 2
+done
+test "$settled" -ge 3
+printf '%s\n' "$status"
+SERVICE_VERSION=$(printf '%s' "$status" | python3 -c "$FIELD" version)
+echo "the service is up at version $SERVICE_VERSION"
+
+step "an administrator account on the server for the service to sign in with"
+# The service's first sign-in has to be a Jellyfin administrator, which its own sign-in route checks,
+# and the account the wizard made belongs to the shared script and keeps its password to itself. So
+# a second administrator is made here: an ordinary account, then its policy read back, changed in
+# the one field, and written again, which is what the dashboard does.
+SERVICE_ADMIN=bridge-check-service
+service_admin_password=$(python3 -c 'import secrets; print(secrets.token_urlsafe(24))')
+read -r SERVICE_ADMIN_ID _ <<<"$(account "$SERVICE_ADMIN" "$service_admin_password")"
+test -n "$SERVICE_ADMIN_ID"
+policy=$(api GET "/Users/$SERVICE_ADMIN_ID" | python3 -c '
+import json, sys
+policy = json.load(sys.stdin)["Policy"]
+policy["IsAdministrator"] = True
+print(json.dumps(policy))
+')
+api POST "/Users/$SERVICE_ADMIN_ID/Policy" "$policy"
+api GET "/Users/$SERVICE_ADMIN_ID" | python3 -c '
+import json, sys
+user = json.load(sys.stdin)
+if not user["Policy"].get("IsAdministrator"):
+    sys.exit("{0} is not an administrator after its policy was written, so the service could not sign in as it.".format(user.get("Name")))
+print("{0} ({1}) is an administrator".format(user.get("Name"), user.get("Id")))
+'
+
+step "the service's first sign-in, which creates its administrator"
+# Its own route: username and password against the server it is told about, and the first user it
+# ever sees becomes its administrator. The port and the empty base path are written out rather than
+# left to default, because the route builds the address by pasting the four parts together.
+signed_in=$(service_session POST /auth/jellyfin "$(printf '{"username": "%s", "password": "%s", "hostname": "%s", "port": 8096, "urlBase": "", "useSsl": false, "serverType": 2}' \
+    "$SERVICE_ADMIN" "$service_admin_password" "$SERVER_ALIAS")")
+# Only the fields that say who was made. The whole answer is that service's user object and what it
+# carries is its business, not this transcript's.
+printf '%s' "$signed_in" | python3 -c '
+import json, sys
+user = json.load(sys.stdin)
+print("the service made user id={0} permissions={1} for Jellyfin user {2!r}".format(
+    user.get("id"), user.get("permissions"), user.get("jellyfinUsername")))
+if user.get("id") != 1:
+    sys.exit("the first sign-in did not become user 1, so it is not the administrator the setup needs.")
+'
+
+step "read the key the service issued, and finish its setup"
+# The key is read once through the session and then travels only as the header the adapter sends
+# it in. It is never printed: it is a credential to a container that is gone in a minute, and a
+# transcript is the one thing here that outlives it.
+SERVICE_KEY=$(service_session GET /settings/main | python3 -c "$FIELD" apiKey)
+test -n "$SERVICE_KEY"
+echo "the service issued a key of ${#SERVICE_KEY} characters"
+service_session POST /settings/initialize | python3 -c '
+import json, sys
+public = json.load(sys.stdin)
+if not public.get("initialized"):
+    sys.exit("the service does not report itself initialized after being told to be.")
+print("the service reports initialized")
+'
+
+step "the key opens the service's own request list, which its status route does not need"
+# The status route is public and a green answer from it says nothing about the key, which
+# docs/bridge.md records as the bound on the plugin's own reachability answer. So the key is proven
+# accepted here on a route that refuses without one, before anything is handed over with it.
+service GET '/request?take=20' | python3 -c '
+import json, sys
+listed = json.load(sys.stdin)
+print("the service holds {0} request(s) before anything is handed over".format(len(listed.get("results", []))))
+if listed.get("results"):
+    sys.exit("a fresh service already holds a request, so nothing below could tell its own from it.")
+'
+
+step "point the plugin at the service"
+# The whole configuration is read, two fields written, and the whole written back, because that is
+# what the dashboard sends and the configuration rules run on the way in: an address with no key
+# would be refused here rather than dialled.
+BRIDGE_ADDRESS="http://$SERVICE_ALIAS:5055"
+configuration=$(api GET "/Plugins/$PLUGIN_ID/Configuration" | BRIDGE_ADDRESS="$BRIDGE_ADDRESS" SERVICE_KEY="$SERVICE_KEY" python3 -c '
+import json, os, sys
+configuration = json.load(sys.stdin)
+configuration["BridgeAddress"] = os.environ["BRIDGE_ADDRESS"]
+configuration["BridgeApiKey"] = os.environ["SERVICE_KEY"]
+print(json.dumps(configuration))
+')
+api POST "/Plugins/$PLUGIN_ID/Configuration" "$configuration"
+api GET "/Plugins/$PLUGIN_ID/Configuration" | BRIDGE_ADDRESS="$BRIDGE_ADDRESS" python3 -c '
+import json, os, sys
+configuration = json.load(sys.stdin)
+if configuration.get("BridgeAddress") != os.environ["BRIDGE_ADDRESS"]:
+    sys.exit("the server holds {0!r} as the bridge address rather than what was written.".format(configuration.get("BridgeAddress")))
+if not configuration.get("BridgeApiKey"):
+    sys.exit("the server holds no bridge key after one was written.")
+print("BridgeAddress={0}  BridgeApiKey=set, {1} characters  BridgeAccounts={2} row(s)".format(
+    configuration["BridgeAddress"], len(configuration["BridgeApiKey"]), len(configuration.get("BridgeAccounts") or [])))
+'
+
+step "the plugin reports the bridge reachable"
+# Reachable is the status route answering, and nothing about the key: docs/bridge.md says so and
+# this does not claim more. That the key is accepted was shown two steps up on a route that needs it.
+api GET "$prefix/Health" | python3 -c "$PYFIELD"'
+import json, sys
+health = json.load(sys.stdin)
+bridge = field(health, "bridge")
+print("Bridge={0}  BridgeLastReachableAt={1}".format(bridge, field(health, "bridgeLastReachableAt")))
+if str(bridge).lower() != "reachable":
+    sys.exit("the plugin reports the bridge as {0!r} with the service up and configured.".format(bridge))
+'
+api GET "$prefix/Capabilities" | python3 -c "$PYFIELD"'
+import json, sys
+capabilities = json.load(sys.stdin)
+print("BridgeConfigured={0}".format(field(capabilities, "bridgeConfigured")))
+if not field(capabilities, "bridgeConfigured"):
+    sys.exit("the capabilities say no bridge is configured after an address was written.")
+'
+
+step "a person asks for a film"
+asker_password=$(python3 -c 'import secrets; print(secrets.token_urlsafe(24))')
+read -r ASKER_ID ASKER_TOKEN <<<"$(account bridge-check-asker "$asker_password")"
+test -n "$ASKER_ID"
+test "$ASKER_ID" != "$ADMIN_ID"
+created=$(as "$ASKER_TOKEN" POST "$prefix/Requests" "$(printf '{
+  "kind": "Movie",
+  "title": "%s",
+  "year": %s,
+  "providerIds": { "Tmdb": "%s" }
+}' "$TITLE" "$YEAR" "$TMDB_ID")")
+printf '%s\n' "$created"
+REQUEST_ID=$(printf '%s' "$created" | python3 -c "$FIELD" id)
+REVISION=$(printf '%s' "$created" | python3 -c "$FIELD" revision)
+echo "request $REQUEST_ID at revision $REVISION"
+
+step "the administrator approves it, which is the handover"
+# The answer is the request as the queue holds it after the submission ran: approved, carrying the
+# service's own number for it, and no failed-handover mark. A handover the service refused would
+# come back approved too, with the mark set and no reference, which is the near-miss this verdict
+# is written against.
+approved=$(api POST "$prefix/Requests/$REQUEST_ID/Approve" "{\"revision\": $REVISION}")
+printf '%s\n' "$approved"
+REFERENCE=$(printf '%s' "$approved" | python3 -c "$PYFIELD"'
+import json, sys
+row = json.load(sys.stdin)
+state = field(row, "state")
+if str(state).lower() != "approved":
+    sys.exit("the request is {0!r} after approval.".format(state))
+if field(row, "handoverFailedAt") is not None:
+    sys.exit("the handover failed at {0}: the approval stands and the service has nothing.".format(field(row, "handoverFailedAt")))
+backend = field(row, "backend")
+if not backend:
+    sys.exit("the approval carries no reference, so nothing was handed over and nothing failed either, which is the answer a server with no bridge gives.")
+if str(field(backend, "service")).lower() != "overseerr":
+    sys.exit("the reference names service {0!r}.".format(field(backend, "service")))
+reference = field(backend, "id")
+if not str(reference).isdigit():
+    sys.exit("the reference {0!r} is not the number the form issues.".format(reference))
+print(reference)
+')
+echo "the service called it $REFERENCE"
+
+step "what the service holds under that number"
+# The request over there: the same kind, the same TMDB number, and the status the mapping table
+# names APPROVED, which is 2 in the form's own enumeration that docs/bridge.md quotes. It arrives
+# under the service's administrator, because no mapping row names the person who asked, and the
+# form's description says an administrator's request is approved on arrival. Its media status is
+# printed and not asserted: what the service does about fetching is downstream of this check.
+service GET "/request/$REFERENCE" | TMDB_ID="$TMDB_ID" python3 -c '
+import json, os, sys
+held = json.load(sys.stdin)
+media = held.get("media") or {}
+who = held.get("requestedBy") or {}
+print("id={0}  type={1}  status={2}  media.tmdbId={3}  media.status={4}  requestedBy.id={5}  createdAt={6}".format(
+    held.get("id"), held.get("type"), held.get("status"), media.get("tmdbId"), media.get("status"), who.get("id"), held.get("createdAt")))
+if held.get("type") != "movie":
+    sys.exit("the service holds a {0!r} and a film was asked for.".format(held.get("type")))
+if str(media.get("tmdbId")) != os.environ["TMDB_ID"]:
+    sys.exit("the service holds TMDB {0!r} and {1} was asked for.".format(media.get("tmdbId"), os.environ["TMDB_ID"]))
+if held.get("status") != 2:
+    sys.exit("the service reports status {0!r}, and 2 is what the mapping table holds as APPROVED.".format(held.get("status")))
+print("the service holds the film under its own number, approved")
+'
+service GET '/request?take=20' | REFERENCE="$REFERENCE" python3 -c '
+import json, os, sys
+listed = json.load(sys.stdin).get("results", [])
+if [str(row.get("id")) for row in listed] != [os.environ["REFERENCE"]]:
+    sys.exit("the service lists {0} and the one request handed over is {1}.".format([row.get("id") for row in listed], os.environ["REFERENCE"]))
+print("the service lists exactly that one request")
+'
+
+step "the reconciliation asks the service and reads the answer through the table"
+# The scheduled task the plugin registers, started by hand rather than waited an hour for. Its
+# answer for this request is the word APPROVED, which the table holds as inert: the service agrees
+# with the decision this side already made, and the request stays approved.
+TASK_ID=$(api GET /ScheduledTasks | python3 -c '
+import json, sys
+mine = [task for task in json.load(sys.stdin) if task.get("Key") == "RequestsBridgeReconciliation"]
+if len(mine) != 1:
+    sys.exit("the server lists {0} reconciliation task(s).".format(len(mine)))
+print(mine[0]["Id"])
+')
+echo "task $TASK_ID"
+api POST "/ScheduledTasks/Running/$TASK_ID"
+for _ in $(seq 1 60); do
+    if api GET "/ScheduledTasks/$TASK_ID" | python3 -c '
+import json, sys
+task = json.load(sys.stdin)
+sys.exit(0 if task.get("State") == "Idle" and task.get("LastExecutionResult") else 1)
+' 2>/dev/null; then
+        break
+    fi
+    sleep 1
+done
+api GET "/ScheduledTasks/$TASK_ID" | python3 -c '
+import json, sys
+task = json.load(sys.stdin)
+result = task.get("LastExecutionResult") or {}
+print("State={0}  LastExecutionResult.Status={1}  StartTimeUtc={2}  EndTimeUtc={3}".format(
+    task.get("State"), result.get("Status"), result.get("StartTimeUtc"), result.get("EndTimeUtc")))
+if task.get("State") != "Idle" or not result:
+    sys.exit("the reconciliation did not finish in the time given.")
+if result.get("Status") != "Completed":
+    sys.exit("the reconciliation ended {0!r}: {1}".format(result.get("Status"), result.get("ErrorMessage")))
+'
+
+step "the request is where the table says APPROVED leaves it"
+api GET "$prefix/Requests/Queue?take=200" | REQUEST_ID="$REQUEST_ID" REFERENCE="$REFERENCE" python3 -c "$PYFIELD"'
+import json, os, sys
+rows = [row for row in field(json.load(sys.stdin), "requests") if str(field(row, "id")) == os.environ["REQUEST_ID"]]
+if len(rows) != 1:
+    sys.exit("the queue holds {0} row(s) for the request.".format(len(rows)))
+row = rows[0]
+state = field(row, "state")
+backend = field(row, "backend") or {}
+print("state={0}  backend={1}  handoverFailedAt={2}".format(state, json.dumps(backend), field(row, "handoverFailedAt")))
+if str(state).lower() != "approved":
+    sys.exit("the request is {0!r} after the reconciliation, and APPROVED moves nothing.".format(state))
+if str(field(backend, "id")) != os.environ["REFERENCE"]:
+    sys.exit("the reference moved to {0!r}.".format(field(backend, "id")))
+'
+api GET "$prefix/Health" | python3 -c "$PYFIELD"'
+import json, sys
+health = json.load(sys.stdin)
+print("Bridge={0}  BridgeLastReachableAt={1}".format(field(health, "bridge"), field(health, "bridgeLastReachableAt")))
+if field(health, "bridgeLastReachableAt") is None:
+    sys.exit("nothing recorded the service as reachable, after the health endpoint and the reconciliation both asked it.")
+'
+
+step "done"
+echo "one request from a person on $image ($framework) arrived on Jellyseerr $SERVICE_VERSION as request $REFERENCE, approved, and the reconciliation read it back through the table"

--- a/scripts/verify-bridge-round-trip.sh
+++ b/scripts/verify-bridge-round-trip.sh
@@ -36,6 +36,12 @@
 # paths - a refused key, a service that goes away, a word the table has not seen - are the suite's
 # and #86's, not this script's.
 #
+# ONE SERVER SETTING IS TURNED ON FOR THE SERVICE, AND THE TRANSCRIPT SAYS WHETHER IT WAS OFF. The
+# pinned service names its client in the `X-Emby-Authorization` header, which a 12.0 server reads
+# only while `EnableLegacyAuthorization` is on, and it is off there by default. The first run of this
+# met that as a 400 on the service's sign-in. The step that turns it on is the same thing an operator
+# on that line does, and it is a fact about the pair of versions rather than about this plugin.
+#
 # The server, the install, the wizard and the administrator account are scripts/server-under-test.sh,
 # which the other container checks source too. Everything else is this script's own, lives for the
 # length of two containers, and is reachable only from loopback ports.
@@ -260,6 +266,36 @@ if not user["Policy"].get("IsAdministrator"):
 print("{0} ({1}) is an administrator".format(user.get("Name"), user.get("Id")))
 '
 
+step "let the server read the header the service signs in with"
+# Jellyseerr 2.7.3 names its client in `X-Emby-Authorization`, which a 10.11 server reads and a 12.0
+# server reads only while `EnableLegacyAuthorization` is on; it is off by default there, and a
+# sign-in with no client named is refused with 400 before a password is looked at. So the switch is
+# turned on where the server has it, and the transcript says which it found. An operator on the 12.0
+# line meets the same wall with this version of the service and turns the same switch.
+system=$(api GET /System/Configuration)
+printf '%s' "$system" | python3 -c '
+import json, sys
+configuration = json.load(sys.stdin)
+if "EnableLegacyAuthorization" not in configuration:
+    print("the server has no EnableLegacyAuthorization setting; nothing to turn on")
+else:
+    print("EnableLegacyAuthorization was {0}".format(configuration["EnableLegacyAuthorization"]))
+'
+if printf '%s' "$system" | python3 -c 'import json, sys; sys.exit(0 if json.load(sys.stdin).get("EnableLegacyAuthorization") is False else 1)'; then
+    api POST /System/Configuration "$(printf '%s' "$system" | python3 -c '
+import json, sys
+configuration = json.load(sys.stdin)
+configuration["EnableLegacyAuthorization"] = True
+print(json.dumps(configuration))
+')"
+    api GET /System/Configuration | python3 -c '
+import json, sys
+if json.load(sys.stdin).get("EnableLegacyAuthorization") is not True:
+    sys.exit("EnableLegacyAuthorization is still off after being written.")
+print("EnableLegacyAuthorization is on now")
+'
+fi
+
 step "the service's first sign-in, which creates its administrator"
 # Its own route: username and password against the server it is told about, and the first user it
 # ever sees becomes its administrator. The port and the empty base path are written out rather than
@@ -360,7 +396,15 @@ created=$(as "$ASKER_TOKEN" POST "$prefix/Requests" "$(printf '{
 }' "$TITLE" "$YEAR" "$TMDB_ID")")
 printf '%s\n' "$created"
 REQUEST_ID=$(printf '%s' "$created" | python3 -c "$FIELD" id)
-REVISION=$(printf '%s' "$created" | python3 -c "$FIELD" revision)
+# The creation answers with the identifier and the outcome and not the row, so the revision an
+# operator decides against is read off the queue, which is where an operator reads it too.
+REVISION=$(api GET "$prefix/Requests/Queue?take=200" | REQUEST_ID="$REQUEST_ID" python3 -c "$PYFIELD"'
+import json, os, sys
+rows = [row for row in field(json.load(sys.stdin), "requests") if str(field(row, "id")) == os.environ["REQUEST_ID"]]
+if len(rows) != 1:
+    sys.exit("the queue holds {0} row(s) for the request just made.".format(len(rows)))
+print(field(rows[0], "revision"))
+')
 echo "request $REQUEST_ID at revision $REVISION"
 
 step "the administrator approves it, which is the handover"


### PR DESCRIPTION
Closes #315. Its last clause asks for a round trip against a real instance rather than a stub alone, with the transcript in the pull request body; everything else the issue asks for landed in #376, and the transcript is below.

### What the failure was, before

Nothing in this tree had ever called a service of the Overseerr form. Every leg drives the adapter through `AnOverseerrService`, an in-process double whose answers are the shapes `docs/bridge.md` quotes out of the form's description, and that page says twice what a description is worth against an instance: the two already disagree about the request-status alphabet. So an adapter that posted the wrong field name, or read the wrong one back, would stay green here for as long as the double agreed with it, and the first reader to find out would be an operator with a real service. The throwaway run below is exactly that defect, and it is red.

### The means

Bash and Python inside it, under `scripts/`, sourcing `scripts/server-under-test.sh` as the other container checks do, and one workflow in the shape of `user-isolation.yaml`. No language, runtime or package is added to the tree; the runner already has docker, curl and python3. The service is a container of Jellyseerr pinned by tag and digest in the script, so a moved tag is a failed pull rather than a different service measured under the same name.

### What is built

- **`scripts/verify-bridge-round-trip.sh`** starts a Jellyfin of one claimed line with the plugin installed, puts it on a network of its own, starts Jellyseerr beside it, makes a second administrator on the Jellyfin for the service to sign in with, turns `EnableLegacyAuthorization` on where the server has it, walks Jellyseerr's own `/auth/jellyfin` first sign-in, reads the key it issued through that session, finishes its setup, points the plugin at it through the server's own configuration route, and reads the plugin's health and capabilities back. Then a person asks for a film by TMDB number, an operator approves it, the approval's answer is checked for the service's own number, the service is asked what it holds under that number, the reconciliation task is run, and the request is read here again.
- **`.github/workflows/bridge-round-trip.yaml`** runs it on both lines, on a pull request or a push touching the bridge, the configuration, the procedure or the shared server scripts, nightly, and on demand. Not on every pull request: it pulls a third party's image and Jellyseerr fetches the film's metadata from TMDB, which are two outbound dependencies more than the other container checks carry.
- **`docs/bridge.md`, `docs/testing.md` and `docs/quality-parity.md`** say what the run measured and what it did not, name the procedure beside the double it does not replace, and carry the workflow's two rows.

### The transcript

Run `33731657684`, the push run on `234daed`, jobs `100572739356` for 10.11 and `100572739618` for 12.0; the pull-request run on the same head, `33731661807`, is green as well. Everything below is the 10.11 job's own lines, with the image pull left out; the 12.0 job reads the same except for the one line marked.

    == start the service from fallenbagel/jellyseerr:2.7.3@sha256:4538137bc5af902dece165f2bf73776d9cf4eafb6dd714670724af8f3eb77764
    == wait for the service to answer
    {"version":"2.7.3","commitTag":"$GIT_SHA","updateAvailable":true,"commitsBehind":0,"restartRequired":false}
    the service is up at version 2.7.3
    == an administrator account on the server for the service to sign in with
    bridge-check-service (e1147fb9f60f4a8a93cffa8afdd6975b) is an administrator
    == let the server read the header the service signs in with
    EnableLegacyAuthorization was True                       (12.0: was False, then "EnableLegacyAuthorization is on now")
    == the service's first sign-in, which creates its administrator
    the service made user id=1 permissions=2 for Jellyfin user 'bridge-check-service'
    == read the key the service issued, and finish its setup
    the service issued a key of 68 characters
    the service reports initialized
    == the key opens the service's own request list, which its status route does not need
    the service holds 0 request(s) before anything is handed over
    == point the plugin at the service
    BridgeAddress=http://jellyseerr:5055  BridgeApiKey=set, 68 characters  BridgeAccounts=0 row(s)
    == the plugin reports the bridge reachable
    Bridge=Reachable  BridgeLastReachableAt=2026-09-03T08:09:19.9028509+00:00
    BridgeConfigured=True
    == a person asks for a film
    {"Id":"fdb3db80479d4aa0882168a702922268","State":"Open","Outcome":"Created"}
    request fdb3db80479d4aa0882168a702922268 at revision 1
    == the administrator approves it, which is the handover
    {"Id":"fdb3db80479d4aa0882168a702922268","Revision":3,"RequestedByUserId":"77b76c47b4e54f92aef0e0976965db22","JoinedByUserIds":[],"Kind":"Movie","DisplayTitle":"Fight Club","DisplayYear":1999,"ProviderIds":{"Tmdb":"550"},"Seasons":[],"State":"Approved","RequestedAt":"2026-09-03T08:09:20.3981058+00:00","StateChangedAt":"2026-09-03T08:09:20.6630302+00:00","StateChangedByUserId":"9392bda8e6004746853c48983851ebce","Availability":"Unknown","Backend":{"Service":"overseerr","Id":"1"}}
    the service called it 1
    == what the service holds under that number
    id=1  type=movie  status=2  media.tmdbId=550  media.status=3  requestedBy.id=1  createdAt=2026-09-03T08:09:20.000Z
    the service holds the film under its own number, approved
    the service lists exactly that one request
    == the reconciliation asks the service and reads the answer through the table
    task d3c304a764bbe55b7f024c26be75eec9
    State=Idle  LastExecutionResult.Status=Completed  StartTimeUtc=2026-09-03T08:09:21.1615899Z  EndTimeUtc=2026-09-03T08:09:21.2100488Z
    == the request is where the table says APPROVED leaves it
    state=Approved  backend={"Service": "overseerr", "Id": "1"}  handoverFailedAt=None
    Bridge=Reachable  BridgeLastReachableAt=2026-09-03T08:09:22.3025511+00:00
    == done
    one request from a person on jellyfin/jellyfin:10.11.11 (net9.0) arrived on Jellyseerr 2.7.3 as request 1, approved, and the reconciliation read it back through the table

What the service itself wrote while that happened, out of the same job:

    [API]: Sign-in attempt from Jellyfin user with access to the media server; creating initial admin user for Jellyseerr {"ip":"::ffff:172.18.0.1","jellyfinUsername":"bridge-check-service"}
    [Media Request]: No Radarr server configured, skipping request processing {"requestId":1,"mediaId":1}
    [Notifications]: Sending notification(s) for MEDIA_AUTO_APPROVED {"subject":"Fight Club (1999)"}

The command that produces the lines above, for a reader who wants them from the run rather than from this body:

    gh run view 33731657684 --repo Flowfin/jellyfin-plugin-requests --log | grep -F "round trip 10.11" | sed 's/^[^\t]*\t[^\t]*\t//' | grep -a "^== \|^the service\|^state=\|^id=\|^Bridge"

### What the transcript states, in its own words

- **The submission's field names are the ones a real service takes**, and the number it answers with is the one this side keeps: `Backend":{"Service":"overseerr","Id":"1"}` here, `id=1` there.
- **The service holds a `movie` with `media.tmdbId=550` at `status=2`.** Two is what `OverseerrWords` turns into `APPROVED` and the mapping table holds as inert. The request arrives under the service's administrator, `requestedBy.id=1`, because no mapping row names the person who asked, and the form's description says an administrator's request is approved on arrival. `media.status=3` is `PROCESSING` in the form's own enumeration and is read by nothing here.
- **After the reconciliation the request is still approved here** with the same reference, and the health endpoint carries a moment the service was last reachable. `APPROVED` moving nothing is the table doing its job.
- **The key was accepted** on a route that refuses without one, before anything was handed over with it. `Reachable` from the plugin still means only that the status route answered, which `docs/bridge.md` records as the bound, and this does not widen it.

### Why Jellyseerr and not Overseerr proper

The note of 30.08. on #315 read Overseerr's description and found that its only route creating the first user takes a Plex account token, which is a credential somebody would have to hold as a secret on this board. Jellyseerr speaks the same form and its `/auth/jellyfin` route creates the first user from a Jellyfin username and password, checked against the Jellyfin it is told about, so the credential is one the job makes on a throwaway server and forgets with it. That is the decision written on the issue on 02.09., and this is it built. Whether Overseerr proper behaves the same is not measured and not claimed.

### What the first two runs found

- **Run `33730767209`, on `49af229`, red on both lines for two different reasons.** On 10.11 the creation answer carries the identifier and the outcome and no revision, so the approval had nothing to decide against; the revision is now read off the queue row. On 12.0 the service's own sign-in was refused with `400` before the password was looked at: Jellyseerr 2.7.3 names its client in `X-Emby-Authorization`, and a 12.0 server reads that header only while `EnableLegacyAuthorization` is on, which is off there by default and on by default on 10.11. Read off the server's own source rather than guessed: `ServerConfiguration.cs` at `v12.0-rc4` declares the property with no initialiser and at `v10.11.11` with `= true`, and `SessionManager.cs` at `v12.0-rc4` throws on an empty client name. The procedure now turns the switch on where the server has it and prints what it found. An operator on the 12.0 line with this version of the service meets the same wall, which is a note the operator guide owes and is filed as its own issue rather than carried here.
- **Run `33731344403`, on `e471f53`, red on both lines at the approval's verdict** while the service's own log already showed the request auto-approved: the server leaves a null field out of the row and the lookup treated the absent failed-handover mark as a defect in the row. The two nullable fields are read as absent-or-value now.

### Each guard was watched biting

**The check itself, against a real defect of the class it exists for.** `throwaway/315-a-submission-in-the-wrong-field`, at `0164cb3`, posts the TMDB number as `tmdbId` rather than `mediaId`, which the double would have accepted without a word. Run `33732017937`, both lines red at the approval:

    the handover failed at 2026-09-03T08:13:35.2184351+00:00: the approval stands and the service has nothing.
    [ERR] Jellyfin.Plugin.Requests.Bridge.BridgeSubmission: Request 66119581-b031-4f28-9505-83e7bd47964a was approved and could not be handed to the external request service. The approval stands and nothing was undone; it carries no reference, so it has not been fetched and can be submitted again.
    System.Net.Http.HttpRequestException: The external request service answered 400 to the submission of request 66119581-b031-4f28-9505-83e7bd47964a. The body of that answer is not quoted, because it is whatever the thing at that address chose to send.

    gh api repos/Flowfin/jellyfin-plugin-requests/actions/runs/33732017937/jobs --jq '.jobs[] | "\(.name)\t\(.conclusion)\t\([.steps[]|select(.conclusion=="failure")|.name]|join("; "))"'
    round trip 12.0     failure Does a request made here arrive on the service
    round trip 10.11    failure Does a request made here arrive on the service

That branch is a throwaway head and never a landing; it stays because nothing here deletes a branch that is not a merged head.

**`EveryWorkflowInTheTreeHasARowInTheParityDocument`**, with the row for the new workflow removed from `docs/quality-parity.md` and the file restored byte for byte afterwards:

    dotnet test Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj -c Release -f net9.0 --filter "FullyQualifiedName~RepositoryDocumentsTests"
    Jellyfin.Plugin.Requests.Tests.RepositoryDocumentsTests.EveryWorkflowInTheTreeHasARowInTheParityDocument [FAIL]
    Fehler!      : Fehler:     1, erfolgreich:    14, übersprungen:     0, gesamt:    15

    the row back
    Bestanden!   : Fehler:     0, erfolgreich:    15, übersprungen:     0, gesamt:    15

### What is not claimed

- **Nothing was run on this machine.** Docker is not running here and starting it is not something to do on somebody's workstation unasked, so the procedure was read, syntax-checked with `bash -n`, and handed to the runner; the runs above are the evidence.
- **Overseerr proper was not exercised**, for the reason above. If a Plex-backed Overseerr round trip is ever wanted, that is a clause of its own on a later issue.
- **No failure path is walked by the green run.** A refused key, a service that goes away and a word the table has not seen are the suite's legs and #86's question; the one failure a run has shown is the refused submission on the throwaway head.
- **Nothing downstream of the service is exercised.** It has no download client, its own log says the request is skipped, and no library here ever fills.
- **The three pages stop saying nothing here has called a service, and each still says what has not been seen from one**: no fixture captured from a service, five of the six words never reported by one, no service ever having moved a request, and the description-reading section untouched. A sentence that was a negative disclosure is not softened anywhere; it is replaced by the measurement and the remainder that stays negative.
- **The Prettier check was run on the three pages this change touches**, inside the tree, and its output is byte-identical to each page once the checkout's CRLF is set aside; the repo-wide `--check` on this machine reports every untouched page for the same line endings and the job runs on a checkout that has neither.

### What had no second reader

Nobody else read this. Every command above was run before the sentence resting on it, and the run numbers are the runs rather than a description of them.
