### PR TITLE
Compare every field the manifest generator holds once per plugin

### DIFF
--- a/Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj
+++ b/Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj
@@ -44,6 +44,10 @@
          files the release path reads instead of a number restated in a test. -->
     <None Include="../build.yaml" Link="build.yaml" CopyToOutputDirectory="PreserveNewest" />
     <None Include="../build-jf12.yaml" Link="build-jf12.yaml" CopyToOutputDirectory="PreserveNewest" />
+    <!-- The manifest generator, next to the suite, because the set of fields a catalogue holds
+         once per plugin is declared there and the identity check reads it from that file rather
+         than restating it. A second copy of that list is a list that drifts. -->
+    <None Include="../scripts/build-manifest.sh" Link="scripts/build-manifest.sh" CopyToOutputDirectory="PreserveNewest" />
     <!-- The plugin's own project file, for the one claim about it that is not visible from the
          built assembly: that the word catalogues are embedded by a wildcard, which is what makes
          adding a language a file and nothing else. -->

--- a/Jellyfin.Plugin.Requests.Tests/PackagingMetadataTests.cs
+++ b/Jellyfin.Plugin.Requests.Tests/PackagingMetadataTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using Xunit;
 
 using PluginUnderTest = global::Jellyfin.Plugin.Requests.Plugin;
@@ -41,6 +42,13 @@ public class PackagingMetadataTests
     /// across the packages. If they diverge, the entry flips between two texts depending on which
     /// package was published last, and a server that moves between the two server lines can end up
     /// treating this as a second, unrelated plugin.
+    ///
+    /// These three are named here because they are the ones this file has always compared, and
+    /// <c>version</c> is not an identity field at all - it is per-version, and it is compared
+    /// because both packages are cut from one number. The fields a CATALOGUE holds once are read
+    /// out of the generator by <see cref="BothPackagesAgreeOnEveryFieldTheGeneratorHoldsOnce"/>,
+    /// which is the wider guard; this one stays because it names <c>version</c> and that one may
+    /// not.
     /// </summary>
     /// <param name="field">The identity field both packaging files must agree on.</param>
     [Theory]
@@ -53,6 +61,135 @@ public class PackagingMetadataTests
             ReadScalar("build.yaml", field),
             ReadScalar("build-jf12.yaml", field),
             StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Every field the manifest generator holds once per plugin, compared across the two packaging
+    /// files, with the list of fields read out of the generator instead of written here.
+    ///
+    /// WHAT THIS CATCHES THAT THE THEORY ABOVE DOES NOT. <c>scripts/build-manifest.sh</c> refuses
+    /// two packages that disagree on any member of its <c>IDENTITY</c> tuple, and that tuple has
+    /// seven members. The theory above compares two of them. A per-line wording in
+    /// <c>description</c>, a different <c>owner</c>, a moved <c>imageUrl</c>: each one passed every
+    /// check on this board and was refused inside the release, after the tag existed and after both
+    /// packages were built. Those two files carry a paragraph of prose each, so the edit that trips
+    /// it is the commonest edit they get.
+    ///
+    /// WHY THE LIST IS READ RATHER THAN RESTATED. A second copy of it drifts against the first, and
+    /// the drift is silent in the direction that matters: a field added to the generator is a field
+    /// this suite would go on not comparing. So the tuple is parsed out of the script, and a script
+    /// whose declaration this cannot find fails here rather than quietly comparing nothing.
+    ///
+    /// <c>description</c> is why the reader below handles a folded block. Both files write that
+    /// field as <c>description: &gt;</c> with the text on the lines beneath, so a reader that took
+    /// the rest of the key's own line would compare <c>&gt;</c> with <c>&gt;</c> and pass whatever
+    /// the paragraphs said.
+    /// </summary>
+    [Fact]
+    public void BothPackagesAgreeOnEveryFieldTheGeneratorHoldsOnce()
+    {
+        var fields = IdentityFieldsTheGeneratorDeclares();
+
+        // A guard that compares an empty set passes for the wrong reason, and the reason is
+        // invisible. The generator declares seven today; the number is not asserted, only that the
+        // reading found something to compare.
+        Assert.NotEmpty(fields);
+
+        foreach (var field in fields)
+        {
+            var fromDefaultLine = ReadValue("build.yaml", field);
+            var fromJf12 = ReadValue("build-jf12.yaml", field);
+
+            Assert.True(
+                string.Equals(fromDefaultLine, fromJf12, StringComparison.Ordinal),
+                FormattableString.Invariant(
+                    $"build.yaml and build-jf12.yaml disagree on '{field}', which scripts/build-manifest.sh holds once per plugin and refuses a divergence in. build.yaml says '{fromDefaultLine}' and build-jf12.yaml says '{fromJf12}'."));
+        }
+    }
+
+    /// <summary>
+    /// The generator's own list of the fields a catalogue holds once per plugin, read out of the
+    /// line that declares it.
+    /// </summary>
+    /// <returns>The field names, in the order the script writes them.</returns>
+    private static List<string> IdentityFieldsTheGeneratorDeclares()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "scripts", "build-manifest.sh");
+        Assert.True(File.Exists(path), FormattableString.Invariant($"{path} was not copied next to the suite."));
+
+        var declaration = File.ReadLines(path)
+            .FirstOrDefault(line => line.StartsWith("IDENTITY = (", StringComparison.Ordinal));
+
+        // Not found is a failure rather than an empty list. If the declaration is renamed or
+        // reformatted, this check has stopped reading the generator, and it says so instead of
+        // passing over nothing.
+        Assert.False(
+            declaration is null,
+            FormattableString.Invariant($"{path} carries no line beginning 'IDENTITY = (', so the fields a catalogue holds once could not be read from the generator."));
+
+        var open = declaration!.IndexOf('(', StringComparison.Ordinal);
+        var close = declaration.LastIndexOf(')');
+        Assert.True(close > open, FormattableString.Invariant($"the IDENTITY declaration in {path} is not one parenthesised line: {declaration}"));
+
+        return declaration.Substring(open + 1, close - open - 1)
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(entry => entry.Trim('"'))
+            .Where(entry => entry.Length > 0)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Reads one top-level field out of a packaging file, whether it is written on the key's own
+    /// line or as a folded block beneath it.
+    /// </summary>
+    /// <param name="packagingFile">The file, as copied next to the suite.</param>
+    /// <param name="key">The key at column zero.</param>
+    /// <returns>The value: the rest of the line unquoted, or the block's lines joined by a space.</returns>
+    private static string ReadValue(string packagingFile, string key)
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, packagingFile);
+        Assert.True(File.Exists(path), FormattableString.Invariant($"{path} was not copied next to the suite."));
+
+        var lines = File.ReadAllLines(path);
+        var prefix = key + ":";
+        var found = new List<string>();
+
+        for (var index = 0; index < lines.Length; index++)
+        {
+            if (!lines[index].StartsWith(prefix, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var rest = lines[index].Substring(prefix.Length).Trim();
+            if (rest != ">" && rest != "|" && rest != ">-" && rest != "|-")
+            {
+                found.Add(rest.Trim('"'));
+                continue;
+            }
+
+            // A folded or literal block: every line beneath it that is indented or blank belongs to
+            // the value, and the first line at column zero is the next key. Blank lines are kept as
+            // nothing rather than dropped from the middle, because two paragraphs that differ only
+            // by where they are split are two different texts to the generator.
+            var block = new List<string>();
+            for (var below = index + 1; below < lines.Length; below++)
+            {
+                var line = lines[below];
+                if (line.Length > 0 && !char.IsWhiteSpace(line[0]))
+                {
+                    break;
+                }
+
+                block.Add(line.Trim());
+            }
+
+            found.Add(string.Join(" ", block).Trim());
+        }
+
+        // Exactly one, for the reason ReadScalar gives: a key that moved or was written twice fails
+        // here rather than handing back the first of two disagreeing values.
+        return Assert.Single(found);
     }
 
     /// <summary>

--- a/scripts/prove-manifest-refusals.sh
+++ b/scripts/prove-manifest-refusals.sh
@@ -143,6 +143,32 @@ refuses "the two packages claim different plugins" \
     "holds one entry per plugin" -- \
     env -C "$work" SOURCE_URL_PREFIX="$prefix" "$generator" out.json requests_a.zip requests_g.zip
 
+# The same refusal reached through a field nobody would call an identity, and this is the shape it
+# arrives in. `guid` above is a divergence somebody has to mean; a per-line sentence in the
+# packaging prose is an ordinary documentation edit, and the generator holds seven fields once per
+# plugin rather than the two a reader remembers. Written as its own case because a proof that only
+# ever drives `guid` says nothing about the other six.
+#
+# The pair is otherwise legal - two version numbers, the newer one on the newer line - so the
+# only thing wrong with it is the sentence, and the refusal cannot be the duplicate-version rule
+# arriving first under another name.
+package requests_k.zip 0.6.0.0 10.11.0.0
+package requests_l.zip 0.7.0.0 12.0.0.0
+python3 - "$work/requests_l.zip.meta.json" <<'DIVERGE'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as handle:
+    document = json.load(handle)
+document["description"] += " On the 12.0 line, which is the sentence that arrives per line."
+with open(path, "w", encoding="utf-8", newline="\n") as handle:
+    json.dump(document, handle, indent=4, sort_keys=True)
+DIVERGE
+refuses "two packages whose prose diverges on one line" \
+    "holds one entry per plugin" -- \
+    env -C "$work" SOURCE_URL_PREFIX="$prefix" "$generator" out.json requests_k.zip requests_l.zip
+
 package requests_h.zip 0.5.0.0 12.0.0.0
 python3 - "$work/requests_h.zip.meta.json" <<'PY'
 import json


### PR DESCRIPTION
Closes #391.

`scripts/build-manifest.sh` refuses two packages that disagree on any of seven fields; `PackagingMetadataTests` compared three, one of which is not an identity field at all. So a divergence in `description`, `overview`, `owner`, `category` or `imageUrl` passed every check on this board and was refused inside the release, after the tag existed and after both packages were built.

I met it writing #389. The first attempt gave each packaging file the sentence about its own server line, and the suite stayed green with the two files disagreeing.

## The guard

`BothPackagesAgreeOnEveryFieldTheGeneratorHoldsOnce` reads the field list out of the generator rather than restating it, so a field added there is compared here without anybody widening a list, and a declaration it cannot find fails rather than leaving the check comparing nothing.

Reading a value needed more than the reader beside it. Both packaging files write `description` as a folded block, so a reader taking the rest of the key's own line would compare `>` with `>` and pass whatever the paragraphs said. `ReadValue` takes the block.

## It bites, and the near-miss is the one somebody makes

Three changes made to the tree, run, and restored. The `description` case is a single word changed deep inside the folded block rather than a different text, because that is what a documentation edit looks like and it is the case a `>`-comparing reader would let through.

    -  ... The 0.2.0.0 release before it does not load on a 10.11.0 server at all.
    +  ... The 0.2.0.0 build before it does not load on a 10.11.0 server at all.

    build.yaml and build-jf12.yaml disagree on 'description', which scripts/build-manifest.sh holds once per plugin and refuses a divergence in.
    Fehler!  : Fehler: 1, erfolgreich: 5, gesamt: 6

    -owner: "Flowfin"
    +owner: "Flowfin Media"

    build.yaml and build-jf12.yaml disagree on 'owner', which scripts/build-manifest.sh holds once per plugin and refuses a divergence in.
    Fehler!  : Fehler: 1, erfolgreich: 5, gesamt: 6

    -IDENTITY = ("guid", ...
    +ONCE_PER_PLUGIN = ("guid", ...

    ...\scripts\build-manifest.sh carries no line beginning 'IDENTITY = (', so the fields a catalogue holds once could not be read from the generator.
    Fehler!  : Fehler: 1, erfolgreich: 5, gesamt: 6

The tree as it stands is green, on the whole suite rather than the filter:

    dotnet test Jellyfin.Plugin.Requests.Tests/Jellyfin.Plugin.Requests.Tests.csproj -c Release -f net9.0
    Bestanden!   : Fehler: 0, erfolgreich: 857, übersprungen: 0, gesamt: 857

The test runner's output is German on this machine; `Fehler` is failures and `erfolgreich` is passes.

## The generator's own proof drove one field

`scripts/prove-manifest-refusals.sh` reached the identity refusal only through a differing `guid` -- "the two packages claim different plugins" -- which is a divergence somebody has to mean. It now also drives it through the packaging prose, on a pair that is legal in every other way so the refusal cannot be the duplicate-version rule arriving first under another name:

    == two packages whose prose diverges on one line
      build-manifest: requests_l.zip.meta.json declares description 'A user who cannot find something asks for it from inside Jellyfin. On the 12.0 line, which is the sentence that arrives per line.' and the manifest already carries 'A user who cannot find something asks for it from inside Jellyfin.'. A catalogue holds one entry per plugin, so a divergence here is an entry whose text changes with whichever package was published last.

With `description` taken out of `IDENTITY` in the generator, that case reports the pair going through, and the script exits non-zero:

    == two packages whose prose diverges on one line
      build-manifest: wrote out.json listing 2 version(s) of Requests.
      ACCEPTED it, so the rule does not bite.
    exit=1

Restored, the whole proof passes:

    bash scripts/prove-manifest-refusals.sh
    Every rule bit, for the reason it names.
    exit=0

## What is not covered

The check compares the two packaging files against each other. It says nothing about whether either agrees with a manifest already published, which is the generator's `MANIFEST_BASE` comparison and is not read here.

It also does not judge the field list. If the generator's `IDENTITY` is wrong -- a field a catalogue does not hold once, or a missing one -- this compares the wrong set faithfully.

## The project file is in the change

The generator is copied next to the suite so the list is read from it rather than from a second copy. #391's `Scope:` line did not name the project file when it was written and now does, rather than the change quietly reaching past it.

## Means

C# in the suite that already reads these two packaging files, and bash in the proof script that already drives this generator. No language, runtime or dependency is added.

## No second reader

Nothing about this change has been read by anybody but me. The proofs above are what stands in place of that.
