### PR TITLE
Apply the hygiene blocking tier to every author, for #390

### DIFF
--- a/.github/workflows/pr-hygiene.yaml
+++ b/.github/workflows/pr-hygiene.yaml
@@ -32,10 +32,10 @@
 # touches no test, and a merge blocked for either teaches people to split a
 # change badly, which is the opposite of what a size check is for.
 #
-# The FAIL tier is skipped for two audiences, for two different reasons, and
-# both skips are written at the check rather than only here. A skipped run says
-# so in its own annotations, so a run that checked less than the whole set
-# cannot be read as one that checked it and found nothing.
+# The FAIL tier applies to every author. One skip is left, for a bot, and it is
+# written at the check rather than only here. A skipped run says so in its own
+# annotations, so a run that checked less than the whole set cannot be read as
+# one that checked it and found nothing.
 #
 # Two checks the sibling board runs are deliberately not adopted here, and the
 # reasons are at checks 1b and 1c below where a reader looking for them will be.
@@ -99,26 +99,23 @@ jobs:
             const changed = files.map((f) => f.filename);
 
             // --- Who the FAIL tier is for --------------------------------------
+            // Every author, and one skip is left, for a bot.
+            //
             // An automated dependency update opens a pull request with no issue
             // behind it, because there is no issue: the update is the whole
             // change and the tool has nothing to link. Failing it would mean a
             // permanently red check on every such pull request, which is the
-            // check that gets switched off rather than satisfied.
+            // check that gets switched off rather than satisfied. That skip is
+            // keyed on the account being a bot rather than on its relationship
+            // to this repository, so no reading of a payload moves it.
             //
-            // Somebody arriving from outside this repository is a separate case
-            // with a separate reason. The issue convention is this board's, they
-            // have no way to know the numbers before they file, and often no
-            // issue exists yet, so failing their contribution on it is a ritual
-            // rather than a caught slip. The linkage is still wanted: whoever
-            // handles the contribution supplies it.
-            //
-            // COLLABORATOR is in the inside set here, and the sibling board
-            // leaves it out. That is a difference measured rather than copied.
-            // `author_association` is not one value: the field a workflow reads
-            // out of the event payload and the field the REST API returns for
-            // the same pull request can disagree, and here they do. On the run
-            // that first exercised this check, the workflow read COLLABORATOR
-            // and the API answered MEMBER for the same number:
+            // THE SKIP FOR AN AUTHOR OUTSIDE THIS REPOSITORY IS GONE, #390, AND
+            // WHAT IT WAS KEYED ON IS WHY. `author_association` is not one
+            // value: the field a workflow reads out of the event payload and
+            // the field the REST API returns for the same pull request can
+            // disagree, and here they do. On the run that first exercised this
+            // check, the workflow read COLLABORATOR and the API answered MEMBER
+            // for the same number:
             //
             //   gh api repos/Flowfin/jellyfin-plugin-requests/pulls/163 --jq '.author_association'
             //   MEMBER
@@ -126,24 +123,27 @@ jobs:
             //   ##[warning]The blocking tier was skipped because the author is
             //   outside this repository (author_association: COLLABORATOR)
             //
-            // The value that decides the check is the one the workflow reads,
-            // so an inside set of OWNER and MEMBER skips the blocking tier for
-            // every pull request this board actually opens, which is a check
-            // that refuses nothing while reporting success. What the wider set
-            // costs is that somebody given push access is inside the tier from
-            // that moment. That is the right reading here: the convention this
-            // tier enforces follows write access, and somebody with none is the
-            // audience the skip is for.
+            // So which audience the skip reached depended on which route read
+            // the field, and a skip whose audience cannot be stated is coverage
+            // nobody can state either. The audience it was written for keeps
+            // what it was owed a different way: the issue convention is this
+            // board's, somebody arriving from outside has no way to know the
+            // numbers before they file, and where a first contribution is
+            // refused on it the reference is supplied by whoever handles the
+            // contribution rather than demanded of them. That is a sentence in
+            // CONTRIBUTING.md and a hand on the pull request, not a green check
+            // that checked nothing.
+            //
+            // The value is still read, and it is now reported rather than acted
+            // on, because the disagreement above is the thing a later reader
+            // will want the run to have recorded.
             const isBot = pr.user && pr.user.type === 'Bot';
-            const INSIDE_ASSOCIATIONS = ['OWNER', 'MEMBER', 'COLLABORATOR'];
-            const isOutside = !INSIDE_ASSOCIATIONS.includes(
-              pr.author_association || 'NONE',
-            );
-            const failTierApplies = !isBot && !isOutside;
+            const association = pr.author_association || 'NONE';
+            const failTierApplies = !isBot;
 
-            // Both skips are written at the check. A run that skipped the
-            // blocking tier says which checks it did not make and why, so it
-            // cannot be read as a run that made them and found nothing.
+            // The skip that is left is written at the check. A run that skipped
+            // the blocking tier says which checks it did not make and why, so
+            // it cannot be read as a run that made them and found nothing.
             if (isBot) {
               warnings.push(
                 'The blocking tier was skipped because this pull request was ' +
@@ -154,17 +154,6 @@ jobs:
                   'not owed here; a version bump from one would still owe a ' +
                   'changelog entry and is not checked, which is the cost of the ' +
                   'skip and is stated rather than hidden.',
-              );
-            } else if (isOutside) {
-              warnings.push(
-                'The blocking tier was skipped because the author is outside ' +
-                  `this repository (author_association: ${pr.author_association || 'NONE'}). ` +
-                  'The two checks not made are the issue reference in the body ' +
-                  'and the changelog entry behind a version bump. The issue ' +
-                  'linkage is still wanted: whoever handles this contribution ' +
-                  'supplies the reference, and files the issue where none ' +
-                  'exists yet. Read this as "not their obligation", never as ' +
-                  '"linkage does not matter here".',
               );
             }
 
@@ -272,6 +261,16 @@ jobs:
               core.warning(w);
             }
             const summary = core.summary.addHeading('Pull request hygiene', 2);
+            summary.addRaw(
+              failTierApplies
+                ? 'The blocking tier applied. The event payload carried ' +
+                    `author_association: ${association}, and since #390 that ` +
+                    'value decides nothing here; it is recorded because the ' +
+                    'two routes that read it have disagreed.'
+                : 'The blocking tier was skipped. The annotation says why, and ' +
+                    `the event payload carried author_association: ${association}.`,
+              true,
+            );
             if (failures.length === 0 && warnings.length === 0) {
               summary.addRaw('Every check passed and nothing was skipped.');
             } else {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,9 +26,15 @@ number, it carries the command that produced it.
 
 A pull request names its issue in the body: `Closes #12`, or `Part of #12` where
 it does not finish it. The `Deterministic pull request hygiene checks` job reads
-the body for that reference. It skips the blocking tier for a pull request from
-somebody outside this repository, so a first contribution is never refused on a
-convention nobody could have known.
+the body for that reference, and since #390 it reads it whoever the author is.
+
+So a first contribution can be refused on a convention nobody could have known,
+and what answers that is a hand rather than a skip: say so in the pull request
+and the reference is supplied, or the issue filed, by whoever handles the
+contribution. The skip it replaces was keyed on `author_association`, a field
+that answers differently on the two routes that read it, so which contributions
+it reached was not a thing anybody could state. A bot is the only author the
+blocking tier still skips, because an automated update has no issue to link.
 
 ## What the gate expects
 

--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -392,10 +392,15 @@ merge.
   repository scans three languages rather than one.
 - `Deterministic PR-hygiene checks` there is
   `Deterministic pull request hygiene checks` here, which is the same job under a
-  name written out, and its blocking tier reaches a different audience: the
-  inside set there is owner and member, and here it also holds collaborator,
+  name written out. Its blocking tier reached a different audience until #390:
+  the inside set there was owner and member, and here it also held collaborator,
   because the value a workflow reads out of the event payload and the value the
-  API returns for the same pull request disagree on this board.
+  API returns for the same pull request disagree on this board. Neither board
+  keys the tier on that value now, so the audience is the same on both and this
+  is parity rather than a difference. What each does with the value it reads
+  still differs: there it is a warning annotation on every run, and here it is a
+  line in the job summary, because an annotation that fires on every pull
+  request is a yellow flag on runs where nothing was skipped.
 - `Enforce greppable invariants` is the same name on both boards, over a
   different rule set. A rule is added the first time an invariant on this board
   is decided, so each set says what its own tree has decided rather than what the


### PR DESCRIPTION
Closes #390.

The blocking tier of `Deterministic pull request hygiene checks` no longer reads
`author_association`. It applies to every author, and the only skip left is for
a bot.

## The issue's premise does not reproduce on this board, and the repair still does

The issue says this board's copy skips its failing tier for authors whose
association is OWNER or MEMBER, quoting `const INSIDE = ["OWNER", "MEMBER"]`.
Neither the constant nor the polarity is this board's. The copy here names the
set the other way round and skips the authors OUTSIDE it:

    $ git grep -nE "const INSIDE|isOutside =|failTierApplies =" origin/master -- .github/workflows/pr-hygiene.yaml
    origin/master:.github/workflows/pr-hygiene.yaml:138:            const INSIDE_ASSOCIATIONS = ['OWNER', 'MEMBER', 'COLLABORATOR'];
    origin/master:.github/workflows/pr-hygiene.yaml:139:            const isOutside = !INSIDE_ASSOCIATIONS.includes(
    origin/master:.github/workflows/pr-hygiene.yaml:142:            const failTierApplies = !isBot && !isOutside;

and it has done so since the commit that added the file, `1675636` of
2026-08-08:

    $ git grep -n "const INSIDE" 1675636 -- .github/workflows/pr-hygiene.yaml
    1675636:.github/workflows/pr-hygiene.yaml:138:            const INSIDE_ASSOCIATIONS = ['OWNER', 'MEMBER', 'COLLABORATOR'];

So the harm the issue describes - a required context that refuses nothing
because every pull request here is written by an inside account - is not what
was happening here. The tier applied on the three most recent pull requests,
read off their runs rather than off the source:

    $ R=Flowfin/jellyfin-plugin-requests
    $ for n in 393 392 388; do
        sha=$(gh pr view $n --repo $R --json headRefOid --jq .headRefOid)
        id=$(gh api "repos/$R/commits/$sha/check-runs?check_name=Deterministic%20pull%20request%20hygiene%20checks" \
             --jq '[.check_runs[] | select(.conclusion != "cancelled")] | sort_by(.completed_at) | last | .id')
        echo "#$n $(gh api repos/$R/check-runs/$id --jq .conclusion) $(gh api repos/$R/check-runs/$id/annotations \
          --jq '[.[] | select(.message | test("author_association"))] | if length == 0 then "the blocking tier applied" else "skipped" end')"
      done
    #393 success the blocking tier applied
    #392 success the blocking tier applied
    #388 success the blocking tier applied

What the decision on smart-collections#246 asks for still applies here, for the
reason that decision gives rather than for the count the issue quotes: the tier
was keyed on a field that answers differently on the two routes that read it, so
which authors a skip reaches is not a thing anybody can state. That disagreement
is measured on this board and the workflow's own comment already carried it -
the payload read COLLABORATOR on the run that first exercised this check and the
REST API answered MEMBER for the same pull request.

## What the change is

`failTierApplies` is `!isBot`. The bot skip stays: it is keyed on the account
being a bot rather than on its relationship to this repository, so no reading of
a payload moves it, and an automated dependency update has no issue to link.

The association is still read, and it is now reported in the job summary instead
of deciding anything, because the disagreement above is what a later reader will
want a run to have recorded. That is a deliberate difference from the sibling
board, which reports it as a warning annotation on every run; an annotation that
fires on every pull request puts a yellow flag on runs where nothing was
skipped, and `docs/quality-parity.md` now carries the difference with its
reason.

Two documents promised the old audience and are corrected in the same change,
because a sentence describing a skip that is gone is worse than no sentence:
`CONTRIBUTING.md` said the tier is skipped for somebody outside this repository,
and `docs/quality-parity.md` carried the audience as a difference from the
sibling board that no longer exists.

What the removed skip was for keeps what it was owed by a hand rather than by a
green check: a first contribution refused on this board's issue convention gets
its reference supplied, or its issue filed, by whoever handles it. That is what
`CONTRIBUTING.md` says now, in place of the promise.

## The check watched refusing, on the head that carries the change

This pull request was opened with a body carrying no issue reference, on
purpose, on this head. Run 33944668750, check run 101248495594 at
`f61e9a4772cfece8eda4f8ab47c6172e6563d656`:

    $ gh api repos/Flowfin/jellyfin-plugin-requests/check-runs/101248495594 --jq '{name,conclusion,started_at}'
    {"conclusion":"failure","name":"Deterministic pull request hygiene checks","started_at":"2026-09-05T04:29:04Z"}

    $ gh api repos/Flowfin/jellyfin-plugin-requests/check-runs/101248495594/annotations --jq '.[] | "\(.annotation_level): \(.message)"'
    failure: The body carries no issue reference. Name the issue this change belongs to, for example `Closes #12` or `Part of #12`.

No annotation names an association, which is the tier having applied rather than
having been skipped.

This body then gained the reference at the top. The `edited` event that carried it
produced no run, and the one on a later title edit did; both are `edited` on the
same head, so what separated them is not readable from here and is recorded rather
than explained. Check run 101252331628 on the same commit:

    $ gh api repos/Flowfin/jellyfin-plugin-requests/check-runs/101252331628 --jq '{name,conclusion,started_at}'
    {"conclusion":"success","name":"Deterministic pull request hygiene checks","started_at":"2026-09-05T05:01:18Z"}

    $ gh api repos/Flowfin/jellyfin-plugin-requests/check-runs/101252331628/annotations --jq 'length'
    0

One head, one association, two outcomes. The title moved as well as the body, and
check 1 reads the body, so what the pair shows is the tier running on this author
and refusing a body without a reference rather than skipping it.

## What this does not claim

**The removal itself is not watched changing an outcome.** No pull request on
this board carries an association outside the set the old code named, so there
is no author for whom the tier runs now that it would not have run for before.
What is watched is check 1 refusing a body on this head; that the same body
would have been let through under an association outside the old set is the
workflow's control flow and is an inference, not a measurement.

**The value the payload carried on this run is not quoted.** The new summary
line reports it, and a job summary is not reachable from the check-runs API, so
nothing above reads it back.

## The means

A `github-script` step in the workflow that already exists, edited in place.
There is nothing to choose: the check being changed is that step, the change is
a deleted condition and the comment that argued for it, and any other means
would be a second place the rule lives.

## Reading

No second reader tonight. The evidence stands in place of one: the red run and
its annotation above, the three prior runs measured for the premise correction,
and the required contexts read on this head before the merge rather than
assumed.
