### PR TITLE
Say what has been released, in the six files that said two releases and no 12.0 package

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,18 +37,27 @@ directly, and carries the fixture it is watched refusing.
 
 ## This is not finished
 
-Two releases exist, and a manifest under Flowfin's control serves both:
+Four releases exist, two per server line, and the manifest under Flowfin's
+control serves two of them:
 
     gh release list --repo Flowfin/jellyfin-plugin-requests --json tagName --jq '.[].tagName'
+    0.3.0.0-jf12-stable
+    0.3.0.0-stable
     0.2.0.0-stable
     0.1.0.0-stable
 
+    curl -sS https://flowfin.dev/manifest.json | jq -r '.[] | select(.name == "Requests") | .versions[] | "\(.version) \(.targetAbi)"'
+    0.2.0.0 10.11.0.0
+    0.1.0.0 10.11.0.0
+
+Read on 2026-09-03, after both `0.3.0.0` tags were published. A server that has
+added the address is offered `0.2.0.0` until the manifest moves, and nothing on
+this board moves it: the release route here publishes a GitHub release and feeds
+no catalogue, which [docs/RELEASING.md](docs/RELEASING.md) says about itself.
 The address an operator adds, what the entries carry and the checksums read back
 against the archives are in [docs/catalogue.md](docs/catalogue.md), which is the
-authority for all of it. Nothing on this board writes that document: the release
-route here publishes a GitHub release and feeds no catalogue, which
-[docs/RELEASING.md](docs/RELEASING.md) says about itself, and what this tree does
-with the published manifest is read it back against the releases once a day.
+authority for all of it, and what this tree does with the published manifest is
+read it back against the releases once a day.
 
 Three things belong here rather than behind the link, because they decide whether
 this is worth installing.
@@ -58,18 +67,32 @@ filled by enumerating one organisation's repositories, this repository does not
 move into it, and the price of that decision is that an operator reaches this
 plugin only by being told the address.
 
-**Both published entries carry the 10.11 line's package.** The 12.0 line has none,
-because the release route builds the one server line `build.yaml` names, so a
-server on the 12.0 line is offered the `net9.0` build rather than nothing. That
-comparison is read at the server's own source rather than assumed, on the same
-page.
+**Both entries the manifest serves carry the 10.11 line's package, and the 12.0
+line's release is not in it.** A `0.3.0.0` package naming `targetAbi 12.0.0.0`
+exists as a release, read from the metadata published beside it:
 
-**A published release has been installed on a server once, on the 10.11 line
-only.** Run `33357925338`, at `501a943`, downloaded `requests_0.2.0.0.zip`,
-checked it against the digest published beside it, and the server answered that
-the plugin was `Active` at `0.2.0.0`. The server was `10.11.11`.
+    gh release download 0.3.0.0-jf12-stable --repo Flowfin/jellyfin-plugin-requests --pattern 'requests_0.3.0.0.zip.meta.json' --dir jf12
+    jq -r '"\(.version) \(.targetAbi)"' jf12/requests_0.3.0.0.zip.meta.json
+    0.3.0.0 12.0.0.0
 
-**On the floor server it claims, the same release does not load.** `build.yaml`
+Until the manifest carries an entry for it, a server on the 12.0 line is offered
+the `net9.0` build rather than nothing. That comparison is read at the server's
+own source rather than assumed, on the same page.
+
+**A published release has been installed on a server of each line, once each.**
+Run `33744830699`, at `2e83259`, downloaded `requests_0.3.0.0.zip` from each
+release, checked each against the digest published beside it, and both servers
+answered that the plugin was `Active` at `0.3.0.0`:
+
+    gh run view 33744830699 --repo Flowfin/jellyfin-plugin-requests --log | grep -o 'Requests loaded and answered on .*'
+    Requests loaded and answered on jellyfin/jellyfin:10.11.11 (net9.0)
+    Requests loaded and answered on jellyfin/jellyfin:12.0-rc4 (net10.0)
+
+The 12.0 server was a release candidate reporting `12.0.0`; no released 12.0
+server has run this. Before that run, `0.2.0.0` had been installed the same way
+on `10.11.11` alone, in run `33357925338` at `501a943`.
+
+**On the floor server it claims, `0.2.0.0` does not load.** `build.yaml`
 says `targetAbi: "10.11.0.0"`, which names the server `10.11.0`, and putting
 `requests_0.2.0.0.zip` on that server reports
 `Requests is NotSupported rather than Active` - run `33358848505`. Jellyfin sets
@@ -81,11 +104,14 @@ the two moves, the SDK the package is built against or the floor it claims, is
 answered on #360: the package is built against the floor from now on and the
 floor stands, because moving the claim would drop every server below `10.11.11`
 without saying so. That answer does not reach a release that already exists.
-**Do not install this on a `10.11.0` server: it will not run.**
+**Do not install `0.2.0.0` on a `10.11.0` server: it will not run.** Whether
+`0.3.0.0`, the first release built against the floor, loads on that server is
+#382's measurement and is not claimed here.
 
-Two further things neither run covers: the bytes are copied into the plugin
-directory rather than fetched and unpacked by the server itself, and the 12.0
-line has no release for anybody to install.
+Two further things the install run does not cover: the bytes are copied into the
+plugin directory rather than fetched and unpacked by the server itself, and no
+server has installed this from the manifest, which does not yet carry `0.3.0.0`
+for either line.
 
 Nothing here should be pointed at a server you care about.
 

--- a/docs/catalogue.md
+++ b/docs/catalogue.md
@@ -184,10 +184,10 @@ the entries name rather than against the `.md5` published beside them:
 Both equal the `checksum` of their entry, so a server that downloads either one and hashes it gets
 the value the manifest promised.
 
-### Both entries claim the 10.11 line, and the 12.0 line has none
+### Both entries the manifest serves claim the 10.11 line, and the 12.0 line's package is not in it
 
-The scheme is one entry per server line, each carrying its line's `targetAbi`. What is published is
-two entries for one line. This board claims two:
+The scheme is one entry per server line, each carrying its line's `targetAbi`. What the manifest
+serves is two entries for one line. This board claims two:
 
     grep -nE '^(version|targetAbi|framework):' build.yaml build-jf12.yaml
     build.yaml:5:version: "0.3.0.0"
@@ -197,9 +197,11 @@ two entries for one line. This board claims two:
     build-jf12.yaml:15:targetAbi: "12.0.0.0"
     build-jf12.yaml:16:framework: "net10.0"
 
-and the release route builds the one `build.yaml` names, which is why there is no second package for
-an entry to point at. `publish.yaml` says so about itself in its own header and refuses a `framework`
-that is not the one it builds.
+and since `0.3.0.0` the release route publishes a package per line, deriving the line from the tag,
+which `publish.yaml` says about itself in its own header. `0.3.0.0-jf12-stable` names
+`targetAbi 12.0.0.0` in the metadata published beside it; read on 2026-09-03, the manifest carries no
+entry for it and none for the 10.11 line's `0.3.0.0` either, and nothing on this board writes the
+manifest.
 
 **So a server on the 12.0 line is offered the `net9.0` build.** A server keeps every entry whose
 `targetAbi` is at or below its own version and then takes the highest version number of what is

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -92,16 +92,18 @@ files:
 - **The 12.0 evidence is against a release candidate.** The image was `jellyfin/jellyfin:12.0-rc4`
   and the server reported `12.0.0`. Listing 12.0 as supported without saying that would be a
   statement about a server nobody has run this on.
-- **A published release has been installed once, and not the way a server installs.** This bullet
-  said no run recorded here had installed from either release. One has since #152:
-  `.github/workflows/release-install.yaml` downloads the newest release of every claimed line,
-  checks the archive against the digest published beside it, and puts the unpacked bytes on a server
-  of that line. Run `33357925338` at `501a943` did it for `0.2.0.0-stable` on `10.11.11`, and the
-  server answered `Requests is Active at 0.2.0.0`. What that still does not cover: the archive is
-  unpacked by the run rather than fetched and unpacked by the server, and the 12.0 line has no
-  release to install at all. The sibling in the set arrives as its own published package and is
-  unpacked whole, so the set half of the run exercises the server's own path and the half about this
-  plugin still does not.
+- **A published release has been installed once per line, and not the way a server installs.** This
+  bullet said no run recorded here had installed from either release, and then that one had for the
+  10.11 line alone. `.github/workflows/release-install.yaml` downloads the newest release of every
+  claimed line, checks the archive against the digest published beside it, and puts the unpacked
+  bytes on a server of that line. Run `33744830699` at `2e83259` did it for `0.3.0.0-stable` on
+  `10.11.11` and for `0.3.0.0-jf12-stable` on `12.0-rc4`, and each server answered
+  `Requests is Active at 0.3.0.0`; run `33357925338` at `501a943` had done it for `0.2.0.0-stable`
+  on `10.11.11` before. What that still does not cover: the archive is unpacked by the run rather
+  than fetched and unpacked by the server, and the manifest a server would fetch from carries no
+  `0.3.0.0` entry for either line. The sibling in the set arrives as its own published package and
+  is unpacked whole, so the set half of the run exercises the server's own path and the half about
+  this plugin still does not.
 - **The floor server of the 10.11 line refuses the published release, and this is the bullet above
   it read against the claim.** `build.yaml` declares `targetAbi: "10.11.0.0"`, which names the
   server `10.11.0`. The same archive on that server ends the run at its verdict step with
@@ -180,13 +182,24 @@ the section below.
 
 ## Upgrading from one shipped version to the next
 
-Two versions have shipped, so there is one hop an operator can actually perform:
+Three versions have shipped on the 10.11 line and one on the 12.0 line, so there are two hops an
+operator can actually perform, both on the 10.11 line:
 
 ```
 gh release list --repo Flowfin/jellyfin-plugin-requests --json tagName --jq '.[].tagName'
+0.3.0.0-jf12-stable
+0.3.0.0-stable
 0.2.0.0-stable
 0.1.0.0-stable
 ```
+
+The hop from `0.1.0.0` to `0.2.0.0` is the one written out below, and it is the one with a test
+behind it. The hop from `0.2.0.0` to `0.3.0.0` carries a queue file forward from shape version 1 to
+shape version 2, which the section above describes, and the two fixtures under
+`Jellyfin.Plugin.Requests.Tests/Storage/Fixtures/` whose names carry `written-by-0.2.0.0` are what
+the shipped store actually wrote. No fixture under `Jellyfin.Plugin.Requests.Tests/Configuration/Fixtures/`
+was written by `0.2.0.0`, so what that hop does with the settings file is expected to follow the rule
+under "Whether a version can be skipped" and has not been measured against the shipped serialisation.
 
 **What `0.1.0.0` left on a disk is its settings file and nothing else.** That version carried the
 store contract and no implementation of it, so an install of it wrote no requests anywhere:
@@ -258,8 +271,10 @@ nothing here is one that can be skipped over.
   should be built against it yet.
 - **Anything about a bridge to an external request service.** There is none; #80 is where the
   interface behind it is defined.
-- **What a server does with a version it reads from a manifest.** No manifest is published, which is
-  #110, and how a server compares versions in one is not measured by this repository.
+- **What a server does with a version it reads from a manifest.** A manifest is published at the
+  address [catalogue.md](catalogue.md) names, and how a server orders its entries is read there at the
+  server's own source rather than measured; no run of this repository has watched a server install
+  from it.
 - **An upgrade watched on a running server.** The hop from `0.1.0.0-stable` is set out above and is
   measured against what the older version's own type writes, not against an installation. Nothing in
   this repository has installed one version of this plugin on a server and then replaced it with the

--- a/docs/operating.md
+++ b/docs/operating.md
@@ -4,11 +4,11 @@ The path from an installed plugin to a queue somebody can work, and the sequence
 queue stops moving. It is written for an operator who has never seen this plugin and does not want to
 read the rest of `docs/` first.
 
-Read the "This is not finished" section of [../README.md](../README.md) before any of it. Two releases
-exist, both carry the package for one of the two claimed server lines, and one of them has been
-installed once on `10.11.11` and answered. On `10.11.0`, the floor that same package claims, the
-server refuses to load it. Nothing below changes either half, and none of it applies on a server
-where the plugin does not load at all.
+Read the "This is not finished" section of [../README.md](../README.md) before any of it. Four releases
+exist, two per claimed server line, and the newest of each line has been installed once on a server of
+that line and answered; the manifest a server fetches still offers only the 10.11 line's `0.2.0.0`. On
+`10.11.0`, the floor that `0.2.0.0` claims, the server refuses to load it. Nothing below changes either
+half, and none of it applies on a server where the plugin does not load at all.
 
 ## From an installed plugin to a queue
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -203,7 +203,7 @@ captured is `0.1.0.0-stable`, and the commit that one was built from carries no 
 anything:
 
     gh release list --repo Flowfin/jellyfin-plugin-requests --json tagName,createdAt
-    [{"createdAt":"2026-08-27T06:50:36Z","tagName":"0.2.0.0-stable"},{"createdAt":"2026-08-08T09:38:30Z","tagName":"0.1.0.0-stable"}]
+    [{"createdAt":"2026-09-03T10:24:47Z","tagName":"0.3.0.0-jf12-stable"},{"createdAt":"2026-09-03T10:24:39Z","tagName":"0.3.0.0-stable"},{"createdAt":"2026-08-27T06:50:36Z","tagName":"0.2.0.0-stable"},{"createdAt":"2026-08-08T09:38:30Z","tagName":"0.1.0.0-stable"}]
     git rev-parse 0.1.0.0-stable^{commit}
     c44552645f0dba120c49599deedbc0244b59dcec
     git ls-tree -r --name-only c445526 -- Jellyfin.Plugin.Requests/Storage
@@ -214,8 +214,8 @@ anything:
 
 The contract and its two exceptions, and no implementation. So the shape that fixture holds is what a
 server running the mainline between `7b62877` and the change that landed the version has on its disk.
-The other release in that listing does ship a store, and its own output is the section below rather
-than a second thing this paragraph is about.
+The later releases in that listing do ship a store; the output of the first of them is the section
+below rather than a second thing this paragraph is about.
 
 ### The version 1 fixtures, which are a shipped version's output
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -80,12 +80,12 @@ promised from then on is #105.
 
 `0.1.0.0`, and the reading that chose it does not reproduce any more. On the day
 the number was picked the template's `1.0.0.0` claimed a released first version
-and nothing had been released. Two releases exist now, so the command returns a
+and nothing had been released. Four releases exist now, so the command returns a
 different number and is written here as the current reading rather than as the
 one that decided anything:
 
     $ gh release list --repo Flowfin/jellyfin-plugin-requests --json tagName --jq 'length'
-    2
+    4
 
 A version that said 1.0 to a catalogue, to a dashboard and to an operator, for a
 tree that then held no request API and no store behind it, was a claim it could


### PR DESCRIPTION
Closes #383.

Both `0.3.0.0` tags were published on 2026-09-03 at `10:24Z`, and six documents went on describing the release position as it stood before them. This change makes each of them say what is true at the commit it lands on, beside the command that reads it, and nothing else.

**Means.** Markdown in the files that carry the claims. A documentation correction has no other means to fit; nothing is built, so no language, runtime or dependency is added.

## What each file said, and says now

- `README.md`: two releases and a manifest serving both; the 12.0 line has no package; one install on one server; a floor-server paragraph whose "the same release" pointed at whichever release the paragraph above it named. Now: four releases and the manifest's two entries, both pasted; the jf12 package's `targetAbi` read from its published metadata; the install run on a server of each line, pasted; the floor paragraph names `0.2.0.0` and leaves `0.3.0.0` on the floor to #382.
- `docs/operating.md`: the opening summary counts four releases, says the newest of each line has been installed once, and that the manifest still offers only `0.2.0.0`.
- `docs/versioning.md`: `length` pastes `4`.
- `docs/compatibility.md`: the install bullet names run `33744830699` for both lines and keeps `33357925338` as the earlier one; the upgrade section counts two hops on the 10.11 line, says which one has a test, and says what the `0.2.0.0` to `0.3.0.0` hop has behind it (two storage fixtures the shipped store wrote) and what it does not (no settings fixture written by `0.2.0.0`); the "What is not promised" bullet that said no manifest is published now points at the one that is.
- `docs/storage.md`: the release listing pastes four entries; the sentence after it no longer says "the other release".
- `docs/catalogue.md`: the heading and paragraph say the manifest serves two 10.11 entries and carries no entry for the jf12 package, and that the release route publishes a package per line since `0.3.0.0`, which `publish.yaml`'s header says about itself.

## Every pasted output, re-run at `0d05ce20130204653a6625faa11e53a1f8499556`

    gh release list --repo Flowfin/jellyfin-plugin-requests --json tagName --jq '.[].tagName'
    0.3.0.0-jf12-stable
    0.3.0.0-stable
    0.2.0.0-stable
    0.1.0.0-stable

    gh release list --repo Flowfin/jellyfin-plugin-requests --json tagName --jq 'length'
    4

    gh release list --repo Flowfin/jellyfin-plugin-requests --json tagName,createdAt
    [{"createdAt":"2026-09-03T10:24:47Z","tagName":"0.3.0.0-jf12-stable"},{"createdAt":"2026-09-03T10:24:39Z","tagName":"0.3.0.0-stable"},{"createdAt":"2026-08-27T06:50:36Z","tagName":"0.2.0.0-stable"},{"createdAt":"2026-08-08T09:38:30Z","tagName":"0.1.0.0-stable"}]

    curl -sS https://flowfin.dev/manifest.json | jq -r '.[] | select(.name == "Requests") | .versions[] | "\(.version) \(.targetAbi)"'
    0.2.0.0 10.11.0.0
    0.1.0.0 10.11.0.0

    gh release download 0.3.0.0-jf12-stable --repo Flowfin/jellyfin-plugin-requests --pattern 'requests_0.3.0.0.zip.meta.json' --dir jf12
    jq -r '"\(.version) \(.targetAbi)"' jf12/requests_0.3.0.0.zip.meta.json
    0.3.0.0 12.0.0.0

    gh run view 33744830699 --repo Flowfin/jellyfin-plugin-requests --log | grep -o 'Requests loaded and answered on .*'
    Requests loaded and answered on jellyfin/jellyfin:10.11.11 (net9.0)
    Requests loaded and answered on jellyfin/jellyfin:12.0-rc4 (net10.0)

The two readers this board runs over its documents, and the formatter, at the same commit:

    bash scripts/check-pasted-evidence.sh README.md docs/operating.md docs/versioning.md docs/compatibility.md docs/storage.md docs/catalogue.md
    read 28 pasted match lines in 6 document(s)
    check-pasted-evidence: every pasted match line reproduces against the file it names.

    bash scripts/check-negative-disclosures.sh
    ran 4 negative disclosure(s) in 24 document(s)
    check-negative-disclosures: every negative disclosure exits as the document says it does.

    npx --yes prettier@3.6.2 --check README.md docs/operating.md docs/versioning.md docs/compatibility.md docs/storage.md docs/catalogue.md
    All matched files use Prettier code style!

The grep #383 asks to be silent:

    git grep -n -i 'Two releases exist\|12.0 line has none\|has no release for anybody' -- README.md docs/ ; echo "exit=$?"
    exit=1

`docs/RELEASING.md:32` still says two lines are two releases rather than one release with two packages. That is the scheme, it is correct, and this grep does not match it.

## What this does not touch

- `docs/quality-parity.md:509` says in a table cell that two releases are published. #346's open pull request carries that file, so the one cell waits for that landing rather than colliding with it; the sentence is prose and pastes nothing.
- Whether `0.3.0.0` loads on the `10.11.0` floor server. The README now says that is #382's measurement and claims nothing either way.
- The manifest's state. It serves `0.2.0.0` and `0.1.0.0` today and every file says so with the date; when it moves, these pastes stop reproducing again, and nothing in this tree refuses that. #383 says that question belongs to the release route and is not decided there or here.
- The other two bullets under "What is not promised at all" in `docs/compatibility.md`, which say no seam issue has landed and no bridge exists. Those are a different topic from the release position and are not corrected in this change.

Nothing runs the build or the suite for a change that touches only markdown, and this one does. This board has no second reader tonight; the commands above stand in place of one.

## One check on this head is red, and it is the fact this change writes down

`the manifest offers what this board has released` failed on `0d05ce2`. It is not in the required set, it reads the manifest a server fetches against the releases that exist, and it says what the six files now say:

    gh run view 33793611449 --repo Flowfin/jellyfin-plugin-requests --log-failed | grep check-manifest-is-fresh
    check-manifest-is-fresh: the newest release for the jf12 line is 0.3.0.0 and the manifest carries no entry at targetAbi 12.0.0.0 at all. That is a release nobody can install: the publish succeeded and the document a server reads never learned of it.
    check-manifest-is-fresh: the newest release for the line build.yaml names is 0.3.0.0 and the newest the manifest offers at targetAbi 10.11.0.0 is 0.2.0.0. A server on that line takes 0.2.0.0 and there is no way for it to learn that 0.3.0.0 exists.
    check-manifest-is-fresh: 2 claimed line(s) disagree with the manifest a server would fetch.

No byte of this change reaches that reading, and it would be red on any head today, including `master` at its next scheduled run, which is what the sweep behind #111 exists to raise. Merging a documentation correction over it does not turn that red into a green: the manifest is still behind the releases, this page says so with the date, and the check goes on saying so until the manifest moves. The two stale bullets found beside the corrected one are #385.
