### PR TITLE
Stop saying the seam has not landed and the bridge does not exist, on the page that says what is promised

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -266,11 +266,17 @@ nothing here is one that can be skipped over.
 
 ## What is not promised at all
 
-- **The seam to the sibling browsing plugin.** Which side owns what, and how each finds the other,
-  are #88, #89 and #92, and none of them has landed. Nothing about that surface is stable and nothing
-  should be built against it yet.
-- **Anything about a bridge to an external request service.** There is none; #80 is where the
-  interface behind it is defined.
+- **The seam to the sibling browsing plugin, beyond what its contract says.** The contract is the
+  sibling board's, [Flowfin/jellyfin-plugin-discover#94](https://github.com/Flowfin/jellyfin-plugin-discover/issues/94),
+  and [seam.md](seam.md) is this side's pointer at it and says what this side owes against it. Its
+  shape is decided on that board and moves on that board's schedule, so nothing here promises what
+  crosses or when it changes. #88, #89 and #92 landed the pointer, the probe each side uses to find
+  the other, and which side owns the catalogue, and all three are closed.
+- **A bridge to any external request service other than the one form it speaks.** The bridge exists:
+  [bridge.md](bridge.md) carries the interface #80 defined, the null implementation every server
+  without a service runs, and the one adapter, which speaks the Overseerr form. What is promised
+  about it is what that page says and no more, and that page says one procedure in this tree calls a
+  running service and nothing in the suite does.
 - **What a server does with a version it reads from a manifest.** A manifest is published at the
   address [catalogue.md](catalogue.md) names, and how a server orders its entries is read there at the
   server's own source rather than measured; no run of this repository has watched a server install


### PR DESCRIPTION
Closes #385.

**Means.** Markdown in the one file that carries the claims; nothing is built.

## What the two bullets said, and say now

The section "What is not promised at all" in `docs/compatibility.md` named #88, #89 and #92 as unlanded and said the bridge did not exist. Read at `origin/master` before this change:

    for n in 88 89 92 80; do gh issue view $n --repo Flowfin/jellyfin-plugin-requests --json number,state,stateReason,closedAt --jq '"\(.number) \(.state) \(.stateReason) \(.closedAt)"'; done
    88 CLOSED COMPLETED 2026-08-11T08:35:59Z
    89 CLOSED COMPLETED 2026-08-12T23:32:13Z
    92 CLOSED COMPLETED 2026-08-11T09:12:31Z
    80 CLOSED COMPLETED 2026-08-11T08:57:49Z

    git ls-tree --name-only origin/master docs/seam.md docs/bridge.md
    docs/bridge.md
    docs/seam.md

The seam bullet now says what is not promised: the seam's shape, because the contract is the sibling board's and moves on its schedule, which is what `docs/seam.md` says of itself under "Which document is authoritative" and "The HTTP API is not the seam". The bridge bullet now says the bridge exists, names the interface, the null implementation and the one adapter as `docs/bridge.md` opens with them, and repeats that page's own bound: one procedure calls a running service and nothing in the suite does. Neither bullet restates a field, a state word or a rule; each points at the page that holds it.

## Checks at the commit this lands on

    bash scripts/check-pasted-evidence.sh docs/compatibility.md
    check-pasted-evidence: every pasted match line reproduces against the file it names.
    bash scripts/check-negative-disclosures.sh
    check-negative-disclosures: every negative disclosure exits as the document says it does.
    npx --yes prettier@3.6.2 --check docs/compatibility.md
    All matched files use Prettier code style!

## What this does not touch

- Whether the seam or the bridge is finished. The bullets point at the two documents and take no reading of them.
- The other two bullets of the section. The manifest one was corrected in #384; the one about an upgrade watched on a running server is still true.
- The manifest's state. `the manifest offers what this board has released` did not run on this head at all, where it ran and failed on #384's; this change touches neither `docs/catalogue.md` nor anything that check reads. The manifest a server fetches still carries no `0.3.0.0` entry, and that reading is red on `master` since run `33794212732`.

Every check that ran on `f08a649` passed, and the one listed as skipping is the CodeQL summary:

    gh pr checks 386 --repo Flowfin/jellyfin-plugin-requests --json name,bucket --jq 'group_by(.bucket) | .[] | "\(.[0].bucket): \(length)"'
    pass: 34
    skipping: 1

Nothing runs the build or the suite for a change that touches only markdown. This board has no second reader tonight; the commands above stand in place of one.
