### PR TITLE
Decide what happens when the service misbehaves, and tell the operator which of the four it is

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Api/CapabilityEndpointTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Api/CapabilityEndpointTests.cs
@@ -116,6 +116,8 @@ public class CapabilityEndpointTests
     [InlineData(BackendReachability.NotConfigured, false)]
     [InlineData(BackendReachability.Reachable, true)]
     [InlineData(BackendReachability.Unreachable, true)]
+    [InlineData(BackendReachability.CredentialRefused, true)]
+    [InlineData(BackendReachability.Incompatible, true)]
     public async Task ABridgeIsReportedWhenThereIsOneAndNeverHowItIsConfigured(
         BackendReachability reachability,
         bool expected)

--- a/Jellyfin.Plugin.Requests.Tests/Bridge/Overseerr/OverseerrBackendTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Bridge/Overseerr/OverseerrBackendTests.cs
@@ -63,8 +63,11 @@ public sealed class OverseerrBackendTests
     }
 
     /// <summary>
-    /// The status route answering is what reachable means, and it is asked at the form's own path
-    /// under the address the operator wrote, with the credential in the header the form reads.
+    /// The status route is asked first, at the form's own path under the address the operator
+    /// wrote, with the credential in the header the form reads, and a service that answers it with a
+    /// version this adapter knows is asked whether the key is accepted next. Both answering is what
+    /// reachable means; what each failure on the way is instead is
+    /// <c>WhenTheServiceMisbehavesTests</c>.
     /// </summary>
     /// <returns>A task that completes when the assertions have run.</returns>
     [Fact]
@@ -76,10 +79,12 @@ public sealed class OverseerrBackendTests
         var reachability = await backend.CheckReachableAsync(CancellationToken.None).ConfigureAwait(true);
 
         Assert.Equal(BackendReachability.Reachable, reachability);
-        var call = Assert.Single(service.Calls);
+        Assert.Equal(2, service.Calls.Count);
+        var call = service.Calls[0];
         Assert.Equal(HttpMethod.Get, call.Method);
         Assert.Equal("/api/v1/status", call.Path);
         Assert.Equal(Key, call.Key);
+        Assert.Equal("/api/v1/auth/me", service.Calls[1].Path);
     }
 
     /// <summary>
@@ -93,12 +98,13 @@ public sealed class OverseerrBackendTests
     [InlineData(Address + "/")]
     public async Task ATrailingSlashOnTheAddressChangesNothing(string written)
     {
-        var service = AnOverseerrService.ThatAnswers(HttpStatusCode.OK);
+        var service = AnOverseerrService.ThatAnswers(HttpStatusCode.OK, "{\"version\":\"2.7.3\"}");
         using var backend = Backend(service, Configured(configuration => configuration.BridgeAddress = written));
 
         await backend.CheckReachableAsync(CancellationToken.None).ConfigureAwait(true);
 
-        Assert.Equal(Address + "/api/v1/status", Assert.Single(service.Calls).Address?.ToString());
+        Assert.Equal(Address + "/api/v1/status", service.Calls[0].Address?.ToString());
+        Assert.Equal(Address + "/api/v1/auth/me", service.Calls[1].Address?.ToString());
     }
 
     /// <summary>
@@ -337,7 +343,8 @@ public sealed class OverseerrBackendTests
     /// credential or the body of the answer. The status is what an operator acts on: a refused key
     /// and a service that fell over are two different numbers, which is why #35 names the 401 and
     /// the 500 as two cases for a client that reads an answer. What is done with the difference is
-    /// #86; what is asserted here is that the difference survives to the caller.
+    /// decided on #86 and held in <c>WhenTheServiceMisbehavesTests</c>; what is asserted here is
+    /// that the difference survives to the caller.
     /// </summary>
     /// <param name="status">What the service answered.</param>
     /// <param name="digits">The same status as the digits the sentence has to carry.</param>
@@ -517,16 +524,17 @@ public sealed class OverseerrBackendTests
     }
 
     /// <summary>
-    /// Across all four calls the credential is in the header and nowhere else: not in an address,
+    /// Across all five calls the credential is in the header and nowhere else: not in an address,
     /// not in a body. This is the guard that keeps the platform's own exception, which names the
     /// destination, from carrying the key into a log, and it is asserted over every call rather
-    /// than the one somebody thought of.
+    /// than the one somebody thought of. The status answer carries a version so the check goes on
+    /// to ask about the key, which is the fifth call and the one this leg would otherwise not see.
     /// </summary>
     /// <returns>A task that completes when the assertions have run.</returns>
     [Fact]
     public async Task NoCallCarriesTheKeyAnywhereButTheHeader()
     {
-        var service = AnOverseerrService.ThatAnswers(HttpStatusCode.OK, "{\"id\":1,\"status\":2}");
+        var service = AnOverseerrService.ThatAnswers(HttpStatusCode.OK, "{\"id\":1,\"status\":2,\"version\":\"2.7.3\"}");
         using var backend = Backend(service);
 
         await backend.CheckReachableAsync(CancellationToken.None).ConfigureAwait(true);
@@ -534,7 +542,7 @@ public sealed class OverseerrBackendTests
         await backend.ReportAsync(Issued("1"), CancellationToken.None).ConfigureAwait(true);
         await backend.WithdrawAsync(Issued("1"), CancellationToken.None).ConfigureAwait(true);
 
-        Assert.Equal(4, service.Calls.Count);
+        Assert.Equal(5, service.Calls.Count);
         Assert.All(service.Calls, call =>
         {
             Assert.Equal(Key, call.Key);

--- a/Jellyfin.Plugin.Requests.Tests/Bridge/Overseerr/WhenTheServiceMisbehavesTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/Bridge/Overseerr/WhenTheServiceMisbehavesTests.cs
@@ -1,0 +1,451 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Requests.Api;
+using Jellyfin.Plugin.Requests.Bridge;
+using Jellyfin.Plugin.Requests.Bridge.Overseerr;
+using Jellyfin.Plugin.Requests.Configuration;
+using Jellyfin.Plugin.Requests.Fulfilment;
+using Jellyfin.Plugin.Requests.Localisation;
+using Jellyfin.Plugin.Requests.Model;
+using Jellyfin.Plugin.Requests.Storage;
+using Jellyfin.Plugin.Requests.Tests.Doubles;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Jellyfin.Plugin.Requests.Tests.Bridge.Overseerr;
+
+/// <summary>
+/// What happens when the service misbehaves, which is #86: the four failures its body names, each
+/// driven through the real adapter and the real submission or reconciliation path against the
+/// in-process service from #35, so that what is measured is the behaviour an operator gets and not
+/// a double agreeing with itself.
+/// <para>
+/// The four are a service that does not answer, a service that refuses this server's key, a service
+/// reporting a version this adapter does not know, and a title the service has never heard of. The
+/// first is temporary and is asked again; the second and third stop the reconciliation and are said
+/// at error; the fourth is a fact about one request. Every leg reads the store back afterwards,
+/// which is the second condition of #86: no failure of the service loses a request or moves it.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit discovers tests on public classes only, so internal would silently run nothing.")]
+public sealed class WhenTheServiceMisbehavesTests
+{
+    private const string Address = "https://requests.nobody-else-names.invalid";
+    private const string Key = "THE-KEY-THAT-AUTHENTICATES-THIS-SERVER";
+    private const string StatusRoute = "/api/v1/status";
+    private const string MeRoute = "/api/v1/auth/me";
+    private const string RequestRoute = "/api/v1/request";
+    private const string Refusal = "{\"status\":403,\"error\":\"You do not have permission to access this endpoint\"}";
+
+    private static readonly Guid Asker = new Guid("86000000-0000-0000-0000-000000000001");
+    private static readonly DateTimeOffset Noon = new DateTimeOffset(2026, 9, 3, 12, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset Later = Noon.AddHours(1);
+
+    /// <summary>
+    /// A service that is up, reports a major version this adapter knows, and accepts the key is
+    /// reachable, and finding that out is two calls in that order with the credential on both. The
+    /// two versions are the two lines the adapter was written against.
+    /// </summary>
+    /// <param name="version">What the status route reports.</param>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Theory]
+    [InlineData("1.33.2")]
+    [InlineData("2.7.3")]
+    public async Task AServiceThatIsUpWithAKnownVersionAndAnAcceptedKeyIsReachable(string version)
+    {
+        var service = AService(version);
+        using var backend = Backend(service);
+
+        var reachability = await backend.CheckReachableAsync(CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Equal(BackendReachability.Reachable, reachability);
+        Assert.Equal([StatusRoute, MeRoute], service.Calls.Select(call => call.Path).ToArray());
+        Assert.All(service.Calls, call => Assert.Equal(Key, call.Key));
+    }
+
+    /// <summary>
+    /// A service that refuses the key is the refused-credential state, said once at error, without
+    /// the key and without the body the service answered with. The status route takes no credential,
+    /// so this is the answer that route could never give, and the form answers it with 403; 401 is
+    /// read the same way for a proxy that answers first.
+    /// </summary>
+    /// <param name="refused">How the service refuses.</param>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Theory]
+    [InlineData(HttpStatusCode.Forbidden)]
+    [InlineData(HttpStatusCode.Unauthorized)]
+    public async Task AServiceThatRefusesTheKeyIsCredentialRefusedAndTheLogSaysSoWithoutTheKey(HttpStatusCode refused)
+    {
+        var log = new RecordingLogger();
+        var service = AService(me: refused);
+        using var backend = Backend(service, log);
+
+        var reachability = await backend.CheckReachableAsync(CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Equal(BackendReachability.CredentialRefused, reachability);
+        Assert.Equal([StatusRoute, MeRoute], service.Calls.Select(call => call.Path).ToArray());
+
+        var said = Assert.Single(log.At(LogLevel.Error));
+        Assert.Contains("refused this server's key", said.Message, StringComparison.Ordinal);
+        Assert.All(log.Lines, line => Assert.DoesNotContain(Key, Written(line), StringComparison.Ordinal));
+        Assert.All(log.Lines, line => Assert.DoesNotContain("You do not have permission", Written(line), StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// A version this adapter does not know is the incompatible state, and the key is not even
+    /// tried: a service of a form this adapter was never read against is not asked anything else.
+    /// A major outside the known list, a development build that names itself with a word first, a
+    /// status answer with no version in it, and a version that is not text are all that state.
+    /// </summary>
+    /// <param name="status">What the status route answers.</param>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Theory]
+    [InlineData("{\"version\":\"3.0.0\"}")]
+    [InlineData("{\"version\":\"develop-1a2b3c4\"}")]
+    [InlineData("{\"commitTag\":\"local\"}")]
+    [InlineData("{\"version\":42}")]
+    public async Task AVersionThisAdapterDoesNotKnowIsIncompatibleAndTheKeyIsNotEvenTried(string status)
+    {
+        var log = new RecordingLogger();
+        var service = AnOverseerrService.ThatAnswersWith(call => call.Path == StatusRoute
+            ? AnOverseerrService.Json(HttpStatusCode.OK, status)
+            : AnOverseerrService.Json(HttpStatusCode.OK, "{\"id\":1}"));
+        using var backend = Backend(service, log);
+
+        var reachability = await backend.CheckReachableAsync(CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Equal(BackendReachability.Incompatible, reachability);
+        Assert.Equal([StatusRoute], service.Calls.Select(call => call.Path).ToArray());
+
+        var said = Assert.Single(log.At(LogLevel.Error));
+        Assert.Contains("version", said.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("develop", said.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Every major the adapter declares it knows is one the check accepts, so the list and the check
+    /// cannot drift apart; a change to one without the other reds here.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task EveryMajorTheAdapterDeclaresIsOneTheCheckAccepts()
+    {
+        Assert.NotEmpty(OverseerrBackend.KnownMajorVersions);
+
+        foreach (var major in OverseerrBackend.KnownMajorVersions)
+        {
+            using var backend = Backend(AService(major + ".0.0"));
+
+            Assert.Equal(BackendReachability.Reachable, await backend.CheckReachableAsync(CancellationToken.None).ConfigureAwait(true));
+        }
+    }
+
+    /// <summary>
+    /// A service that is down is unreachable, the run walks nothing and says so at warning, and the
+    /// next run asks again and gets on with it: nothing remembers the service as down, so it recovers
+    /// without anybody acting. That is the whole of what "retried with a bound" means here, and the
+    /// bound is the one every call carries. Between the two runs the request is exactly as it was.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AServiceThatIsDownIsUnreachableAndIsAskedAgainOnTheNextRun()
+    {
+        var down = true;
+        var log = new RecordingLogger();
+        var store = new InMemoryRequestStore();
+        var handedOver = await AHandedOverRequestAsync(store, "1").ConfigureAwait(true);
+        var service = AnOverseerrService.ThatAnswersWith(call => down
+            ? throw new HttpRequestException("There is nothing listening at that address. (requests.nobody-else-names.invalid:443)")
+            : Answer(call, reporting: new Dictionary<string, string> { ["1"] = "{\"id\":1,\"status\":4}" }));
+        using var backend = Backend(service, log);
+
+        var first = await ReconcilingAsync(store, backend, log).ConfigureAwait(true);
+        var between = await Held(store, handedOver.Request.Id).ConfigureAwait(true);
+
+        Assert.False(first.Asked);
+        Assert.Equal(BackendReachability.Unreachable, first.Reachability);
+        Assert.Equal(RequestState.Approved, between.Request.State);
+        Assert.Equal(handedOver.Request.Backend, between.Request.Backend);
+        Assert.Equal(handedOver.Revision, between.Revision);
+        Assert.Contains(log.At(LogLevel.Warning), line => line.Message.Contains("next run will ask again", StringComparison.Ordinal));
+        Assert.Empty(log.At(LogLevel.Error));
+
+        down = false;
+
+        var second = await ReconcilingAsync(store, backend, log).ConfigureAwait(true);
+        var after = await Held(store, handedOver.Request.Id).ConfigureAwait(true);
+
+        Assert.True(second.Asked);
+        Assert.Equal(1, second.Examined);
+        Assert.Equal(1, second.Moved);
+        Assert.Equal(RequestState.Failed, after.Request.State);
+    }
+
+    /// <summary>
+    /// A refused key stops the run: nothing is asked about any request, the run says so at error
+    /// rather than warning, and every handed-over request is left exactly as it was, revision
+    /// included. The service is told to say the one word that moves a request, so a run that asked
+    /// would have moved it.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ARefusedKeyStopsTheRunAtErrorAndLeavesEveryHandedOverRequestAsItIs()
+    {
+        var log = new RecordingLogger();
+        var store = new InMemoryRequestStore();
+        var handedOver = await AHandedOverRequestAsync(store, "1").ConfigureAwait(true);
+        var service = AService(me: HttpStatusCode.Forbidden, reporting: new Dictionary<string, string> { ["1"] = "{\"id\":1,\"status\":4}" });
+        using var backend = Backend(service, log);
+
+        var report = await ReconcilingAsync(store, backend, log).ConfigureAwait(true);
+        var held = await Held(store, handedOver.Request.Id).ConfigureAwait(true);
+
+        Assert.False(report.Asked);
+        Assert.Equal(BackendReachability.CredentialRefused, report.Reachability);
+        Assert.Equal([StatusRoute, MeRoute], service.Calls.Select(call => call.Path).ToArray());
+        Assert.Equal(RequestState.Approved, held.Request.State);
+        Assert.Equal(handedOver.Revision, held.Revision);
+        Assert.Contains(log.At(LogLevel.Error), line => line.Message.Contains("nothing will be until the key is corrected", StringComparison.Ordinal));
+        Assert.Empty(log.At(LogLevel.Warning));
+        Assert.All(log.Lines, line => Assert.DoesNotContain(Key, Written(line), StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// A version the adapter does not know stops the run the same way a refused key does, as an
+    /// incompatibility said at error, with nothing asked and nothing moved.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AnUnknownVersionStopsTheRunAsAnIncompatibility()
+    {
+        var log = new RecordingLogger();
+        var store = new InMemoryRequestStore();
+        var handedOver = await AHandedOverRequestAsync(store, "1").ConfigureAwait(true);
+        var service = AService("3.0.0", reporting: new Dictionary<string, string> { ["1"] = "{\"id\":1,\"status\":4}" });
+        using var backend = Backend(service, log);
+
+        var report = await ReconcilingAsync(store, backend, log).ConfigureAwait(true);
+        var held = await Held(store, handedOver.Request.Id).ConfigureAwait(true);
+
+        Assert.False(report.Asked);
+        Assert.Equal(BackendReachability.Incompatible, report.Reachability);
+        Assert.Equal([StatusRoute], service.Calls.Select(call => call.Path).ToArray());
+        Assert.Equal(RequestState.Approved, held.Request.State);
+        Assert.Equal(handedOver.Revision, held.Revision);
+        Assert.Contains(log.At(LogLevel.Error), line => line.Message.Contains("version this plugin does not know", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// A title the service has never heard of fails that one handover and no other. The form answers
+    /// such a submission with a 500 carrying its TMDB client's message, which <c>docs/bridge.md</c>
+    /// reads off the route; here the first request is marked as one whose handover failed, with the
+    /// approval standing and no reference, and the next approval is handed over as if nothing had
+    /// happened. The service's own sentence is in no log line, because it is whatever the thing at
+    /// that address chose to send.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task ATitleTheServiceDoesNotKnowFailsThatHandoverAndTheNextOneGoesThrough()
+    {
+        var log = new RecordingLogger();
+        var store = new InMemoryRequestStore();
+        var unknown = await store.AddAsync(AFilm(new Guid("86000000-0000-0000-0000-0000000000aa"), tmdb: "603"), CancellationToken.None).ConfigureAwait(true);
+        var known = await store.AddAsync(AFilm(new Guid("86000000-0000-0000-0000-0000000000bb"), tmdb: "550"), CancellationToken.None).ConfigureAwait(true);
+        var service = AnOverseerrService.ThatAnswersWith(call => call.Body.Contains("603", StringComparison.Ordinal)
+            ? AnOverseerrService.Json(HttpStatusCode.InternalServerError, "{\"status\":500,\"message\":\"[TMDB] Failed to fetch movie details: 404\"}")
+            : AnOverseerrService.Json(HttpStatusCode.Created, "{\"id\":9,\"status\":2}"));
+        using var backend = Backend(service, log);
+        var submission = new BridgeSubmission(backend, store, new TestClock(Noon), log);
+
+        var refused = await submission.SubmitAsync(unknown, CancellationToken.None).ConfigureAwait(true);
+        var accepted = await submission.SubmitAsync(known, CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Equal(RequestState.Approved, refused.Request.State);
+        Assert.Null(refused.Request.Backend);
+        Assert.Equal(Noon, refused.Request.HandoverFailedAt);
+        Assert.Equal("9", accepted.Request.Backend?.Id);
+        Assert.Null(accepted.Request.HandoverFailedAt);
+        Assert.Equal(2, service.Calls.Count(call => call.Path == RequestRoute));
+
+        var said = Assert.Single(log.At(LogLevel.Error));
+        Assert.Contains(unknown.Request.Id.ToString("D"), said.Message, StringComparison.Ordinal);
+        Assert.All(log.Lines, line => Assert.DoesNotContain("[TMDB]", Written(line), StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// A reference the service no longer knows is a fact about that one request: it is left exactly
+    /// as it is, and the others in the same run still move on what the service says about them.
+    /// </summary>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Fact]
+    public async Task AReferenceTheServiceNoLongerKnowsLeavesThatRequestAloneAndTheOthersStillMove()
+    {
+        var log = new RecordingLogger();
+        var store = new InMemoryRequestStore();
+        var forgotten = await AHandedOverRequestAsync(store, "1").ConfigureAwait(true);
+        var remembered = await AHandedOverRequestAsync(store, "2").ConfigureAwait(true);
+        var service = AService(reporting: new Dictionary<string, string> { ["2"] = "{\"id\":2,\"status\":4}" });
+        using var backend = Backend(service, log);
+
+        var report = await ReconcilingAsync(store, backend, log).ConfigureAwait(true);
+        var left = await Held(store, forgotten.Request.Id).ConfigureAwait(true);
+        var moved = await Held(store, remembered.Request.Id).ConfigureAwait(true);
+
+        Assert.True(report.Asked);
+        Assert.Equal(2, report.Examined);
+        Assert.Equal(1, report.Moved);
+        Assert.Equal(RequestState.Approved, left.Request.State);
+        Assert.Equal(forgotten.Revision, left.Revision);
+        Assert.Equal(RequestState.Failed, moved.Request.State);
+        Assert.Empty(log.At(LogLevel.Error));
+    }
+
+    /// <summary>
+    /// The two states that stop the bridge reach the operator's page as themselves, through the
+    /// health answer and the sentence the catalogue carries for each, so an operator reads which of
+    /// the two it is without opening a log. The third condition of #86, for the two failures the
+    /// page did not have a word for before.
+    /// </summary>
+    /// <param name="version">What the status route reports.</param>
+    /// <param name="me">What the route that returns whoever the key stands for answers.</param>
+    /// <param name="expected">What the page is told.</param>
+    /// <returns>A task that completes when the assertions have run.</returns>
+    [Theory]
+    [InlineData("2.7.3", HttpStatusCode.Forbidden, BackendReachability.CredentialRefused)]
+    [InlineData("3.0.0", HttpStatusCode.OK, BackendReachability.Incompatible)]
+    public async Task TheOperatorPageIsToldWhichOfTheTwoStoppedTheBridge(string version, HttpStatusCode me, BackendReachability expected)
+    {
+        var store = new InMemoryRequestStore();
+        var clock = new TestClock(Noon);
+        using var backend = Backend(AService(version, me));
+        var health = new HealthController(
+            store,
+            backend,
+            new FulfilmentSweep(store, new FakeLibrary(), clock, new RecordingJournal(), new RecordingSink(), new RecordingRequesterNotice(), new RecordingLogger()),
+            new BridgeWatch(),
+            clock);
+
+        var answered = await health.HealthAsync(CancellationToken.None).ConfigureAwait(true);
+        var answer = Assert.IsType<PluginHealth>(Assert.IsType<OkObjectResult>(answered.Result).Value);
+
+        Assert.Equal(expected, answer.Bridge);
+        Assert.Null(answer.BridgeLastReachableAt);
+
+        var sentence = StringCatalogue.Shipped.For(culture: null)["queue.health.bridge." + expected];
+        Assert.False(string.IsNullOrWhiteSpace(sentence));
+        Assert.Contains("until", sentence, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A service that is up, of a known version, and accepts the key, and answers the given
+    /// per-reference reports on the request route; anything else it is asked about is unknown to it.
+    /// </summary>
+    /// <param name="version">What the status route reports.</param>
+    /// <param name="me">What the route that returns whoever the key stands for answers.</param>
+    /// <param name="reporting">What the service says about each reference, by reference.</param>
+    /// <returns>The service.</returns>
+    private static AnOverseerrService AService(
+        string version = "2.7.3",
+        HttpStatusCode me = HttpStatusCode.OK,
+        IReadOnlyDictionary<string, string>? reporting = null)
+        => AnOverseerrService.ThatAnswersWith(call => call.Path switch
+        {
+            StatusRoute => AnOverseerrService.Json(HttpStatusCode.OK, "{\"version\":\"" + version + "\",\"commitTag\":\"local\"}"),
+            MeRoute => AnOverseerrService.Json(me, me == HttpStatusCode.OK ? "{\"id\":1}" : Refusal),
+            _ => Answer(call, reporting ?? new Dictionary<string, string>())
+        });
+
+    /// <summary>
+    /// The answer to a question about one reference, where the status and key routes are already
+    /// answered as up and accepted.
+    /// </summary>
+    /// <param name="call">The call as it arrived.</param>
+    /// <param name="reporting">What the service says about each reference, by reference.</param>
+    /// <returns>The answer.</returns>
+    private static HttpResponseMessage Answer(AnOverseerrService.Call call, IReadOnlyDictionary<string, string> reporting)
+    {
+        if (call.Path == StatusRoute)
+        {
+            return AnOverseerrService.Json(HttpStatusCode.OK, "{\"version\":\"2.7.3\"}");
+        }
+
+        if (call.Path == MeRoute)
+        {
+            return AnOverseerrService.Json(HttpStatusCode.OK, "{\"id\":1}");
+        }
+
+        var id = call.Path.StartsWith(RequestRoute + "/", StringComparison.Ordinal)
+            ? call.Path[(RequestRoute.Length + 1)..]
+            : string.Empty;
+
+        return reporting.TryGetValue(id, out var report)
+            ? AnOverseerrService.Json(HttpStatusCode.OK, report)
+            : AnOverseerrService.Json(HttpStatusCode.NotFound, "{\"message\":\"Request not found.\"}");
+    }
+
+    private static OverseerrBackend Backend(AnOverseerrService service, RecordingLogger? log = null)
+        => new OverseerrBackend(
+            new FakeInstallSettings(new PluginConfiguration { BridgeAddress = Address, BridgeApiKey = Key }),
+            service,
+            log ?? new RecordingLogger(),
+            OverseerrBackend.DefaultAnswerWithin);
+
+    private static Task<ReconciliationReport> ReconcilingAsync(IRequestStore store, IRequestBackend backend, RecordingLogger log)
+        => new BridgeReconciliation(
+            store,
+            backend,
+            new TestClock(Later),
+            new RecordingJournal(),
+            new RecordingRequesterNotice(),
+            new BridgeWatch(),
+            log).ReconcileAsync(CancellationToken.None);
+
+    private static async Task<StoredRequest> Held(InMemoryRequestStore store, Guid id)
+    {
+        var stored = await store.GetAsync(id, CancellationToken.None).ConfigureAwait(false);
+
+        return Assert.NotNull(stored);
+    }
+
+    private static string Written(RecordingLogger.Line line)
+        => line.Message + (line.Exception?.ToString() ?? string.Empty);
+
+    /// <summary>
+    /// One approved request carrying the reference the service issued for it, which is the state a
+    /// handover leaves behind and the only one a reconciliation asks about.
+    /// </summary>
+    /// <param name="store">Where it goes.</param>
+    /// <param name="reference">What the service called it.</param>
+    /// <returns>The request and the revision the store holds it at.</returns>
+    private static Task<StoredRequest> AHandedOverRequestAsync(InMemoryRequestStore store, string reference)
+        => store.AddAsync(
+            AFilm(new Guid("86000000-0000-0000-0000-0000000000" + reference.PadLeft(2, '0')), tmdb: "593") with
+            {
+                Backend = new BackendReference { Service = OverseerrBackend.ServiceName, Id = reference }
+            },
+            CancellationToken.None);
+
+    private static MediaRequest AFilm(Guid id, string tmdb)
+        => new MediaRequest
+        {
+            Id = id,
+            RequestedByUserId = Asker,
+            RequestedAt = Noon,
+            Kind = RequestedItemKind.Movie,
+            DisplayTitle = "Solaris",
+            DisplayYear = 1972,
+            ProviderIds = new Dictionary<string, string>(StringComparer.Ordinal) { ["Tmdb"] = tmdb },
+            State = RequestState.Approved,
+            StateChangedAt = Noon
+        };
+}

--- a/Jellyfin.Plugin.Requests/Api/CapabilitiesController.cs
+++ b/Jellyfin.Plugin.Requests/Api/CapabilitiesController.cs
@@ -70,11 +70,11 @@ public sealed class CapabilitiesController : RequestsControllerBase
         // Asked of the bridge rather than decided from which implementation the container handed
         // back, because "nothing is configured" is the interface's own answer to this question and a
         // type comparison here would be a second way of asking it. On every install today this is
-        // the null bridge answering without leaving the process. Where an adapter makes the call
-        // slow or makes it fail, what a bound on it looks like is #86, and this endpoint follows
-        // that rather than swallowing the failure: an answer that claimed no bridge because the
-        // bridge threw would be a lie about the install, and the operator would read it as proof
-        // their configuration never took.
+        // the null bridge answering without leaving the process until an address is written. With
+        // one, the adapter bounds every call it makes and answers a failure as a value rather than
+        // throwing, which #86 decided, and this endpoint follows that rather than swallowing
+        // anything: an answer that claimed no bridge because the bridge failed would be a lie about
+        // the install, and the operator would read it as proof their configuration never took.
         var reachability = await _backend.CheckReachableAsync(cancellationToken).ConfigureAwait(false);
 
         return Ok(new InstallCapabilities

--- a/Jellyfin.Plugin.Requests/Bridge/BackendReachability.cs
+++ b/Jellyfin.Plugin.Requests/Bridge/BackendReachability.cs
@@ -3,9 +3,19 @@ namespace Jellyfin.Plugin.Requests.Bridge;
 /// <summary>
 /// Whether there is an external request service behind this plugin, and whether it answered.
 /// <para>
-/// Three values rather than a yes or a no, because "nothing is configured" and "something is
-/// configured and did not answer" are opposite facts about a server and a caller that reduces them
-/// to one tells an operator their bridge is down on an install that never had one.
+/// More than a yes or a no, because "nothing is configured" and "something is configured and did
+/// not answer" are opposite facts about a server and a caller that reduces them to one tells an
+/// operator their bridge is down on an install that never had one.
+/// </para>
+/// <para>
+/// <b>Three of the values are failures, and they are told apart by what an operator does next.</b>
+/// #86 decided them. A service that did not answer is temporary and is asked again on the next call,
+/// with every call bounded so that a service which hangs costs a run ten seconds and not the night.
+/// A service that refused this server's key is not temporary: retrying it hides the problem, so the
+/// bridge stops and says so until the key is corrected. A service reporting a version this plugin
+/// does not know stops it the same way, because no retry fixes a version. Each of the three is its
+/// own sentence on the operator's page, and <c>docs/bridge.md</c> carries what every caller does with
+/// each of them.
 /// </para>
 /// </summary>
 public enum BackendReachability
@@ -17,13 +27,29 @@ public enum BackendReachability
     NotConfigured = 0,
 
     /// <summary>
-    /// An external service is configured and answered.
+    /// An external service is configured, answered, reports a version this plugin knows how to speak
+    /// to, and accepted this server's key.
     /// </summary>
     Reachable = 1,
 
     /// <summary>
-    /// An external service is configured and did not answer. What follows from that is #86, which
-    /// decides what a bound retry is and what stops rather than retrying.
+    /// An external service is configured and did not answer, or answered a failure to being asked
+    /// whether it is up. Temporary: nothing is walked, nothing remembers it as down, and the next
+    /// call asks again.
     /// </summary>
-    Unreachable = 2
+    Unreachable = 2,
+
+    /// <summary>
+    /// An external service is configured, answered, and refused this server's key. The bridge is
+    /// stopped: nothing is reconciled until the key is corrected, and the operator is told rather
+    /// than the key being tried again until somebody notices.
+    /// </summary>
+    CredentialRefused = 3,
+
+    /// <summary>
+    /// An external service is configured, answered, and reports a version this plugin does not know
+    /// how to speak to. The bridge is stopped the way it is for a refused key, because a form this
+    /// adapter was never read or measured against is not one to send a request in.
+    /// </summary>
+    Incompatible = 4
 }

--- a/Jellyfin.Plugin.Requests/Bridge/BridgeReconciliation.cs
+++ b/Jellyfin.Plugin.Requests/Bridge/BridgeReconciliation.cs
@@ -45,8 +45,16 @@ namespace Jellyfin.Plugin.Requests.Bridge;
 /// <para>
 /// <b>One request's failure never stops the others.</b> A service that cannot answer about one
 /// reference is a fact about that reference - it may have been issued by a service an operator has
-/// since replaced - so the run reports it and carries on. Which failures an adapter tells apart, and
-/// what each of them then does, is #86 and is not decided here.
+/// since replaced - so the run reports it and carries on.
+/// </para>
+/// <para>
+/// <b>A refused key and an unknown version stop the run and are said at error.</b> Those two are
+/// not temporary, which #86 decided: an unreachable service is asked again on the next run because
+/// outages end, and a refused key is asked again on the next run only because the operator may have
+/// corrected it, so the line for it says what the queue is not getting until they do. Two calls an
+/// hour is the whole of that retry. Nothing is walked in either case, and every request handed to
+/// the service is left exactly as it is, which is the second condition of #86 held by the run's
+/// shape: a run that asks nothing can corrupt nothing.
 /// </para>
 /// </summary>
 public sealed class BridgeReconciliation
@@ -247,10 +255,23 @@ public sealed class BridgeReconciliation
                 break;
 
             case BackendReachability.Unreachable:
-                // Said rather than swallowed, which is this issue's fourth condition. One line for
-                // the run and not one per request: the fact is about the service.
+                // Said rather than swallowed, which is #83's fourth condition. One line for the run
+                // and not one per request: the fact is about the service. At warning, because an
+                // outage is temporary and the next run is the retry.
                 _logger.LogWarning(
                     "The external request service did not answer, so nothing was reconciled this run. Every request handed to it is left exactly as it is and the next run will ask again.");
+                break;
+
+            case BackendReachability.CredentialRefused:
+                // Not temporary, so at error rather than warning: the adapter has already written
+                // why, and this line says what it costs the queue and what ends it.
+                _logger.LogError(
+                    "The external request service refused this server's key, so nothing was reconciled this run and nothing will be until the key is corrected. Every request handed to it is left exactly as it is.");
+                break;
+
+            case BackendReachability.Incompatible:
+                _logger.LogError(
+                    "The external request service reports a version this plugin does not know, so nothing was reconciled this run and nothing will be until one of the two is updated. Every request handed to it is left exactly as it is.");
                 break;
 
             default:

--- a/Jellyfin.Plugin.Requests/Bridge/BridgeSubmission.cs
+++ b/Jellyfin.Plugin.Requests/Bridge/BridgeSubmission.cs
@@ -105,8 +105,13 @@ public sealed class BridgeSubmission
             // would stop is a submission rather than the approval, so the honest answer is the
             // approved request with no reference on it.
             //
-            // Which failures an adapter distinguishes, and what each of them then does, is #86. What
-            // is decided here is only that none of them loses the approval.
+            // Every failure the adapter raises lands here the same way, which #86 decided: a
+            // service that is down, a key it refused and a title it does not know are all one
+            // handover that did not happen, marked on the request and never retried on its own,
+            // because an approval is one operator act and one call. Which of the three it was is
+            // in the exception's own sentence, and the operator's page says which of the first two
+            // the bridge is in without the log. What is decided here is only that none of them
+            // loses the approval.
             _logger.LogError(
                 reason,
                 "Request {RequestId} was approved and could not be handed to the external request service. The approval stands and nothing was undone; it carries no reference, so it has not been fetched and can be submitted again.",

--- a/Jellyfin.Plugin.Requests/Bridge/IRequestBackend.cs
+++ b/Jellyfin.Plugin.Requests/Bridge/IRequestBackend.cs
@@ -22,10 +22,11 @@ namespace Jellyfin.Plugin.Requests.Bridge;
 /// </para>
 /// <para>
 /// <b>What this interface does not decide.</b> What an approval means when a submission fails is
-/// #82. What happens when the service is unreachable, refuses the credential, or is asked about a
-/// title it has never heard of is #86. How a Jellyfin user is named to the service is #84, and
-/// where the credential lives is #85. This is the shape those answers have to fit through, and it
-/// names no service, no protocol and no address on purpose.
+/// #82. What happens when the service is unreachable, refuses the credential, reports a version the
+/// adapter does not know, or is asked about a title it has never heard of was decided on #86 and is
+/// carried by <see cref="BackendReachability"/> and by <c>docs/bridge.md</c>. How a Jellyfin user
+/// is named to the service is #84, and where the credential lives is #85. This is the shape those
+/// answers have to fit through, and it names no service, no protocol and no address on purpose.
 /// </para>
 /// <para>
 /// <b>Cancellation.</b> A cancelled call throws <see cref="System.OperationCanceledException"/>,
@@ -40,8 +41,9 @@ public interface IRequestBackend
     /// </summary>
     /// <param name="cancellationToken">Cancels the check.</param>
     /// <returns>
-    /// Which of the three states the bridge is in. Nothing configured is an answer rather than a
-    /// failure.
+    /// Which state the bridge is in. Nothing configured is an answer rather than a failure, and a
+    /// failure is a value here rather than an exception, so a scheduled task asking this cannot die
+    /// on the answer.
     /// </returns>
     Task<BackendReachability> CheckReachableAsync(CancellationToken cancellationToken);
 
@@ -53,7 +55,8 @@ public interface IRequestBackend
     /// <returns>
     /// What the service called it, or <see langword="null"/> where nothing was handed over and
     /// there is therefore nothing to keep. A null answer is the ordinary one on a server with no
-    /// service configured, and it is not a failure: a failure is an exception, in #86.
+    /// service configured, and it is not a failure: a failure is an exception, which the caller
+    /// marks on the request and never retries, decided on #86.
     /// </returns>
     Task<BackendReference?> SubmitAsync(MediaRequest request, CancellationToken cancellationToken);
 

--- a/Jellyfin.Plugin.Requests/Bridge/NoRequestBackend.cs
+++ b/Jellyfin.Plugin.Requests/Bridge/NoRequestBackend.cs
@@ -13,8 +13,9 @@ namespace Jellyfin.Plugin.Requests.Bridge;
 /// above has a branch for the absence.
 /// </para>
 /// <para>
-/// Nothing here fails. There is no service to be unreachable, no credential to be refused and no
-/// title to be unknown, so the failures in #86 belong to an adapter and not to this. What it does
+/// Nothing here fails. There is no service to be unreachable, no credential to be refused, no
+/// version to be unknown and no title to be unknown, so the four failures #86 decided belong to an
+/// adapter and not to this. What it does
 /// not do is pretend: it reports that nothing is configured rather than that something answered,
 /// and it hands back no reference rather than one it invented, because a made-up reference is a row
 /// an operator would later try to reconcile against a service that never saw it.

--- a/Jellyfin.Plugin.Requests/Bridge/Overseerr/OverseerrBackend.cs
+++ b/Jellyfin.Plugin.Requests/Bridge/Overseerr/OverseerrBackend.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -27,13 +28,26 @@ namespace Jellyfin.Plugin.Requests.Bridge.Overseerr;
 /// an address gets the next approval handed over rather than the one after the next restart.
 /// </para>
 /// <para>
-/// <b>Four calls, one each.</b> <c>GET /status</c> says whether the service is up, and it is
-/// answered without a credential, so a green answer from it says nothing about whether the key is
-/// accepted; <c>docs/bridge.md</c> records that bound and #86 owns the question of which call would
-/// answer it. <c>POST /request</c> hands an approval over and the number the service answers with
-/// is what is kept. <c>GET /request/{id}</c> asks where something stands, and the number it reports
-/// is turned into the mapping table's word by <see cref="OverseerrWords"/>, which is the one place
-/// that step lives. <c>DELETE /request/{id}</c> takes something back.
+/// <b>Five calls on four operations.</b> Asking whether the service is there is two of them, in
+/// order: <c>GET /status</c> says whether it is up and which version it is, and it is answered
+/// without a credential, so a green answer from it says nothing about whether the key is accepted;
+/// <c>GET /auth/me</c> returns whoever the key stands for and is refused when the key is wrong, which
+/// is the question the first call cannot answer, decided on #86. <c>POST /request</c> hands an
+/// approval over and the number the service answers with is what is kept. <c>GET /request/{id}</c>
+/// asks where something stands, and the number it reports is turned into the mapping table's word by
+/// <see cref="OverseerrWords"/>, which is the one place that step lives. <c>DELETE /request/{id}</c>
+/// takes something back.
+/// </para>
+/// <para>
+/// <b>The four ways a service misbehaves, and what each one is here.</b> #86 decided them and
+/// <c>docs/bridge.md</c> carries the table. A service that does not answer, or answers a failure to
+/// being asked whether it is up, is <see cref="BackendReachability.Unreachable"/>: temporary, nothing
+/// here remembers it, and the next call asks again. A service that refuses the key is
+/// <see cref="BackendReachability.CredentialRefused"/>, and one reporting a major version outside
+/// <see cref="KnownMajorVersions"/> is <see cref="BackendReachability.Incompatible"/>; both stop the
+/// reconciliation until an operator acts, because retrying either hides the problem. A title the
+/// service does not know is a refused submission and a fact about that one request, which
+/// <see cref="BridgeSubmission"/> marks on the request and nothing else is held up by.
 /// </para>
 /// <para>
 /// <b>The credential travels in a header and never in an address.</b> The form takes it as
@@ -58,13 +72,12 @@ namespace Jellyfin.Plugin.Requests.Bridge.Overseerr;
 /// otherwise stop a whole reconciliation run for one slow answer.
 /// </para>
 /// <para>
-/// <b>What is not decided here.</b> Which failures are told apart, and what a bound retry is, is #86.
-/// A submission that the service accepts and that this side then cannot write back is
-/// <see cref="BridgeSubmission"/>'s, and its log line carries the identifier so the two can be
-/// reconciled by hand. Nothing here has been run against a service: every leg that proves this
-/// class drives it through an in-process handler, which is the headless rule in
-/// <c>docs/testing.md</c>, and <c>docs/bridge.md</c> says what a reading of a description is worth
-/// against a reading of an instance.
+/// <b>What is not decided here.</b> A submission that the service accepts and that this side then
+/// cannot write back is <see cref="BridgeSubmission"/>'s, and its log line carries the identifier so
+/// the two can be reconciled by hand. Every leg that proves this class drives it through an
+/// in-process handler, which is the headless rule in <c>docs/testing.md</c>; <c>docs/bridge.md</c>
+/// says what one round trip against a running service measured, and that no failure path has been
+/// walked against one.
 /// </para>
 /// </summary>
 public sealed class OverseerrBackend : IRequestBackend, IDisposable
@@ -92,6 +105,18 @@ public sealed class OverseerrBackend : IRequestBackend, IDisposable
     /// How long one call is given on a server, before it is given up on.
     /// </summary>
     public static readonly TimeSpan DefaultAnswerWithin = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// The major versions of the form this adapter knows how to speak to, which are the two lines it
+    /// was written against: <c>1</c> is Overseerr's, whose own description <c>docs/bridge.md</c>
+    /// quotes, and <c>2</c> is Jellyseerr's, which the round trip in the same document was measured
+    /// on. A service reporting any other major, or a version that does not begin with a number, is
+    /// <see cref="BackendReachability.Incompatible"/>: the bridge stops rather than speaking a form
+    /// it has never been read or measured against, and this list is what grows on the day a new line
+    /// is. A breaking change inside a major this list names is not caught by it, and that bound is
+    /// stated where the list is documented rather than hidden by a longer check.
+    /// </summary>
+    public static readonly IReadOnlyList<int> KnownMajorVersions = new ReadOnlyCollection<int>(new[] { 1, 2 });
 
     private const string Prefix = "api/v1/";
 
@@ -154,19 +179,69 @@ public sealed class OverseerrBackend : IRequestBackend, IDisposable
 
         try
         {
-            using var answer = await SendAsync(bridge, HttpMethod.Get, "status", content: null, cancellationToken)
+            // Up first, then the version, then the key, and each question is asked only once the one
+            // before it is answered: a service that is down is reported as down and never as a
+            // refused key, and a service this adapter cannot speak to is not asked anything in a
+            // form it may not have.
+            using var status = await SendAsync(bridge, HttpMethod.Get, "status", content: null, cancellationToken)
                 .ConfigureAwait(false);
 
-            if (answer.IsSuccessStatusCode)
+            if (!status.IsSuccessStatusCode)
             {
-                return BackendReachability.Reachable;
+                _logger.LogWarning(
+                    "The external request service answered {StatusCode} when asked whether it is up, so it is reported as unreachable. Nothing else was asked of it.",
+                    (int)status.StatusCode);
+
+                return BackendReachability.Unreachable;
             }
 
-            _logger.LogWarning(
-                "The external request service answered {StatusCode} when asked whether it is up, so it is reported as unreachable. Nothing else was asked of it.",
-                (int)answer.StatusCode);
+            var reported = await ReadAsync(status, cancellationToken).ConfigureAwait(false);
 
-            return BackendReachability.Unreachable;
+            if (MajorVersion(reported) is not int major)
+            {
+                // The version is whatever the thing at that address chose to send, so it is not
+                // quoted; the operator reads it off the service itself.
+                _logger.LogError(
+                    "The external request service reports a version this plugin cannot read, so the bridge is stopped: nothing is asked about and nothing is reconciled until one of the two is updated. Nothing else was asked of it.");
+
+                return BackendReachability.Incompatible;
+            }
+
+            if (!KnownMajorVersions.Contains(major))
+            {
+                _logger.LogError(
+                    "The external request service reports major version {Major}, which this plugin does not know how to speak to, so the bridge is stopped: nothing is asked about and nothing is reconciled until one of the two is updated. Nothing else was asked of it.",
+                    major);
+
+                return BackendReachability.Incompatible;
+            }
+
+            // The status route takes no credential, so a green answer from it says nothing about
+            // the key. The route that returns whoever the key stands for is what answers that: the
+            // form refuses it with 403 when the key is wrong, and 401 is read the same way for a
+            // proxy in front of the service that answers first. The body is not read; who the key
+            // stands for is the service's business.
+            using var me = await SendAsync(bridge, HttpMethod.Get, "auth/me", content: null, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (me.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+            {
+                _logger.LogError(
+                    "The external request service refused this server's key, so the bridge is stopped: nothing is asked about and nothing is reconciled until the key is corrected in the plugin's settings.");
+
+                return BackendReachability.CredentialRefused;
+            }
+
+            if (!me.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "The external request service answered {StatusCode} when asked whether the key is accepted, so it is reported as unreachable. Nothing else was asked of it.",
+                    (int)me.StatusCode);
+
+                return BackendReachability.Unreachable;
+            }
+
+            return BackendReachability.Reachable;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -177,9 +252,10 @@ public sealed class OverseerrBackend : IRequestBackend, IDisposable
 #pragma warning restore CA1031
         {
             // Every way of not answering is the same answer here: configured, and did not answer.
-            // The interface names that state so a caller does not have to tell a refused connection
-            // from a name that does not resolve, and #86 is where the ones worth telling apart are
-            // decided.
+            // A refused connection, a name that does not resolve, a call that ran out of its bound
+            // and a body that is not JSON are one fact to a caller, which is that the service is not
+            // there to be asked; the ones worth telling apart are the answers above, which need the
+            // service to have answered at all.
             _logger.LogWarning(
                 reason,
                 "The external request service could not be asked whether it is up, so it is reported as unreachable. Nothing else was asked of it.");
@@ -394,6 +470,30 @@ public sealed class OverseerrBackend : IRequestBackend, IDisposable
         throw new HandoverRefusedException(
             "The account mapped for user " + Text(user)
             + " is not a number, and the external request service identifies its users by number, so the request was not handed over. The approval stands and nothing was sent; correct the row and hand it over again.");
+    }
+
+    /// <summary>
+    /// The major version out of what the status route reports, or nothing where the version is
+    /// missing, is not text, or does not begin with a number. The digits before the first dot and
+    /// nothing else, because that is what both lines this adapter knows put there; a development
+    /// build of either names itself with a word first, and is unknown here on purpose.
+    /// </summary>
+    /// <param name="body">What the status route answered.</param>
+    /// <returns>The major version, or <see langword="null"/> where none can be read.</returns>
+    private static int? MajorVersion(JsonElement body)
+    {
+        if (body.ValueKind != JsonValueKind.Object
+            || !body.TryGetProperty("version", out var version)
+            || version.ValueKind != JsonValueKind.String)
+        {
+            return null;
+        }
+
+        var text = version.GetString() ?? string.Empty;
+        var dot = text.IndexOf('.', StringComparison.Ordinal);
+        var leading = dot < 0 ? text : text[..dot];
+
+        return int.TryParse(leading, NumberStyles.None, CultureInfo.InvariantCulture, out var major) ? major : null;
     }
 
     private static long? Number(JsonElement body, string name)

--- a/Jellyfin.Plugin.Requests/Localisation/Strings/en.json
+++ b/Jellyfin.Plugin.Requests/Localisation/Strings/en.json
@@ -121,6 +121,8 @@
   "queue.health.bridge.NotConfigured": "No external request service is set up, so approving is an answer and nothing is fetched.",
   "queue.health.bridge.Reachable": "The external request service answered.",
   "queue.health.bridge.Unreachable": "The external request service is not answering.",
+  "queue.health.bridge.CredentialRefused": "The external request service refused this server's key, so nothing is reconciled until the key is corrected in the plugin's settings.",
+  "queue.health.bridge.Incompatible": "The external request service reports a version this plugin does not know, so nothing is reconciled until one of the two is updated.",
   "queue.health.bridgeLastReachable": "It last answered {0}.",
   "queue.health.bridgeNeverReachable": "Nothing here has seen it answer since this server started.",
   "queue.health.count": "{0}: {1}",

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,8 +68,8 @@ service, and the six lines below are two paths rather than six: a client each,
 and the socket pipeline each is handed at registration.
 
     git grep -nE 'HttpClient|WebRequest|WebSocket|Socket' -- Jellyfin.Plugin.Requests
-    Jellyfin.Plugin.Requests/Bridge/Overseerr/OverseerrBackend.cs:99:    private readonly HttpClient _client;
-    Jellyfin.Plugin.Requests/Bridge/Overseerr/OverseerrBackend.cs:141:        _client = new HttpClient(handler, disposeHandler: false)
+    Jellyfin.Plugin.Requests/Bridge/Overseerr/OverseerrBackend.cs:124:    private readonly HttpClient _client;
+    Jellyfin.Plugin.Requests/Bridge/Overseerr/OverseerrBackend.cs:166:        _client = new HttpClient(handler, disposeHandler: false)
     Jellyfin.Plugin.Requests/Notify/OutboundSink.cs:61:    private readonly HttpClient _client;
     Jellyfin.Plugin.Requests/Notify/OutboundSink.cs:104:        _client = new HttpClient(handler, disposeHandler: false)
     Jellyfin.Plugin.Requests/PluginServiceRegistrator.cs:95:            new SocketsHttpHandler(),

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -231,9 +231,82 @@ request, was answered `APPROVED`, and left the request as it was. That is the in
 else; no run against a service has ever moved a request, because no service has ever answered
 `DECLINED` or `FAILED` here, and what the suite measures for those is the reconciliation against a
 double, on both claimed target frameworks. Which failures an adapter tells apart, and what each of
-them then does, is #86 and is not decided here. And **the person who asked is not told when their request fails this way** - no
+them then does, is the section below, and none of the four has been produced by a running service. And **the person who asked is not told when their request fails this way** - no
 sentence is written for that state, so they find out on their own page. That is a gap rather than a
 decision, and `RequesterMessage.ForMove` is where it is written down.
+
+## When the service misbehaves
+
+Four things go wrong with a service that exists, and #86 decided on 2026-08-28 what each one does
+here. This is what was built against that ruling, one row per failure, each driven through
+`OverseerrBackend` and the real submission or reconciliation path against the in-process service in
+[`WhenTheServiceMisbehavesTests`](../Jellyfin.Plugin.Requests.Tests/Bridge/Overseerr/WhenTheServiceMisbehavesTests.cs).
+**Nothing in this section has been walked against a running service.**
+
+| The service                                                  | The adapter answers                | The reconciliation                                                                         | An approval                                                                                  | The operator's page says                                            |
+| ------------------------------------------------------------ | ---------------------------------- | ------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| does not answer, or answers a failure to `GET /status`       | `Unreachable`                      | walks nothing, says so at warning, and the next run asks again                             | fails once and is marked on the request; nothing retries it                                  | that it is not answering, and when it last did                      |
+| refuses the key on `GET /auth/me`                            | `CredentialRefused`                | walks nothing, says so at error, and nothing is reconciled until the key is corrected      | fails once and is marked on the request, because the service refuses the call too            | that the key was refused, and that the settings are where to fix it |
+| reports a version whose major is not in `KnownMajorVersions` | `Incompatible`                     | walks nothing, says so at error, and nothing is reconciled until one of the two is updated | is not gated: one operator act is one call, and whatever it answers is marked on the request | that the version is unknown                                         |
+| does not know the title, or the reference                    | a refused submission, or no report | leaves that one request as it is and carries on with the others                            | fails that one handover and is marked on it; the next approval goes through                  | the handover column on that row, from #283                          |
+
+**"Retried with a bound" is the next call, and the bound is on every call.** An unreachable service
+is asked again by the next scheduled run and by the next approval, because outages end, and nothing
+here remembers it as down: the adapter keeps no state between calls, so a service that comes back is
+found back by the first thing that asks. The bound is the ten seconds every call is given, which is
+what makes the retry safe: a service that hangs costs a run ten seconds and not the night. What is
+deliberately not built is a retry inside one call, because the health panel asks on every turn of the
+queue and would wait that many times over, and because the schedule already is the retry.
+`AServiceThatIsDownIsUnreachableAndIsAskedAgainOnTheNextRun` holds the first half and
+`AServiceThatNeverAnswersIsGivenUpOnWithinTheBound` the second.
+
+**"Stop" is the reconciliation, said at error, and the page.** A refused key and an unknown version
+are not temporary, and retrying either would hide the problem behind a log line at warning that reads
+like an outage. So the run walks nothing, the line for it is at error and says what ends it, and the
+health panel carries a sentence of its own for each rather than "not answering". The run still asks
+the two questions again next hour, because the operator may have corrected the key by then and
+nothing else would notice; two bounded calls an hour is the whole of that, and no request is asked
+about until the answer is `Reachable`. An approval made meanwhile is not held back: it is one
+operator act and one call, its failure is marked on the request the way every failed handover is, and
+the panel says why. `ARefusedKeyStopsTheRunAtErrorAndLeavesEveryHandedOverRequestAsItIs` and
+`AnUnknownVersionStopsTheRunAsAnIncompatibility` hold the run's half;
+`TheOperatorPageIsToldWhichOfTheTwoStoppedTheBridge` holds the page's.
+
+**Which versions are known, and why by major.** `KnownMajorVersions` names `1` and `2`: Overseerr's
+line, whose description the section below quotes, and Jellyseerr's, which the round trip below was
+measured on. The check reads the digits before the first dot of what `GET /status` reports and
+nothing else, so a development build, which names itself with a word first, is unknown on purpose,
+and so is a version that is missing or not text. What that bound does not catch is a breaking change
+inside a major the list names, and no reading of a version string could; the round trip is what
+catches that, on the day it runs red. `AVersionThisAdapterDoesNotKnowIsIncompatibleAndTheKeyIsNotEvenTried`
+holds the four shapes of unknown, and `EveryMajorTheAdapterDeclaresIsOneTheCheckAccepts` keeps the
+list and the check from drifting apart.
+
+**No failure loses a request or moves it**, which is the second condition, and it is held by shape
+rather than by a check inside the loop. A run that asks nothing can change nothing, and every leg in
+that file reads the store back afterwards and compares the revision: a request handed over before
+the key was refused is at the same revision after the run that met the refusal. On the submission
+side the approval was written before the service was asked, so no answer can cost it, which
+[`BridgeSubmission`](../Jellyfin.Plugin.Requests/Bridge/BridgeSubmission.cs) says about itself.
+
+**What the form answers a title it does not know with.** The submission route hands the number to
+its TMDB client and maps anything that client throws to a `500` carrying the client's message; read
+off the same file on the measured line, fetched 2026-09-03:
+
+    curl -sS -o request.ts -w "http=%{http_code} bytes=%{size_download}\n" \
+      https://raw.githubusercontent.com/fallenbagel/jellyseerr/v2.7.3/server/routes/request.ts
+    http=200 bytes=20249
+
+    grep -n -B 1 'status: 500, message: error.message' request.ts
+    313-        default:
+    314:          return next({ status: 500, message: error.message });
+
+So a title the service does not know is one refused submission, and the message in that body is not
+quoted into any log here, because it is whatever the thing at that address chose to send.
+`ATitleTheServiceDoesNotKnowFailsThatHandoverAndTheNextOneGoesThrough` holds both halves, and
+`AReferenceTheServiceNoLongerKnowsLeavesThatRequestAloneAndTheOthersStillMove` holds the same rule on
+the reconciliation side, where a reference the service answers `404` to is no report rather than a
+failure.
 
 ## What needs a bridge
 
@@ -453,17 +526,20 @@ so that nobody reads its presence as a claim about this form.
 
 **What the adapter refuses to carry, and where a failure goes.** The credential is a header on every
 call and never part of an address or a body, which `NoCallCarriesTheKeyAnywhereButTheHeader` asserts
-over all four calls. A refused call is an exception naming the status the service answered and never
+over all five calls. A refused call is an exception naming the status the service answered and never
 the body it answered with, because the body is whatever the thing at that address chose to send. A
 body that is not JSON, and JSON with no identifier or no status in it, are failures and never a
 reference or a word; those are the two cases #35 named and could not reach before something here read
 a body. A call that runs past ten seconds is given up on as a timeout and not as a cancellation,
 because the reconciliation stops its whole run on a cancellation and one slow answer is one request
-left as it is. Which of those failures are told apart, and what a bound retry is, is still #86.
+left as it is. Which of those failures are told apart, and what each of them then does, is
+[When the service misbehaves](#when-the-service-misbehaves) above.
 
-**`Reachable` still means the status route answered**, and the section below says what that does not
-say: that route takes no credential, so a green answer is a service that is up and nothing about
-whether the key is accepted.
+**`Reachable` means three things were answered, in order**: `GET /status` succeeded, the version it
+reports has a major in `KnownMajorVersions`, and `GET /auth/me` did not refuse the key. Each question
+is asked only once the one before it is answered, so a service that is down is reported as down and
+never as a refused key. The section below quotes why the first alone was never enough: `/status`
+takes no credential, and which route answers the second question is written there.
 
 **One request has made the round trip against a running service, on both claimed lines.**
 `scripts/verify-bridge-round-trip.sh` starts Jellyseerr `2.7.3`, pinned by digest in the script,
@@ -488,8 +564,9 @@ described route creating the first user takes a Plex account token, and Jellysee
 username and password the job makes and forgets; whether Overseerr proper behaves the same is not
 measured. The service has no download client, so its own log says the request is skipped rather than
 fetched, and nothing downstream of the service is exercised. No failure path is walked: a refused
-key, a service that goes away and a word the table has not seen are the suite's legs and #86's
-question. And one server setting is turned on for the service on the 12.0 line: Jellyseerr `2.7.3`
+key, a service that goes away, a version the adapter does not know and a word the table has not seen
+are the suite's legs, in `WhenTheServiceMisbehavesTests` and `ReconcilingWithTheServiceTests`, and
+none of them has been produced by a running service. And one server setting is turned on for the service on the 12.0 line: Jellyseerr `2.7.3`
 names its client in the `X-Emby-Authorization` header, which a 12.0 server reads only while
 `EnableLegacyAuthorization` is on, and it is off there by default. The first run of the procedure met
 that as a `400` on the service's sign-in, the procedure now turns the switch on where the server has
@@ -554,14 +631,16 @@ authenticated by a route putting the value in a URL would put the leak back wher
 
 ### The four operations, against the four this side has
 
-`IRequestBackend` has four and no more, and each one lands on a path item in that document.
+`IRequestBackend` has four and no more, and each one lands on a path item in that document; the first
+lands on two, for the reason under the table.
 
-| This side             | The form                      | What it answers                                   |
-| --------------------- | ----------------------------- | ------------------------------------------------- |
-| `CheckReachableAsync` | `GET /status`                 | that the service is up, and nothing about the key |
-| `SubmitAsync`         | `POST /request`               | `201` with the request the service created        |
-| `ReportAsync`         | `GET /request/{requestId}`    | `200` with that request                           |
-| `WithdrawAsync`       | `DELETE /request/{requestId}` | `204` and no body                                 |
+| This side             | The form                      | What it answers                                       |
+| --------------------- | ----------------------------- | ----------------------------------------------------- |
+| `CheckReachableAsync` | `GET /status`                 | that the service is up and which version it is        |
+| `CheckReachableAsync` | `GET /auth/me`                | whoever the key stands for, or `403` when it is wrong |
+| `SubmitAsync`         | `POST /request`               | `201` with the request the service created            |
+| `ReportAsync`         | `GET /request/{requestId}`    | `200` with that request                               |
+| `WithdrawAsync`       | `DELETE /request/{requestId}` | `204` and no body                                     |
 
 **`/status` is answered without a credential**, and for the first row that is a problem rather than a
 convenience:
@@ -572,8 +651,47 @@ convenience:
         security: []
 
 A green answer from it says the service is up and says nothing about whether the key is accepted, so
-`Reachable` read off `/status` alone reports a working bridge on an install whose credential is
-wrong. Which call answers the second question is #86's and is not decided here.
+`Reachable` read off `/status` alone would report a working bridge on an install whose credential is
+wrong. What answers the second question, decided on #86, is the route that returns whoever the key
+stands for. It declares no `security` of its own, so the document's default applies, which is the
+session cookie or the `X-Api-Key` header, and it asks for no permission beyond the key being accepted:
+
+    /auth/me:
+      get:
+        summary: Get logged-in user
+        description: Returns the currently logged-in user.
+
+The form refuses it, and every other route under that default, with one status when the key is
+wrong. That is read off the middleware every such route sits behind rather than off the description,
+which does not say, and it reads the same in both lines the adapter knows. Fetched 2026-09-03:
+
+    curl -sS -o auth.ts -w "http=%{http_code} bytes=%{size_download}\n" \
+      https://raw.githubusercontent.com/sct/overseerr/develop/server/middleware/auth.ts
+    http=200 bytes=1560
+
+    grep -n -A 4 'if (!req.user' auth.ts
+    48:    if (!req.user || !req.user.hasPermission(permissions ?? 0, options)) {
+    49-      res.status(403).json({
+    50-        status: 403,
+    51-        error: 'You do not have permission to access this endpoint',
+    52-      });
+
+    curl -sS -o auth.ts -w "http=%{http_code} bytes=%{size_download}\n" \
+      https://raw.githubusercontent.com/fallenbagel/jellyseerr/v2.7.3/server/middleware/auth.ts
+    http=200 bytes=1560
+
+    grep -n -A 4 'if (!req.user' auth.ts
+    48:    if (!req.user || !req.user.hasPermission(permissions ?? 0, options)) {
+    49-      res.status(403).json({
+    50-        status: 403,
+    51-        error: 'You do not have permission to access this endpoint',
+    52-      });
+
+So the adapter reads a `403` from that route as the key being refused, and a `401` the same way, for
+a proxy in front of the service that answers before the service does. The body is not read: who the
+key stands for is the service's business, and what this side wants to know is answered by the status
+alone. Nothing here runs that route against a service, and a service that has moved the refusal to
+another status is not something this page can know about.
 
 **A submission has two required fields and every other one is optional:**
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -211,7 +211,7 @@ are read at both moments a configuration reaches this plugin, from the same list
 | OutboundNoticeAddress                                       | set to something that is not http or https                                        | a notice cannot be posted there, so the sink would send nothing while the page shows an address             |
 | AnnouncesApprovals, AnnouncesDeclines, AnnouncesFulfilments | all three off while an address is set                                             | nothing would ever be posted to the address, which is a second way of saying off and the one nobody can see |
 | BridgeAddress                                               | set to something that is not http or https                                        | nothing can be dialled there, so the bridge would report itself configured and hand nothing over            |
-| BridgeApiKey                                                | empty while BridgeAddress is set                                                  | the service answers its status route without a key and refuses every other call, which reads as up          |
+| BridgeApiKey                                                | empty while BridgeAddress is set                                                  | the service refuses every call that needs a key, and the panel would report a refused key nobody typed      |
 | BridgeAccounts                                              | a row names no user, a user twice, no account, or an account that is not a number | a request would arrive under an account nobody chose, or under two, and the refusal names the row           |
 
 **Nothing is corrected on the way in.** A quota of zero is not raised to one and a retention of five

--- a/docs/personal-data.md
+++ b/docs/personal-data.md
@@ -340,7 +340,7 @@ a raw identifier. It was found by reading the page against the tree rather than 
     211b90c 2026-08-27 Draw who last moved a request, and keep a deleted account apart from an unanswered call
 
     git grep -n 'queue.movedBy.deleted' -- Jellyfin.Plugin.Requests/
-    Jellyfin.Plugin.Requests/Localisation/Strings/en.json:135:  "queue.movedBy.deleted": "A person who has been deleted",
+    Jellyfin.Plugin.Requests/Localisation/Strings/en.json:137:  "queue.movedBy.deleted": "A person who has been deleted",
     Jellyfin.Plugin.Requests/Web/queue.html:564:                        return RequestsShell.word("queue.movedBy.deleted");
 
 What the page draws is an identifier the dashboard's user list does not hold, and it says so only
@@ -398,8 +398,8 @@ server that has no backend and the adapter that speaks the Overseerr form, and t
 every call to the first until an address is written:
 
     git grep -n ': IRequestBackend' -- Jellyfin.Plugin.Requests/
-    Jellyfin.Plugin.Requests/Bridge/NoRequestBackend.cs:23:public sealed class NoRequestBackend : IRequestBackend
-    Jellyfin.Plugin.Requests/Bridge/Overseerr/OverseerrBackend.cs:70:public sealed class OverseerrBackend : IRequestBackend, IDisposable
+    Jellyfin.Plugin.Requests/Bridge/NoRequestBackend.cs:24:public sealed class NoRequestBackend : IRequestBackend
+    Jellyfin.Plugin.Requests/Bridge/Overseerr/OverseerrBackend.cs:83:public sealed class OverseerrBackend : IRequestBackend, IDisposable
 
 What it sends when it is on is one submission per approval, in the form's own field names: the kind
 of thing as `movie` or `tv`, the request's TMDB identifier and no other provider's, the seasons asked

--- a/scripts/verify-bridge-round-trip.sh
+++ b/scripts/verify-bridge-round-trip.sh
@@ -33,8 +33,8 @@
 #
 # WHAT IS NOT. Nothing downstream of the service: it has no download client configured, so its own
 # log says the request is skipped rather than fetched, and no library here ever fills. The failure
-# paths - a refused key, a service that goes away, a word the table has not seen - are the suite's
-# and #86's, not this script's.
+# paths - a refused key, a service that goes away, a version the adapter does not know, a word the
+# table has not seen - are the suite's, in WhenTheServiceMisbehavesTests, not this script's.
 #
 # ONE SERVER SETTING IS TURNED ON FOR THE SERVICE, AND THE TRANSCRIPT SAYS WHETHER IT WAS OFF. The
 # pinned service names its client in the `X-Emby-Authorization` header, which a 12.0 server reads


### PR DESCRIPTION
Closes #86.

The bridge had one word for everything a configured service could do wrong, `Unreachable`, and three of the four failures #86 names had no behaviour: a service that refused this server's key read as one that was down and was asked again every hour at warning, a service of a version this adapter was never read against was spoken to in a form it may not have, and neither had a sentence on the operator's page. This builds the ruling of 2026-08-28 on that issue, one row per failure, and holds each one with a leg through the real adapter and the real submission or reconciliation path against the in-process service from #35.

### The means

C# in the files that already carry the bridge, with no language, runtime or package added. `SiblingIndependenceTests` refused the first cut: a collection expression building the known-versions list made the compiler reference `System.Runtime.InteropServices`, which is not on the written-down list, and the list is built from a plain array instead. The page gains two sentences in the catalogue and no code, because the panel already turns the reachability value into a word by name.

### What is built

- **Two new words in `BackendReachability`.** `CredentialRefused` and `Incompatible`, each documented with what an operator does next, beside the three that were there.
- **The adapter asks three questions in order.** `GET /status` for up and for the version, whose major has to be in `KnownMajorVersions` (`1` for Overseerr's line, whose description `docs/bridge.md` quotes, `2` for Jellyseerr's, which the round trip was measured on); then `GET /auth/me`, because `/status` takes no credential and the route that returns whoever the key stands for is the one the form refuses with `403` when the key is wrong, read off the middleware in both lines and quoted on the page. A `401` is read the same way for a proxy in front. The body of that answer is not read.
- **The reconciliation stops at error on either of the two**, walks nothing, and says what ends it; the run still asks the two questions next hour because the operator may have corrected the key by then, and that is the whole of the retry. An unreachable service is said at warning and asked again by the next run and the next approval, nothing remembers it as down, and the bound is the ten seconds every call already carries. A title the service does not know is one refused submission marked on that request; a reference it no longer knows is one request left alone while the others move.
- **The operator's page** carries a sentence of its own for each new state, drawn through the existing group lookup.
- **`docs/bridge.md`** carries the table of the four failures, what "retried with a bound" and "stop" mean here and what is deliberately not built, the known-versions bound and what it cannot catch, the `/auth/me` entry and the middleware quotes, and the submission route's `500` for an unknown title. Every sentence in the tree that said #86 was undecided now says what was decided.

### Each guard was watched failing alone

Same command each time, `net9.0`, one file changed and restored byte for byte afterwards:

    dotnet test Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj -c Release -f net9.0 --filter "FullyQualifiedName~WhenTheServiceMisbehavesTests|FullyQualifiedName~OverseerrBackendTests|FullyQualifiedName~PluginHealthTests|FullyQualifiedName~PageWordsTests"

    the 401/403 reading of /auth/me replaced by 410/409
    ARefusedKeyStopsTheRunAtErrorAndLeavesEveryHandedOverRequestAsItIs [FAIL]
    AServiceThatRefusesTheKeyIsCredentialRefusedAndTheLogSaysSoWithoutTheKey (both rows) [FAIL]
    TheOperatorPageIsToldWhichOfTheTwoStoppedTheBridge (CredentialRefused) [FAIL]
    Fehler!      : Fehler:     4, erfolgreich:    52, gesamt:    56

    KnownMajorVersions reduced to { 1 }
    ten legs red, every one that drives a 2.7.3 service through the check, in both test classes
    Fehler!      : Fehler:    10, erfolgreich:    46, gesamt:    56

    the reconciliation's CredentialRefused case removed, so a refused key falls to the default arm
    ARefusedKeyStopsTheRunAtErrorAndLeavesEveryHandedOverRequestAsItIs [FAIL]
    Fehler!      : Fehler:     1, erfolgreich:    55, gesamt:    56

    the page sentence for Incompatible deleted from en.json
    PluginHealthTests.EverySentenceThePanelDrawsIsAKeyRatherThanText [FAIL]
    WhenTheServiceMisbehavesTests.TheOperatorPageIsToldWhichOfTheTwoStoppedTheBridge (Incompatible) [FAIL]
    PageWordsTests.EveryKeyThePagesNameIsOneTheEnglishCatalogueCarries [FAIL]
    Fehler!      : Fehler:     3, erfolgreich:    53, gesamt:    56

The third run was made twice. The first attempt removed nothing, because its pattern assumed LF line endings on a working copy that has CRLF, and the green it produced is not evidence of anything; the run above is the second attempt, with the mention count of `CredentialRefused` in that file measured at zero before the suite ran.

### The whole suite, at the head being pushed

    git rev-parse HEAD
    d014262adbdc267ff5d060f3b33225d1644c558f

    dotnet build Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror
        0 Warnung(en)
        0 Fehler

    dotnet test Jellyfin.Plugin.Requests.sln --configuration Release -warnaserror --no-build
    Bestanden!   : Fehler:     0, erfolgreich:   856, übersprungen:     0, gesamt:   856 - net9.0
    Bestanden!   : Fehler:     0, erfolgreich:   856, übersprungen:     0, gesamt:   856 - net10.0

    bash scripts/check-pasted-evidence.sh
    check-pasted-evidence: every pasted match line reproduces against the file it names.
    bash scripts/check-negative-disclosures.sh
    check-negative-disclosures: every negative disclosure exits as the document says it does.

Seventeen rows are new here: fifteen in `WhenTheServiceMisbehavesTests` and two in the capability endpoint's theory. Three legs in `OverseerrBackendTests` asserted one call for the reachability check, or passed only because their status body carried no version, which now reads as incompatible; they answer a version and count both calls now. The pasted evidence in `SECURITY.md` and `docs/personal-data.md` moved with the lines it names, re-run rather than edited.

### What this does not do

- **Nothing here has been walked against a running service.** Every leg drives the adapter through the in-process handler, and the `403` from `/auth/me` is read off the middleware source in both lines rather than seen from one. `.github/workflows/bridge-round-trip.yaml` runs on this pull request because `Bridge/**` changed, and that run is the first time the two-call check meets a real Jellyseerr `2.7.3`; I merge only once it is green, and a red there means my reading of that route is wrong and this branch changes.
- **An approval is not gated on the version.** A refused key refuses the submission on its own; an unknown version does not, and an approval made against one is one operator act and one call, marked on the request if it fails. `docs/bridge.md` says so in the table rather than leaving it to be found.
- **No retry inside a call**, on purpose: the health panel asks on every turn of the queue, and the schedule already is the retry. The reasoning is on the page.
- **`BridgeLastReachableAt` still moves only on `Reachable`**, so "it last answered" on the panel is the last time the check came back green rather than the last time the service sent any status.
- **The Prettier check was run inside the tree on the four pages this change touches** and passes; the repo-wide `--check` on this machine reports untouched pages for CRLF line endings, as the two previous adapter pull requests recorded, and the job runs on a checkout that has none.
- **Which sentence the operator guide's bridge section should carry for each failure** is #102 and lands after this, against what this builds rather than before it.

### What had no second reader

Nobody else read this. Every command above was run before the sentence resting on it.
